### PR TITLE
Move chatroom waiting room implementation to core

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -220,6 +220,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
         os.path.join("templates", "launch.html"),
         os.path.join("templates", "complete.html"),
         os.path.join("templates", "thanks.html"),
+        os.path.join("templates", "waiting.html"),
         os.path.join("static", "robots.txt")
     ]
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -96,6 +96,12 @@ class Experiment(object):
             "Transformation": Transformation,
         }
 
+        #: dictionary, the properties of this experiment that are exposed
+        #: to the public over an AJAX call
+        if not hasattr(self, 'public_properties'):
+            # Guard against subclasses replacing this with a @property
+            self.public_properties = {}
+
     @property
     def recruiter(self):
         """Recruiter, the Dallinger class that recruits participants.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -365,8 +365,11 @@ def summary():
 def experiment_property(prop):
     """Get a property of the experiment by name."""
     exp = Experiment(session)
-    p = getattr(exp, prop)
-    return success_response(field=prop, data=p, request_type=prop)
+    try:
+        value = exp.public_properties[prop]
+    except KeyError:
+        abort(404)
+    return success_response(field=prop, data=value, request_type=prop)
 
 
 @app.route("/<page>", methods=["GET"])

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -151,3 +151,33 @@ submitNextResponse = function (n) {
         }
     });
 };
+
+waitForQuorum = function () {
+    reqwest({
+        url: "/summary",
+        method: "get",
+        success: function (resp) {
+            summary = resp.summary;
+            n = numReady(resp.summary);
+            percent = Math.round((n/quorum)*100.0) + "%";
+            $("#waiting-progress-bar").css("width", percent);
+            $("#progress-percentage").text(percent);
+            if (n >= quorum) {
+                allow_exit();
+                go_to_page("exp");
+            } else {
+                setTimeout(function(){
+                    waitForQuorum();
+                }, 1000);
+            }
+        }
+    });
+};
+
+numReady = function(summary) {
+    for (var i = 0; i < summary.length; i++) {
+        if (summary[i][0] == "working") {
+            return summary[i][1];
+        }
+    }
+};

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -1,7 +1,6 @@
 <!doctype html>
 <html>
     <head>
-        <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
         <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
         <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
         <script src="/static/scripts/dallinger.js" type="text/javascript"> </script>

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -21,7 +21,9 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.experiment_repeats = 1
         self.num_participants = config.get('n')
         self.initial_recruitment_size = self.num_participants
-        self.quorum = self.num_participants
+        self.public_properties = {
+            'quorum': self.num_participants
+        }
         self.config = config
         if not self.config.ready:
             self.config.load()

--- a/demos/chatroom/static/scripts/experiment.js
+++ b/demos/chatroom/static/scripts/experiment.js
@@ -165,32 +165,3 @@ getQuorum = function () {
     });
 };
 
-waitForQuorum = function () {
-    reqwest({
-        url: "/summary",
-        method: "get",
-        success: function (resp) {
-            summary = resp.summary;
-            n = numReady(resp.summary);
-            percent = Math.round((n/quorum)*100.0) + "%";
-            $("#waiting-progress-bar").css("width", percent);
-            $("#progress-percentage").text(percent);
-            if (n >= quorum) {
-                allow_exit();
-                go_to_page("exp");
-            } else {
-                setTimeout(function(){
-                    waitForQuorum();
-                }, 1000);
-            }
-        }
-    });
-};
-
-numReady = function(summary) {
-    for (var i = 0; i < summary.length; i++) {
-        if (summary[i][0] == "working") {
-            return summary[i][1];
-        }
-    }
-};

--- a/demos/rogers/experiment.py
+++ b/demos/rogers/experiment.py
@@ -43,6 +43,13 @@ class RogersExperiment(Experiment):
             self.setup()
         self.save()
 
+    @property
+    def public_properties(self):
+        return {
+            'practice_repeats': self.practice_repeats,
+            'experiment_repeats': self.experiment_repeats,
+        }
+
     def setup(self):
         """First time setup."""
         super(RogersExperiment, self).setup()

--- a/docs/source/learning_to_use_dallinger.rst
+++ b/docs/source/learning_to_use_dallinger.rst
@@ -41,6 +41,7 @@ Experimental design
 -  Using properties 1 through 5
 -  Processes
 -  Failing
+-  :doc:`waiting_rooms`
 
 Running experiments
 '''''''''''''''''''

--- a/docs/source/required_experimental_files.rst
+++ b/docs/source/required_experimental_files.rst
@@ -43,6 +43,8 @@ name. The files are as follows:
    something goes wrong.
 -  launch.html - this page is shown when the /launch route is pinged and
    the experiment starts successfully.
+-  waiting.html - this page shows a standard waiting room for experiments
+   that require multiple users at once.
 -  robots.txt - this file is returned to bots (e.g. from Google) that
    bump into the experiment when crawling the internet.
 -  dallinger.js - this is a javascript library with a number of helpful

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -60,6 +60,7 @@ Redis
 Richerson
 Sanborn
 Senghas
+serializable
 Sforza
 Shiffrin
 silico

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -36,6 +36,9 @@ what to do with the database when the server receives requests from outside.
   .. autoinstanceattribute:: known_classes
     :annotation:
 
+  .. autoinstanceattribute:: public_properties
+    :annotation:
+
   .. automethod:: __init__
 
   .. automethod:: add_node_to_network

--- a/docs/source/waiting_rooms.rst
+++ b/docs/source/waiting_rooms.rst
@@ -1,0 +1,24 @@
+Waiting rooms
+=============
+
+By default, Dallinger begins an experiment as soon as a user agrees to
+the informed consent form and has read the instructions. However, some
+experiment designs require multiple users to be synchronized.
+
+For this reason, Dallinger includes a waiting room implementation, which
+will hold users between instructions and the experiment until a certain
+number are ready.
+
+Using the waiting room
+^^^^^^^^^^^^^^^^^^^^^^
+
+To use the waiting room, users must first be directed into it rather than
+the experiment. The :doc:`demos/chatroom/index` demo shows an example of this.
+
+Your ``instructions.html`` should call ``go_to_page('waiting')`` and should
+not call ``create_participant``.
+
+You will also need to define how many users should be held together before
+progressing. This is done through the ``quorum`` global variable. The waiting
+room will call a javascript function called ``getQuorum`` which should set
+quorum to be the appropriate value for your experiment.

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -47,6 +47,9 @@ Experiment routes
     GET /experiment/<property>
 
 Returns the value of the requested property as a JSON ``<property>``.
+The property must be a key in the ``experiment.public_properties``
+mapping and be JSON serializable. Experiments have no public properties
+by default.
 
 ::
 

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -12,6 +12,10 @@ class TestExperiment(Experiment):
         self.experiment_repeats = 1
         self.setup()
 
+    @property
+    def public_properties(self):
+        return {'exists': True}
+
     def create_network(self):
         """Return a new network."""
         return Star(max_size=2)

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -184,6 +184,18 @@ class TestExperimentServer(FlaskAppTest):
         assert worker_summary[0] == [u'approved', 1]
         assert worker_summary[1] == [u'submitted', 1]
 
+    def test_existing_experiment_property(self):
+        p_id = self._create_participant()
+        resp = self.app.get('/experiment/exists'.format(p_id))
+        data = json.loads(resp.data)
+        assert data.get('status') == 'success'
+        assert data.get('exists') is True
+
+    def test_nonexisting_experiment_property(self):
+        p_id = self._create_participant()
+        resp = self.app.get('/experiment/missing'.format(p_id))
+        assert resp.status_code == 404
+
     def test_not_found(self):
         resp = self.app.get('/BOGUS')
         assert resp.status_code == 404


### PR DESCRIPTION
This moves the chatroom implementation of the waiting room to core and begins documentation.

## Description
The chatroom implementation of the waiting room has been moved into core Dallinger, using the same functionality. The reliance on global variables and polling has not been removed.

## Motivation and Context
This is an intermediate step towards high quality waiting rooms, by making the existing chatroom implementation the standard.

## How Has This Been Tested?
Additional unit tests for formalised interfaces, manual testing of chatroom and of instructions to apply waiting room to other experiments (using the snake demo).

## Screenshots (if appropriate):
N/A