### PR TITLE
Enable setting config variables through config.set

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -6,6 +6,7 @@ import distutils.util
 import imp
 import logging
 import os
+from sets import Set
 import threading
 
 from .compat import unicode
@@ -77,8 +78,11 @@ class Configuration(object):
         self.data = deque()
         self.types = {}
         self.synonyms = {}
-        self.sensitive = set()
+        self.sensitive = Set()
         self.ready = False
+
+    def set(self, key, value):
+        self.extend({key: value})
 
     def extend(self, mapping, cast_types=False, strict=False):
         normalized_mapping = {}
@@ -131,7 +135,7 @@ class Configuration(object):
         except KeyError:
             raise AttributeError
 
-    def register(self, key, type_, synonyms=set(), sensitive=False):
+    def register(self, key, type_, synonyms=Set(), sensitive=False):
         if key in self.types:
             raise KeyError('Config key {} is already registered'.format(key))
         if type_ not in self.SUPPORTED_TYPES:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -6,7 +6,6 @@ import distutils.util
 import imp
 import logging
 import os
-from sets import Set
 import threading
 
 from .compat import unicode
@@ -78,7 +77,7 @@ class Configuration(object):
         self.data = deque()
         self.types = {}
         self.synonyms = {}
-        self.sensitive = Set()
+        self.sensitive = set()
         self.ready = False
 
     def set(self, key, value):
@@ -135,7 +134,9 @@ class Configuration(object):
         except KeyError:
             raise AttributeError
 
-    def register(self, key, type_, synonyms=Set(), sensitive=False):
+    def register(self, key, type_, synonyms=None, sensitive=False):
+        if synonyms is None:
+            synonyms = set()
         if key in self.types:
             raise KeyError('Config key {} is already registered'.format(key))
         if type_ not in self.SUPPORTED_TYPES:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -128,6 +128,9 @@ class Configuration(object):
     def __getitem__(self, key):
         return self.get(key)
 
+    def __setitem__(self, key, value):
+        return self.extend({key: value})
+
     def __getattr__(self, key):
         try:
             return self.get(key)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -81,7 +81,7 @@ class Configuration(object):
         self.ready = False
 
     def set(self, key, value):
-        self.extend({key: value})
+        return self.extend({key: value})
 
     def extend(self, mapping, cast_types=False, strict=False):
         normalized_mapping = {}

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,6 +71,11 @@ class TestConfiguration(object):
         config.extend({'num_participants': 1})
         config.get('num_participants', None)
 
+    def test_setting_by_set(self):
+        config = Configuration()
+        config.ready = True
+        config.set("mode", u"live")
+
     def test_get_without_default_raises(self):
         config = Configuration()
         config.register('num_participants', int)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,11 @@ class TestConfiguration(object):
         config.ready = True
         config.set("mode", u"live")
 
+    def test_setting_by_assignment(self):
+        config = Configuration()
+        config.ready = True
+        config["mode"] = u"live"
+
     def test_get_without_default_raises(self):
         config = Configuration()
         config.register('num_participants', int)


### PR DESCRIPTION
Make it possible to set config variables via `set`:

```
config.set("mode", u"live")
```