### PR TITLE
Use Codecov, not Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
 - nosetests --with-coverage --cover-package wallace
 # - nosetests tests._test_heroku --nocapture
 after_success:
-- coveralls
+- bash <(curl -s https://codecov.io/bash)
 notifications:
   email:
     recipients:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Wallace
 =======
 [![Build Status](https://travis-ci.org/berkeley-cocosci/Wallace.svg?branch=master)](https://travis-ci.org/berkeley-cocosci/Wallace)
-[![Coverage Status](https://coveralls.io/repos/github/berkeley-cocosci/Wallace/badge.svg?branch=master)](https://coveralls.io/github/berkeley-cocosci/Wallace?branch=master)
+[![codecov](https://codecov.io/gh/Dallinger/Dallinger/branch/master/graph/badge.svg)](https://codecov.io/gh/Dallinger/Dallinger)
 [![Code Climate](https://codeclimate.com/github/berkeley-cocosci/Wallace/badges/gpa.svg)](https://codeclimate.com/github/berkeley-cocosci/Wallace)
 [![License](https://img.shields.io/github/license/berkeley-cocosci/Wallace.svg)](http://en.wikipedia.org/wiki/MIT_License)
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 alabaster==0.7.9
 coverage==3.7.1
-coveralls==0.4.2
+codecov==2.0.5
 nose==1.3.4
 pypandoc==1.2.0
 Sphinx==1.4.5

--- a/wallace/heroku/requirements.txt
+++ b/wallace/heroku/requirements.txt
@@ -2,7 +2,7 @@
 APScheduler==3.0.5
 click==3.3
 coverage==3.7.1
-coveralls==0.4.2
+codecov==2.0.5
 psiturk-wallace==2.2.0
 nose==1.3.4
 pexpect==3.3


### PR DESCRIPTION
I’ve been less than impressed with Coverall’s interface lately — time
to try something new.