### PR TITLE
Bugfixes for data exporting

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -615,11 +615,25 @@ def dump_database(id):
     if not os.path.exists(dump_dir):
         os.makedirs(dump_dir)
 
-    subprocess.check_call(
-        "heroku pg:backups capture --app " + app_name(id), shell=True)
+    try:
+        subprocess.check_call([
+            "heroku",
+            "pg:backups",
+            "capture"
+            "--app",
+            app_name(id)
+        ])
+    except Exception:
+        pass
 
-    backup_url = subprocess.check_output(
-        "heroku pg:backups public-url --app " + app_name(id), shell=True)
+    backup_url = subprocess.check_output([
+        "heroku",
+        "pg:backups",
+        "public-url",
+        "--app",
+        app_name(id)
+    ])
+
     backup_url = backup_url.replace('"', '').rstrip()
     backup_url = re.search("https:.*", backup_url).group(0)
     print(backup_url)
@@ -627,7 +641,12 @@ def dump_database(id):
     log("Downloading the backup...")
     dump_path = os.path.join(dump_dir, dump_filename)
     with open(dump_path, 'wb') as file:
-        subprocess.check_call(['curl', '-o', dump_path, backup_url], stdout=file)
+        subprocess.check_call([
+            'curl',
+            '-o',
+            dump_path,
+            backup_url
+        ], stdout=file)
 
     return dump_path
 
@@ -801,10 +820,19 @@ def export(app, local):
 
         dump_path = dump_database(id)
 
-        subprocess.check_call(
-            "pg_restore --verbose --no-owner --clean -d dallinger " +
-            os.path.join("data", id, "data.dump"),
-            shell=True)
+        try:
+            subprocess.check_call([
+                "pg_restore",
+                "--verbose",
+                "--no-owner",
+                "--clean",
+                "-d",
+                "dallinger",
+                os.path.join("data", id, "data.dump")
+            ])
+
+        except Exception:
+            pass
 
     all_tables = [
         "node",

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -3,6 +3,7 @@
 
 """The Dallinger command-line utility."""
 
+import errno
 import imp
 import inspect
 import os
@@ -763,8 +764,15 @@ def export(app, local):
 
     subdata_path = os.path.join("data", id, "data")
 
-    # Create the data package
-    os.makedirs(subdata_path)
+    # Create the data package if it doesn't already exist.
+    try:
+        os.makedirs(subdata_path)
+
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(subdata_path):
+            pass
+        else:
+            raise
 
     # Copy the experiment code into a code/ subdirectory
     try:


### PR DESCRIPTION
## Description
This fixes two bugs in data exporting:

1. When the data directory already exists, we no longer fail because of the `makedirs` call.
2. There are a couple of subprocess calls that return error codes but which are harmless. We no longer fail to export the data in those instances.

## How Has This Been Tested?
Tested locally and by downloading data from Heroku with and without each change.