### PR TITLE
Log level in debug mode

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -262,6 +262,7 @@ def debug(verbose):
         logfile = os.path.join(cwd, logfile)
     config.extend({
         "mode": u"debug",
+        "loglevel": 0,
         "logfile": logfile
     })
     config.write_config()

--- a/dallinger/config/.dallingerconfig
+++ b/dallinger/config/.dallingerconfig
@@ -10,10 +10,3 @@ heroku_password = ???
 [Email Access]
 dallinger_email_address = ???
 dallinger_email_password = ???
-
-[Server]
-port = 5000
-logfile = -
-loglevel = 0
-threads = 1
-clock_on = true

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -8,5 +8,5 @@ database_url = postgresql://postgres@localhost/dallinger
 host = localhost
 port = 22362
 logfile = server.log
-loglevel = 2
+loglevel = 0
 threads = auto

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -71,8 +71,13 @@ class StandaloneServer(Application):
 
 def launch():
     config = get_config()
-    LOG_LEVELS = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR,
-                  logging.CRITICAL]
+    LOG_LEVELS = [
+        logging.DEBUG,
+        logging.INFO,
+        logging.WARNING,
+        logging.ERROR,
+        logging.CRITICAL
+    ]
     LOG_LEVEL = LOG_LEVELS[config.get('loglevel')]
     logging.basicConfig(format='%(asctime)s %(message)s', level=LOG_LEVEL)
 

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -36,13 +36,6 @@ in like so:
     dallinger_email_address = ???
     dallinger_email_password = ???
 
-    [Server]
-    port = 5000
-    logfile = -
-    loglevel = 0
-    threads = 1
-    clock_on = true
-
 In the next steps, we'll fill in your config file with keys.
 
 Amazon Web Services API Keys


### PR DESCRIPTION
This fixes an issue where `debug` mode does not open browser windows for recruitment if the log level is too high. This sets it to zero when in debug mode. Along the way, it cleans up some other log-level-related code.