### PR TITLE
Be sure to specify the region when connecting to boto

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -209,11 +209,14 @@ def export(id, local=False, scrub_pii=False):
     return path_to_data
 
 
-def user_s3_bucket():
+def user_s3_bucket(canonical_user_id=None):
     """Get the user's S3 bucket."""
     conn = _s3_connection()
+    if not canonical_user_id:
+        canonical_user_id = conn.get_canonical_user_id()
+
     s3_bucket_name = "dallinger-{}".format(
-        hashlib.sha256(conn.get_canonical_user_id()).hexdigest()[0:8])
+        hashlib.sha256(canonical_user_id).hexdigest()[0:8])
 
     if not conn.lookup(s3_bucket_name):
         bucket = conn.create_bucket(

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -238,9 +238,10 @@ def _s3_connection():
     if not config.ready:
         config.load()
 
-    return boto.connect_s3(
-        config.get('aws_access_key_id'),
-        config.get('aws_secret_access_key'),
+    return boto.s3.connect_to_region(
+        config.get('aws_region'),
+        aws_access_key_id=config.get('aws_access_key_id'),
+        aws_secret_access_key=config.get('aws_secret_access_key'),
     )
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -7,6 +7,7 @@ import pandas as pd
 
 import dallinger
 from dallinger.config import get_config
+from dallinger.utils import generate_random_id
 
 
 class TestData(object):
@@ -18,6 +19,32 @@ class TestData(object):
     )
 
     config = get_config()
+
+    def test_connection_to_s3(self):
+        conn = dallinger.data._s3_connection()
+        assert conn
+
+    def test_user_s3_bucket_first_time(self):
+        conn = dallinger.data._s3_connection()
+        bucket = dallinger.data.user_s3_bucket(
+            canonical_user_id=generate_random_id(),
+        )
+        assert bucket
+        conn.delete_bucket(bucket)
+
+    def test_user_s3_bucket_thrice(self):
+        conn = dallinger.data._s3_connection()
+        id = generate_random_id()
+        for i in range(3):
+            bucket = dallinger.data.user_s3_bucket(
+                canonical_user_id=id,
+            )
+            assert bucket
+        conn.delete_bucket(bucket)
+
+    def test_user_s3_bucket_no_id_provided(self):
+        bucket = dallinger.data.user_s3_bucket()
+        assert bucket
 
     def test_dataset_creation(self):
         """Load a dataset."""


### PR DESCRIPTION
## Description
This changes the boto API used to connect to S3 to one that is more explicit about which AWS region to use.

## Motivation and Context
This fixes a `IllegalLocationConstraintException` error I was getting in tests.

## How Has This Been Tested?
I checked that I can successfully connect to S3 using this function with a couple different AWS accounts, and I ran tox.
