### PR TITLE
Fix issue with README formatting on PyPI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_install:
 - rvm install 2.1.5
 - pip install --upgrade setuptools pip
 install:
-- pip install tox
+- pip install tox==2.6.0
 - gem install danger
 - gem install danger-commit_lint
 - gem install chandler

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ addons:
     - enchant
 before_install:
 - rvm install 2.1.5
-- pip install --upgrade setuptools pip
+- pip install --upgrade setuptools pip wheel
 install:
 - pip install tox==2.6.0
 - gem install danger

--- a/setup.py
+++ b/setup.py
@@ -2,20 +2,13 @@
 
 from setuptools import setup
 
-try:
-    with open('README.rst', 'r') as file:
-        long_description = file.read()
-
-except (OSError, IOError) as e:
-    with open('README.md', 'r') as file:
-        long_description = file.read()
-
 setup_args = dict(
     name='dallinger',
     packages=['dallinger', 'demos'],
     version="2.7.0",
     description='Laboratory automation for the behavioral and social sciences',
-    long_description=long_description,
+    setup_requires=['setuptools-markdown==0.2'],
+    long_description_markdown_filename='README.md',
     url='http://github.com/Dallinger/Dallinger',
     maintainer='Jordan Suchow',
     maintainer_email='suchow@berkeley.edu',

--- a/tox.ini
+++ b/tox.ini
@@ -31,3 +31,16 @@ whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt
     make -C docs html spelling
+
+[flake8]
+exclude =
+    .tox,
+    .git,
+    __pycache__,
+    docs/source/conf.py,
+    build,
+    dist,
+    *.pyc,
+    *.egg-info,
+    .cache,
+    .eggs


### PR DESCRIPTION
Fixes an issue on PyPI where the README was not being rendered correctly:

![image](https://cloud.githubusercontent.com/assets/613981/22918106/9a401912-f256-11e6-9b7b-d2a6bd4ca5ac.png)

vs.

![image](https://cloud.githubusercontent.com/assets/613981/22918109/9e0a1cc8-f256-11e6-8a16-ae5dc1029494.png)
