### PR TITLE
Waiting room improvements

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -296,7 +296,8 @@ def debug(verbose, bot):
     except OSError:
         error("Couldn't start Heroku for local debugging.")
         raise
-    else:
+
+    try:
         # Wait for server to start
         ready = False
         for line in iter(p.stdout.readline, ''):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -360,7 +360,7 @@ def debug(verbose, bot):
 
                 # Check for bot exceptions
                 match = re.search('Exception on ', line)
-                if match:
+                if match and not verbose:
                     error("There was an error running the experiment.")
                     if participant:
                         participant.driver.quit()

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -119,7 +119,7 @@ class Experiment(object):
             # Config not yet loaded
             debug_mode = False
 
-        recruiter = config.get('recruiter')
+        recruiter = config.get('recruiter', None)
         if debug_mode and recruiter != 'bots':
             return HotAirRecruiter
         if recruiter == 'bots':

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -3,7 +3,6 @@
 from datetime import datetime
 from json import dumps
 from operator import attrgetter
-import json
 import re
 import traceback
 import user_agents
@@ -532,7 +531,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     if quorum:
         count = models.Participant.query.filter_by(
             status='working').count()
-        message = json.dumps({
+        message = dumps({
             'q': quorum,
             'n': count,
         })

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -528,7 +528,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
 
     # Notify waiting room
     experiment = Experiment(session)
-    quorum = getattr(experiment, 'quorum', None)
+    quorum = experiment.public_properties.get('quorum')
     if quorum:
         count = models.Participant.query.filter_by(
             status='working').count()

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger(__file__)
 
-app = util.import_app("dallinger.experiment_server.experiment_server:app")
+WORKER_CLASS = 'geventwebsocket.gunicorn.workers.GeventWebSocketWorker'
 
 
 def when_ready(arbiter):
@@ -45,7 +45,7 @@ class StandaloneServer(Application):
 
     def load(self):
         """Return our application to be run."""
-        return app
+        return util.import_app("dallinger.experiment_server.sockets:app")
 
     def load_user_config(self):
         config = get_config()
@@ -59,6 +59,7 @@ class StandaloneServer(Application):
         self.options = {
             'bind': bind_address,
             'workers': workers,
+            'worker_class': WORKER_CLASS,
             'loglevels': self.loglevels,
             'loglevel': self.loglevels[config.get("loglevel")],
             'accesslog': config.get("logfile"),
@@ -71,6 +72,7 @@ class StandaloneServer(Application):
 
 def launch():
     config = get_config()
+    config.load_config()
     LOG_LEVELS = [
         logging.DEBUG,
         logging.INFO,

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -4,6 +4,7 @@ from ..heroku.worker import conn
 from flask_sockets import Sockets
 from redis import ConnectionError
 import gevent
+import socket
 
 sockets = Sockets(app)
 
@@ -53,7 +54,7 @@ class ChatBackend(object):
         """
         try:
             client.send(data)
-        except:
+        except socket.error:
             for channel in self.clients:
                 self.unsubscribe(client, channel)
 

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -1,0 +1,86 @@
+from flask_sockets import Sockets
+from .experiment_server import app
+from .experiment_server import WAITING_ROOM_CHANNEL
+from ..heroku.worker import conn
+import gevent
+
+sockets = Sockets(app)
+
+CHANNELS = [
+    WAITING_ROOM_CHANNEL
+]
+
+
+class ChatBackend(object):
+    """Chat backend which relays messages from a redis pubsub to clients.
+
+    This is run by each web process; all processes receive the messages.
+
+    Inspired by https://devcenter.heroku.com/articles/python-websockets
+    """
+
+    def __init__(self):
+        self.pubsub = conn.pubsub()
+        self.pubsub.subscribe(CHANNELS)
+        app.logger.debug('Subscribed to channels: {}'.format(CHANNELS))
+
+        self.clients = {}
+        for channel in CHANNELS:
+            self.clients[channel] = []
+
+    def subscribe(self, client, channel=None):
+        """Register a new client to receive messages."""
+        if channel is not None:
+            if channel not in self.channels:
+                raise ValueError('Unknown channel: {}'.format(channel))
+            self.clients[channel].append(client)
+        else:
+            for channel in CHANNELS:
+                self.clients[channel].append(client)
+
+    def unsubscribe(self, client, channel):
+        if client in self.clients[channel]:
+            self.clients[channel].remove(client)
+
+    def send(self, client, data):
+        """Send data to one client.
+
+        Automatically discards invalid connections.
+        """
+        try:
+            client.send(data)
+        except:
+            for channel in self.clients:
+                self.unsubscribe(client, channel)
+
+    def run(self):
+        """Listens for new messages in redis, and sends them to clients."""
+        for message in self.pubsub.listen():
+            data = message.get('data')
+            if message['type'] == 'message':
+                channel = message['channel']
+                count = len(self.clients[channel])
+                if count:
+                    app.logger.debug(
+                        'Relaying message on channel {} to {} clients: {}'.format(
+                            channel, len(self.clients[channel]), data))
+                    for client in self.clients[channel]:
+                        gevent.spawn(
+                            self.send, client, '{}:{}'.format(channel, data))
+
+    def start(self):
+        """Starts listening in the background."""
+        gevent.spawn(self.run)
+
+
+chats = ChatBackend()
+chats.start()
+
+
+@sockets.route('/receive_chat')
+def outbox(ws):
+    chats.subscribe(ws)
+
+    while not ws.closed:
+        # Wait for chat backend
+        gevent.sleep(0.1)

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -91,7 +91,10 @@ create_participant = function() {
             mode;
     }
 
-    if (participant_id === undefined || participant_id === "undefined") {
+    var deferred = $.Deferred();
+    if (participant_id !== undefined && participant_id !== 'undefined') {
+        deferred.resolve();
+    } else {
         reqwest({
             url: url,
             method: "post",
@@ -99,6 +102,7 @@ create_participant = function() {
             success: function(resp) {
                 console.log(resp);
                 participant_id = resp.participant.id;
+                deferred.resolve();
             },
             error: function (err) {
                 errorResponse = JSON.parse(err.response);
@@ -106,6 +110,7 @@ create_participant = function() {
             }
         });
     }
+    return deferred;
 };
 
 lock = false;
@@ -155,6 +160,7 @@ submitNextResponse = function (n) {
 waitForQuorum = function () {
     var ws_scheme = (window.location.protocol === "https:") ? 'wss://' : 'ws://';
     var inbox = new ReconnectingWebSocket(ws_scheme + location.host + "/receive_chat");
+    var deferred = $.Deferred();
     inbox.onmessage = function (msg) {
         if (msg.data.indexOf('quorum:') !== 0) { return; }
         var data = JSON.parse(msg.data.substring(7));
@@ -164,10 +170,10 @@ waitForQuorum = function () {
         $("#waiting-progress-bar").css("width", percent);
         $("#progress-percentage").text(percent);
         if (n >= quorum) {
-            allow_exit();
-            go_to_page("exp");
+            deferred.resolve();
         }
     };
+    return deferred;
 };
 
 numReady = function(summary) {

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -20,8 +20,13 @@
             </div>
         </div>
         <script type="text/javascript">
-            waitForQuorum();
-            create_participant();
+            var awaitingQuorum = waitForQuorum();
+            var creatingParticipant = create_participant();
+            // wait for both deferreds to resolve
+            $.when(awaitingQuorum, create_participant).done(function () {
+                allow_exit();
+                go_to_page("exp");
+            });
         </script>
     </body>
 </html>

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -2,9 +2,10 @@
 <html>
     <head>
         <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
-        <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-        <script src="/static/scripts/dallinger.js" type="text/javascript"> </script>
-        <script src="/static/scripts/experiment.js" type="text/javascript"> </script>
+        <script src="/static/scripts/reqwest.min.js" type="text/javascript"></script>
+        <script src="/static/scripts/reconnecting-websocket.js"></script>
+        <script src="/static/scripts/dallinger.js" type="text/javascript"></script>
+        <script src="/static/scripts/experiment.js" type="text/javascript"></script>
         <link rel="stylesheet" type="text/css" href="static/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="static/css/dallinger.css">
     </head>
@@ -17,10 +18,9 @@
                 </div>
             </div>
         </div>
-        <script>
-            create_participant();
-            getQuorum();
+        <script type="text/javascript">
             waitForQuorum();
+            create_participant();
         </script>
     </body>
 </html>

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <html>
     <head>
+        <script src="/static/scripts/store+json2.min.js" type="text/javascript"></script>
         <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
         <script src="/static/scripts/reqwest.min.js" type="text/javascript"></script>
         <script src="/static/scripts/reconnecting-websocket.js"></script>

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -23,7 +23,7 @@
             var awaitingQuorum = waitForQuorum();
             var creatingParticipant = create_participant();
             // wait for both deferreds to resolve
-            $.when(awaitingQuorum, create_participant).done(function () {
+            $.when(awaitingQuorum, creatingParticipant).done(function () {
                 allow_exit();
                 go_to_page("exp");
             });

--- a/demos/chatroom/static/scripts/experiment.js
+++ b/demos/chatroom/static/scripts/experiment.js
@@ -153,15 +153,3 @@ $(document).keypress(function (e) {
     return false;
   }
 });
-
-quorum = 1e6;
-getQuorum = function () {
-    reqwest({
-        url: "/experiment/quorum",
-        method: "get",
-        success: function (resp) {
-            quorum = resp.quorum;
-        }
-    });
-};
-

--- a/demos/chatroom/static/scripts/reconnecting-websocket.js
+++ b/demos/chatroom/static/scripts/reconnecting-websocket.js
@@ -1,0 +1,26 @@
+/*
+https://github.com/joewalnes/reconnecting-websocket
+
+MIT License:
+
+Copyright (c) 2010-2012, Joe Walnes
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+!function(a,b){"function"==typeof define&&define.amd?define([],b):"undefined"!=typeof module&&module.exports?module.exports=b():a.ReconnectingWebSocket=b()}(this,function(){function a(b,c,d){function l(a,b){var c=document.createEvent("CustomEvent");return c.initCustomEvent(a,!1,!1,b),c}var e={debug:!1,automaticOpen:!0,reconnectInterval:1e3,maxReconnectInterval:3e4,reconnectDecay:1.5,timeoutInterval:2e3};d||(d={});for(var f in e)this[f]="undefined"!=typeof d[f]?d[f]:e[f];this.url=b,this.reconnectAttempts=0,this.readyState=WebSocket.CONNECTING,this.protocol=null;var h,g=this,i=!1,j=!1,k=document.createElement("div");k.addEventListener("open",function(a){g.onopen(a)}),k.addEventListener("close",function(a){g.onclose(a)}),k.addEventListener("connecting",function(a){g.onconnecting(a)}),k.addEventListener("message",function(a){g.onmessage(a)}),k.addEventListener("error",function(a){g.onerror(a)}),this.addEventListener=k.addEventListener.bind(k),this.removeEventListener=k.removeEventListener.bind(k),this.dispatchEvent=k.dispatchEvent.bind(k),this.open=function(b){h=new WebSocket(g.url,c||[]),b||k.dispatchEvent(l("connecting")),(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","attempt-connect",g.url);var d=h,e=setTimeout(function(){(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","connection-timeout",g.url),j=!0,d.close(),j=!1},g.timeoutInterval);h.onopen=function(){clearTimeout(e),(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","onopen",g.url),g.protocol=h.protocol,g.readyState=WebSocket.OPEN,g.reconnectAttempts=0;var d=l("open");d.isReconnect=b,b=!1,k.dispatchEvent(d)},h.onclose=function(c){if(clearTimeout(e),h=null,i)g.readyState=WebSocket.CLOSED,k.dispatchEvent(l("close"));else{g.readyState=WebSocket.CONNECTING;var d=l("connecting");d.code=c.code,d.reason=c.reason,d.wasClean=c.wasClean,k.dispatchEvent(d),b||j||((g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","onclose",g.url),k.dispatchEvent(l("close")));var e=g.reconnectInterval*Math.pow(g.reconnectDecay,g.reconnectAttempts);setTimeout(function(){g.reconnectAttempts++,g.open(!0)},e>g.maxReconnectInterval?g.maxReconnectInterval:e)}},h.onmessage=function(b){(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","onmessage",g.url,b.data);var c=l("message");c.data=b.data,k.dispatchEvent(c)},h.onerror=function(b){(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","onerror",g.url,b),k.dispatchEvent(l("error"))}},1==this.automaticOpen&&this.open(!1),this.send=function(b){if(h)return(g.debug||a.debugAll)&&console.debug("ReconnectingWebSocket","send",g.url,b),h.send(b);throw"INVALID_STATE_ERR : Pausing to reconnect websocket"},this.close=function(a,b){"undefined"==typeof a&&(a=1e3),i=!0,h&&h.close(a,b)},this.refresh=function(){h&&h.close()}}return a.prototype.onopen=function(){},a.prototype.onclose=function(){},a.prototype.onconnecting=function(){},a.prototype.onmessage=function(){},a.prototype.onerror=function(){},a.debugAll=!1,a.CONNECTING=WebSocket.CONNECTING,a.OPEN=WebSocket.OPEN,a.CLOSING=WebSocket.CLOSING,a.CLOSED=WebSocket.CLOSED,a});

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,10 @@ boto==2.15.0
 cached-property==1.3.0
 click==6.7
 Flask==0.10.1
+Flask-Sockets==0.2.1
 future==0.16.0
+gevent==1.2.1
+greenlet==0.4.12
 gunicorn==18.0
 localconfig==0.4.2
 pexpect==4.2.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,7 @@ def cwd():
 def experiment_dir(cwd):
     os.chdir('tests/experiment')
     yield
+    # The cwd fixture will return to the starting directory.
 
 
 @pytest.fixture(scope='class', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,12 @@ def cwd():
     os.chdir(root)
 
 
+@pytest.fixture(scope="class")
+def experiment_dir(cwd):
+    os.chdir('tests/experiment')
+    yield
+
+
 @pytest.fixture(scope='class', autouse=True)
 def reset_config():
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,10 +19,10 @@ def cwd():
 
 
 @pytest.fixture(scope="class")
-def experiment_dir(cwd):
+def experiment_dir():
     os.chdir('tests/experiment')
     yield
-    # The cwd fixture will return to the starting directory.
+    cwd()
 
 
 @pytest.fixture(scope='class', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -44,3 +44,12 @@ def aws_creds():
         'aws_secret_access_key': config.get('aws_secret_access_key')
     }
     return creds
+
+
+@pytest.fixture
+def db_session():
+    import dallinger.db
+    session = dallinger.db.init_db(drop_all=True)
+    yield session
+    session.rollback()
+    session.close()

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -156,7 +156,7 @@ class TestDebugServer(object):
             p.sendcontrol('c')
             p.read()
         finally:
-            shutil.rmtree(fake_home)
+            shutil.rmtree(fake_home, ignore_errors=True)
 
     def test_warning_if_no_heroku_present(self):
         # Heroku requires a home directory to start up

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,39 @@
+def test_serialized(db_session):
+    from dallinger.db import serialized
+    from dallinger.models import Participant
+
+    counts = []
+
+    # Define a serialized function which writes
+    # a row based on a separate query
+    def write(session):
+        count = session.query(Participant).count()
+        counts.append(count)
+        session.add(Participant(
+            worker_id='serialized_{}'.format(count + 1),
+            assignment_id='test',
+            hit_id='test',
+            mode='test',
+        ))
+    serialized_write = serialized(write)
+
+    # Make the thread-scoped session SERIALIZABLE and read data with it
+    db_session.connection(
+        execution_options={'isolation_level': 'SERIALIZABLE'})
+    assert Participant.query.count() == 0
+
+    # Now make a change using a separate session
+    # that will change the value read above
+    session2 = db_session.session_factory()
+    session2.connection(
+        execution_options={'isolation_level': 'SERIALIZABLE'})
+    write(session2)
+    session2.commit()
+
+    # Now run the serialized write.
+    # It should succeed, but only after retrying the transaction.
+    serialized_write(db_session)
+
+    # Which we can check by making sure that `write`
+    # calculated the count at least 3 times
+    assert counts == [0, 0, 1]

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -14,7 +14,7 @@ class FlaskAppTest(unittest.TestCase):
         # when running via the CLI
         os.chdir('tests/experiment')
 
-        from dallinger.experiment_server.experiment_server import app
+        from dallinger.experiment_server.sockets import app
         app.config['DEBUG'] = True
         app.config['TESTING'] = True
         self.app = app.test_client()
@@ -26,6 +26,10 @@ class FlaskAppTest(unittest.TestCase):
         self.db.rollback()
         self.db.close()
         os.chdir('../..')
+
+        # Make sure the greenlet handling chat is stopped
+        from dallinger.experiment_server.sockets import chat_backend
+        chat_backend.stop()
 
 
 class TestExperimentServer(FlaskAppTest):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1,6 +1,7 @@
 from mock import Mock
 import gevent
 import pytest
+import socket
 
 
 @pytest.fixture
@@ -40,7 +41,7 @@ class TestChatBackend:
 
     def test_send_exception(self, chat):
         client = Mock()
-        client.send.side_effect = Exception()
+        client.send.side_effect = socket.error()
         chat.subscribe(client)
         chat.send(client, 'message')
         assert chat.clients == {'quorum': []}

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -63,9 +63,5 @@ class TestChatBackend:
 
     def test_outbox(self, sockets):
         ws = Mock()
-        ws.closed = False
         sockets.outbox(ws)
-        ws.closed = True
-
-        gevent.wait()
         assert ws in sockets.chat_backend.clients['quorum']

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -1,0 +1,71 @@
+from mock import Mock
+import gevent
+import pytest
+
+
+@pytest.fixture
+def sockets():
+    from dallinger.experiment_server import sockets
+    return sockets
+
+
+@pytest.fixture
+def chat(sockets):
+    return sockets.ChatBackend()
+
+
+@pytest.mark.usefixtures("experiment_dir")
+class TestChatBackend:
+
+    def test_subscribe_one_channel(self, chat):
+        client = Mock()
+        chat.subscribe(client, 'quorum')
+        assert chat.clients == {'quorum': [client]}
+
+    def test_subscribe_all_channels(self, chat):
+        client = Mock()
+        chat.subscribe(client)
+        assert chat.clients == {'quorum': [client]}
+
+    def test_unsubscribe(self, chat):
+        client = Mock()
+        chat.subscribe(client, 'quorum')
+        chat.unsubscribe(client, 'quorum')
+        assert chat.clients == {'quorum': []}
+
+    def test_send(self, chat):
+        client = Mock()
+        chat.send(client, 'message')
+        client.send.assert_called_once_with('message')
+
+    def test_send_exception(self, chat):
+        client = Mock()
+        client.send.side_effect = Exception()
+        chat.subscribe(client)
+        chat.send(client, 'message')
+        assert chat.clients == {'quorum': []}
+
+    def test_run(self, chat):
+        client = Mock()
+        chat.subscribe(client)
+
+        chat.pubsub = Mock()
+        chat.pubsub.listen.return_value = [{
+            'type': 'message',
+            'channel': 'quorum',
+            'data': 'Calloo! Callay!',
+        }]
+
+        chat.run()
+
+        gevent.wait()  # wait for event loop
+        client.send.assert_called_once_with('quorum:Calloo! Callay!')
+
+    def test_outbox(self, sockets):
+        ws = Mock()
+        ws.closed = False
+        sockets.outbox(ws)
+        ws.closed = True
+
+        gevent.wait()
+        assert ws in sockets.chat_backend.clients['quorum']


### PR DESCRIPTION
## Description
This includes two improvements to the waiting room:
- Make the node creation / network filling endpoint run using the SERIALIZABLE postgresql isolation level, and retry any transactions that fail due to coincident writes by another client.
- Communicate notifications about how full the waiting room is using websockets (set up using flask-sockets -- important note: this involves switching gunicorn to run using a gevent-based worker).

## Motivation and Context
The isolation level change fixes an issue where network nodes might not be linked correctly once the quorum is reached and all workers move to the experiment.

The websockets change allows for less latency in updating clients as the number of participants changes. It also lays the groundwork for the use of websocket communication in actual experiments.

## How Has This Been Tested?
More testing is needed, which is why this is still marked as a work in progress:
- Check that it works when deployed to heroku
