### PR TITLE
Support Selenium drivers other than local PhantomJS

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -8,6 +8,8 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
+from dallinger.config import get_config
+config = get_config()
 
 logger = logging.getLogger(__file__)
 
@@ -19,7 +21,22 @@ class BotBase(object):
     def __init__(self, URL):
         logger.info("Starting up bot with URL: %s." % URL)
         self.URL = URL
-        self.driver = webdriver.PhantomJS()
+        driver_url = config.get('webdriver_url', None)
+        driver_type = config.get('webdriver_type', 'phantomjs').lower()
+        if driver_url:
+            capabilities = {}
+            if driver_type == 'firefox':
+                capabilities = webdriver.DesiredCapabilities.FIREFOX
+            elif driver_type == 'phantomjs':
+                capabilities = webdriver.DesiredCapabilities.PHANTOMJS
+            self.driver = webdriver.Remote(
+                desired_capabilities=capabilities,
+                command_executor=driver_url
+            )
+        elif driver_type == 'phantomjs':
+            self.driver = webdriver.PhantomJS()
+        elif driver_type == 'firefox':
+            self.driver = webdriver.Firefox()
         self.driver.set_window_size(1024, 768)
         logger.info("Started PhantomJs webdriver.")
 

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -29,6 +29,9 @@ class BotBase(object):
                 capabilities = webdriver.DesiredCapabilities.FIREFOX
             elif driver_type == 'phantomjs':
                 capabilities = webdriver.DesiredCapabilities.PHANTOMJS
+            else:
+                raise ValueError(
+                    'Unsupported remote webdriver_type: {}'.format(driver_type))
             self.driver = webdriver.Remote(
                 desired_capabilities=capabilities,
                 command_executor=driver_url
@@ -37,6 +40,9 @@ class BotBase(object):
             self.driver = webdriver.PhantomJS()
         elif driver_type == 'firefox':
             self.driver = webdriver.Firefox()
+        else:
+            raise ValueError(
+                'Unsupported webdriver_type: {}'.format(driver_type))
         self.driver.set_window_size(1024, 768)
         logger.info("Started PhantomJs webdriver.")
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -59,6 +59,8 @@ default_keys = (
     ('title', unicode, []),
     ('us_only', bool, []),
     ('whimsical', bool, []),
+    ('webdriver_type', unicode, []),
+    ('webdriver_url', unicode, []),
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -60,3 +60,11 @@ def db_session():
     yield session
     session.rollback()
     session.close()
+
+
+def pytest_addoption(parser):
+    parser.addoption("--firefox", action="store_true", help="Run firefox bot tests")
+    parser.addoption("--phantomjs", action="store_true", help="Run phantomjs bot tests")
+    parser.addoption("--webdriver", nargs="?", action="store",
+                     help="URL of selenium server including /wd/hub to run remote tests against",
+                     metavar='URL')

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -1,8 +1,69 @@
+import pytest
+from selenium.webdriver import PhantomJS, Firefox, Remote
+
+from dallinger.config import get_config
+
+config = get_config()
+
 
 class TestBots(object):
 
     def test_create_bot(self):
         """Create a bot."""
+        config.ready = True
         from dallinger.bots import BotBase
         bot = BotBase("http://dallinger.io")
         assert bot
+
+    @pytest.mark.skipif(not pytest.config.getvalue("phantomjs"),
+                        reason="--phantomjs was not specified")
+    def test_bot_using_phantomjs(self):
+        """Create a bot."""
+        config.ready = True
+        config.extend({'webdriver_type': u'phantomjs'})
+        from dallinger.bots import BotBase
+        bot = BotBase("http://dallinger.io")
+        assert isinstance(bot.driver, PhantomJS)
+
+    @pytest.mark.skipif(not pytest.config.getvalue("firefox"),
+                        reason="--firefox was not specified")
+    def test_bot_using_firefox(self):
+        """Create a bot."""
+        return
+        config.ready = True
+        config.extend({'webdriver_type': u'firefox'})
+        from dallinger.bots import BotBase
+        bot = BotBase("http://dallinger.io")
+        assert isinstance(bot.driver, Firefox)
+
+    @pytest.mark.skipif(not pytest.config.getvalue("webdriver"),
+                        reason="--webdriver was not specified")
+    @pytest.mark.skipif(not pytest.config.getvalue("phantomjs"),
+                        reason="--phantomjs was not specified")
+    def test_bot_using_webdriver_phantomjs(self):
+        """Create a bot."""
+        config.ready = True
+        config.extend({
+            'webdriver_type': u'phantomjs',
+            'webdriver_url': pytest.config.getvalue("webdriver").decode("ascii")
+        })
+        from dallinger.bots import BotBase
+        bot = BotBase("http://dallinger.io")
+        assert isinstance(bot.driver, Remote)
+        assert bot.driver.capabilities['browserName'] == 'phantomjs'
+
+    @pytest.mark.skipif(not pytest.config.getvalue("webdriver"),
+                        reason="--webdriver was not specified")
+    @pytest.mark.skipif(not pytest.config.getvalue("firefox"),
+                        reason="--firefox was not specified")
+    def test_bot_using_webdriver_firefox(self):
+        """Create a bot."""
+        config.ready = True
+        config.extend({
+            'webdriver_type': u'firefox',
+            'webdriver_url': pytest.config.getvalue("webdriver").decode("ascii")
+        })
+        from dallinger.bots import BotBase
+        bot = BotBase("http://dallinger.io")
+        assert isinstance(bot.driver, Remote)
+        assert bot.driver.capabilities['browserName'] == 'firefox'


### PR DESCRIPTION

## Description
This change allows users to specify the webdriver_url configuration parameter, which points at a Selenium Server, such as http://192.168.1.2:4444/wd/hub. If this is specified the webdriver.Remote backend is used.
In addition, webdriver_type determines the browser being used. If a URL is specified these are passed as desired_capabilities to the hub server, otherwise it is used to pick a local webdriver. Currently supported values are 'phantomjs' and 'firefox'.

## Motivation and Context
This allows users to see the bots running in a real browser, to aid debugging, or to take advantage of browser specific features.

## How Has This Been Tested?
This is being used to develop the griduniverse bot
