### PR TITLE
Defend experiment server against AWS

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -389,6 +389,18 @@ class Experiment(object):
         """
         self.fail_participant(participant)
 
+    def assignment_reassigned(self, participant):
+        """What to do if the assignment assigned to a participant is
+        reassigned to another participant while the first participant
+        is still working.
+
+        This runs when a participant is created with the same assignment_id
+        as another participant if the earlier participant still has the status
+        "working". Calls :func:`~dallinger.experiments.Experiment.fail_participant`.
+
+        """
+        self.fail_participant(participant)
+
     @exp_class_working_dir
     def sandbox(self, exp_config=None, app_id=None):
         """Deploys and runs an experiment in sandbox mode.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1383,6 +1383,7 @@ def worker_function(event_type, assignment_id, participant_id):
                     exp.log("All checks passed.", key)
                     participant.status = "approved"
                     exp.submission_successful(participant=participant)
+                    session.commit()
                     exp.recruit()
 
     elif event_type == "NotificationMissing":

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1339,6 +1339,7 @@ def worker_function(event_type, assignment_id, participant_id):
         if participant.status == "working":
             participant.end_time = datetime.now()
             participant.status = "submitted"
+            session.commit()
 
             # Approve the assignment.
             exp.recruiter().approve_hit(assignment_id)
@@ -1351,6 +1352,7 @@ def worker_function(event_type, assignment_id, participant_id):
             if not worked:
                 participant.status = "bad_data"
                 exp.data_check_failed(participant=participant)
+                session.commit()
                 exp.recruiter().recruit_participants(n=1)
             else:
                 # If their data is ok, pay them a bonus.
@@ -1374,6 +1376,7 @@ def worker_function(event_type, assignment_id, participant_id):
                     exp.log("Attention check failed.", key)
                     participant.status = "did_not_attend"
                     exp.attention_check_failed(participant=participant)
+                    session.commit()
                     exp.recruiter().recruit_participants(n=1)
                 else:
                     # All good. Possibly recruit more participants.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -491,16 +491,16 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     # check this worker hasn't already taken part
     parts = models.Participant.query.filter_by(worker_id=worker_id).all()
     if parts:
-        print("participant already exists!")
-        return Response(status=200)
-
-    # make the participant
-    participant = models.Participant(worker_id=worker_id,
-                                     assignment_id=assignment_id,
-                                     hit_id=hit_id,
-                                     mode=mode)
-    session.add(participant)
-    session.commit()
+        participant = parts[0]
+        print("Error: Warning: request received to create participant with non-unqiue worker_id. Creation aborted.")
+    else:
+        # make the participant
+        participant = models.Participant(worker_id=worker_id,
+                                         assignment_id=assignment_id,
+                                         hit_id=hit_id,
+                                         mode=mode)
+        session.add(participant)
+        session.commit()
 
     # return the data
     return success_response(field="participant",

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1336,7 +1336,7 @@ def worker_function(event_type, assignment_id, participant_id):
             exp.assignment_returned(participant=participant)
 
     elif event_type == 'AssignmentSubmitted':
-        if participant.status == "working":
+        if participant.status in ["working", "returned", "abandoned"]:
             participant.end_time = datetime.now()
             participant.status = "submitted"
             session.commit()

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -131,6 +131,7 @@ class Participant(Base, SharedMixin):
             "did_not_attend",
             "bad_data",
             "missing_notification",
+            "replaced",
             name="participant_status"
         ),
         nullable=False,

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -204,8 +204,8 @@ class MTurkService(object):
     def extend_hit(self, hit_id, number, duration_hours):
         """Extend an existing HIT and return an updated description"""
         duration_as_secs = int(duration_hours * 3600)
-        self.mturk.extend_hit(hit_id, assignments_increment=number)
         self.mturk.extend_hit(hit_id, expiration_increment=duration_as_secs)
+        self.mturk.extend_hit(hit_id, assignments_increment=number)
 
         updated_hit = self.mturk.get_hit(hit_id)[0]
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -107,6 +107,25 @@ class TestExperimentServer(FlaskAppTest):
         assert data.get('status') == 'success'
         assert data.get('participant').get('status') == u'working'
 
+    def test_prevent_duplicate_participant_for_worker(self):
+        worker_id = self.worker_counter
+        hit_id = self.hit_counter
+        assignment_id = self.assignment_counter
+        self.worker_counter += 1
+        self.hit_counter += 1
+        self.assignment_counter += 1
+        resp = self.app.post('/participant/{}/{}/{}/debug'.format(
+            worker_id, hit_id, assignment_id
+        ))
+
+        assert resp.status_code == 200
+
+        resp = self.app.post('/participant/{}/{}/{}/debug'.format(
+            worker_id, hit_id, assignment_id
+        ))
+
+        assert resp.status_code == 403
+
     def test_node_vectors(self):
         p_id = self._create_participant()
         n_id = self._create_node(p_id)

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -490,8 +490,8 @@ class TestMTurkServiceWithFakeConnection(object):
         with_mock.extend_hit(hit_id='hit1', number=2, duration_hours=1.0)
 
         with_mock.mturk.extend_hit.assert_has_calls([
+            mock.call('hit1', expiration_increment=3600),
             mock.call('hit1', assignments_increment=2),
-            mock.call('hit1', expiration_increment=3600)
         ])
 
     def test_disable_hit_simple_passthrough(self, with_mock):


### PR DESCRIPTION
This prevents a request to AWS to extend the hit from causing a fatal error/death spiral

## Description
I have made the following changes:
1. the psiturk recruiter commits on init, this means whenever we are about to get in touch with AWS through psiturk we commit the current transaction first.
2. When recruiting participants Dallinger tries to extend the duration of the hit before opening more slots for participants
3. contact with AWS is put in try/except brackets with informative error messages as well as tracebacks

## Motivation and Context
This fixes an issue that arose when a request to AWS to add more time failed (even though a request to add more participants succeeded) causing the db to roll back to a state that could not accent the new participants that had been recruited.

## How Has This Been Tested?
I ran a small experiment and it worked fine. The error with AWS is extremely rare so it is unlikely that we can test it directly.

