### PR TITLE
Open experiment for new participants in debug mode

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,6 +3,6 @@ branch = True
 source = dallinger
 
 [report]
-fail_under = 42
+fail_under = 41
 show_missing = True
 skip_covered = True

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ docs/source/demos
 .DS_Store
 README.rst
 .netrc
+.vagrant/

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -269,26 +269,15 @@ def debug(verbose):
 
     # Set the mode to debug.
     config = get_config()
-    logfile = os.path.join(cwd, config.get("logfile"))
+    logfile = config.get('logfile')
+    if logfile != '-':
+        logfile = os.path.join(cwd, logfile)
     config.extend({
         "mode": u"debug",
         "launch_in_sandbox_mode": True,
         "logfile": logfile
     })
-
-    # Swap in the HotAirRecruiter
-    os.rename("dallinger_experiment.py", "dallinger_experiment_tmp.py")
-    with open("dallinger_experiment_tmp.py", "r+") as f:
-        with open("dallinger_experiment.py", "w+") as f2:
-            f2.write("from dallinger.recruiters import HotAirRecruiter\n")
-            for idx, line in enumerate(f):
-                if re.search("\s*self.recruiter = (.*)", line):
-                    p = line.partition("self.recruiter =")
-                    f2.write(p[0] + p[1] + ' HotAirRecruiter\n')
-                else:
-                    f2.write(line)
-
-    os.remove("dallinger_experiment_tmp.py")
+    config.write_config()
 
     # Start up the local server
     log("Starting up the server...")

--- a/dallinger/compat.py
+++ b/dallinger/compat.py
@@ -1,0 +1,6 @@
+"""Compatibility utilities."""
+
+try:
+    unicode = unicode
+except NameError:  # Python 3
+    unicode = str

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -6,12 +6,9 @@ import distutils.util
 import os
 import threading
 
-marker = object()
+from .compat import unicode
 
-try:
-    unicode = unicode
-except NameError:  # Python 3
-    unicode = str
+marker = object()
 
 LOCAL_CONFIG = 'config.txt'
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -13,6 +13,8 @@ try:
 except NameError:  # Python 3
     unicode = str
 
+LOCAL_CONFIG = 'config.txt'
+
 
 class Configuration(object):
 
@@ -88,6 +90,15 @@ class Configuration(object):
             data.update(dict(parser.items(section)))
         self.extend(data, cast_types=True)
 
+    def write_config(self):
+        parser = SafeConfigParser()
+        parser.add_section('Parameters')
+        for layer in reversed(self.data):
+            for k, v in layer.items():
+                parser.set('Parameters', k, str(v))
+        with open(LOCAL_CONFIG, 'w') as fp:
+            parser.write(fp)
+
     def load_from_environment(self):
         self.extend(os.environ, cast_types=True)
 
@@ -95,12 +106,11 @@ class Configuration(object):
         if self.ready:
             raise ValueError("Already loaded")
         globalConfigName = ".dallingerconfig"
-        localConfigName = "config.txt"
         if 'OPENSHIFT_SECRET_TOKEN' in os.environ:
             globalConfig = os.path.join(os.environ['OPENSHIFT_DATA_DIR'], globalConfigName)
         else:
             globalConfig = os.path.expanduser(os.path.join("~/", globalConfigName))
-        localConfig = os.path.join(os.getcwd(), localConfigName)
+        localConfig = os.path.join(os.getcwd(), LOCAL_CONFIG)
 
         defaults_folder = os.path.join(os.path.dirname(__file__), "default_configs")
         local_defaults_file = os.path.join(defaults_folder, "local_config_defaults.txt")

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -1,3 +1,6 @@
+[Experiment Configuration]
+mode = debug
+
 [HIT Configuration]
 title = Stroop task
 description = Judge the color of a series of words.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -18,8 +18,6 @@ from dallinger.config import get_config
 from dallinger.models import Network, Node, Info, Transformation, Participant
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
-from dallinger.recruiters import HotAirRecruiter
-from dallinger.recruiters import PsiTurkRecruiter
 from dallinger.transformations import Compression, Response
 from dallinger.transformations import Mutation, Replication
 from dallinger.networks import Empty
@@ -50,6 +48,8 @@ class Experiment(object):
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
+        from dallinger.recruiters import HotAirRecruiter
+        from dallinger.recruiters import PsiTurkRecruiter
 
         #: Boolean, determines whether the experiment logs output when
         #: running. Default is True.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -14,14 +14,18 @@ import uuid
 
 from sqlalchemy import and_
 
+from dallinger.config import get_config
 from dallinger.models import Network, Node, Info, Transformation, Participant
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
+from dallinger.recruiters import HotAirRecruiter
+from dallinger.recruiters import PsiTurkRecruiter
 from dallinger.transformations import Compression, Response
 from dallinger.transformations import Mutation, Replication
 from dallinger.networks import Empty
 
 logger = logging.getLogger(__file__)
+config = get_config()
 
 
 def exp_class_working_dir(meth):
@@ -46,7 +50,6 @@ class Experiment(object):
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
-        from recruiters import PsiTurkRecruiter
 
         #: Boolean, determines whether the experiment logs output when
         #: running. Default is True.
@@ -68,8 +71,11 @@ class Experiment(object):
         self.experiment_repeats = 0
 
         #: Recruiter, the Dallinger class that recruits participants.
-        #: Default is PsiTurkRecruiter.
-        self.recruiter = PsiTurkRecruiter
+        #: Default is HotAirRecruiter in debug mode and PsiTurkRecruiter in other modes.
+        if config.get('mode') == 'debug':
+            self.recruiter = HotAirRecruiter
+        else:
+            self.recruiter = PsiTurkRecruiter
 
         #: int, the number of participants
         #: requested when the experiment first starts. Default is 1.

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -11,6 +11,11 @@ logger = logging.getLogger(__file__)
 app = util.import_app("dallinger.experiment_server.experiment_server:app")
 
 
+def when_ready(arbiter):
+    # Signal to parent process that server has started.
+    print('Ready.')
+
+
 class StandaloneServer(Application):
     loglevels = ["debug", "info", "warning", "error", "critical"]
 
@@ -60,6 +65,7 @@ class StandaloneServer(Application):
             'errorlog': config.get("logfile"),
             'proc_name': 'psiturk_experiment_server',
             'limit_request_line': '0',
+            'when_ready': when_ready,
         }
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -61,6 +61,10 @@ class HotAirRecruiter(object):
         """Talk about closing recruitment."""
         logger.info("Close recruitment.")
 
+    def approve_hit(self, assignment_id):
+        """Approve the HIT."""
+        return True
+
 
 class SimulatedRecruiter(object):
     """A recruiter that recruits simulated participants."""

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -3,6 +3,17 @@
 from boto.mturk.connection import MTurkConnection
 from psiturk.models import Participant
 from dallinger.config import get_config
+from dallinger.utils import get_base_url
+from dallinger.utils import generate_random_id
+import logging
+
+logger = logging.getLogger(__file__)
+
+
+def generate_debug_ad_url():
+    return "{}?assignmentId=debug{}&hitId={}&workerId={}&mode=debug".format(
+        get_base_url(), generate_random_id(), generate_random_id(), generate_random_id(),
+    )
 
 
 class Recruiter(object):
@@ -35,17 +46,20 @@ class HotAirRecruiter(object):
         """Create a hot air recruiter."""
         super(HotAirRecruiter, self).__init__()
 
-    def open_recruitment(self):
+    def open_recruitment(self, n=1):
         """Talk about opening recruitment."""
-        print("Opening recruitment.")
+        logger.info("Opening recruitment.")
+        self.recruit_participants(n)
 
     def recruit_participants(self, n=1):
         """Talk about recruiting participants."""
-        print("Recruiting a new participant.")
+        for i in range(n):
+            ad_url = generate_debug_ad_url()
+            logger.info('New participant requested: {}'.format(ad_url))
 
     def close_recruitment(self):
         """Talk about closing recruitment."""
-        print("Close recruitment.")
+        logger.info("Close recruitment.")
 
 
 class SimulatedRecruiter(object):
@@ -61,7 +75,7 @@ class SimulatedRecruiter(object):
 
     def recruit_participants(self, n=1, exp=None):
         """Recruit n participants."""
-        for i in xrange(n):
+        for i in range(n):
             newcomer = exp.agent_type()
             exp.newcomer_arrival_trigger(newcomer)
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -1,0 +1,20 @@
+from dallinger.config import get_config
+import os
+import random
+import string
+
+
+def get_base_url():
+    config = get_config()
+    if 'OPENSHIFT_SECRET_TOKEN' in os.environ:
+        base_url = "http://{}/ad".format(config.get('host'))
+    else:
+        base_url = "http://{}:{}/ad".format(
+            config.get('host'), config.get("port")
+        )
+    return base_url
+
+
+def generate_random_id(size=6, chars=string.ascii_uppercase + string.digits):
+    ''' Generate random id numbers '''
+    return ''.join(random.choice(chars) for x in range(size))

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -17,11 +17,12 @@ see something that looks like:
 
 ::
 
-    ❯❯ Server is running on 0.0.0.0:5000. Press Ctrl+C to exit.
+    New participant requested: http://0.0.0.0:5000/ad?assignmentId=debug9TXPFF&hitId=P8UTMZ&workerId=SP7HJ4&mode=debug
 
-This indicates that the server is running.
+and your browser should automatically open to this URL.
+You can start interacting as the first participant in the experiment.
 
-@@@ Add instructions on how to open in browser once we've done story 136.
+In the terminal, press Ctrl+C to exit the server.
 
 **Help, the experiment page is blank!** This may happen if you are using
 an ad-blocker. Try disabling your ad-blocker and refresh the page.

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -12,6 +12,7 @@ Cirulli
 conda
 config
 css
+Ctrl
 dallinger
 Dallinger
 dynos

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -128,4 +128,4 @@ class TestDebugServer(object):
         port = get_config().get('port')
         p = pexpect.spawn('dallinger', ['debug'])
         p.expect_exact('Server is running on 0.0.0.0:{}. Press Ctrl+C to exit.'.format(port))
-        p.terminate()
+        p.sendcontrol('c')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,5 +105,5 @@ worldwide = false
             python.sendline('print config.types')
             python.expect_exact("custom_parameter': <type 'int'>")
         finally:
-            python.close()
+            python.sendcontrol('c')
             os.chdir('../..')


### PR DESCRIPTION
## Description
This switches to a better (and working) approach for switching to the HotAirRecruiter when running in debug mode. It also adjusts the HotAirRecruiter to log the URL for a new participant when one is recruited, and monitors the output from debug mode to open the browser when that URL is printed.

## Motivation and Context
With the removal of the psiTurk shell, it's no longer possible to request a participant URL using the `debug` command. This is an alternative approach.

(Note, this is currently targeted at the remove-psiturk-server branch, but it should be updated to target the development branch once PR 356 is merged.)

## How Has This Been Tested?
Tested by manually running `dallinger debug`
