### PR TITLE
Load configuration even without local config.txt

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -148,13 +148,18 @@ class Configuration(object):
         defaults_folder = os.path.join(os.path.dirname(__file__), "default_configs")
         local_defaults_file = os.path.join(defaults_folder, "local_config_defaults.txt")
         global_defaults_file = os.path.join(defaults_folder, "global_config_defaults.txt")
-        if not os.path.exists(localConfig):
-            raise ValueError("No config.txt in the current directory")
 
-        # read default global and local, then user's global and local. This way
-        # any field not in the user's files will be set to the default value.
-        for config_file in [global_defaults_file, local_defaults_file, globalConfig, localConfig]:
+        # Load the configuration, with local settings overriding global ones.
+        for config_file in [
+            global_defaults_file,
+            local_defaults_file,
+            globalConfig,
+        ]:
             self.load_from_config_file(config_file)
+
+        if os.path.exists(localConfig):
+            self.load_from_config_file(localConfig)
+
         self.load_from_environment()
         self.ready = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     coverage combine
     coverage report
     coverage xml
-passenv = DATABASE_URL PORT
+passenv = DATABASE_URL PORT aws_access_key_id aws_secret_access_key
 whitelist_externals =
     find
 


### PR DESCRIPTION
Previously, when a local config.txt cannot be found in the current
working directory, a value error was raised. This PR allows the
configuration to load even when there is no such config.txt. This
makes it possible to use the configuration even outside the context of
an experiment directory (e.g., to get AWS keys in a function that loads data from S3, for use in analysis scripts).