### PR TITLE
convert property1 from String to Text

### DIFF
--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -41,19 +41,19 @@ class SharedMixin(object):
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.
-    property2 = Column(String(256), nullable=True, default=None)
+    property2 = Column(Text, nullable=True, default=None)
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.
-    property3 = Column(String(256), nullable=True, default=None)
+    property3 = Column(Text, nullable=True, default=None)
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.
-    property4 = Column(String(256), nullable=True, default=None)
+    property4 = Column(Text, nullable=True, default=None)
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.
-    property5 = Column(String(256), nullable=True, default=None)
+    property5 = Column(Text, nullable=True, default=None)
 
     #: boolean indicating whether the Network has failed which
     #: prompts Dallinger to ignore it unless specified otherwise. Objects are

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -37,7 +37,7 @@ class SharedMixin(object):
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.
-    property1 = Column(String(256), nullable=True, default=None)
+    property1 = Column(Text, nullable=True, default=None)
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.


### PR DESCRIPTION
## Description
Converts property1 from String to Text

## Motivation and Context
Allows storage or strings of arbitrary length, which is useful if we want to store complex json objects

## How Has This Been Tested?
I have saved long strings