### PR TITLE
Delete .pyc files before test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
 
 [testenv]
 commands =
+    find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
     coverage run {envbindir}/nosetests {posargs}
     coverage report


### PR DESCRIPTION
Some tox runs were failing because of outdated .pyc files. This deletes the files before running the tests.