### PR TITLE
Don't execute subprocess commands in shell

### DIFF
--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -10,3 +10,4 @@ port = 22362
 logfile = server.log
 loglevel = 0
 threads = auto
+whimsical = true

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -35,8 +35,7 @@ def scale_up_dynos(app):
             "heroku",
             "ps:scale",
             "{}={}:{}".format(process, num_dynos[process], dyno_type),
-            "--app",
-            app,
+            "--app", app,
         ])
 
     if config.get('clock_on'):
@@ -44,6 +43,5 @@ def scale_up_dynos(app):
             "heroku",
             "ps:scale",
             "clock=1:{}".format(dyno_type),
-            "--app",
-            app,
+            "--app", app,
         ])

--- a/demos/rogers/tests/tests.py
+++ b/demos/rogers/tests/tests.py
@@ -39,18 +39,14 @@ class TestRogers(object):
 
         autobots = 36
 
-        sandbox_output = subprocess.check_output(
-            "dallinger sandbox",
-            shell=True)
+        sandbox_output = subprocess.check_output(["dallinger", "sandbox"])
 
         m = re.search('Running as experiment (.*)...', sandbox_output)
         exp_id = m.group(1)
         url = "http://" + exp_id + ".herokuapp.com"
 
         # Open the logs in the browser.
-        subprocess.call(
-            "dallinger logs --app " + exp_id,
-            shell=True)
+        subprocess.call(["dallinger", "log", "--app", exp_id])
 
         def autobot(session, url, i):
             """Define the behavior of each worker."""

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -24,7 +24,7 @@ class TestCommandLine(object):
         os.chdir("..")
 
     def test_dallinger_help(self):
-        output = subprocess.check_output("dallinger", shell=True)
+        output = subprocess.check_output(["dallinger"])
         assert("Usage: dallinger [OPTIONS] COMMAND [ARGS]" in output)
 
 


### PR DESCRIPTION
Removes all instances of `shell=True`. Closes #353.