### PR TITLE
Add version number to header

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -41,20 +41,18 @@ from dallinger.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
+header = """
+    ____        ____
+   / __ \____ _/ / (_)___  ____ ____  _____
+  / / / / __ `/ / / / __ \/ __ `/ _ \/ ___/
+ / /_/ / /_/ / / / / / / / /_/ /  __/ /
+/_____/\__,_/_/_/_/_/ /_/\__, /\___/_/
+                        /____/
+                                 {:>8}
 
-def print_header():
-    """Print a fancy-looking header."""
-    log("""
-        ____        ____
-       / __ \____ _/ / (_)___  ____ ____  _____
-      / / / / __ `/ / / / __ \/ __ `/ _ \/ ___/
-     / /_/ / /_/ / / / / / / / /_/ /  __/ /
-    /_____/\__,_/_/_/_/_/ /_/\__, /\___/_/
-                            /____/
-
-                    Laboratory automation for
-           the behavioral and social sciences.
-    """, 0.5, False)
+                Laboratory automation for
+       the behavioral and social sciences.
+""".format("v" + __version__)
 
 
 def log(msg, delay=0.5, chevrons=True, verbose=True):
@@ -96,7 +94,7 @@ def setup():
 
 def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     """Check the app and, if compatible with Dallinger, freeze its state."""
-    print_header()
+    log(header, chevrons=False)
 
     # Verify that the package is usable.
     log("Verifying that directory is compatible with Dallinger...")
@@ -653,7 +651,7 @@ def awaken(app, databaseurl):
               help='Scrub PII')
 def export(app, local, no_scrub):
     """Export the data."""
-    print_header()
+    log(header, chevrons=False)
     data.export(str(app), local=local, scrub_pii=(not no_scrub))
 
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -2,12 +2,16 @@
 # -*- coding: utf-8 -*-
 import filecmp
 import os
-import pexpect
 import subprocess
+from ConfigParser import NoOptionError, SafeConfigParser
+
+import pexpect
 from pytest import raises
-from ConfigParser import SafeConfigParser, NoOptionError
+
+import dallinger.command_line
 from dallinger.compat import unicode
-from dallinger.config import get_config, LOCAL_CONFIG
+from dallinger.config import LOCAL_CONFIG, get_config
+import dallinger.version
 
 
 class TestCommandLine(object):
@@ -136,3 +140,10 @@ class TestDebugServer(object):
         p.expect_exact('Server is running')
         p.sendcontrol('c')
         p.read()
+
+
+class TestHeader(object):
+
+    def test_header_contains_version_number(self):
+        # Make the header contains the version number
+        assert dallinger.version.__version__ in dallinger.command_line.header

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -145,5 +145,5 @@ class TestDebugServer(object):
 class TestHeader(object):
 
     def test_header_contains_version_number(self):
-        # Make the header contains the version number
+        # Make sure header contains the version number.
         assert dallinger.version.__version__ in dallinger.command_line.header


### PR DESCRIPTION
Closes #200.

## Description
Prints the version number in the header.

## Motivation and Context
This is useful because when people share log output errors, we can verify that they're using the stated version of Dallinger.

## How Has This Been Tested?
Test added to suite.

## Screenshots (if appropriate):
```
❯ dallinger debug --verbose

    ____        ____
   / __ \____ _/ / (_)___  ____ ____  _____
  / / / / __ `/ / / / __ \/ __ `/ _ \/ ___/
 / /_/ / /_/ / / / / / / / /_/ /  __/ /
/_____/\__,_/_/_/_/_/ /_/\__, /\___/_/
                        /____/
                                   v2.7.0

                Laboratory automation for
       the behavioral and social sciences.
```