### PR TITLE
Fix Chandler config. permissions

### DIFF
--- a/scripts/github_releases.sh
+++ b/scripts/github_releases.sh
@@ -1,2 +1,3 @@
 echo "machine api.github.com\n  login DallingerBot\n  password $CHANDLER_GITHUB_API_TOKEN" > ~/.netrc
+chmod 0600 ~/.netrc
 chandler push


### PR DESCRIPTION
This fixes the permissions of the generated Chandler configuration file
so that Travis CI can automatically update GitHub releases.