### PR TITLE
Install Dallinger via PyPi on Heroku

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -174,7 +174,6 @@ def setup_experiment(debug=True, verbose=False, app=None):
 
     heroku_files = [
         "Procfile",
-        "requirements.txt",
         "psiturkapp.py",
         "worker.py",
         "clock.py",

--- a/dallinger/heroku/requirements.txt
+++ b/dallinger/heroku/requirements.txt
@@ -1,4 +1,3 @@
--e git+https://github.com/Dallinger/Dallinger.git@v2.0.0#egg=dallinger
 APScheduler==3.0.5
 click==3.3
 codecov==2.0.5


### PR DESCRIPTION
## Description
This install Dallinger via PyPi on Heroku, rather than installing it from GitHub. This fixes a bug where the demo-specific requirements were being overwritten by the generic Heroku requirements.