### PR TITLE
Remove MathJax

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ sys.path.insert(0, src)
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
-    'sphinx.ext.mathjax',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon'
 ]


### PR DESCRIPTION
MathJax, which is currently unused, causes a loading message to flash
at the bottom left corner of every documentation page. This removes
MathJax, thereby removing the flashing message.