### PR TITLE
Support experiment-defined background tasks and pubsub channels

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -49,6 +49,9 @@ def exp_class_working_dir(meth):
 class Experiment(object):
     """Define the structure of an experiment."""
     app_id = None
+    # Optional Redis channel to create and subscribe to on launch. Note that if
+    # you define a channel, you probably also want to override the send()
+    # method, since this is where messages from Redis will be sent.
     channel = None
     exp_config = None
 
@@ -105,6 +108,9 @@ class Experiment(object):
 
     @property
     def background_tasks(self):
+        """An experiment may define functions or methods to be started as
+        background tasks upon experiment launch.
+        """
         return []
 
     @property
@@ -130,6 +136,16 @@ class Experiment(object):
         if recruiter == 'bots':
             return BotRecruiter.from_current_config
         return MTurkRecruiter.from_current_config
+
+    def send(self, raw_message):
+        """socket interface implementation, and point of entry for incoming
+        Redis messages.
+
+        param raw_message is a string with a channel prefix, for example:
+
+            'shopping:{"type":"buy","color":"blue","quantity":"2"}'
+        """
+        pass
 
     def setup(self):
         """Create the networks if they don't already exist."""

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -49,6 +49,7 @@ def exp_class_working_dir(meth):
 class Experiment(object):
     """Define the structure of an experiment."""
     app_id = None
+    channel = None
     exp_config = None
 
     def __init__(self, session=None):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -103,6 +103,10 @@ class Experiment(object):
             self.public_properties = {}
 
     @property
+    def background_tasks(self):
+        return []
+
+    @property
     def recruiter(self):
         """Recruiter, the Dallinger class that recruits participants.
         Default is HotAirRecruiter in debug mode and MTurkRecruiter in other modes.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -2,7 +2,6 @@
 
 from datetime import datetime
 import gevent
-import hashlib
 from json import dumps
 from operator import attrgetter
 import re
@@ -50,9 +49,6 @@ q = Queue(connection=redis)
 WAITING_ROOM_CHANNEL = 'quorum'
 
 app = Flask('Experiment_Server')
-# This might only be necessary for Flask-SocketIO:
-secret = hashlib.sha256(config.get("aws_secret_access_key")).hexdigest()
-app.config["SECRET_KEY"] = secret
 
 Experiment = experiment.load()
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1,6 +1,7 @@
 """ This module provides the backend Flask server that serves an experiment. """
 
 from datetime import datetime
+import hashlib
 from json import dumps
 from operator import attrgetter
 import re
@@ -48,6 +49,9 @@ q = Queue(connection=redis)
 WAITING_ROOM_CHANNEL = 'quorum'
 
 app = Flask('Experiment_Server')
+# This might only be necessary for Flask-SocketIO:
+secret = hashlib.sha256(config.get("aws_secret_access_key")).hexdigest()
+app.config["SECRET_KEY"] = secret
 
 Experiment = experiment.load()
 
@@ -1442,4 +1446,5 @@ def insert_mode(page_html, mode):
             page_html[match.end():]
         return new_html
     else:
+        traceback.print_exc()
         raise ExperimentError("insert_mode_failed")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -229,21 +229,11 @@ def launch():
     def inject_experiment():
         return dict(experiment=exp)
 
-    """Initialize a Socket.IO server if appropriate."""
-    # try:
-    #     from dallinger_experiment import socketio
-    # except ImportError:
-    #     pass
-    # else:
-    #     socketio.init_app(app)
-    #     for task in exp.background_tasks:
-    #         socketio.start_background_task(task)
-    # from flask_sockets import Sockets
-    # if hasattr(exp, 'sockets') and exp.sockets is None:
-    #     exp.sockets = Sockets(app)
+    for task in exp.background_tasks:
+        gevent.spawn(task)
 
-    # Storing return value as a reminder that spawn() returns a greenlet:
-    threads = [gevent.spawn(task) for task in exp.background_tasks]
+    # If the experiment defines a channel, subscribe the experiment to the
+    # redis communication channel:
     if exp.channel is not None:
         from dallinger.experiment_server.sockets import chat_backend
         chat_backend.subscribe(exp, exp.channel)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -223,6 +223,11 @@ def launch():
     url_info = exp.recruiter().open_recruitment(n=exp.initial_recruitment_size)
     session.commit()
 
+    """Inject the experiment variable into the template context."""
+    @app.context_processor
+    def inject_experiment():
+        return dict(experiment=exp)
+
     return success_response("recruitment_url", url_info, request_type="launch")
 
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1457,5 +1457,4 @@ def insert_mode(page_html, mode):
             page_html[match.end():]
         return new_html
     else:
-        traceback.print_exc()
         raise ExperimentError("insert_mode_failed")

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -31,7 +31,8 @@ class ChatBackend(object):
     def _join_pubsub(self, channels):
         try:
             self.pubsub.subscribe(channels)
-            app.logger.debug('Subscribed to channels: {}'.format(channels))
+            app.logger.debug(
+                'Subscribed to channels: {}'.format(self.pubsub.channels.keys()))
         except ConnectionError:
             app.logger.exception('Could not connect to redis.')
 

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -39,6 +39,7 @@ class ChatBackend(object):
 
     def subscribe(self, client, channel=None):
         """Register a new client to receive messages."""
+        app.logger.debug('{} subscribing to channel {}'.format(client, channel))
         if channel is not None:
             if channel not in self.clients:
                 raise ValueError('Unknown channel: {}'.format(channel))
@@ -59,6 +60,7 @@ class ChatBackend(object):
 
         Automatically discards invalid connections.
         """
+        app.logger.debug('sending {} to client {}'.format(data, client))
         try:
             client.send(data)
         except socket.error:

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -10,7 +10,8 @@ import socket
 sockets = Sockets(app)
 
 CHANNELS = [
-    WAITING_ROOM_CHANNEL
+    WAITING_ROOM_CHANNEL,
+    'griduniverse'
 ]
 
 

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -2,6 +2,7 @@ from collections import defaultdict
 from .experiment_server import app
 from .experiment_server import WAITING_ROOM_CHANNEL
 from ..heroku.worker import conn
+from flask import request
 from flask_sockets import Sockets
 from redis import ConnectionError
 import gevent
@@ -105,7 +106,13 @@ app.before_first_request(chat_backend.start)
 
 @sockets.route('/receive_chat')
 def outbox(ws):
-    chat_backend.subscribe(ws)
+    """This route was highjacked temporarily for the Griduniverse socket.
+    It both subscribes the websocket to the chat backend
+    so the front-end clients get messages via redis,
+    and it puts messages from the clients into redis so they can be sent on
+    to the Experiment, which is also registered with the chat_backend.
+    """
+    chat_backend.subscribe(ws, channel=request.args.get('channel'))
 
     while not ws.closed:
         # Wait for chat backend

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -44,7 +44,6 @@ class ChatBackend(object):
 
     def subscribe(self, client, channel=None):
         """Register a new client to receive messages."""
-        app.logger.debug('{} subscribing to channel {}'.format(client, channel))
         if channel is not None:
             self.clients[channel].append(client)
             self._join_pubsub([channel])
@@ -64,7 +63,6 @@ class ChatBackend(object):
 
         Automatically discards invalid connections.
         """
-        app.logger.debug('sending {} to client {}'.format(data, client))
         try:
             client.send(data)
         except socket.error:

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -32,7 +32,8 @@ class ChatBackend(object):
         try:
             self.pubsub.subscribe(channels)
             app.logger.debug(
-                'Subscribed to channels: {}'.format(self.pubsub.channels.keys()))
+                'Subscribed to channels: {}'.format(self.pubsub.channels.keys())
+            )
         except ConnectionError:
             app.logger.exception('Could not connect to redis.')
 
@@ -46,7 +47,8 @@ class ChatBackend(object):
         """Register a new client to receive messages."""
         if channel is not None:
             self.clients[channel].append(client)
-            self._join_pubsub([channel])
+            if channel not in self.pubsub.channels:
+                self._join_pubsub([channel])
         else:
             for channel in DEFAULT_CHANNELS:
                 self.clients[channel].append(client)

--- a/dallinger/nodes.py
+++ b/dallinger/nodes.py
@@ -108,6 +108,10 @@ class Environment(Node):
                 s for s in self.infos(type=State) if s.creation_time < time]
             return max(states, key=attrgetter('creation_time'))
 
+    def update(self, contents):
+        state = State(origin=self, contents=contents)
+        return state
+
     def _what(self):
         """Return the most recent state."""
         return self.state()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -36,8 +36,16 @@ class TestChatBackend:
     def test_subscribe_to_new_channel_subscribes_on_redis(self, chat):
         client = Mock()
         chat.pubsub = Mock()
+        chat.pubsub.channels = {}
         chat.subscribe(client, 'custom')
         chat.pubsub.subscribe.assert_called_once_with(['custom'])
+
+    def test_subscribe_wont_duplicate_channel(self, chat):
+        client1 = Mock()
+        chat.pubsub = Mock()
+        chat.pubsub.channels = {'custom'}
+        chat.subscribe(client1, 'custom')
+        chat.pubsub.subscribe.assert_not_called()
 
     def test_unsubscribe(self, chat):
         client = Mock()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -35,8 +35,9 @@ class TestChatBackend:
 
     def test_subscribe_to_new_channel_subscribes_on_redis(self, chat):
         client = Mock()
+        chat.pubsub = Mock()
         chat.subscribe(client, 'custom')
-        assert 'custom' in chat.pubsub.channels
+        chat.pubsub.subscribe.assert_called_once_with(['custom'])
 
     def test_unsubscribe(self, chat):
         client = Mock()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -18,15 +18,25 @@ def chat(sockets):
 @pytest.mark.usefixtures("experiment_dir")
 class TestChatBackend:
 
-    def test_subscribe_one_channel(self, chat):
+    def test_subscribe_all_default_channels(self, chat):
+        client = Mock()
+        chat.subscribe(client)
+        assert chat.clients == {'quorum': [client]}
+
+    def test_subscribe_explicitly_to_a_default_channel(self, chat):
         client = Mock()
         chat.subscribe(client, 'quorum')
         assert chat.clients == {'quorum': [client]}
 
-    def test_subscribe_all_channels(self, chat):
+    def test_subscribe_to_new_channel_registers_client_for_channel(self, chat):
         client = Mock()
-        chat.subscribe(client)
-        assert chat.clients == {'quorum': [client]}
+        chat.subscribe(client, 'custom')
+        assert chat.clients == {'custom': [client]}
+
+    def test_subscribe_to_new_channel_subscribes_on_redis(self, chat):
+        client = Mock()
+        chat.subscribe(client, 'custom')
+        assert 'custom' in chat.pubsub.channels
 
     def test_unsubscribe(self, chat):
         client = Mock()
@@ -74,11 +84,20 @@ class TestChatBackend:
 
         assert chat.age[client] == 0
 
-    def test_outbox(self, sockets):
+    def test_outbox_subscribes_to_default_channel(self, sockets):
         ws = Mock()
+        sockets.request = Mock()
+        sockets.request.args.get.return_value = None
         sockets.outbox(ws)
 
         ws.closed = True
         gevent.wait()
 
         assert ws in sockets.chat_backend.clients['quorum']
+
+    def test_outbox_subscribes_to_requested_channel(self, sockets):
+        ws = Mock()
+        sockets.request = Mock()
+        sockets.request.args.get.return_value = 'special'
+        sockets.outbox(ws)
+        assert ws in sockets.chat_backend.clients['special']


### PR DESCRIPTION
Allow experiments to define background tasks and channels to be set up by the framework on experiment launch

## Description
* Experiments can define a list property `background_tasks` which will be run as `gevent` `greenlet`s on experiment launch
* Experiments can define a `channel` property which will be added to the set of active pubsub channels, and the experiment object itself will be subscribed to the channel on launch
* Adds support for subscribing to a specific channel when registering a websocket via the `/receive_chat` route
* Adds a new `/send_chat` route, allowing websocket clients to send messages to a pubsub channel

## Motivation and Context
The Griduniverse demo requires a flexible bidirectional communication channel between clients and the Experiment process

## How Has This Been Tested?
* Changes to the ChatBackend class have automated tests
* `/receive_chat` has automated tests
* `/send_chat` has extensive manual testing using the Griduniverse demo
