### PR TITLE
Use DYNO environment variable

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -385,8 +385,6 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
 
         "heroku addons:create papertrail",
 
-        "heroku config:set ON_HEROKU=true",
-
         "heroku config:set HOST=" +
         app_name(id) + ".herokuapp.com",
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,9 @@ setup_args = dict(
 )
 
 # If not on Heroku, install setuptools-markdown.
-if not os.environ.get("ON_HEROKU", False):
+try:
+    os.environ["DYNO"]
+except KeyError:
     setup_args.update({
         "setup_requires": ['setuptools-markdown==0.2'],
         "long_description_markdown_filename": 'README.md',


### PR DESCRIPTION
Environment variables set by user are not available when setup.py
is run, so default to one that is alway present when on Heroku.