### PR TITLE
Switch to using pytest as the test runner.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - python: 2.7
     env: TOXENV=style
   - python: 2.7
-    env: TOXENV=py27-docs
+    env: TOXENV=docs
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
   - python: 2.7
     env: TOXENV=style
   - python: 2.7
-    env: TOXENV=docs
+    env: TOXENV=py27-docs
 addons:
   apt:
     packages:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,8 +2,8 @@ alabaster==0.7.9
 coverage==4.3.1
 codecov==2.0.5
 flake8==3.2.1
-nose==1.3.7
 pypandoc==1.3.3
+pytest==3.0.5
 recommonmark==0.4.0
 Sphinx==1.4.9
 sphinxcontrib-spelling==2.3.0

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -15,7 +15,7 @@ The tests include:
 * Making sure that a source distribution of the Python package can be created.
 * Running `flake8 <https://flake8.readthedocs.io>`_ to make sure Python code
   conforms to the `PEP 8 <https://www.python.org/dev/peps/pep-0008/>`_ style guide.
-* Running the tests for the Python code using `nose <http://nose.readthedocs.io/>`_
+* Running the tests for the Python code using `pytest <http://doc.pytest.org/>`_
   and making sure they pass in Python 2.7.
 * Making sure that `code coverage <https://coverage.readthedocs.io/>`_
   for the Python code is above the desired threshold.
@@ -27,11 +27,11 @@ You can also run all these tests locally, simply by running::
 
 To run just the Python tests::
 
-	nosetests
+	pytest
 
 To build documentation::
 
-	tox -e docs
+	tox -e py27-docs
 
 To run flake8::
 

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -31,7 +31,7 @@ To run just the Python tests::
 
 To build documentation::
 
-	tox -e py27-docs
+	tox -e docs
 
 To run flake8::
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+usefixtures = cwd
+testpaths = tests

--- a/tests/_test_bartlett.py
+++ b/tests/_test_bartlett.py
@@ -1,6 +1,5 @@
 # from dallinger import nodes, information, db, models
 # from dallinger.information import Meme, Gene
-# from nose.tools import raises
 # import subprocess
 # import re
 # import requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import os
 import pytest
 
 
+# This fixture is used automatically and ensures that
+# the current working directory is reset if other test classes changed it.
 @pytest.fixture(scope="class")
 def cwd():
     root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,9 @@
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="class")
+def cwd():
+    root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    os.chdir(root)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -2,7 +2,7 @@
 
 from dallinger import nodes, information, db, models
 from dallinger.information import Meme, Gene
-from nose.tools import raises
+from pytest import raises
 
 
 class TestAgents(object):
@@ -84,16 +84,15 @@ class TestAgents(object):
         assert transmission.origin_id == agent1.id
         assert transmission.destination_id == agent2.id
 
-    @raises(ValueError)
     def test_agent_transmit_no_connection(self):
         net = models.Network()
         self.db.add(net)
         agent1 = nodes.ReplicatorAgent(network=net)
         agent2 = nodes.ReplicatorAgent(network=net)
         info = models.Info(origin=agent1, contents="foo")
-        agent1.transmit(what=info, to_whom=agent2)
+        with raises(ValueError):
+            agent1.transmit(what=info, to_whom=agent2)
 
-    @raises(ValueError)
     def test_agent_transmit_invalid_info(self):
         net = models.Network()
         self.db.add(net)
@@ -103,7 +102,8 @@ class TestAgents(object):
         agent1.connect(direction="to", whom=agent2)
         info = models.Info(origin=agent2, contents="foo")
 
-        agent1.transmit(what=info, to_whom=agent2)
+        with raises(ValueError):
+            agent1.transmit(what=info, to_whom=agent2)
 
     def test_agent_transmit_everything_to_everyone(self):
         net = models.Network()

--- a/tests/test_clock.py
+++ b/tests/test_clock.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from nose.tools import assert_raises
+from pytest import raises
 
 from dallinger.config import get_config
 
@@ -26,9 +26,9 @@ class TestClock(object):
     def test_clock_expects_config_to_be_ready(self):
         assert not get_config().ready
         jobs = self.clock.scheduler.get_jobs()
-        with assert_raises(RuntimeError) as assertion:
+        with raises(RuntimeError) as excinfo:
             jobs[0].func()
-        assert assertion.exception.message == 'Config loading not finished'
+        assert excinfo.value.message == 'Config loading not finished'
 
     def test_launch_loads_config(self):
         original_start = self.clock.scheduler.start

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import os
 from tempfile import NamedTemporaryFile
 
-from nose.tools import assert_raises
+from pytest import raises
 import pexpect
 
 from dallinger.config import Configuration
@@ -21,7 +21,7 @@ class TestConfiguration(object):
     def test_type_mismatch(self):
         config = Configuration()
         config.register('num_participants', int)
-        with assert_raises(ValueError):
+        with raises(ValueError):
             config.extend({'num_participants': 1.0})
 
     def test_type_mismatch_with_cast_types(self):
@@ -35,7 +35,7 @@ class TestConfiguration(object):
         config = Configuration()
         config.register('num_participants', int)
         config.extend({'num_participants': 1})
-        with assert_raises(RuntimeError):
+        with raises(RuntimeError):
             config.get('num_participants', 1)
 
     def test_layering_of_configs(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import sys
 from datetime import datetime
 from dallinger import models, db, nodes
-from nose.tools import raises, assert_raises
+from pytest import raises
 from dallinger.nodes import Agent, Source
 from dallinger.information import Gene
 from dallinger.transformations import Mutation
@@ -258,12 +258,12 @@ class TestModels(object):
             assert n in [node3, node4]
         assert node3.neighbors(direction="from") == [node2]
 
-        assert_raises(ValueError, node1.connect, whom=node1)
+        raises(ValueError, node1.connect, whom=node1)
 
         net = models.Network()
         self.add(net)
 
-        assert_raises(TypeError, node1.connect, whom=net)
+        raises(TypeError, node1.connect, whom=net)
 
     def test_node_outdegree(self):
         net = models.Network()
@@ -467,7 +467,6 @@ class TestModels(object):
 
         assert repr(info).split("-") == ["Info", str(info.id), "info"]
 
-    @raises(ValueError)
     def test_info_write_twice(self):
         """Overwrite an info's contents."""
         net = models.Network()
@@ -478,7 +477,8 @@ class TestModels(object):
         self.add(node, info)
 
         assert info.contents == "foo"
-        info.contents = "ofo"
+        with raises(ValueError):
+            info.contents = "ofo"
 
     ##################################################################
     # Transmission

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,6 +1,6 @@
 from dallinger import networks, nodes, db, models
 import random
-from nose.tools import assert_raises, raises
+from pytest import raises
 
 
 class TestNetworks(object):
@@ -47,7 +47,6 @@ class TestNetworks(object):
         assert net.nodes(type=nodes.Agent) == [agent]
         assert isinstance(net, models.Network)
 
-    @raises(NotImplementedError)
     def test_network_base_add_node_not_implemented(self):
         net = models.Network()
         self.db.add(net)
@@ -55,7 +54,8 @@ class TestNetworks(object):
         node = models.Node(network=net)
         self.db.add(net)
         self.db.commit()
-        net.add_node(node)
+        with raises(NotImplementedError):
+            net.add_node(node)
 
     def test_network_sources(self):
         net = networks.Network()
@@ -181,7 +181,7 @@ class TestNetworks(object):
 
         node1.connect(whom=[node2, agent1, agent2])
 
-        assert_raises(TypeError, node1.connect, whom=source1)
+        raises(TypeError, node1.connect, whom=source1)
 
         assert set(node1.neighbors(direction="to")) == set([node2, agent1, agent2])
         assert len(node1.vectors(direction="outgoing")) == 3
@@ -190,7 +190,7 @@ class TestNetworks(object):
         agent1.fail()
         agent2.fail()
 
-        assert_raises(ValueError, node1.neighbors, direction="ghbhfgjd")
+        raises(ValueError, node1.neighbors, direction="ghbhfgjd")
 
     def test_network_repr(self):
         net = networks.Network()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-     py27,style,py27-docs
+     docs,py27,style
 
 [testenv]
 commands =
@@ -17,7 +17,7 @@ commands =
 deps =
     flake8
 
-[testenv:py27-docs]
+[testenv:docs]
 whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist =
-     docs,style,py27
+     py27,style,py27-docs
 
 [testenv]
 commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
-    coverage run {envbindir}/nosetests {posargs}
+    coverage run {envbindir}/pytest {posargs}
     coverage report
     coverage xml
 passenv = DATABASE_URL PORT
@@ -17,7 +17,7 @@ commands =
 deps =
     flake8
 
-[testenv:docs]
+[testenv:py27-docs]
 whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt


### PR DESCRIPTION
## Description
The pytest runner is more expressive and better fits the style of assertions being used in Dallinger. This change uses it in documentation and in tox, as well as removes the dependency on nosetests.


## Motivation and Context
The nosetest runner presents poor assertion errors, pytest allows for providing significantly more debug feedback, as well as good support for fixtures that make tests faster and more reliable.

## How Has This Been Tested?
Running the tests, and observing better output than nose.
