### PR TITLE
Use check_call rather than call in order to reveal errors

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -27,7 +27,7 @@ def scale_up_dynos(app):
     }
 
     for process in ["web", "worker"]:
-        subprocess.call([
+        subprocess.check_call([
             "heroku",
             "ps:scale",
             "{}={}:{}".format(process, num_dynos[process], dyno_type),
@@ -36,7 +36,7 @@ def scale_up_dynos(app):
         ])
 
     if dlgr.config.server_parameters.clock_on:
-        subprocess.call([
+        subprocess.check_call([
             "heroku",
             "ps:scale",
             "clock=1:{}".format(dyno_type),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
This changes all instances of `subprocess.call` to `subprocess.check_call` so that errors are raised when a command fails to execute correctly.

## Description
<!--- Describe your changes in detail -->
Using `subprocess.call` will continue on silently even if the subprocess throws an error. If this happens, Dallinger should either raise an error or explicitly handle the error at the very least. I am making the assumption here that an error should always be raised, but if there are specific cases that are ok for errors to happen I can handle those as a special case.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #352 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran nosetests locally.