### PR TITLE
Refactor response submission

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -108,10 +108,12 @@ lock = false;
 
 submitResponses = function () {
     submitNextResponse(0);
+    submitAssignment();
 };
 
 submit_responses = function () {
     submitResponses();
+    submitAssignment();
 };
 
 submitNextResponse = function (n) {
@@ -123,28 +125,23 @@ submitNextResponse = function (n) {
         }
     );
 
-    // submit a request for the next one.
-    if (n === ids.length) {
-        submitAssignment();
-    } else {
-        reqwest({
-            url: "/question/" + participant_id,
-            method: "post",
-            type: "json",
-            data: {
-                question: $("#" + ids[n]).attr("name"),
-                number: n + 1,
-                response: $("#" + ids[n]).val()
-            },
-            success: function() {
-                submitNextResponse(n + 1);
-            },
-            error: function (err) {
-                errorResponse = JSON.parse(err.response);
-                if (errorResponse.hasOwnProperty("html")) {
-                    $("body").html(errorResponse.html);
-                }
+    reqwest({
+        url: "/question/" + participant_id,
+        method: "post",
+        type: "json",
+        data: {
+            question: $("#" + ids[n]).attr("name"),
+            number: n + 1,
+            response: $("#" + ids[n]).val()
+        },
+        success: function() {
+            submitNextResponse(n + 1);
+        },
+        error: function (err) {
+            errorResponse = JSON.parse(err.response);
+            if (errorResponse.hasOwnProperty("html")) {
+                $("body").html(errorResponse.html);
             }
-        });
-    }
+        }
+    });
 };


### PR DESCRIPTION
Previously, submitting the responses on a page also submitted the
assignment, which causes a problem if you don’t want the two to be
linked in that way (e.g., you have a questionnaire before and after the
experiment). This dissociates the two.

Fixes #284.