### PR TITLE
Fix clock and worker processes

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -406,7 +406,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1):
 
         "heroku pg:wait",
 
-        "heroku addons:create rediscloud:250",
+        "heroku addons:create heroku-redis:premium-0",
 
         "heroku addons:create papertrail",
 
@@ -672,7 +672,7 @@ def hibernate(app):
     addons = [
         "heroku-postgresql",
         # "papertrail",
-        "rediscloud",
+        "heroku-redis",
     ]
     for addon in addons:
         subprocess.call(
@@ -737,7 +737,7 @@ def awaken(app, databaseurl):
         shell=True)
 
     subprocess.call(
-        "heroku addons:create rediscloud:250 --app {}".format(heroku_id(app)),
+        "heroku addons:create heroku-redis:premium-0 --app {}".format(heroku_id(app)),
         shell=True)
 
     # Scale up the dynos.

--- a/dallinger/heroku/worker.py
+++ b/dallinger/heroku/worker.py
@@ -12,7 +12,7 @@ from rq import (
 
 listen = ['high', 'default', 'low']
 
-redis_url = os.getenv('REDISCLOUD_URL', 'redis://localhost:6379')
+redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
 
 conn = redis.from_url(redis_url)
 


### PR DESCRIPTION
We've been having trouble with the worker and clock processes on Heroku and think it may be due to Redis taking a long time to come online. This is a work-in-progress fix.