### PR TITLE
Add -no-owner flag to dallinger/command_line.py

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -779,7 +779,7 @@ def export(app, local):
         dump_path = dump_database(id)
 
         subprocess.call(
-            "pg_restore --verbose --clean -d dallinger " +
+            "pg_restore --verbose --no-owner --clean -d dallinger " +
             os.path.join("data", id, "data.dump"),
             shell=True)
 


### PR DESCRIPTION
## Description
The —no-owner flag to fixes an issue where if the user is not set as a “superuser” in Postgres, the data export command fails because it tries to perform an action that only these superusers can do.
