### PR TITLE
Bugfixes for data exporting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,10 @@ install:
 - gem install chandler
 before_script:
 - bundle exec danger
-- psql -c 'create database db;' -U postgres
+- createdb dallinger -U postgres
 env:
   global:
-  - DATABASE_URL=postgresql://postgres@localhost/db
+  - DATABASE_URL=postgresql://postgres@localhost/dallinger
   - PORT=5000
   - secure: isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg=
   - secure: rWBAifHvKlQabe6gvz+edMEtjtDnpwI4RFHJB1ytYSNVKQ59s7fIk2q39IZc8K3Uix7ZtP3G7ws6ufQhOj44Pm4j1J+rbLnDjdMtmcDN5aiSnwb05JpltZXCNjUqAu/CBFZ44lnNenZp4uSLhU/kLVhB2Q+UPvyWNFgApEVoiHM=

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -127,7 +127,8 @@ def copy_local_to_csv(local_db, path, scrub_pii=False):
     for table in table_names:
         csv_path = os.path.join(path, "{}.csv".format(table))
         with open(csv_path, "w") as f:
-            cur.copy_to(f, table, sep=",", null="")
+            sql = "COPY {} TO STDOUT WITH CSV HEADER".format(table)
+            cur.copy_expert(sql, f)
             if table is "participant" and scrub_pii:
                 _scrub_participant_table(csv_path)
 

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -122,7 +122,7 @@ def copy_heroku_to_local(id):
 
 def copy_local_to_csv(local_db, path, scrub_pii=False):
     """Copy a local database to a set of CSV files."""
-    conn = psycopg2.connect(database="dallinger", user="postgres")
+    conn = psycopg2.connect(database=local_db, user="postgres")
     cur = conn.cursor()
     for table in table_names:
         csv_path = os.path.join(path, "{}.csv".format(table))


### PR DESCRIPTION
1. When exporting data from Heroku, the local `dallinger` database and not
the backup of the Heroku database was converted to CSV. Now the correct
database is exported.

2. When converting to CSV, headers were not included. Now they are.