### PR TITLE
Tell Hound CI to respect the configuration

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,2 +1,3 @@
 python:
   enabled: true
+  config_file: setup.cfg


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Hound CI should respect the configuration of Flake8 as specified in `setup.cfg`.
