### PR TITLE
Enable flake8 checks and fix errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ matrix:
   - python: 2.7
     env: TOXENV=py27
   - python: 2.7
+    env: TOXENV=style
+  - python: 2.7
     env: TOXENV=docs
 addons:
   apt:

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -371,7 +371,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1):
             app_name(id),
         ])
 
-    except Exception as e:
+    except:
         pass
 
     database_size = config.get('Database Parameters', 'database_size')
@@ -445,10 +445,10 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1):
         try:
             r.set("foo", "bar")
             ready = True
-        except redis.exceptions.ConnectionError as e:
+        except redis.exceptions.ConnectionError:
             time.sleep(2)
 
-    # Set the notification URL in the cofig file to the notifications URL.
+    # Set the notification URL in the config file to the notifications URL.
     config.set(
         "Server Parameters",
         "notification_url",
@@ -469,8 +469,8 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1):
 
     # Launch the Heroku app.
     log("Pushing code to Heroku...")
-    subprocess.check_call("git push heroku HEAD:master", stdout=out,
-                    stderr=out, shell=True)
+    subprocess.check_call(
+        "git push heroku HEAD:master", stdout=out, stderr=out, shell=True)
 
     log("Scaling up the dynos...")
     scale_up_dynos(app_name(id))
@@ -921,7 +921,8 @@ def verify_package(verbose=True):
 
     for f in files:
         if os.path.exists(f):
-            log("✗ {} will CONFLICT with shared front-end files inserted at run-time, please delete or rename.".format(f),
+            log("✗ {} will CONFLICT with shared front-end files inserted at run-time, "
+                "please delete or rename.".format(f),
                 delay=0, chevrons=False, verbose=verbose)
             return False
 

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -51,9 +51,9 @@ def scoped_session_decorator(func):
     @wraps(func)
     def wrapper(*args, **kwargs):
         from dallinger.db import session as dallinger_session
-        with sessions_scope(dallinger_session) as session:
+        with sessions_scope(dallinger_session):
             from psiturk.db import db_session as psi_session
-            with sessions_scope(psi_session) as session_psiturk:
+            with sessions_scope(psi_session):
                 # The sessions used in func come from the funcs globals, but
                 # they will be proxied thread locals vars from the session
                 # registry, and will therefore be identical to those returned

--- a/dallinger/experiments.py
+++ b/dallinger/experiments.py
@@ -309,7 +309,8 @@ class Experiment(object):
     def data_check_failed(self, participant):
         """What to do if a participant fails the data check.
 
-        Runs when `participant` has failed :func:`~dallinger.experiments.Experiment.data_check`. By default calls
+        Runs when `participant` has failed
+        :func:`~dallinger.experiments.Experiment.data_check`. By default calls
         :func:`~dallinger.experiments.Experiment.fail_participant`.
 
         """

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -71,10 +71,10 @@ def check_db_for_missing_notifications():
             hit_id = p.hit_id
 
             # general email settings:
-            username = os.getenv('dallinger_email_username')
-            fromaddr = username + "@gmail.com"
-            email_password = os.getenv("dallinger_email_key")
-            toaddr = config.get('HIT Configuration', 'contact_email_on_error')
+            # username = os.getenv('dallinger_email_username')
+            # fromaddr = username + "@gmail.com"
+            # email_password = os.getenv("dallinger_email_key")
+            # toaddr = config.get('HIT Configuration', 'contact_email_on_error')
             whimsical = os.getenv("whimsical")
 
             if status == "Approved":
@@ -115,11 +115,11 @@ def check_db_for_missing_notifications():
  at your earliest convenience.\n\nI remain your faithful and obedient servant,
 \nWilliam H. Dallinger\n\n P.S. Please do not respond to this message, I am busy
  with other matters.""".format(
-                        datetime.now(),
-                        assignment_id,
-                        round(duration/60),
-                        round(p_time/60),
-                        round((p_time-duration)/60)))
+                            datetime.now(),
+                            assignment_id,
+                            round(duration/60),
+                            round(p_time/60),
+                            round((p_time-duration)/60)))
                     msg['Subject'] = "A matter of minor concern."
                 else:
                     msg = MIMEText(
@@ -132,9 +132,9 @@ def check_db_for_missing_notifications():
  Dallinger has auto-corrected the problem. Nonetheless you may wish to check the
  database.\n\nBest,\nThe Dallinger dev. team.\n\n Error details:\nAssignment: {}
 \nAllowed time: {}\nTime since participant started: {}""").format(
-                        assignment_id,
-                        round(duration/60),
-                        round(p_time/60))
+                            assignment_id,
+                            round(duration/60),
+                            round(p_time/60))
                     msg['Subject'] = "Dallinger automated email - minor error."
 
                 # This method commented out as gmail now blocks emails from
@@ -193,11 +193,11 @@ def check_db_for_missing_notifications():
  and intelligence for which I know you so well.\n\nI remain your faithful and
  obedient servant,\nWilliam H. Dallinger\n\nP.S. Please do not respond to this
  message, I am busy with other matters.""".format(
-                        datetime.now(),
-                        assignment_id,
-                        round(duration/60),
-                        round(p_time/60),
-                        round((p_time-duration)/60)))
+                            datetime.now(),
+                            assignment_id,
+                            round(duration/60),
+                            round(p_time/60),
+                            round((p_time-duration)/60)))
                     msg['Subject'] = "Most troubling news."
                 else:
                     msg = MIMEText(
@@ -216,9 +216,9 @@ def check_db_for_missing_notifications():
  emails this suggests something is wrong with your experiment code.\n\nBest,
 \nThe Dallinger dev. team.\n\n Error details:\nAssignment: {}
 \nAllowed time: {}\nTime since participant started: {}""").format(
-                        assignment_id,
-                        round(duration/60),
-                        round(p_time/60))
+                            assignment_id,
+                            round(duration/60),
+                            round(p_time/60))
                     msg['Subject'] = "Dallinger automated email - major error."
 
                 # This method commented out as gmail now blocks emails from
@@ -242,5 +242,6 @@ def check_db_for_missing_notifications():
                        "Experiment shut down. Please check database and then manually "
                        "resume experiment."
                        .format(p.id))
+
 
 scheduler.start()

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -14,6 +14,7 @@ from sqlalchemy import (
     DateTime,
     Float
 )
+from sqlalchemy.sql.expression import false
 from sqlalchemy.orm import relationship, validates
 
 from .db import Base
@@ -845,7 +846,7 @@ class Node(Base, SharedMixin):
 
             vectors = Vector.query\
                 .with_entities(Vector.origin_id, Vector.destination_id)\
-                .filter(and_(Vector.failed == False,
+                .filter(and_(Vector.failed == false(),
                              or_(Vector.destination_id == self.id,
                                  Vector.origin_id == self.id))).all()
 
@@ -957,13 +958,13 @@ class Node(Base, SharedMixin):
         if direction == "all":
             if status == "all":
                 return Transmission.query\
-                    .filter(and_(Transmission.failed == False,
+                    .filter(and_(Transmission.failed == false(),
                                  or_(Transmission.destination_id == self.id,
                                      Transmission.origin_id == self.id)))\
                     .all()
             else:
                 return Transmission.query\
-                    .filter(and_(Transmission.failed == False,
+                    .filter(and_(Transmission.failed == false(),
                                  Transmission.status == status,
                                  or_(Transmission.destination_id == self.id,
                                      Transmission.origin_id == self.id)))\
@@ -975,7 +976,7 @@ class Node(Base, SharedMixin):
                     .all()
             else:
                 return Transmission.query\
-                    .filter(and_(Transmission.failed == False,
+                    .filter(and_(Transmission.failed == false(),
                                  Transmission.destination_id == self.id,
                                  Transmission.status == status))\
                     .all()
@@ -986,7 +987,7 @@ class Node(Base, SharedMixin):
                     .all()
             else:
                 return Transmission.query\
-                    .filter(and_(Transmission.failed == False,
+                    .filter(and_(Transmission.failed == false(),
                                  Transmission.origin_id == self.id,
                                  Transmission.status == status))\
                     .all()
@@ -1547,7 +1548,7 @@ class Info(Base, SharedMixin):
         if relationship == "all":
             return Transformation\
                 .query\
-                .filter(and_(Transformation.failed == False,
+                .filter(and_(Transformation.failed == false(),
                              or_(Transformation.info_in == self,
                                  Transformation.info_out == self)))\
                 .all()

--- a/dallinger/networks.py
+++ b/dallinger/networks.py
@@ -4,7 +4,6 @@ from operator import attrgetter
 import random
 
 from .models import Network
-from .models import Node
 from .nodes import Source
 
 

--- a/demos/rogers/experiment.py
+++ b/demos/rogers/experiment.py
@@ -8,7 +8,7 @@ from dallinger.models import Node, Network, Participant
 from dallinger import transformations
 from sqlalchemy import Integer, Float
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.sql.expression import cast
+from sqlalchemy.sql.expression import cast, false
 from sqlalchemy import and_
 from operator import attrgetter
 import random
@@ -204,7 +204,7 @@ class RogersExperiment(Experiment):
         gene = node.infos(type=LearningGene)[0].contents
         if (gene == "social"):
             prev_agents = RogersAgent.query\
-                .filter(and_(RogersAgent.failed == False,
+                .filter(and_(RogersAgent.failed == false(),
                              RogersAgent.network_id == network.id,
                              RogersAgent.generation == node.generation - 1))\
                 .all()

--- a/demos/rogers/tests/tests.py
+++ b/demos/rogers/tests/tests.py
@@ -96,12 +96,20 @@ class TestRogers(object):
                     if working is True:
                         agent_id = agent.json()['node']['id']
                         args = {'info_type': "LearningGene"}
-                        information = session.get(url + '/node/' + str(agent_id) + '/infos', params=args, headers=headers)
+                        information = session.get(
+                            url + '/node/' + str(agent_id) + '/infos',
+                            params=args, headers=headers)
                         args = {'status': "pending", 'direction': "incoming"}
-                        transmission = session.get(url + '/node/' + str(agent_id) + '/transmissions', params=args, headers=headers)
-                        information2 = session.get(url + '/info/' + str(agent_id) + '/' + str(transmission.json()['transmissions'][0]['info_id']), headers=headers)
+                        transmission = session.get(
+                            url + '/node/' + str(agent_id) + '/transmissions',
+                            params=args, headers=headers)
+                        information2 = session.get(
+                            url + '/info/' + str(agent_id) + '/' +
+                            str(transmission.json()['transmissions'][0]['info_id']),
+                            headers=headers)
                         args = {'contents': 'blue', 'info_type': 'Meme'}
-                        information3 = session.post(url + '/info/' + str(agent_id), data=args, headers=headers)
+                        information3 = session.post(
+                            url + '/info/' + str(agent_id), data=args, headers=headers)
                 except:
                     working = False
                     print("critical error for bot {}".format(i))
@@ -181,17 +189,21 @@ class TestRogers(object):
                 num_completed_participants = len(exp.networks()[0].nodes(type=Agent))
 
                 if p_times:
-                    print("Running simulated experiment... participant {} of {}, {} participants failed. Prev time: {}".format(
-                        num_completed_participants+1,
-                        exp.networks()[0].max_size,
-                        len(exp.networks()[0].nodes(failed=True)),
-                        p_times[-1]),
+                    print(
+                        "Running simulated experiment... participant {} of {}, "
+                        "{} participants failed. Prev time: {}".format(
+                            num_completed_participants+1,
+                            exp.networks()[0].max_size,
+                            len(exp.networks()[0].nodes(failed=True)),
+                            p_times[-1]),
                         end="\r")
                 else:
-                    print("Running simulated experiment... participant {} of {}, {} participants failed.".format(
-                        num_completed_participants+1,
-                        exp.networks()[0].max_size,
-                        len(exp.networks()[0].nodes(failed=True))),
+                    print(
+                        "Running simulated experiment... participant {} of {}, "
+                        "{} participants failed.".format(
+                            num_completed_participants+1,
+                            exp.networks()[0].max_size,
+                            len(exp.networks()[0].nodes(failed=True))),
                         end="\r")
                 sys.stdout.flush()
 
@@ -227,7 +239,10 @@ class TestRogers(object):
                         process_start_time = timenow()
                         agent.receive()
                         from operator import attrgetter
-                        current_state = max(State.query.filter_by(network_id=agent.network_id).all(), key=attrgetter('creation_time')).contents
+                        current_state = max(
+                            State.query.filter_by(network_id=agent.network_id).all(),
+                            key=attrgetter('creation_time')
+                        ).contents
                         if float(current_state) >= 0.5:
                             right_answer = "blue"
                             wrong_answer = "yellow"
@@ -245,7 +260,8 @@ class TestRogers(object):
                         exp.info_post_request(
                             node=agent,
                             info=info)
-                        #print("state: {}, answer: {}, score: {}, fitness {}".format(current_state, info.contents, agent.score, agent.fitness))
+                        # print("state: {}, answer: {}, score: {}, fitness {}".format(
+                        #     current_state, info.contents, agent.score, agent.fitness))
                         process_stop_time = timenow()
                         process_time += (process_stop_time - process_start_time)
 
@@ -272,7 +288,7 @@ class TestRogers(object):
                 p_stop_time = timenow()
                 p_times.append(p_stop_time - p_start_time)
 
-            print("Running simulated experiment...      done!                                      ")
+            print("Running simulated experiment...      done!")
             sys.stdout.flush()
 
             overall_stop_time = timenow()
@@ -326,8 +342,12 @@ class TestRogers(object):
                         assert len(agent.vectors(direction="incoming")) in [2, 3]
                         assert not agent.is_connected(direction="from", whom=source)
                         assert agent.is_connected(direction="from", whom=environment)
-                        assert RogersAgent in [type(a) for a in agent.neighbors(direction="from")] or\
-                            RogersAgentFounder in [type(a) for a in agent.neighbors(direction="from")]
+                        assert (
+                            RogersAgent in [
+                                type(a) for a in agent.neighbors(direction="from")] or
+                            RogersAgentFounder in [
+                                type(a) for a in agent.neighbors(direction="from")]
+                        )
 
             print("Testing nodes...                     done!")
             sys.stdout.flush()
@@ -354,12 +374,17 @@ class TestRogers(object):
 
                 for agent in agents:
                     if agent.generation == 0:
-                        assert len(models.Vector.query.filter_by(origin_id=source.id, destination_id=agent.id).all()) == 1
+                        assert len(models.Vector.query.filter_by(
+                            origin_id=source.id, destination_id=agent.id).all()) == 1
                     else:
-                        assert len(models.Vector.query.filter_by(origin_id=source.id, destination_id=agent.id).all()) == 0
+                        assert len(models.Vector.query.filter_by(
+                            origin_id=source.id, destination_id=agent.id).all()) == 0
 
                 for agent in agents:
-                    assert len([v for v in vectors if v.origin_id == environment.id and v.destination_id == agent.id]) == 1
+                    assert len([
+                        v for v in vectors
+                        if v.origin_id == environment.id and v.destination_id == agent.id
+                    ]) == 1
 
                 for v in [v for v in vectors if v.origin_id == source.id]:
                     assert isinstance(v.destination, RogersAgentFounder)
@@ -384,9 +409,15 @@ class TestRogers(object):
 
                 for agent in agents:
                     assert len([i for i in infos if i.origin_id == agent.id]) == 2
-                    assert len([i for i in infos if i.origin_id == agent.id and isinstance(i, Gene)]) == 1
-                    assert len([i for i in infos if i.origin_id == agent.id and isinstance(i, LearningGene)]) == 1
-                    assert len([i for i in infos if i.origin_id == agent.id and isinstance(i, Meme)]) == 1
+                    assert len([
+                        i for i in infos if i.origin_id == agent.id and isinstance(i, Gene)
+                    ]) == 1
+                    assert len([
+                        i for i in infos if i.origin_id == agent.id and isinstance(i, LearningGene)
+                    ]) == 1
+                    assert len([
+                        i for i in infos if i.origin_id == agent.id and isinstance(i, Meme)
+                    ]) == 1
 
             print("Testing infos...                     done!")
             sys.stdout.flush()
@@ -412,9 +443,15 @@ class TestRogers(object):
                     types = [type(t.info) for t in in_ts]
 
                     assert len(in_ts) == 2
-                    assert len([t for t in transmissions if t.destination_id == agent.id and t.status == "pending"]) == 0
+                    assert len([
+                        t for t in transmissions
+                        if t.destination_id == agent.id and t.status == "pending"
+                    ]) == 0
 
-                    lg = [i for i in infos if i.origin_id == agent.id and isinstance(i, LearningGene)]
+                    lg = [
+                        i for i in infos
+                        if i.origin_id == agent.id and isinstance(i, LearningGene)
+                    ]
                     assert len(lg) == 1
                     lg = lg[0]
 
@@ -467,7 +504,8 @@ class TestRogers(object):
             print("Testing bonus payments...", end="\r")
             sys.stdout.flush()
 
-            assert exp.bonus(participant=Participant.query.filter_by(uniqueid=p_ids[0]).all()[0]) == exp.bonus_payment
+            assert exp.bonus(participant=Participant.query.filter_by(
+                uniqueid=p_ids[0]).all()[0]) == exp.bonus_payment
 
             print("Testing bonus payments...            done!")
             sys.stdout.flush()
@@ -490,5 +528,5 @@ class TestRogers(object):
                 print("Participant {}: {}, total: {}".format(i, p_times[i], total_time))
 
             print("#########")
-            test = [p.total_seconds() for p in p_times]
+            test = [p_time.total_seconds() for p_time in p_times]
             print(test)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,7 @@
 alabaster==0.7.9
 coverage==4.2
 codecov==2.0.5
+flake8==3.2.1
 nose==1.3.7
 pypandoc==1.3.3
 recommonmark==0.4.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+# flake8: noqa
 #
 # Dallinger documentation build configuration file, created by
 # sphinx-quickstart on Wed Aug 10 14:50:29 2016.
@@ -44,6 +45,7 @@ try:
 except ImportError:
     pass
 else:
+    sphinxcontrib.spelling  # to satisfy flake8
     extensions.append("sphinxcontrib.spelling")
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -35,4 +35,4 @@ To build documentation::
 
 To run flake8::
 
-	tox -e pep8
+	flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ description-file = README.md
 
 [flake8]
 max-line-length = 100
-exclude = lib,.git,.tox
+exclude = bin,lib,src,.git,.tox

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,3 +38,6 @@ description-file = README.md
 
 [bumpversion:file:.github_changelog_generator]
 
+[flake8]
+max-line-length = 100
+exclude = lib,.git,.tox

--- a/tests/_test_bartlett.py
+++ b/tests/_test_bartlett.py
@@ -8,7 +8,8 @@
 
 # class TestBartlett(object):
 
-#     sandbox_output = subprocess.check_output("cd demos/bartlett1932; dallinger sandbox", shell=True)
+#     sandbox_output = subprocess.check_output(
+#         "cd demos/bartlett1932; dallinger sandbox", shell=True)
 #     exp_id = re.search('Running as experiment (.*)...', sandbox_output).group(1)
 #     exp_address = "http://" + exp_id + ".herokuapp.com"
 
@@ -30,9 +31,14 @@
 #             agent_id = agent.json()['agents']['id']
 #             args = {'destination_id': agent_id}
 #             transmission = requests.get(exp_address + '/transmissions', data=args)
-#             info = requests.get(exp_address + '/information/' + str(transmission.json()['transmissions'][0]['info_id']), data=args)
+#             info = requests.get(
+#                 exp_address + '/information/' +
+#                 str(transmission.json()['transmissions'][0]['info_id']),
+#                 data=args)
 #             args = {'origin_id': agent_id, 'contents': 'test test test', 'info_type': 'base'}
 #             requests.post(exp_address + '/information', data=args)
 
 #     #subprocess.call("heroku apps:destroy --app " + exp_id + " --confirm " + exp_id, shell=True)
-#     # for app in $(heroku apps | sed '/[pt]/ d'); do heroku apps:destroy --app $app --confirm $app; done
+#     # for app in $(heroku apps | sed '/[pt]/ d'); do
+#     #     heroku apps:destroy --app $app --confirm $app;
+#     # done

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -40,7 +40,8 @@ class TestModels(object):
         net = models.Network.query.one()
 
         # create a participant
-        participant = models.Participant(worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+        participant = models.Participant(
+            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
         self.db.add(participant)
         self.db.commit()
 
@@ -83,7 +84,10 @@ class TestModels(object):
         assert net.role == "default"
 
         # test __repr__()
-        assert repr(net) == "<Network-1-network with 3 nodes, 3 vectors, 2 infos, 1 transmissions and 1 transformations>"
+        assert repr(net) == (
+            "<Network-1-network with 3 nodes, 3 vectors, 2 infos, "
+            "1 transmissions and 1 transformations>"
+        )
 
         # test __json__()
         assert net.__json__() == {
@@ -341,15 +345,15 @@ class TestModels(object):
         self.db.add(net)
         node1 = models.Node(network=net)
         node2 = models.Node(network=net)
-        #vector = models.Vector(origin=node1, destination=node2)
-        #self.add(node1, node2, vector)
+        # vector = models.Vector(origin=node1, destination=node2)
+        # self.add(node1, node2, vector)
         self.add(node1, node2)
         self.db.commit()
 
         node1.connect(whom=node2)
 
         self._check_single_connection(node1, node2)
-        #assert len(vector.transmissions) == 0
+        # assert len(vector.transmissions) == 0
 
     def test_kill_vector(self):
         net = models.Network()
@@ -492,8 +496,8 @@ class TestModels(object):
 
         info = models.Info(origin=node1)
         node1.transmit(what=node1.infos()[0], to_whom=node2)
-        #transmission = models.Transmission(info=info, destination=node2)
-        #self.add(node1, node2, vector, info, transmission)
+        # transmission = models.Transmission(info=info, destination=node2)
+        # self.add(node1, node2, vector, info, transmission)
 
         transmission = node1.transmissions()[0]
         vector = node1.vectors()[0]

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -203,7 +203,10 @@ class TestNetworks(object):
         source = nodes.RandomBinaryStringSource(network=net)
         source.connect(whom=net.nodes(type=nodes.Agent))
 
-        assert repr(net) == "<Network-" + str(net.id) + "-network with 3 nodes, 2 vectors, 0 infos, 0 transmissions and 0 transformations>"
+        assert repr(net) == (
+            "<Network-" + str(net.id) + "-network with 3 nodes, 2 vectors, "
+            "0 infos, 0 transmissions and 0 transformations>"
+        )
 
     def test_create_chain(self):
         net = networks.Chain()
@@ -236,7 +239,10 @@ class TestNetworks(object):
             net.add_node(agent)
         self.db.commit()
 
-        assert repr(net) == "<Network-" + str(net.id) + "-chain with 5 nodes, 4 vectors, 0 infos, 0 transmissions and 0 transformations>"
+        assert repr(net) == (
+            "<Network-" + str(net.id) + "-chain with 5 nodes, 4 vectors, "
+            "0 infos, 0 transmissions and 0 transformations>"
+        )
 
     def test_create_fully_connected(self):
         net = networks.FullyConnected()
@@ -249,7 +255,10 @@ class TestNetworks(object):
 
         assert len(net.nodes(type=nodes.Agent)) == 4
         assert len(net.vectors()) == 12
-        assert [len(n.vectors(direction="outgoing")) for n in net.nodes(type=nodes.Agent)] == [3, 3, 3, 3]
+        assert [
+            len(n.vectors(direction="outgoing"))
+            for n in net.nodes(type=nodes.Agent)
+        ] == [3, 3, 3, 3]
 
     def test_create_empty(self):
         """Empty networks should have nodes, but no edges."""
@@ -288,7 +297,10 @@ class TestNetworks(object):
             agent = nodes.Agent(network=net)
             net.add_node(agent)
 
-        assert repr(net) == "<Network-" + str(net.id) + "-fully-connected with 4 nodes, 12 vectors, 0 infos, 0 transmissions and 0 transformations>"
+        assert repr(net) == (
+            "<Network-" + str(net.id) + "-fully-connected with 4 nodes, 12 vectors, "
+            "0 infos, 0 transmissions and 0 transformations>"
+        )
 
     def test_create_scale_free(self):
         m0 = 4
@@ -323,7 +335,10 @@ class TestNetworks(object):
             agent = nodes.Agent(network=net)
             net.add_node(agent)
 
-        assert repr(net) == "<Network-" + str(net.id) + "-scale-free with 6 nodes, 28 vectors, 0 infos, 0 transmissions and 0 transformations>"
+        assert repr(net) == (
+            "<Network-" + str(net.id) + "-scale-free with 6 nodes, 28 vectors, "
+            "0 infos, 0 transmissions and 0 transformations>"
+        )
 
     def test_create_sequential_microsociety(self):
         """Create a sequential microsociety."""
@@ -367,7 +382,8 @@ class TestNetworks(object):
     #     n_gens = 4
     #     gen_size = 4
 
-    #     net = networks.DiscreteGenerational(generations=n_gens, generation_size=gen_size, initial_source=True)
+    #     net = networks.DiscreteGenerational(
+    #         generations=n_gens, generation_size=gen_size, initial_source=True)
 
     #     source = nodes.RandomBinaryStringSource()
     #     net.add(source)

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -79,9 +79,18 @@ class TestProcesses(object):
 
         # Ensure that the process had reached fixation.
         from operator import attrgetter
-        assert max(agent1.infos(), key=attrgetter('creation_time')).contents == max(agent2.infos(), key=attrgetter('creation_time')).contents
-        assert max(agent2.infos(), key=attrgetter('creation_time')).contents == max(agent3.infos(), key=attrgetter('creation_time')).contents
-        assert max(agent3.infos(), key=attrgetter('creation_time')).contents == max(agent1.infos(), key=attrgetter('creation_time')).contents
+        assert (
+            max(agent1.infos(), key=attrgetter('creation_time')).contents ==
+            max(agent2.infos(), key=attrgetter('creation_time')).contents
+        )
+        assert (
+            max(agent2.infos(), key=attrgetter('creation_time')).contents ==
+            max(agent3.infos(), key=attrgetter('creation_time')).contents
+        )
+        assert (
+            max(agent3.infos(), key=attrgetter('creation_time')).contents ==
+            max(agent1.infos(), key=attrgetter('creation_time')).contents
+        )
 
     def test_moran_process_sexual(self):
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-     py27,docs
+     py27,style,docs
 
 [testenv]
 commands =
@@ -9,9 +9,9 @@ commands =
     coverage report
 passenv = DATABASE_URL PORT
 
-[testenv:pep8]
+[testenv:style]
 commands =
-    flake8 --max-line-length=100
+    flake8
 deps =
     flake8
 


### PR DESCRIPTION
## Description
This fixes Python code formatting that doesn't conform to PEP8, and adds a job to tox and travis to fail if new formatting errors are committed.

I think the only noteworthy change here is comparing to `sqlalchemy.sql.expression.false` in query expressions instead of using `== False` which is disallowed by PEP8. It's a workaround that I found at http://stackoverflow.com/a/18998106

## Motivation and Context
Enforcing PEP8 helps with readability of the codebase, which is important for a project involving multiple developers, and it's generally seen as a best practice for Python projects.

## How Has This Been Tested?
Tested by running flake8
