### PR TITLE
Collect coverage for code run in subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,14 @@
 [run]
 branch = True
 source = dallinger
+parallel = True
 
 [report]
-fail_under = 41
+fail_under = 55
 show_missing = True
 skip_covered = True
+
+[paths]
+source =
+    dallinger
+    .tox/py27/lib/python2.7/site-packages/dallinger

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -294,7 +294,6 @@ def worker_submitted():
     return jsonify(**resp)
 
 
-
 @app.route('/ad', methods=['GET'])
 @nocache
 def advertisement():

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 alabaster==0.7.9
 coverage==4.3.1
+coverage_pth==0.0.1
 codecov==2.0.5
 flake8==3.2.1
 pypandoc==1.3.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,13 @@
 import os
-
 import pytest
+
+
+@pytest.fixture(scope='session', autouse=True)
+def subprocess_coverage():
+    # Set env var to trigger starting coverage for subprocesses
+    coverage_path = os.path.dirname(os.path.dirname(__file__))
+    os.environ['COVERAGE_PROCESS_START'] = os.path.join(coverage_path, '.coveragerc')
+    os.environ['COVERAGE_FILE'] = os.path.join(coverage_path, '.coverage')
 
 
 # This fixture is used automatically and ensures that

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -131,7 +131,7 @@ class TestDebugServer(object):
 
     def test_startup(self):
         # Make sure debug server starts without error
-        port = get_config().get('port')
         p = pexpect.spawn('dallinger', ['debug'])
-        p.expect_exact('Server is running on 0.0.0.0:{}. Press Ctrl+C to exit.'.format(port))
+        p.expect_exact('Server is running')
         p.sendcontrol('c')
+        p.read()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -144,5 +144,6 @@ worldwide = false
             python.sendline('print config.types')
             python.expect_exact("custom_parameter': <type 'int'>")
         finally:
-            python.sendcontrol('c')
+            python.sendcontrol('d')
+            python.read()
             os.chdir('../..')

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
     coverage run {envbindir}/pytest {posargs}
+    coverage combine
     coverage report
     coverage xml
 passenv = DATABASE_URL PORT


### PR DESCRIPTION
This fixes #396 by configuring coverage.py to initialize for subprocesses started during test runs, and then combining all the coverage data before reporting.

## Motivation and Context
This helps us get coverage for modules like `command_line.py` and `experiment_server.py` that are only run in a separate process.
