### PR TITLE
Use localconfig for dallinger.config

### DIFF
--- a/dallinger/__init__.py
+++ b/dallinger/__init__.py
@@ -10,7 +10,11 @@ from . import (
     experiments
 )
 
+from localconfig import config
+config.read("config.txt")
+
 __all__ = (
+    "config",
     "models",
     "information",
     "nodes",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 APScheduler==3.2.0
 click==6.6
 future==0.15.2
+localconfig==0.4.2
 pexpect==4.2.1
 psiturk-dallinger==3.0.1
 psycopg2==2.6.2


### PR DESCRIPTION
This commit adds a new submodule to Dallinger, dallinger.config, which
contains the contents of the experiment-specific configuration file,
automatically parsed as much as possible. This makes it possible, for
example, to access the “us_only” parameter of the “HIT Configuration”
section through:

```
dallinger.hit_configuration.us_only
```