### PR TITLE
Fix issues with websockets on Heroku

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -157,10 +157,11 @@ submitNextResponse = function (n) {
     });
 };
 
-waitForQuorum = function () {
+waitForQuorum = function (onOpen) {
     var ws_scheme = (window.location.protocol === "https:") ? 'wss://' : 'ws://';
     var inbox = new ReconnectingWebSocket(ws_scheme + location.host + "/receive_chat");
     var deferred = $.Deferred();
+    inbox.onopen = onOpen;
     inbox.onmessage = function (msg) {
         if (msg.data.indexOf('quorum:') !== 0) { return; }
         var data = JSON.parse(msg.data.substring(7));

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -20,9 +20,16 @@
             </div>
         </div>
         <script type="text/javascript">
-            var awaitingQuorum = waitForQuorum();
-            var creatingParticipant = create_participant();
-            // wait for both deferreds to resolve
+            var creatingParticipant = $.Deferred();
+            var awaitingQuorum = waitForQuorum(function () {
+                // Send create participant request once the websocket is open
+                // so we'll be sure to receive our own quorum update
+                create_participant().done(function () {
+                    creatingParticipant.resolve();
+                });
+            });
+
+            // wait for quorum to be reached AND for participant to be created
             $.when(awaitingQuorum, creatingParticipant).done(function () {
                 allow_exit();
                 go_to_page("exp");

--- a/demos/chatroom/config.txt
+++ b/demos/chatroom/config.txt
@@ -28,3 +28,4 @@ num_dynos_web = 1
 num_dynos_worker = 1
 host = 0.0.0.0
 notification_url = None
+clock_on = true

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -14,7 +14,10 @@ class TestExperiment(Experiment):
 
     @property
     def public_properties(self):
-        return {'exists': True}
+        return {
+            'exists': True,
+            'quorum': 1,
+        }
 
     def create_network(self):
         """Return a new network."""

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -62,7 +62,23 @@ class TestChatBackend:
         gevent.wait()  # wait for event loop
         client.send.assert_called_once_with('quorum:Calloo! Callay!')
 
+    def test_stop(self, chat):
+        chat.start()
+        chat.stop()
+
+    def test_heartbeat(self, chat):
+        client = Mock()
+
+        for i in range(300):
+            chat.heartbeat(client)
+
+        assert chat.age[client] == 0
+
     def test_outbox(self, sockets):
         ws = Mock()
         sockets.outbox(ws)
+
+        ws.closed = True
+        gevent.wait()
+
         assert ws in sockets.chat_backend.clients['quorum']


### PR DESCRIPTION
## Description
A couple fixes for the websocket-based waiting room:
1. Send a ping message every 30s so that Heroku doesn't close the websocket connection after 55s.
2. Wait to send the create participant request until the websocket connection has been opened, so that the user receives the quorum update for their own participant.

## Motivation and Context
Without these fixes, the waiting room doesn't work reliably on Heroku.

## How Has This Been Tested?
I ran `dallinger sandbox` using this branch (which requires updating demos/chatroom/requirements.txt to use dallinger from git) and confirmed that Jesse and I could enter the chatroom.
