### PR TITLE
Remove unused parameter "anonymize_data"

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -116,7 +116,7 @@ class Configuration(object):
 
         # @@@ Temporary workaround until we remove use of psiturk recruiter
         parser.add_section('Database Parameters')
-        for key in ('database_url', 'table_name', 'anonymize_data', 'database_size'):
+        for key in ('database_url', 'table_name', 'database_size'):
             parser.set('Database Parameters', key, str(self.get(key)))
         parser.add_section('Server Parameters')
         for key in ('host', 'port', 'notification_url'):
@@ -199,7 +199,6 @@ def get_config():
     default_keys = (
         ('ad_group', unicode, []),
         ('amt_keywords', unicode, []),
-        ('anonymize_data', bool, []),
         ('approve_requirement', int, []),
         ('auto_recruit', bool, []),
         ('aws_access_key_id', unicode, [], True),

--- a/demos/2048/config.txt
+++ b/demos/2048/config.txt
@@ -21,7 +21,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]

--- a/demos/bartlett1932/config.txt
+++ b/demos/bartlett1932/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]
@@ -34,4 +33,3 @@ logfile = -
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/chatroom/config.txt
+++ b/demos/chatroom/config.txt
@@ -22,7 +22,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = hobby-dev
 
 [Server Parameters]

--- a/demos/concentration/config.txt
+++ b/demos/concentration/config.txt
@@ -21,7 +21,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]

--- a/demos/function-learning/config.txt
+++ b/demos/function-learning/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = true
 database_size = standard-0
 
 [Server Parameters]
@@ -32,4 +31,3 @@ notification_url = None
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/iterated-drawing/config.txt
+++ b/demos/iterated-drawing/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]
@@ -34,4 +33,3 @@ logfile = -
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/mcmcp/config.txt
+++ b/demos/mcmcp/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]
@@ -32,4 +31,3 @@ notification_url = None
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/rogers/config.txt
+++ b/demos/rogers/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-2
 
 [Server Parameters]
@@ -32,4 +31,3 @@ notification_url = None
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/sheep-market/config.txt
+++ b/demos/sheep-market/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]
@@ -34,4 +33,3 @@ logfile = -
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-

--- a/demos/snake/config.txt
+++ b/demos/snake/config.txt
@@ -21,7 +21,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]

--- a/demos/vox-populi/config.txt
+++ b/demos/vox-populi/config.txt
@@ -20,7 +20,6 @@ browser_exclude_rule = MSIE, mobile, tablet
 [Database Parameters]
 database_url = postgresql://postgres@localhost/dallinger
 table_name = psiturk
-anonymize_data = false
 database_size = standard-0
 
 [Server Parameters]
@@ -34,4 +33,3 @@ logfile = -
 
 [Shell Parameters]
 launch_in_sandbox_mode = true
-


### PR DESCRIPTION
There's a parameter `anonymize_data` that's unused. This PR removes it. The behavior will soon be to do this anonymization by default (see `data-tools-2` branch), with a `--no-scrub` option to keep PII in the exported data.