### PR TITLE
Use heroku local for local debugging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,12 @@ matrix:
     env: TOXENV=docs
 addons:
   apt:
+    sources:
+    - heroku
     packages:
     - pandoc
     - enchant
+    - heroku-toolbelt
 before_install:
 - rvm install 2.1.5
 - pip install --upgrade setuptools pip wheel

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -267,9 +267,8 @@ def debug(verbose):
 
     # Start up the local server
     log("Starting up the server...")
-    path = os.path.realpath(os.path.join(__file__, '..', 'heroku', 'launch.py'))
     p = subprocess.Popen(
-        [sys.executable, '-u', path],
+        ['heroku', 'local'],
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
     )
@@ -277,10 +276,10 @@ def debug(verbose):
     # Wait for server to start
     ready = False
     for line in iter(p.stdout.readline, ''):
-        if re.match('^Ready.$', line):
+        sys.stdout.write(line)
+        if re.match('^.*? web.1 .*? Ready.$', line.strip()):
             ready = True
             break
-        sys.stdout.write(line)
 
     if ready:
         host = config.get('host')

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -290,7 +290,8 @@ def debug(verbose):
     # Wait for server to start
     ready = False
     for line in iter(p.stdout.readline, ''):
-        sys.stdout.write(line)
+        if verbose:
+            sys.stdout.write(line)
         if re.match('^.*? worker.1 .*? Connection refused.$', line.strip()):
             error('Could not connect to redis instance, experiment may not behave correctly.')
         if re.match('^.*? web.1 .*? Ready.$', line.strip()):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -292,9 +292,12 @@ def debug(verbose):
     for line in iter(p.stdout.readline, ''):
         if verbose:
             sys.stdout.write(line)
-        if re.match('^.*? worker.1 .*? Connection refused.$', line.strip()):
+        line = line.strip()
+        if re.match('^.*? worker.1 .*? Connection refused.$', line):
             error('Could not connect to redis instance, experiment may not behave correctly.')
-        if re.match('^.*? web.1 .*? Ready.$', line.strip()):
+        if not verbose and re.match('^.*? web.1 .*? \[ERROR\] (.*?)$', line):
+            error(line)
+        if re.match('^.*? web.1 .*? Ready.$', line):
             ready = True
             break
 

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -12,8 +12,8 @@ app = util.import_app("dallinger.experiment_server.experiment_server:app")
 
 
 def when_ready(arbiter):
-    # Signal to parent process that server has started.
-    print('Ready.')
+    # Signal to parent process that server has started
+    logger.warn('Ready.')
 
 
 class StandaloneServer(Application):

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -17,7 +17,7 @@ see something that looks like:
 
 ::
 
-    New participant requested: http://0.0.0.0:5000/ad?assignmentId=debug9TXPFF&hitId=P8UTMZ&workerId=SP7HJ4&mode=debug
+    12:00:00 PM web.1    |  2017-01-01 12:00:00,000 New participant requested: http://0.0.0.0:5000/ad?assignmentId=debug9TXPFF&hitId=P8UTMZ&workerId=SP7HJ4&mode=debug
 
 and your browser should automatically open to this URL.
 You can start interacting as the first participant in the experiment.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -96,12 +96,11 @@ etc. <aws_etc_keys>`.
 Install Heroku
 ^^^^^^^^^^^^^^
 
-To run experiments locally or on the internet you need the Heroku Command Line
-Interface installed. You need at least version 3.28.0 to use Dallinger. You
-only need a Heroku account to launch experiments on the internet, you do not
-need it for local debugging.
+To run experiments locally or on the internet, you will need the Heroku Command
+Line Interface installed, version 3.28.0 or better. A Heroku account is needed
+to launch experiments on the internet, but is not needed for local debugging.
 
-You can check your currently installed version by running:
+To check which version of the Heroku CLI you have installed, run:
 
 ::
 
@@ -110,12 +109,9 @@ You can check your currently installed version by running:
 The Heroku CLI is available for download from
 `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
 
-Install redis
+Install Redis
 ^^^^^^^^^^^^^
 
-Accurate debugging of experiments also requires you to have redis
-installed. If this is not installed you may find that local participant
-data does not get updated as you progress through the experiment.
-
-You can find installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
-
+Debugging experiments requires you to have Redis installed and the Redis
+server running. You can find installation instructions at
+`redis.com <https://redis.io/topics/quickstart>`__.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -91,3 +91,31 @@ you can move on.
 
 Next, you'll need :doc:`access keys for AWS, Heroku,
 etc. <aws_etc_keys>`.
+
+
+Install Heroku
+^^^^^^^^^^^^^^
+
+To run experiments locally or on the internet you need the Heroku Command Line
+Interface installed. You need at least version 3.28.0 to use Dallinger. You
+only need a Heroku account to launch experiments on the internet, you do not
+need it for local debugging.
+
+You can check your currently installed version by running:
+
+::
+
+    heroku --version
+
+The Heroku CLI is available for download from
+`heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
+
+Install redis
+^^^^^^^^^^^^^
+
+Accurate debugging of experiments also requires you to have redis
+installed. If this is not installed you may find that local participant
+data does not get updated as you progress through the experiment.
+
+You can find installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ description-file = README.md
 
 [flake8]
 max-line-length = 100
-exclude = bin,lib,src,.git,.tox
+exclude = bin,lib,src,.git,.tox,.eggs

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -137,7 +137,7 @@ class TestDebugServer(object):
     def test_startup(self):
         # Make sure debug server starts without error
         p = pexpect.spawn('dallinger', ['debug'])
-        p.expect_exact('Server is running')
+        p.expect_exact('Server is running', timeout=120)
         p.sendcontrol('c')
         p.read()
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -2,7 +2,10 @@
 # -*- coding: utf-8 -*-
 import filecmp
 import os
+import shutil
 import subprocess
+import sys
+import tempfile
 from ConfigParser import NoOptionError, SafeConfigParser
 
 import pexpect
@@ -135,11 +138,25 @@ class TestDebugServer(object):
         os.chdir(self.orig_dir)
 
     def test_startup(self):
+        # Heroku requires a home directory to start up
+        # We create a fake one using tempfile and set it into the
+        # environment to handle sandboxes on CI servers
+        fake_home = tempfile.mkdtemp()
         # Make sure debug server starts without error
-        p = pexpect.spawn('dallinger', ['debug'])
-        p.expect_exact('Server is running', timeout=120)
-        p.sendcontrol('c')
-        p.read()
+        try:
+            environ = os.environ.copy()
+            environ.update({'HOME': fake_home})
+            p = pexpect.spawn(
+                'dallinger',
+                ['debug', '--verbose'],
+                env=environ,
+            )
+            p.logfile = sys.stdout
+            p.expect_exact('Server is running', timeout=120)
+            p.sendcontrol('c')
+            p.read()
+        finally:
+            shutil.rmtree(fake_home)
 
 
 class TestHeader(object):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -158,9 +158,38 @@ class TestDebugServer(object):
         finally:
             shutil.rmtree(fake_home)
 
+    def test_warning_if_no_heroku_present(self):
+        # Heroku requires a home directory to start up
+        # We create a fake one using tempfile and set it into the
+        # environment to handle sandboxes on CI servers
+        fake_home = tempfile.mkdtemp()
+        # Make sure debug server starts without error
+        try:
+            environ = os.environ.copy()
+            # Remove the path item that has heroku in it
+            path_items = environ['PATH'].split(':')
+            path_items = [
+                item for item in path_items
+                if not os.path.exists(os.path.join(item, 'heroku'))
+            ]
+            environ.update({
+                'HOME': fake_home,
+                'PATH': ':'.join(path_items)
+            })
+            p = pexpect.spawn(
+                'dallinger',
+                ['debug', '--verbose'],
+                env=environ,
+            )
+            p.logfile = sys.stdout
+            p.expect_exact("Couldn't start Heroku for local debugging", timeout=120)
+            p.sendcontrol('c')
+            p.read()
+        finally:
+            shutil.rmtree(fake_home)
+
 
 class TestHeader(object):
-
     def test_header_contains_version_number(self):
         # Make sure header contains the version number.
         assert dallinger.version.__version__ in dallinger.command_line.header


### PR DESCRIPTION
This change sets the debug command line tool to use heroku's local plugin rather than directly invoking scripts.

## Description
The `dallinger debug` command now calls `heroku local` in the context of the created experiment, delegating responsibility for invoking processes to heroku itself. This adds a heroku dependency for users not planning on launching real experiments, who otherwise wouldn't need it. It also makes the debugging more representative of real experiments.

In addition, this tidies some of the output of the debug command to make it more user friendly, and updates documentation.

## Motivation and Context
This makes the debug command much more representative of how real applications are deployed. Specifically, it is now possible to rely on workers and clocks being available in debug mode.

## How Has This Been Tested?
Manual testing only. 

## Screenshots (if appropriate):
N/A