### PR TITLE
Add instructions for users with Anaconda 3

### DIFF
--- a/docs/source/dallinger_with_anaconda.rst
+++ b/docs/source/dallinger_with_anaconda.rst
@@ -5,6 +5,34 @@ If you are interested in Dallinger and use
 `Anaconda <https://www.continuum.io/downloads>`__, you'll need to adapt
 the standard instructions slightly.
 
+Getting Python 2.7 started if you have Anaconda 3
+----------------
+
+If you have Anaconada 3 (i.e., Anaconda running Python 3), you'll need to create a virtual environment for Python 2.7.
+
+To initialize the new environment, type the following command into the command line:
+
+::
+
+    conda create -n py27 python=2.7 anaconda
+    
+You can customize the name of your Python 2.7 environment by changing the ``py27`` to your environment name of choice. Once it's created, then activate your new environment at the command line:
+
+::
+
+    source activate py27
+    
+If you didn't choose to stick with the ``py27`` name, make sure that you change that to reflect your environment name. Once you've activated the environment, you can proceed with the rest of the instructions below.
+
+Whenever you want to leave the environment, you can deactivate it at the command line:
+
+::
+    source deactivate py27
+    
+Again, be sure to change ``py27`` to whatever you called your environment.
+
+For more information about creating virtual environments within Anaconda, check out [http://conda.pydata.org/docs/using/envs.html].
+
 Install psycopg2
 ----------------
 


### PR DESCRIPTION
Add information about how to create a Python 2.7 virtual environment for Dallinger users who installed Anaconda 3.