### PR TITLE
Fix bug in waiting for Redis

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -420,18 +420,18 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1):
 
     # Wait for Redis database to be ready.
     log("Waiting for Redis...")
-    redis_URL = subprocess.check_output(
-        "heroku config:get REDIS_URL --app {}".format(app_name(id)),
-        shell=True
-    )
     ready = False
     while not ready:
+        redis_URL = subprocess.check_output(
+            "heroku config:get REDIS_URL --app {}".format(app_name(id)),
+            shell=True
+        )
         r = redis.from_url(redis_URL)
         try:
             r.set("foo", "bar")
             ready = True
-        except redis.exceptions.ConnectionError:
-            pass
+        except redis.exceptions.ConnectionError as e:
+            time.sleep(2)
 
     # Set the notification URL in the cofig file to the notifications URL.
     config.set(


### PR DESCRIPTION
To check if the Redis queue is available, we try to write to it.
However, sometimes the URL for the Redis queue is not immediately
available. The existing implementation retrieves this URL once and then
pings it over and over. The new implementation retrieves the URL once
per ping. Thus it is updated as soon as the URL becomes available,
preventing an infinite hang.