### PR TITLE
Various tweaks to configuration

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -54,7 +54,6 @@ default_keys = (
     ('notification_url', unicode, []),
     ('num_dynos_web', int, []),
     ('num_dynos_worker', int, []),
-    ('num_participants', int, []),
     ('organization_name', unicode, []),
     ('threads', unicode, []),
     ('title', unicode, []),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -25,7 +25,7 @@ SENSITIVE_KEY_NAMES = (
 
 default_keys = (
     ('ad_group', unicode, []),
-    ('amt_keywords', unicode, []),
+    ('keywords', unicode, []),
     ('approve_requirement', int, []),
     ('auto_recruit', bool, []),
     ('aws_access_key_id', unicode, [], True),

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -126,7 +126,7 @@ class MTurkRecruiter(object):
             'max_assignments': n,
             'title': self.config.get('title'),
             'description': self.config.get('description'),
-            'keywords': self.config.get('amt_keywords'),
+            'keywords': self.config.get('keywords'),
             'reward': self.config.get('base_payment'),
             'duration_hours': self.config.get('duration'),
             'lifetime_days': self.config.get('lifetime'),

--- a/demos/2048/config.txt
+++ b/demos/2048/config.txt
@@ -6,7 +6,7 @@ n = 3
 [MTurk]
 title = War of the Ghosts
 description = Read a brief story and answer some questions about it.
-amt_keywords = Psychology, reading, text
+keywords = Psychology, reading, text
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/bartlett1932/config.txt
+++ b/demos/bartlett1932/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = War of the Ghosts
 description = Read a brief story and answer some questions about it.
-amt_keywords = Psychology, reading, text
+keywords = Psychology, reading, text
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/chatroom/config.txt
+++ b/demos/chatroom/config.txt
@@ -7,7 +7,7 @@ n = 2
 [MTurk]
 title = Coordination game
 description = Coordinate with other players.
-amt_keywords = Coordination, chat
+keywords = Coordination, chat
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/concentration/config.txt
+++ b/demos/concentration/config.txt
@@ -6,7 +6,7 @@ num_participants = 10
 [MTurk]
 title = Concentration game
 description = Play a round of the game Concentration.
-amt_keywords = game, videogame, play
+keywords = game, videogame, play
 base_payment = 1.00
 lifetime = 24
 duration = 0.25

--- a/demos/function-learning/config.txt
+++ b/demos/function-learning/config.txt
@@ -5,7 +5,7 @@ mode = sandbox
 [MTurk]
 title = Function learning
 description = Learn the relationship between the sizes of two objects.
-amt_keywords = Psychology, game, learning
+keywords = Psychology, game, learning
 base_payment = 1.00
 lifetime = 24
 duration = 1

--- a/demos/iterated-drawing/config.txt
+++ b/demos/iterated-drawing/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = Remember the drawing
 description = View an image and then try to recreate it
-amt_keywords = Psychology, drawing, images
+keywords = Psychology, drawing, images
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/mcmcp/config.txt
+++ b/demos/mcmcp/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = Select the image
 description = Decide which image is a better match to a given category.
-amt_keywords = vision, categorization, images
+keywords = vision, categorization, images
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/rogers/config.txt
+++ b/demos/rogers/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = Judge the dots
 description = Look at some dots and determine if there are more blue or yellow ones
-amt_keywords = Psychology, vision, dots
+keywords = Psychology, vision, dots
 base_payment = 1.00
 lifetime = 24
 duration = 0.5

--- a/demos/sheep-market/config.txt
+++ b/demos/sheep-market/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = The Sheep Market
 description = Draw an image of a sheep
-amt_keywords = Psychology, drawing, images
+keywords = Psychology, drawing, images
 base_payment = 1.00
 lifetime = 24
 duration = 0.1

--- a/demos/snake/config.txt
+++ b/demos/snake/config.txt
@@ -6,7 +6,7 @@ n = 10
 [MTurk]
 title = Snake game
 description = Play a round of the snake game.
-amt_keywords = game, videogame, play
+keywords = game, videogame, play
 base_payment = 1.00
 lifetime = 24
 duration = 0.25

--- a/demos/vox-populi/config.txt
+++ b/demos/vox-populi/config.txt
@@ -5,7 +5,7 @@ auto_recruit = true
 [MTurk]
 title = Estimate these almanac facts
 description = Estimate a few values
-amt_keywords = Psychology, drawing, images
+keywords = Psychology, drawing, images
 base_payment = 1.00
 lifetime = 24
 duration = 0.25

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -23,16 +23,112 @@ first among environment variables, then in a ``config.txt`` in the experiment
 directory, and then in the ``.dallingerconfig`` file, using whichever value
 is found first. If the parameter is not found, Dallinger will use the default.
 
-To create a new experiment-specific configuration variable, define
-``extra_parameters`` in your ``experiment.py`` file:
+Built-in configuration
+----------------------
 
-::
+Built-in configuration parameters include:
 
-    def extra_parameters():
-        config.register('n', int, [], False)
+``mode``
+    Run the experiment in this mode. Options include ``debug`` (local testing),
+    ``sandbox`` (MTurk sandbox), and ``live`` (MTurk).
 
-Here, ``'n'`` is a string with the name of the parameter, ``int`` is its type,
-``[]`` is a list of synonyms that be used to access the same parameter, and
-``False`` is a boolean signifying that this configuration parameter is not
-sensitive and can be saved in plain text. Once defined in this way, a
-parameter can be used anywhere that built-in parameters are used.
+``title``
+    Title of the HIT on Amazon Mechanical Turk.
+
+``description``
+    Description of the HIT on Amazon Mechanical Turk.
+
+``keywords``
+    Comma-separated list of keywords to use on Amazon Mechanical Turk.
+
+``lifetime``
+    How long in hours that your HIT remains visible to workers.
+
+``duration``
+    How long in hours participants have until the HIT will time out.
+
+``us_only``
+    A boolean that control whether this HIT is available only to MTurk workers
+    in the U.S.
+
+``base_payment``
+    Base payment in U.S. dollars.
+
+``approve_requirement``
+    The percentage of past MTurk HITs that must have been approved for a worker
+    to qualify to participate in your experiment. 1-100.
+
+``contact_email_on_error`` *unicode*
+    Email address displayed when there is an error.
+
+``auto_recruit``
+    Whether recruitment should be automatic.
+
+``group``
+    A string. *Unicode string*.
+
+``loglevel``
+    A number between 0 and 4 that controls the verbosity of logs, from ``debug``
+    to ``critical``.
+
+``organization_name`` [string]
+    Identifies your institution, business, or organization.
+
+``browser_exclude_rule`` [comma separated string]
+    A set of rules you can apply to prevent participants with unsupported web
+    browsers from participating in your experiment.
+
+``database_url``
+    URI of the Postgres database.
+
+``database_size``
+    Size of the database on Heroku. See `Heroku Postgres plans <https://devcenter.heroku.com/articles/heroku-postgres-plans>`__.
+
+``dyno_type``
+    Heroku dyno type to use. See `Heroku dynos types <https://devcenter.heroku.com/articles/dyno-types>`__.
+
+``num_dynos_web``
+    Number of Heroku dynos to use for processing incoming HTTP requests. It is
+    recommended that you use at least two.
+
+``num_dynos_worker``
+    Number of Heroku dynos to use for performing other computations.
+
+``host``
+    IP address of the host.
+
+``port``
+    Port of the host.
+
+``notification_url``
+    URL where notifications are sent. This should not be set manually.
+
+``clock_on``
+    If the clock process is on, it will perform a series of checks that ensure
+    the integrity of the database.
+
+``logfile``
+    Where to write logs.
+
+``aws_access_key_id``
+    AWS access key ID.
+
+``aws_secret_access_key``
+    AWS access key secret.
+
+``aws_region``
+    AWS region to use. Defaults to ``us-east-1``.
+
+``dallinger_email_address``
+    A Gmail address for use by Dallinger to send status emails.
+
+``dallinger_email_password``
+    Password for the aforementioned Gmail address.
+
+``heroku_team``
+    The name of the Heroku team to which all applications will be assigned.
+    This is useful for centralized billing. Note, however, that it will prevent
+    you from using free-tier dynos.
+
+``whimsical``
+    What's life without whimsy?

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -1,0 +1,16 @@
+Extra Configuration
+===================
+
+To create a new experiment-specific configuration variable, define
+``extra_parameters`` in your ``experiment.py`` file:
+
+::
+
+    def extra_parameters():
+        config.register('n', int, [], False)
+
+Here, ``'n'`` is a string with the name of the parameter, ``int`` is its type,
+``[]`` is a list of synonyms that be used to access the same parameter, and
+``False`` is a boolean signifying that this configuration parameter is not
+sensitive and can be saved in plain text. Once defined in this way, a
+parameter can be used anywhere that built-in parameters are used.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,6 +15,7 @@ Laboratory automation for the behavioral and social sciences.
     monitoring_a_live_experiment
     postico_and_postgres
     command_line_utility
+    configuration
     python_module
     registration_on_OSF
 
@@ -36,7 +37,7 @@ Laboratory automation for the behavioral and social sciences.
     the_experiment_class
     web_api
     communicating_with_the_server
-    configuration
+    extra_configuration
 
 .. toctree::
     :maxdepth: 1

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -18,11 +18,13 @@ Ctrl
 dallinger
 Dallinger
 dallingerconfig
+dyno
 dynos
 et
 frontend
 GitHub
 Google
+Gmail
 Griffiths
 GSoC
 Heroku

--- a/tests/experiment/config.txt
+++ b/tests/experiment/config.txt
@@ -1,7 +1,7 @@
 [MTurk]
 title = Stroop task
 description = Judge the color of a series of words.
-amt_keywords = Perception, Psychology
+keywords = Perception, Psychology
 lifetime = 24
 us_only = true
 approve_requirement = 95

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -84,7 +84,7 @@ def stub_config(**kwargs):
         'lifetime': 0.1,
         'title': 'fake experiment title',
         'description': 'fake HIT description',
-        'amt_keywords': ['kw1', 'kw2', 'kw3'],
+        'keywords': ['kw1', 'kw2', 'kw3'],
     }
     defaults.update(kwargs)
 


### PR DESCRIPTION
This PR makes a few tweaks to the configuration:

+ Removes `num_participants` from the default config. (It's experiment-specific.)

+ Renames `amt_keywords` to `keywords`

+ Add documentation for the configuration object