### PR TITLE
Simplify configuration API naming

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -113,7 +113,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     # Load configuration.
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
 
     # Check that the demo-specific requirements are satisfied.
     try:
@@ -342,7 +342,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
     # Load configuration.
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
 
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
@@ -482,7 +482,7 @@ def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
     # Load configuration.
     config = get_config()
-    config.load_config()
+    config.load()
 
     # Set the mode.
     config.extend({
@@ -501,7 +501,7 @@ def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
     # Load configuration.
     config = get_config()
-    config.load_config()
+    config.load()
 
     # Set the mode.
     config.extend({
@@ -520,7 +520,7 @@ def deploy(verbose, app):
 def qualify(qualification, value, worker):
     """Assign a qualification to a worker."""
     config = get_config()
-    config.load_config()
+    config.load()
     mturk = MTurkService(
         aws_access_key_id=config.get('aws_access_key_id'),
         aws_secret_access_key=config.get('aws_secret_access_key'),
@@ -607,7 +607,7 @@ def awaken(app, databaseurl):
     """Restore the database from a given url."""
     id = app
     config = get_config()
-    config.load_config()
+    config.load()
 
     database_size = config.get('database_size')
 

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -158,7 +158,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     if exp_config:
         config.extend(exp_config)
 
-    config.write_config(filter_sensitive=True)
+    config.write(filter_sensitive=True)
 
     # Zip up the temporary directory and place it in the cwd.
     if not debug:
@@ -263,7 +263,7 @@ def debug(verbose):
         "loglevel": 0,
         "logfile": logfile
     })
-    config.write_config()
+    config.write()
 
     # Start up the local server
     log("Starting up the server...")
@@ -439,7 +439,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         "notification_url": u"http://" + app_name(id) + ".herokuapp.com/notifications",
         "database_url": db_url.rstrip().decode('utf8'),
     })
-    config.write_config()
+    config.write()
 
     subprocess.check_call("git add config.txt", stdout=out, shell=True),
     time.sleep(0.25)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -179,7 +179,7 @@ class Configuration(object):
     def load_from_environment(self):
         self.extend(os.environ, cast_types=True)
 
-    def load_config(self):
+    def load(self):
         if self.ready:
             raise ValueError("Already loaded")
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -163,7 +163,7 @@ class Configuration(object):
             data.update(dict(parser.items(section)))
         self.extend(data, cast_types=True, strict=True)
 
-    def write_config(self, filter_sensitive=False):
+    def write(self, filter_sensitive=False):
         parser = SafeConfigParser()
         parser.add_section('Parameters')
         for layer in reversed(self.data):

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -155,7 +155,7 @@ class Configuration(object):
         if sensitive:
             self.sensitive.add(key)
 
-    def load_from_config_file(self, filename):
+    def load_from_file(self, filename):
         parser = SafeConfigParser()
         parser.read(filename)
         data = {}
@@ -200,10 +200,10 @@ class Configuration(object):
             local_defaults_file,
             globalConfig,
         ]:
-            self.load_from_config_file(config_file)
+            self.load_from_file(config_file)
 
         if os.path.exists(localConfig):
-            self.load_from_config_file(localConfig)
+            self.load_from_file(localConfig)
 
         self.load_from_environment()
         self.ready = True

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -236,7 +236,7 @@ def _s3_connection():
     """An S3 connection using the AWS keys in the config."""
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
 
     return boto.connect_s3(
         config.get('aws_access_key_id'),

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -39,7 +39,7 @@ def exp_class_working_dir(meth):
             )
             os.chdir(new_path)
             # Override configs
-            config.load_from_config_file(LOCAL_CONFIG)
+            config.load_from_file(LOCAL_CONFIG)
             return meth(self, *args, **kwargs)
         finally:
             os.chdir(orig_path)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -37,7 +37,7 @@ from .utils import nocache
 
 config = get_config()
 if not config.ready:
-    config.load_config()
+    config.load()
 
 # Initialize the Dallinger database.
 session = db.session

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -147,7 +147,7 @@ def check_db_for_missing_notifications():
 
 def launch():
     if not config.ready:
-        config.load_config()
+        config.load()
     scheduler.start()
 
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -21,7 +21,7 @@ def scale_up_dynos(app):
     """Scale up the Heroku dynos."""
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
 
     dyno_type = config.get('dyno_type')
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -94,7 +94,7 @@ class MTurkRecruiter(object):
     def from_current_config(cls):
         config = get_config()
         if not config.ready:
-            config.load_config()
+            config.load()
         ad_url = '{}/ad'.format(get_base_url())
         hit_domain = os.getenv('HOST')
         return cls(config, hit_domain, ad_url)

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -24,7 +24,7 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.quorum = self.num_participants
         self.config = config
         if not self.config.ready:
-            self.config.load_config()
+            self.config.load()
         self.setup()
 
     def create_network(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def aws_creds():
     from dallinger.config import get_config
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
     creds = {
         'aws_access_key_id': config.get('aws_access_key_id'),
         'aws_secret_access_key': config.get('aws_secret_access_key')

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -35,7 +35,7 @@ class TestSetupExperiment(object):
         self.orig_dir = os.getcwd()
         os.chdir("demos/bartlett1932")
         config = get_config()
-        config.load_from_config_file(LOCAL_CONFIG)
+        config.load_from_file(LOCAL_CONFIG)
 
     def teardown(self):
         os.chdir(self.orig_dir)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,7 +140,7 @@ num_participants = 10
 worldwide = false
 """)
             configfile.flush()
-            config.load_from_config_file(configfile.name)
+            config.load_from_file(configfile.name)
         config.ready = True
         assert config.get('num_participants') == 10
         assert config.get('deploy_worldwide') is False

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -18,7 +18,7 @@ def run_check():
     os.chdir('tests/experiment')
     config = get_config()
     if not config.ready:
-        config.load_config()
+        config.load()
     # Import the FUT here, after config load, and return it
     from dallinger.heroku.clock import run_check
     yield run_check

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -33,7 +33,7 @@ class TestHotAirRecruiter(object):
         os.chdir('tests/experiment')
         config = get_config()
         if not config.ready:
-            config.load_config()
+            config.load()
         yield HotAirRecruiter()
         os.chdir('../..')
 


### PR DESCRIPTION
Simplifies the configuration API naming.

## Description

Before:
`config.load_config()`
`config.write_config()`
`config.load_from_config_file()`

After:
`config.load()`
`config.write()`
`config.load_from_file()`

## Motivation and Context
Removes redundancy.

## How Has This Been Tested?
All hit by the test suite.

