### PR TITLE
Implement experiment status route and completion check (156)

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -444,7 +444,7 @@ class Experiment(object):
     def experiment_completed(self):
         """Checks the current state of the experiment to see whether it has
         completed"""
-        status_url = 'https://{}.herokuapp.com/experiment_status'.format(
+        status_url = 'https://{}.herokuapp.com/summary'.format(
             app_name(self.app_id)
         )
         data = {}
@@ -453,8 +453,8 @@ class Experiment(object):
             data = resp.json()
         except (ValueError, requests.exceptions.RequestException):
             logger.exception('Error fetching experiment status.')
-        logger.debug('Current application state: {}'.format(data.get('state', {})))
-        return data.get('state', {}).get('completed', False)
+        logger.debug('Current application state: {}'.format(data))
+        return data.get('completed', False)
 
     def retrieve_data(self):
         """Retrieves and saves data from a running experiment"""

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -8,6 +8,7 @@ import logging
 from operator import itemgetter
 import os
 import random
+import requests
 import sys
 import time
 import uuid
@@ -15,6 +16,7 @@ import uuid
 from sqlalchemy import and_
 
 from dallinger.models import Network, Node, Info, Transformation, Participant
+from dallinger.heroku import app_name
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
 from dallinger.transformations import Compression, Response
@@ -433,8 +435,6 @@ class Experiment(object):
 
     def _finish_experiment(self):
         self.log("Waiting for experiment to complete.", "")
-        self.log("Experiment end detection is not currently implemented, "
-                 "press CTRL-C to end.", "")
         while self.experiment_completed() is False:
             time.sleep(30)
         data = self.retrieve_data()
@@ -444,8 +444,17 @@ class Experiment(object):
     def experiment_completed(self):
         """Checks the current state of the experiment to see whether it has
         completed"""
-        # Not implemented
-        return False
+        status_url = 'https://{}.herokuapp.com/experiment_status'.format(
+            app_name(self.app_id)
+        )
+        data = {}
+        try:
+            resp = requests.get(status_url)
+            data = resp.json()
+        except (ValueError, requests.exceptions.RequestException):
+            logger.exception('Error fetching experiment status.')
+        logger.debug('Current application state: {}'.format(data.get('state', {})))
+        return data.get('state', {}).get('completed', False)
 
     def retrieve_data(self):
         """Retrieves and saves data from a running experiment"""

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -553,14 +553,6 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     session.add(participant)
     session.commit()
 
-    # make a psiturk participant too, for now
-    from psiturk.models import Participant as PsiturkParticipant
-    psiturk_participant = PsiturkParticipant(workerid=worker_id,
-                                             assignmentid=assignment_id,
-                                             hitid=hit_id)
-    session_psiturk.add(psiturk_participant)
-    session_psiturk.commit()
-
     # return the data
     return success_response(field="participant",
                             data=participant.__json__(),

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -1,11 +1,20 @@
 from dallinger.config import get_config
 from dallinger.experiments import Experiment
+from dallinger.networks import Star
 
 config = get_config()
 
 
 class TestExperiment(Experiment):
-    pass
+
+    def __init__(self, session=None):
+        super(TestExperiment, self).__init__(session)
+        self.experiment_repeats = 1
+        self.setup()
+
+    def create_network(self):
+        """Return a new network."""
+        return Star(max_size=2)
 
 
 def extra_settings():

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1,3 +1,4 @@
+import json
 import os
 import unittest
 
@@ -63,6 +64,17 @@ class TestExperimentServer(FlaskAppTest):
             'mode': 'debug',
         })
         assert 'Informed Consent Form' in resp.data
+
+    def test_experiment_status(self):
+        resp = self.app.get('/experiment_status')
+        assert resp.status_code == 200
+        data = json.loads(resp.data)
+        assert data.get('status', 'success')
+        state = data.get('state', {})
+        assert state.get('completed') is True
+        assert state.get('unfilled_networks') == 0
+        assert state.get('working_participants') == 0
+        assert state.get('nodes_remaining') == 0
 
     def test_not_found(self):
         resp = self.app.get('/BOGUS')

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -20,7 +20,7 @@ class FlaskAppTest(unittest.TestCase):
         self.app = app.test_client()
 
         import dallinger.db
-        self.db = dallinger.db.init_db()
+        self.db = dallinger.db.init_db(drop_all=True)
 
     def tearDown(self):
         self.db.rollback()
@@ -29,6 +29,30 @@ class FlaskAppTest(unittest.TestCase):
 
 
 class TestExperimentServer(FlaskAppTest):
+    worker_counter = 0
+    hit_counter = 0
+    assignment_counter = 0
+
+    def _create_participant(self):
+        worker_id = self.worker_counter
+        hit_id = self.hit_counter
+        assignment_id = self.assignment_counter
+        self.worker_counter += 1
+        self.hit_counter += 1
+        self.assignment_counter += 1
+        resp = self.app.post('/participant/{}/{}/{}/debug'.format(
+            worker_id, hit_id, assignment_id
+        ))
+        return json.loads(resp.data).get('participant', {}).get('id')
+
+    def _create_node(self, participant_id):
+        resp = self.app.post('/node/{}'.format(participant_id))
+        return json.loads(resp.data).get('node', {}).get('id')
+
+    def _update_participant_status(self, participant_id, status):
+        from dallinger.models import Participant
+        participant = Participant.query.get(participant_id)
+        participant.status = status
 
     def test_default(self):
         resp = self.app.get('/')
@@ -65,16 +89,70 @@ class TestExperimentServer(FlaskAppTest):
         })
         assert 'Informed Consent Form' in resp.data
 
-    def test_experiment_status(self):
-        resp = self.app.get('/experiment_status')
+    def test_participant_info(self):
+        p_id = self._create_participant()
+        resp = self.app.get('/participant/{}'.format(p_id))
+        data = json.loads(resp.data)
+        assert data.get('status') == 'success'
+        assert data.get('participant').get('status') == u'working'
+
+    def test_node_vectors(self):
+        p_id = self._create_participant()
+        n_id = self._create_node(p_id)
+        resp = self.app.get('/node/{}/vectors'.format(n_id))
+        data = json.loads(resp.data)
+        assert data.get('status') == 'success'
+        assert data.get('vectors') == []
+
+    def test_node_infos(self):
+        p_id = self._create_participant()
+        n_id = self._create_node(p_id)
+        resp = self.app.get('/node/{}/infos'.format(n_id))
+        data = json.loads(resp.data)
+        assert data.get('status') == 'success'
+        assert data.get('infos') == []
+
+    def test_summary(self):
+        resp = self.app.get('/summary')
         assert resp.status_code == 200
         data = json.loads(resp.data)
-        assert data.get('status', 'success')
-        state = data.get('state', {})
-        assert state.get('completed') is True
-        assert state.get('unfilled_networks') == 0
-        assert state.get('working_participants') == 0
-        assert state.get('nodes_remaining') == 0
+        assert data.get('status') == 'success'
+        assert data.get('completed') is False
+        assert data.get('unfilled_networks') == 1
+        assert data.get('required_nodes') == 2
+        assert data.get('nodes_remaining') == 2
+        assert data.get('summary') == []
+
+        p1_id = self._create_participant()
+        self._create_node(p1_id)
+        resp = self.app.get('/summary')
+        data = json.loads(resp.data)
+        assert data.get('completed') is False
+        assert data.get('nodes_remaining') == 1
+        worker_summary = data.get('summary')
+        assert len(worker_summary) == 1
+        assert worker_summary[0] == [u'working', 1]
+
+        p2_id = self._create_participant()
+        self._create_node(p2_id)
+        resp = self.app.get('/summary')
+        data = json.loads(resp.data)
+        assert data.get('completed') is False
+        assert data.get('nodes_remaining') == 0
+        worker_summary = data.get('summary')
+        assert len(worker_summary) == 1
+        assert worker_summary[0] == [u'working', 2]
+
+        self._update_participant_status(p1_id, 'submitted')
+        self._update_participant_status(p2_id, 'approved')
+
+        resp = self.app.get('/summary')
+        data = json.loads(resp.data)
+        assert data.get('completed') is True
+        worker_summary = data.get('summary')
+        assert len(worker_summary) == 2
+        assert worker_summary[0] == [u'approved', 1]
+        assert worker_summary[1] == [u'submitted', 1]
 
     def test_not_found(self):
         resp = self.app.get('/BOGUS')


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implements new experiment server route to check experiment status.

The route returns a `state` JSON object with `completed`, `unfilled_networks`, `nodes_remaining`, and `working_participants` attributes.

This route is automatically polled when an experiment is run via a python call to `experiment.sandbox()` or `experiment.deploy()`.

## Motivation and Context
This implements Story 156.

## How Has This Been Tested?
There is an automated test that the route returns the expected values with the test experiment (which starts out in completed state). I also tested the route manually via debug mode, and confirmed that the route was polled when deployed in a heroku sandbox.
