### PR TITLE
Allow requirements specified by URL

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -114,7 +114,7 @@ def setup_experiment(debug=True, verbose=False, app=None):
     # Check that the demo-specific requirements are satisfied.
     try:
         with open("requirements.txt", "r") as f:
-            dependencies = f.readlines()
+            dependencies = [r for r in f.readlines() if r[:3] != "-e "]
     except:
         dependencies = []
 


### PR DESCRIPTION
This allows requirements to be specified by URL, e.g.,

```
-e git://github.com/Dallinger/Dallinger.git#egg=dallinger
```