### PR TITLE
Misc improvements to testing infrastructure

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[run]
+branch = True
+source = dallinger
+
+[report]
+fail_under = 30
+show_missing = True
+skip_covered = True

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@
 *.db-journal
 *.zip
 .env
+.tox
 /snapshots/
 *-
 site/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,30 @@
 language: python
-sudo: required
-python:
-- '2.7'
+sudo: false
 cache:
   - apt
+  - bundler
   - pip
-env:
-  matrix:
-    - GROUP=docs
-    - GROUP=nosetests
+matrix:
+  include:
+  - python: 2.7
+    env: TOXENV=py27
+  - python: 2.7
+    env: TOXENV=docs
 addons:
   apt:
     packages:
     - pandoc
     - enchant
+before_install:
+- rvm install 2.1.5
+- pip install --upgrade setuptools pip
 install:
-- pip install -r dev-requirements.txt
-- python setup.py develop
+- pip install tox
 - gem install danger
 - gem install danger-commit_lint
 - gem install chandler
 before_script:
+- bundle exec danger
 - psql -c 'create database db;' -U postgres
 env:
   global:
@@ -31,9 +35,7 @@ env:
   - secure: fd4hFOH60UV8laBN4Mjva0w/EmVK3SVC5p/0O1oqPriPhUpoJ3eVVRvITbdvPctEJJgRR9t62rPk+Rv4EOXeRFfsjZK9gOfQqv/9VhJBebdQfOx2dwQLjDiGTrklkokDIDyfpyYOoJzZ/oP+6EneD403ilHnXC4fd/4EDQmaIRI=
   - secure: 3rnkGugv5Hp71gjwQMUj5tup7/xk94p5IXEh0VItSXTziKn0pBY+yrCzAuIzlylbrl0baLaZOFGEFn2K+Jf+tr9mmN23X+zOUNsIqC4swlLLJx6hzH5AZaRmqzGjURM2gLISUayXGT9flOXyOKzzCGFELJKG9KlVyEOJ4fk04wQ=
 script:
-- bundle exec danger
-- make -C docs html spelling
-- nosetests --with-coverage --cover-package dallinger
+- tox
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,4 +6,5 @@ pypandoc==1.3.3
 recommonmark==0.4.0
 Sphinx==1.4.9
 sphinxcontrib-spelling==2.3.0
+tox==2.5.0
 -r requirements.txt

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -138,12 +138,15 @@ NB: To stop working on the virtual environment, run ``deactivate``. To
 list all available virtual environments, run ``workon`` with no
 arguments.
 
-Install enchant
----------------
+Install prerequisites for building documentation
+------------------------------------------------
 
-To be able to build the documentation, you will need to have the Enchant
-library installed. Please follow the instructions `here
-<http://pythonhosted.org/pyenchant/download.html>`__ to install it.
+To be able to build the documentation, you will need:
+
+* pandoc. Please follow the instructions `here
+  <http://pandoc.org/installing.html>`__ to install it.
+* the Enchant library. Please follow the instructions `here
+  <http://pythonhosted.org/pyenchant/download.html>`__ to install it.
 
 Install Dallinger
 ---------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,6 +28,7 @@ Laboratory automation for the behavioral and social sciences.
     :caption: Developer documentation
 
     developing_dallinger_setup_guide
+    running_the_tests
     required_experimental_files
     classes
     the_experiment_class

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -1,0 +1,38 @@
+Running the tests
+=================
+
+If you push a commit to a branch in the Dallinger organization on GitHub,
+or open a pull request from your own fork, Dallinger's automated code tests
+will be run on `Travis <https://travis-ci.org/>`_.
+
+Current build status: |status|
+
+.. |status| image:: https://travis-ci.org/Dallinger/Dallinger.svg?branch=master
+   :target: https://travis-ci.org/Dallinger/Dallinger
+
+The tests include:
+
+* Making sure that a source distribution of the Python package can be created.
+* Running `flake8 <https://flake8.readthedocs.io>`_ to make sure Python code
+  conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guide.
+* Running the tests for the Python code using `nose <http://nose.readthedocs.io/>`_
+  and making sure they pass in Python 2.7.
+* Making sure that `code coverage <https://coverage.readthedocs.io/>`_
+  for the Python code is above the desired threshold.
+* Making sure the docs build without error.
+
+You can also run all these tests locally, simply by running::
+
+	tox
+
+To run just the Python tests::
+
+	nosetests
+
+To build documentation::
+
+	tox -e docs
+
+To run flake8::
+
+	tox -e pep8

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -1,5 +1,6 @@
 al
 app
+apps
 backend
 boolean
 booleans
@@ -16,6 +17,7 @@ Dallinger
 dynos
 et
 frontend
+GitHub
 Google
 Griffiths
 Heroku
@@ -32,9 +34,11 @@ Kalish
 Kegl
 Lewandowsky
 md
+Meme
 MTurk
 neighbour
 ons
+pandoc
 Papertrail
 Populi
 Postgres

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,22 @@
+[tox]
+envlist =
+     py27,docs
+
+[testenv]
+commands =
+    pip install -r dev-requirements.txt
+    coverage run {envbindir}/nosetests {posargs}
+    coverage report
+passenv = DATABASE_URL PORT
+
+[testenv:pep8]
+commands =
+    flake8 --max-line-length=100
+deps =
+    flake8
+
+[testenv:docs]
+whitelist_externals = make
+commands =
+    pip install -r dev-requirements.txt
+    make -C docs html spelling


### PR DESCRIPTION
- Run coverage as a wrapper of nosetests rather than using nosetest's coverage plugin.
  This fixes a problem where completely uncovered files were not reported.
- Also report on branch coverage.
- Make the build fail if coverage is under a threshold (currently 30%; we can increase it over time).
- Set up tox and make travis run tox.
  This makes it easier to run the same tests locally that are run by Travis.
- Use Travis' matrix feature to run tests in parallel with building docs.
- Don't require Travis' sudo support. We don't need it and tests start faster without it.
- Add documentation about running tests
- Add missing documentation about installing the pandoc dependency
- Add a few missing words to the spelling list
- Add command to run flake8 (but don't run it automatically yet; I'll add that in a separate pull request once I've fixed the errors)

## How Has This Been Tested?

I've run tox locally, and the revised travis build is passing.