### PR TITLE
Properly link in static files for documentation of demos

### DIFF
--- a/docs/source/build_demo_docs.py
+++ b/docs/source/build_demo_docs.py
@@ -5,28 +5,30 @@ import subprocess as sp
 
 
 def make_demo(name, src, dst):
-    print("Making '{}'' demo...".format(name))
+    print("Making '{}' demo...".format(name))
 
+    static_files = []
     for file in os.listdir(src):
         if file.endswith(".jpg") or file.endswith(".png"):
             shutil.copy(
                 os.path.join(src, file),
-                os.path.join(dst, "demos", file)
+                os.path.join(dst, file)
             )
+            static_files.append(file)
 
     # convert and copy the README to the static location
     sp.call([
         "pandoc",
         "--from", "markdown",
         "--to", "rst",
-        "-o", os.path.join(dst, "demos", "{}.rst".format(name)),
+        "-o", os.path.join(dst, "index.rst"),
         os.path.join(src, "README.md")
     ])
 
     # add a link to download the demo to the readme
-    with open(os.path.join(dst, "demos", "{}.rst".format(name)), "a") as fh:
+    with open(os.path.join(dst, "index.rst"), "a") as fh:
         fh.write("\n\n")
-        fh.write("`Download the demo <../_static/{}.zip>`__.\n".format(name))
+        fh.write("`Download the demo <../../_static/{}.zip>`__.\n".format(name))
 
     # create a temporary directory
     tempdir = tempfile.mkdtemp()
@@ -51,12 +53,15 @@ def make_demo(name, src, dst):
         sp.call(["zip", "-r", zipname, name])
 
         # copy the zip file to the static location
-        shutil.copy(os.path.join(tempdir, zipname), os.path.join(dst, "_static", zipname))
+        shutil.copy(os.path.join(tempdir, zipname), os.path.join(dst, zipname))
+        static_files.append(zipname)
 
     finally:
         # remove the temporary directory
         os.chdir(origdir)
         shutil.rmtree(tempdir)
+
+    return static_files
 
 
 def build(root):
@@ -64,7 +69,14 @@ def build(root):
         os.makedirs(os.path.join(root, "demos"))
 
     demos_dir = os.path.abspath(os.path.join(root, "..", "..", "demos"))
+    static_files = []
     for demo in os.listdir(demos_dir):
         src = os.path.join(demos_dir, demo)
         if os.path.isdir(src):
-            make_demo(demo, src, root)
+            dst = os.path.join(root, "demos", demo)
+            if not os.path.exists(dst):
+                os.makedirs(dst)
+            static = make_demo(demo, src, dst)
+            static_files.extend([os.path.join("demos", demo, x) for x in static])
+
+    return static_files

--- a/docs/source/build_demo_docs.py
+++ b/docs/source/build_demo_docs.py
@@ -28,7 +28,8 @@ def make_demo(name, src, dst):
     # add a link to download the demo to the readme
     with open(os.path.join(dst, "index.rst"), "a") as fh:
         fh.write("\n\n")
-        fh.write("`Download the demo <../../_static/{}.zip>`__.\n".format(name))
+        fh.write(
+            "`Download the demo <../../_static/{}.zip>`__.\n".format(name))
 
     # create a temporary directory
     tempdir = tempfile.mkdtemp()
@@ -77,6 +78,7 @@ def build(root):
             if not os.path.exists(dst):
                 os.makedirs(dst)
             static = make_demo(demo, src, dst)
-            static_files.extend([os.path.join("demos", demo, x) for x in static])
+            static_files.extend(
+                [os.path.join("demos", demo, x) for x in static])
 
     return static_files

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -397,4 +397,5 @@ root = os.path.abspath(os.path.dirname(__file__))
 sys.path.append(root)
 
 import build_demo_docs
-build_demo_docs.build(root)
+static = build_demo_docs.build(root)
+html_static_path.extend(static)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,7 +21,7 @@ Laboratory automation for the behavioral and social sciences.
     :caption: Demos
     :glob:
 
-    demos/*
+    demos/*/*
 
 .. toctree::
     :maxdepth: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This puts the static files for demos into their own directories so that name conflicts do not occur. Note that Sphinx will still copy the files into its own `_images` folder, but it will properly handle name conflicts (I checked this) so that if two images have the same name, they will get properly renamed by Sphinx itself.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Fixes #216 
