### PR TITLE
Stop sending Jordan so many emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,12 +43,6 @@ after_success:
 - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     sh scripts/github_releases.sh;
   fi
-notifications:
-  email:
-    recipients:
-      - suchow@post.harvard.edu
-    on_success: always
-    on_failure: always
 before_deploy:
 - pandoc --from=markdown --to=rst --output=README.rst README.md
 deploy:


### PR DESCRIPTION
Instead, use the Travis defaults: send the committer and the commit
author when a build becomes or continues to be broken, or when a
previously broken build becomes fixed.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I get so many Travis emails.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I want fewer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
It has not been tested.

## Screenshots (if appropriate):

![image](https://cloud.githubusercontent.com/assets/613981/21740182/789224ee-d47f-11e6-8e91-d1914c12e64c.png)
