### PR TITLE
Set up a release process

### DIFF
--- a/.github_changelog_generator
+++ b/.github_changelog_generator
@@ -1,0 +1,6 @@
+unreleased=false
+since-tag=v1.0.0
+enhancement-labels='enhancement,demo,docs'
+bugs-label='Bugs squashed'
+enhancement-label='Enhancements'
+issues-label='Issues closed'

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/build
 docs/source/demos
 .DS_Store
 README.rst
+.netrc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 sudo: required
+rvm:
+- '2.2'
 python:
 - '2.7'
 cache: pip
@@ -19,6 +21,7 @@ install:
 - git config --global user.email "dallinger@mailinator.com"
 - git config --global user.name "William Henry Dallinger FRS"
 - gem install danger
+- gem install chandler
 before_script:
 - psql -c 'create database db;' -U postgres
 env:
@@ -36,6 +39,9 @@ script:
 # - nosetests tests._test_heroku --nocapture
 after_success:
 - bash <(curl -s https://codecov.io/bash)
+- if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+    sh scripts/github_releases.sh;
+  fi
 notifications:
   email:
     recipients:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Change Log

--- a/Dangerfile
+++ b/Dangerfile
@@ -22,3 +22,6 @@ demo = github.pr_labels.include?("demo")
 has_label = enhancement || bug || release || demo
 
 warn("Please label as 'enhancement', 'bug', 'demo', or 'release'.", sticky: true) if !has_label
+
+# Require change log entries on PRs with a release label.
+fail("Please update the change log for this release.") if release && !git.modified_files.include?("CHANGELOG.md")

--- a/Dangerfile
+++ b/Dangerfile
@@ -14,6 +14,11 @@ if git.commits.any? { |c| c.message =~ /^Merge branch/ }
 end
 
 # Require labels on PRs.
-has_enhancement_label = github.pr_labels.include?("enhancement")
-has_bug_label = github.pr_labels.include?("bug")
-warn("Please label as 'enhancement', 'bug', 'demo', or 'release'.", sticky: true) if !has_enhancement_label && !has_bug_label
+enhancement = github.pr_labels.include?("enhancement")
+bug = github.pr_labels.include?("bug")
+release = github.pr_labels.include?("release")
+demo = github.pr_labels.include?("demo")
+
+has_label = enhancement || bug || release || demo
+
+warn("Please label as 'enhancement', 'bug', 'demo', or 'release'.", sticky: true) if !has_label

--- a/scripts/github_releases.sh
+++ b/scripts/github_releases.sh
@@ -1,0 +1,2 @@
+echo "machine api.github.com\n  login DallingerBot\n  password $CHANDLER_GITHUB_API_TOKEN" > ~/.netrc
+chandler push


### PR DESCRIPTION
This sets up Danger to check that PRs with the label "release" have updated change logs. It also add Chandler, a program that automatically syncs GitHub release notes with the change log, though in a dry run mode until it is tested further.