### PR TITLE
Update data export for new Heroku CLI

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -614,13 +614,22 @@ def dump_database(id):
         os.makedirs(dump_dir)
 
     try:
-        subprocess.check_call([
+        FNULL = open(os.devnull, 'w')
+        subprocess.call([
             "heroku",
             "pg:backups",
             "capture"
             "--app",
             app_name(id)
-        ])
+        ], stdout=FNULL, stderr=FNULL)
+
+        subprocess.call([  # for more recent versions of Heroku CLI.
+            "heroku",
+            "pg:backups:capture",
+            "--app",
+            app_name(id)
+        ], stdout=FNULL, stderr=FNULL)
+
     except Exception:
         pass
 


### PR DESCRIPTION
This fixes a data export issue that I believe has been encountered by @thomasmorgan, @mongates, and @Gecia. The issue arose because of an update to the Heroku CLI. The command to back up a Postgres database used to be:

```
heroku pg:backups capture
```

but is now:

```
heroku pg:backups:capture
```

To test the change, I confirmed that data can be exported using the latest version of the Heroku CLI. I haven't tested the backwards compatibility because I don't know how to downgrade to an earlier version of the Heroku CLI.