### PR TITLE
Increase size of worker_id column

### DIFF
--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -86,7 +86,7 @@ class Participant(Base, SharedMixin):
 
     #: A String, a concatenation of :attr:`~dallinger.models.Participant.worker_id`
     #: and :attr:`~dallinger.models.Participant.assignment_id`, used by psiTurk.
-    unique_id = Column(String(50), nullable=False, index=True)
+    unique_id = Column(String(75), nullable=False, index=True)
 
     #: A String, the id of the hit the participant is working on
     hit_id = Column(String(50), nullable=False)


### PR DESCRIPTION
Fixes a problem where some workers seem to have longer ids. Closes #348.