### PR TITLE
Sort import statements

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -3,25 +3,26 @@
 
 """The Dallinger command-line utility."""
 
-from dallinger import db
-from dallinger.version import __version__
-
-import boto
-import click
 import imp
 import inspect
 import os
 import pexpect
 import pkg_resources
-from psiturk.psiturk_config import PsiturkConfig
-import psycopg2
 import re
-import requests
 import shutil
 import subprocess
 import tempfile
 import time
 import uuid
+
+import boto
+import click
+from psiturk.psiturk_config import PsiturkConfig
+import psycopg2
+import requests
+
+from dallinger import db
+from dallinger.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 

--- a/dallinger/custom.py
+++ b/dallinger/custom.py
@@ -1,8 +1,12 @@
 """Import custom routes into the experiment server."""
 
-import dallinger
-from dallinger import db
-from dallinger import models
+from datetime import datetime
+from json import dumps
+import logging
+from operator import attrgetter
+import os
+import requests
+import traceback
 
 from flask import (
     Blueprint,
@@ -11,22 +15,18 @@ from flask import (
     send_from_directory,
     render_template
 )
-
-from datetime import datetime
-from json import dumps
-import logging
-from operator import attrgetter
-import os
 from psiturk.db import db_session as session_psiturk
 from psiturk.db import init_db
 from psiturk.psiturk_config import PsiturkConfig
 from psiturk.user_utils import PsiTurkAuthorization
-import requests
 from rq import get_current_job
 from rq import Queue
 from sqlalchemy.orm.exc import NoResultFound
-import traceback
 from worker import conn
+
+import dallinger
+from dallinger import db
+from dallinger import models
 
 # Load the configuration options.
 config = PsiturkConfig()

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
+
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base

--- a/dallinger/experiments.py
+++ b/dallinger/experiments.py
@@ -1,19 +1,20 @@
 """The base experiment class."""
 
+from collections import Counter
+import imp
+import inspect
+from operator import itemgetter
+import random
+import sys
+
+from sqlalchemy import and_
+
 from dallinger.models import Network, Node, Info, Transformation, Participant
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
 from dallinger.transformations import Compression, Response
 from dallinger.transformations import Mutation, Replication
 from dallinger.networks import Empty
-
-from collections import Counter
-import imp
-import inspect
-from operator import itemgetter
-import random
-from sqlalchemy import and_
-import sys
 
 
 class Experiment(object):

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -1,17 +1,17 @@
 """A clock process."""
 
-from dallinger import db
-from dallinger.models import Participant
-
-from apscheduler.schedulers.blocking import BlockingScheduler
-from boto.mturk.connection import MTurkConnection
 from datetime import datetime
 from email.mime.text import MIMEText
 import json
 import os
+
+from apscheduler.schedulers.blocking import BlockingScheduler
+from boto.mturk.connection import MTurkConnection
 from psiturk.psiturk_config import PsiturkConfig
 import requests
-# import smtplib
+
+from dallinger import db
+from dallinger.models import Participant
 
 config = PsiturkConfig()
 config.load_config()

--- a/dallinger/heroku/worker.py
+++ b/dallinger/heroku/worker.py
@@ -1,8 +1,8 @@
 """Heroku web worker."""
 
 from future.builtins import map
-
 import os
+
 import redis
 from rq import (
     Worker,

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1,8 +1,7 @@
 """Define Dallinger's core models."""
 
 from datetime import datetime
-
-from .db import Base
+import inspect
 
 from sqlalchemy import ForeignKey, or_, and_
 from sqlalchemy import (
@@ -17,7 +16,7 @@ from sqlalchemy import (
 )
 from sqlalchemy.orm import relationship, validates
 
-import inspect
+from .db import Base
 
 DATETIME_FMT = "%Y-%m-%dT%H:%M:%S.%f"
 

--- a/dallinger/networks.py
+++ b/dallinger/networks.py
@@ -1,9 +1,11 @@
 """Network structures commonly used in simulations of evolution."""
 
-from .models import Network, Node
-from .nodes import Source
 from operator import attrgetter
 import random
+
+from .models import Network
+from .models import Node
+from .nodes import Source
 
 
 class Chain(Network):

--- a/dallinger/nodes.py
+++ b/dallinger/nodes.py
@@ -1,12 +1,15 @@
 """Define kinds of nodes: agents, sources, and environments."""
 
-from dallinger.models import Node, Info
-from dallinger.information import State
-from sqlalchemy import Integer
-from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.sql.expression import cast
 from operator import attrgetter
 import random
+
+from sqlalchemy.ext.hybrid import hybrid_property
+from sqlalchemy import Integer
+from sqlalchemy.sql.expression import cast
+
+from dallinger.information import State
+from dallinger.models import Info
+from dallinger.models import Node
 
 
 class Agent(Node):

--- a/dallinger/processes.py
+++ b/dallinger/processes.py
@@ -1,8 +1,9 @@
 """Processes manipulate networks and their parts."""
 
+import random
+
 from nodes import Agent
 from nodes import Source
-import random
 
 
 def random_walk(network):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1,7 +1,8 @@
 """Recruiters manage the flow of participants to the experiment."""
 
-from boto.mturk.connection import MTurkConnection
 import os
+
+from boto.mturk.connection import MTurkConnection
 from psiturk.models import Participant
 from psiturk.psiturk_config import PsiturkConfig
 


### PR DESCRIPTION
According to PEP8:

```
Imports should be grouped in the following order:

standard library imports
related third party imports
local application/library specific imports

You should put a blank line between each group of imports.
```