### PR TITLE
OSF integration

### DIFF
--- a/dallinger/__init__.py
+++ b/dallinger/__init__.py
@@ -11,7 +11,8 @@ from . import (
     transformations,
     experiment,
     experiments,
-    heroku
+    heroku,
+    registration
 )
 
 import logging
@@ -32,4 +33,5 @@ __all__ = (
     "heroku",
     "experiment",
     "experiments",
+    "registration",
 )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -37,6 +37,7 @@ from dallinger.heroku import (
     scale_up_dynos
 )
 from dallinger.mturk import MTurkService
+from dallinger import registration
 from dallinger.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -317,6 +318,12 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
     (id, tmp) = setup_experiment(debug=False, verbose=verbose, app=app,
                                  exp_config=exp_config)
 
+    # Register the experiment using all configured registration services.
+    config = get_config()
+    if config.get("mode") == u"live":
+        log("Registering the experiment on configured services...")
+        registration.register(id, snapshot=None)
+
     # Log in to Heroku if we aren't already.
     log("Making sure that you are logged in to Heroku.")
     heroku.log_in()
@@ -500,7 +507,7 @@ def deploy(verbose, app):
 
     # Set the mode.
     config.extend({
-        "mode": u"sandbox",
+        "mode": u"live",
         "logfile": u"-",
     })
 

--- a/dallinger/registration.py
+++ b/dallinger/registration.py
@@ -1,0 +1,76 @@
+"""Register experiments through the Open Science Framework."""
+
+import logging
+import os
+
+import requests
+
+from dallinger.config import get_config
+
+logger = logging.getLogger(__file__)
+config = get_config()
+root = "https://api.osf.io/v2"
+
+
+def register(dlgr_id, snapshot=None):
+    """Register the experiment using configured services."""
+    try:
+        config.get("osf_access_token")
+    except KeyError:
+        pass
+    else:
+        osf_id = _create_osf_project(dlgr_id)
+        _upload_assets_to_OSF(dlgr_id, osf_id)
+
+
+def _create_osf_project(dlgr_id, description=None):
+    """Create a project on the OSF."""
+
+    if not description:
+        description = "Experiment {} registered by Dallinger.".format(
+            dlgr_id
+        )
+
+    r = requests.post(
+        "{}/nodes/".format(root),
+        data={
+            "type": "nodes",
+            "category": "project",
+            "title": "Experiment dlgr-{}".format(dlgr_id[0:8]),
+            "description": description,
+        },
+        headers={
+            "Authorization": "Bearer {}".format(config.get("osf_access_token"))
+        }
+    )
+    r.raise_for_status()
+    osf_id = r.json()['data']['id']
+
+    logger.info("Project registered on OSF at http://osf.io/{}".format(osf_id))
+
+    return osf_id
+
+
+def _upload_assets_to_OSF(dlgr_id, osf_id, provider="osfstorage"):
+    """Upload experimental assets to the OSF."""
+    root = "https://files.osf.io/v1"
+    snapshot_filename = "{}-code.zip".format(dlgr_id)
+    snapshot_path = os.path.join("snapshots", snapshot_filename)
+    r = requests.put(
+        "{}/resources/{}/providers/{}/".format(
+            root,
+            osf_id,
+            provider,
+        ),
+        params={
+            "kind": "file",
+            "name": snapshot_filename,
+        },
+        headers={
+            "Authorization": "Bearer {}".format(
+                config.get("osf_access_token")),
+            "Content-Type": "text/plain",
+        },
+        data=open(snapshot_path, 'rb'),
+    )
+    r.raise_for_status()

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -15,7 +15,7 @@ through
 
 ::
 
-    dallinger setup 
+    dallinger setup
 
 which will prepopulate a hidden file ``.dallingerconfig`` in your home
 directory. Alternatively, you can create this file yourself and fill it
@@ -110,6 +110,23 @@ And fill in the appropriate section of ``.dallingerconfig``:
     [Heroku Access]
     heroku_email_address = ???
     heroku_password = ???
+
+
+Open Science Framework (optional)
+---------------------------------
+
+There is an optional integration that uses the `Open Science Framework
+<https://osf.io/>`__ (OSF) to register experiments. First, create an account
+on the OSF. Next create a new OSF personal access token on the `OSF settings
+page <https://osf.io/settings/tokens/>`__.
+
+Finally, fill in the appropriate section of ``.dallingerconfig``:
+
+::
+
+    [OSF]
+    osf_access_token = ???
+
 
 Done?
 -----

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Laboratory automation for the behavioral and social sciences.
     monitoring_a_live_experiment
     postico_and_postgres
     command_line_utility
+    registration_on_OSF
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/registration_on_OSF.rst
+++ b/docs/source/registration_on_OSF.rst
@@ -1,0 +1,8 @@
+Registration on the OSF
+=======================
+
+Dallinger integrates with the `Open Science Framework <https://osf.io/>`__
+(OSF), creating a new OSF project and uploading your experiment code to the
+project on launch. To enable, specify a personal access token ``osf_access_token``
+in your ``.dallingerconfig`` file. You can generate a new OSF personal access
+token on the `OSF settings page <https://osf.io/settings/tokens/>`__.

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,7 @@
+
+class TestRegistration(object):
+
+    def test_registration_module(self):
+        from dallinger import registration
+        assert registration
+        assert registration.register


### PR DESCRIPTION
Dallinger now integrates with the [Open Science Framework](https://osf.io/) (OSF), creating a new OSF project and uploading experiment code to the project on launch. To enable, specify a personal access token ``osf_access_token`` in your ``.dallingerconfig`` file. You can generate a new OSF personal access token on the [OSF settings page](https://osf.io/settings/tokens/).

Next steps include uploading data to the OSF project on export.