### PR TITLE
Update command line, demos, etc. to use new configurator

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -24,7 +24,6 @@ import webbrowser
 
 import boto
 import click
-from localconfig import LocalConfig
 from dallinger.config import get_config
 import psycopg2
 import redis
@@ -151,26 +150,6 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     with open(os.path.join(dst, "experiment_id.txt"), "w") as file:
         file.write(generated_uid)
 
-    if exp_config:
-        # Read existing config, we can't use PsiturkConfig here because
-        # it doesn't allow setting a file write location
-        config_file = os.path.join(dst, 'config.txt')
-        local_config = LocalConfig(config_file, interpolation=True)
-        # Supplement and override settings with passed in values
-        for section_name in exp_config:
-            if getattr(local_config, local_config._to_dot_key(section_name)) is None:
-                local_config.add_section(section_name)
-            if getattr(exp_config, '_to_dot_key', None) is not None:
-                # We have a local config object
-                section_items = exp_config.items(exp_config._to_dot_key(section_name))
-            else:
-                # We have a dictionary key
-                section_items = exp_config.get(section_name).items()
-            for key, value in section_items:
-                local_config.set(section_name, key, value)
-        # Re-write the experiment's local config file with the results:
-        local_config.save(config_file)
-
     # Zip up the temporary directory and place it in the cwd.
     if not debug:
         log("Freezing the experiment package...")
@@ -180,6 +159,11 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     # Change directory to the temporary folder.
     cwd = os.getcwd()
     os.chdir(dst)
+
+    # Write the custom config
+    if exp_config:
+        config.extend(exp_config)
+        config.write_config()
 
     # Check directories.
     if not os.path.exists(os.path.join("static", "scripts")):
@@ -210,7 +194,6 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
         src = os.path.join(src_base, "heroku", filename)
         shutil.copy(src, os.path.join(dst, filename))
 
-    config = get_config()
     clock_on = config.get('clock_on', False)
 
     # If the clock process has been disabled, overwrite the Procfile.
@@ -353,7 +336,8 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
 
     # Load configuration.
     config = get_config()
-    config.load_config()
+    if not config.ready:
+        config.load_config()
 
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
@@ -413,8 +397,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         "heroku config:set psiturk_secret_access_id=" +
         quote(config.get('psiturk_secret_access_id')),
 
-        "heroku config:set auto_recruit=" +
-        quote(config.get('auto_recruit')),
+        "heroku config:set auto_recruit={}".format(config.get('auto_recruit')),
 
         "heroku config:set dallinger_email_username=" +
         quote(config.get('dallinger_email_address')),
@@ -428,7 +411,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         "heroku config:set heroku_password=" +
         quote(config.get('heroku_password')),
 
-        "heroku config:set whimsical=" + whimsical,
+        "heroku config:set whimsical={}".format(whimsical),
     ]
     for cmd in cmds:
         subprocess.check_call(
@@ -449,17 +432,16 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         except redis.exceptions.ConnectionError:
             time.sleep(2)
 
-    # Set the notification URL in the config file to the notifications URL.
-    config.set(
-        "Server Parameters",
-        "notification_url",
-        "http://" + app_name(id) + ".herokuapp.com/notifications")
-
-    # Set the database URL in the config file to the newly generated one.
     log("Saving the URL of the postgres database...")
     db_url = subprocess.check_output(
         "heroku config:get DATABASE_URL --app " + app_name(id), shell=True)
-    config.set("Database Parameters", "database_url", db_url.rstrip())
+    # Set the notification URL and database URL in the config file.
+    config.extend({
+        "notification_url": u"http://" + app_name(id) + ".herokuapp.com/notifications",
+        "database_url": db_url.rstrip().decode('utf8'),
+    })
+    config.write_config()
+
     subprocess.check_call("git add config.txt", stdout=out, shell=True),
     time.sleep(0.25)
     subprocess.check_call(
@@ -509,11 +491,9 @@ def sandbox(verbose, app):
     config.load_config()
 
     # Set the mode.
-    config.set("Experiment Configuration", "mode", "sandbox")
-    config.set("Server Parameters", "logfile", "-")
-
-    # Ensure that we launch in sandbox mode.
-    config.set("Shell Parameters", "launch_in_sandbox_mode", "true")
+    config.extend({"mode": u"sandbox",
+                   "logfile": u"-",
+                   "launch_in_sandbox_mode": True})
 
     # Do shared setup.
     deploy_sandbox_shared_setup(verbose=verbose, app=app)
@@ -529,11 +509,9 @@ def deploy(verbose, app):
     config.load_config()
 
     # Set the mode.
-    config.set("Experiment Configuration", "mode", "deploy")
-    config.set("Server Parameters", "logfile", "-")
-
-    # Ensure that we do not launch in sandbox mode.
-    config.set("Shell Parameters", "launch_in_sandbox_mode", "false")
+    config.extend({"mode": u"sandbox",
+                   "logfile": u"-",
+                   "launch_in_sandbox_mode": False})
 
     # Do shared setup.
     deploy_sandbox_shared_setup(verbose=verbose, app=app)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -121,6 +121,7 @@ class Configuration(object):
             self.load_from_config_file(config_file)
         self.ready = True
 
+
 configurations = threading.local()
 
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -3,6 +3,7 @@ from __future__ import unicode_literals
 from collections import deque
 from ConfigParser import SafeConfigParser
 import distutils.util
+import imp
 import os
 import threading
 
@@ -102,6 +103,10 @@ class Configuration(object):
     def load_config(self):
         if self.ready:
             raise ValueError("Already loaded")
+
+        # Apply extra settings before loading the configs
+        self.apply_extra_settings()
+
         globalConfigName = ".dallingerconfig"
         if 'OPENSHIFT_SECRET_TOKEN' in os.environ:
             globalConfig = os.path.join(os.environ['OPENSHIFT_DATA_DIR'], globalConfigName)
@@ -120,6 +125,26 @@ class Configuration(object):
         for config_file in [global_defaults_file, local_defaults_file, globalConfig, localConfig]:
             self.load_from_config_file(config_file)
         self.ready = True
+
+    def apply_extra_settings(self):
+        extra_settings = None
+        try:
+            from dallinger_experiment import extra_settings
+        except ImportError:
+            try:
+                exp = imp.load_source('dallinger_experiment', "dallinger_experiment.py")
+                extra_settings = getattr(exp, 'extra_settings', None)
+            except (ImportError, IOError):
+                pass
+            if extra_settings is None:
+                try:
+                    # We may be in the original source directory, try experiment.py
+                    exp = imp.load_source('dallinger_experiment', "experiment.py")
+                    extra_settings = getattr(exp, 'extra_settings', None)
+                except (ImportError, IOError):
+                    pass
+        if extra_settings is not None:
+            extra_settings()
 
 
 configurations = threading.local()

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -121,7 +121,6 @@ class Configuration(object):
             self.load_from_config_file(config_file)
         self.ready = True
 
-
 configurations = threading.local()
 
 
@@ -143,11 +142,16 @@ def get_config():
         ('browser_exclude_rule', unicode, []),
         ('clock_on', bool, []),
         ('contact_email_on_error', unicode, []),
+        ('dallinger_email_address', unicode, []),
+        ('dallinger_email_password', unicode, []),
         ('database_size', unicode, []),
         ('database_url', unicode, []),
         ('description', unicode, []),
         ('duration', float, []),
         ('dyno_type', unicode, []),
+        ('heroku_email_address', unicode, []),
+        ('heroku_password', unicode, []),
+        ('heroku_team', unicode, []),
         ('host', unicode, ['HOST']),
         ('port', int, ['PORT']),
         ('launch_in_sandbox_mode', bool, []),
@@ -166,7 +170,8 @@ def get_config():
         ('table_name', unicode, []),
         ('threads', unicode, []),
         ('title', unicode, []),
-        ('us_only', bool, [])
+        ('us_only', bool, []),
+        ('whimsical', bool, []),
     ):
         configurations.config.register(key, type_, synonyms)
     return configurations.config

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -105,7 +105,7 @@ class Configuration(object):
             raise ValueError("Already loaded")
 
         # Apply extra settings before loading the configs
-        self.apply_extra_settings()
+        self.register_extra_settings()
 
         globalConfigName = ".dallingerconfig"
         if 'OPENSHIFT_SECRET_TOKEN' in os.environ:
@@ -126,7 +126,7 @@ class Configuration(object):
             self.load_from_config_file(config_file)
         self.ready = True
 
-    def apply_extra_settings(self):
+    def register_extra_settings(self):
         extra_settings = None
         try:
             from dallinger_experiment import extra_settings

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -14,7 +14,7 @@ import uuid
 
 from sqlalchemy import and_
 
-from dallinger.config import get_config
+from dallinger.config import get_config, LOCAL_CONFIG
 from dallinger.models import Network, Node, Info, Transformation, Participant
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
@@ -35,6 +35,8 @@ def exp_class_working_dir(meth):
                 sys.modules[self.__class__.__module__].__file__
             )
             os.chdir(new_path)
+            # Override configs
+            config.load_from_config_file(LOCAL_CONFIG)
             return meth(self, *args, **kwargs)
         finally:
             os.chdir(orig_path)
@@ -48,8 +50,6 @@ class Experiment(object):
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
-        from dallinger.recruiters import HotAirRecruiter
-        from dallinger.recruiters import PsiTurkRecruiter
 
         #: Boolean, determines whether the experiment logs output when
         #: running. Default is True.
@@ -69,13 +69,6 @@ class Experiment(object):
         #: int, the number of non practice networks (see
         #: :attr:`~dallinger.models.Network.role`). Default is 0.
         self.experiment_repeats = 0
-
-        #: Recruiter, the Dallinger class that recruits participants.
-        #: Default is HotAirRecruiter in debug mode and PsiTurkRecruiter in other modes.
-        if config.get('mode') == 'debug':
-            self.recruiter = HotAirRecruiter
-        else:
-            self.recruiter = PsiTurkRecruiter
 
         #: int, the number of participants
         #: requested when the experiment first starts. Default is 1.
@@ -99,6 +92,24 @@ class Experiment(object):
             "State": State,
             "Transformation": Transformation,
         }
+
+    @property
+    def recruiter(self):
+        """Recruiter, the Dallinger class that recruits participants.
+        Default is HotAirRecruiter in debug mode and PsiTurkRecruiter in other modes.
+        """
+        from dallinger.recruiters import HotAirRecruiter
+        from dallinger.recruiters import PsiTurkRecruiter
+
+        try:
+            debug_mode = config.get('mode') == 'debug'
+        except RuntimeError:
+            # Config not yet loaded
+            debug_mode = False
+
+        if debug_mode:
+            return HotAirRecruiter
+        return PsiTurkRecruiter
 
     def setup(self):
         """Create the networks if they don't already exist."""
@@ -384,16 +395,13 @@ class Experiment(object):
         run specific settings grouped by section.
         """
         import dallinger as dlgr
-        from psiturk.psiturk_config import PsiturkConfig
-        psiturk_config = PsiturkConfig()
-        psiturk_config.load_config()
-
-        # Set the mode.
-        psiturk_config.set("Experiment Configuration", "mode", "sandbox")
-        psiturk_config.set("Server Parameters", "logfile", "-")
 
         # Ensure that psiTurk is in sandbox mode.
-        psiturk_config.set("Shell Parameters", "launch_in_sandbox_mode", "true")
+        config.extend({
+            "mode": u"sandbox",
+            "logfile": u"-",
+            "launch_in_sandbox_mode": True,
+        })
 
         if app_id is None:
             app_id = str(uuid.uuid4())
@@ -418,12 +426,12 @@ class Experiment(object):
         psiturk_config = PsiturkConfig()
         psiturk_config.load_config()
 
-        # Set the mode.
-        psiturk_config.set("Experiment Configuration", "mode", "deploy")
-        psiturk_config.set("Server Parameters", "logfile", "-")
-
         # Ensure that psiTurk is not in sandbox mode.
-        psiturk_config.set("Shell Parameters", "launch_in_sandbox_mode", "false")
+        config.extend({
+            "mode": u"sandbox",
+            "logfile": u"-",
+            "launch_in_sandbox_mode": False,
+        })
 
         if app_id is None:
             app_id = str(uuid.uuid4())

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -47,12 +47,6 @@ BONUSED = 7
 
 
 config = get_config()
-try:
-    from dallinger_experiment import extra_settings
-except ImportError:
-    pass
-else:
-    extra_settings()
 if not config.ready:
     config.load_config()
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -3,7 +3,7 @@
 import pexpect
 import subprocess
 
-import dallinger as dlgr
+from dallinger.config import get_config
 
 
 def app_name(id):
@@ -19,11 +19,15 @@ def log_in():
 
 def scale_up_dynos(app):
     """Scale up the Heroku dynos."""
-    dyno_type = dlgr.config.server_parameters.dyno_type
+    config = get_config()
+    if not config.ready:
+        config.load_config()
+
+    dyno_type = config.get('dyno_type')
 
     num_dynos = {
-        "web": dlgr.config.server_parameters.num_dynos_web,
-        "worker": dlgr.config.server_parameters.num_dynos_worker
+        "web": config.get('num_dynos_web'),
+        "worker": config.get('num_dynos_worker'),
     }
 
     for process in ["web", "worker"]:
@@ -35,7 +39,7 @@ def scale_up_dynos(app):
             app,
         ])
 
-    if dlgr.config.server_parameters.clock_on:
+    if config.get('clock_on'):
         subprocess.check_call([
             "heroku",
             "ps:scale",

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -1,6 +1,10 @@
 """Coordination chatroom game."""
 
 import dallinger as dlgr
+try:
+    unicode = unicode
+except NameError:  # Python 3
+    unicode = str
 
 
 class CoordinationChatroom(dlgr.experiments.Experiment):
@@ -14,12 +18,16 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.initial_recruitment_size = self.num_participants
         self.quorum = self.num_participants
         self.setup()
+        self.config = dlgr.config.get_config()
+        self.config.register('network', unicode)
+        if not self.config.ready:
+            self.config.load_config()
 
     def create_network(self):
         """Create a new network by reading the configuration file."""
         class_ = getattr(
             dlgr.networks,
-            dlgr.config.experiment_configuration.network
+            self.config.get('network')
         )
         return class_(max_size=self.num_participants)
 

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -1,11 +1,8 @@
 """Coordination chatroom game."""
 
 import dallinger as dlgr
+from dallinger.compat import unicode
 from dallinger.config import get_config
-try:
-    unicode = unicode
-except NameError:  # Python 3
-    unicode = str
 
 config = get_config()
 

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -1,10 +1,18 @@
 """Coordination chatroom game."""
 
 import dallinger as dlgr
+from dallinger.config import get_config
 try:
     unicode = unicode
 except NameError:  # Python 3
     unicode = str
+
+config = get_config()
+
+
+def extra_settings():
+    config.register('network', unicode)
+    config.register('n', int)
 
 
 class CoordinationChatroom(dlgr.experiments.Experiment):
@@ -14,14 +22,13 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         """Initialize the experiment."""
         super(CoordinationChatroom, self).__init__(session)
         self.experiment_repeats = 1
-        self.num_participants = dlgr.config.experiment_configuration.n
+        self.num_participants = config.get('n')
         self.initial_recruitment_size = self.num_participants
         self.quorum = self.num_participants
-        self.setup()
-        self.config = dlgr.config.get_config()
-        self.config.register('network', unicode)
+        self.config = config
         if not self.config.ready:
             self.config.load_config()
+        self.setup()
 
     def create_network(self):
         """Create a new network by reading the configuration file."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Updates for remove-psiturk-server (based on stories/136-debug-recruiter to support configuration writing) to use new configuration object universally to get and set config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
