### PR TITLE
Add Vagrant setup

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,61 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/xenial64"
+
+  config.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  end
+
+  config.vm.network "forwarded_port", guest: 5000, host: 5000, auto_correct: true
+
+  config.vm.provision "shell", privileged: false, inline: <<-SHELL
+    sudo apt-get update
+
+    # Python dependencies
+    sudo apt-get install -y python2.7 python-pip
+
+    # Postgres setup
+    sudo apt-get install -y postgresql-9.5 postgresql-server-dev-9.5 
+    sudo -u postgres createuser -ds ubuntu
+    createdb dallinger
+    # trust all connections
+    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo service postgresql reload
+
+    # Virtual environment
+    echo 'source ~/venv/bin/activate' >> ~/.bashrc
+    echo 'cd /vagrant' >> ~/.bashrc
+    sudo pip install virtualenv
+    virtualenv --no-site-packages ~/venv
+    source ~/venv/bin/activate
+    cd /vagrant
+
+    # Documentation building dependencies
+    sudo apt-get install -y enchant pandoc zip
+    pip install pyenchant
+    pip install -r dev-requirements.txt
+
+    # Dallinger install
+    python setup.py develop
+    dallinger setup
+    echo 'port = 5000' >> ~/.dallingerconfig
+
+    # Heroku CLI installation
+    sudo apt-get install software-properties-common
+    sudo add-apt-repository "deb https://cli-assets.heroku.com/branches/stable/apt ./"
+    curl -L https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+    sudo apt-get update
+    sudo apt-get install heroku
+
+    # Redis server
+    sudo apt-get install redis-server -y
+
+    # Test runner
+    sudo apt-get install tox -y
+
+
+  SHELL
+end

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -2,7 +2,7 @@ Developer Installation
 ======================
 
 We recommend installing Dallinger on Mac OS X. It's also possible to use
-Ubuntu.
+Ubuntu, either directly or :doc:`in a virtual machine <vagrant_setup>`. Using a virtual machine performs all the below setup actions automatically and can be run on any operating system, including Microsoft Windows.
 
 Install Python 2.7
 ------------------

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -72,6 +72,7 @@ Ternate
 txt
 Ubuntu
 url
+virtualization
 Vox
 walkthrough
 walkthroughs

--- a/docs/source/vagrant_setup.rst
+++ b/docs/source/vagrant_setup.rst
@@ -1,0 +1,30 @@
+Vagrant installation
+====================
+
+Install the Vagrant virtual machine management system from `Hashicorp <https://www.vagrantup.com/docs/installation/>`__ and the `VirtualBox <https://www.virtualbox.org/>`__ virtualization software.
+
+If you already use a different Virtual Machine provider, it may be compatible with Vagrant, in which case you may need to modify the ``Vagrantfile``. This method is not recommended.
+
+Starting Dallinger
+------------------
+
+The first time you start the virtual machine, Vagrant will download an Ubuntu Linux image and run installation steps. This will take some time and downloads a large amount of data through the internet connection. The command to begin this process is:
+
+::
+
+    vagrant up
+
+You can then connect to the vagrant machine over ssh and interact with dallinger. This is done through:
+
+::
+
+    vagrant ssh
+
+You will be in the ``/vagrant`` directory which is shared with the host machine. You can use Dallinger and run tests as usual from this prompt. When running an experiment, you should specify port 5000 as the experiment's port, which will then be made available to the host on port 5000.
+
+When you're finished, shut the Vagrant machine down by running:
+
+::
+
+    vagrant halt
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,4 +38,18 @@ description-file = README.md
 
 [flake8]
 max-line-length = 100
-exclude = bin,lib,src,.git,.tox,.eggs
+exclude = 
+    bin,
+    build,
+    .cache,
+    dist,
+    docs/source/conf.py,
+    *.egg-info,
+    .eggs,
+    .git,
+    lib,
+    *.pyc,
+    __pycache__,
+    src,
+    .tox,
+

--- a/tox.ini
+++ b/tox.ini
@@ -31,16 +31,3 @@ whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt
     make -C docs html spelling
-
-[flake8]
-exclude =
-    .tox,
-    .git,
-    __pycache__,
-    docs/source/conf.py,
-    build,
-    dist,
-    *.pyc,
-    *.egg-info,
-    .cache,
-    .eggs


### PR DESCRIPTION
## Description

This adds a simple Vagrant file using Ubuntu Xenial that installs according to the developer installation instructions.

## Motivation and Context

The aim of this change is to make bootstrapping for new developers simpler, and to provide easy isolation of Dallinger components for developers who need that. It also makes installation on Windows easier.

## How Has This Been Tested?

This has been my primary development environment for about 100 hours of work on the Dallinger project, both on Mac and Ubuntu hosts.