### PR TITLE
Bot queue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ addons:
     - pandoc
     - enchant
     - heroku-toolbelt
+    - redis-server
 before_install:
 - rvm install 2.1.5
 - pip install --upgrade setuptools pip wheel

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -48,6 +48,7 @@ class BotBase(object):
 
     def sign_up(self):
         """Accept HIT, give consent and start experiment."""
+        print self.URL
         try:
             self.driver.get(self.URL)
             logger.info("Loaded ad page.")

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -97,11 +97,16 @@ class BotBase(object):
         logger.error("Bot class does not define participate method.")
         raise NotImplementedError
 
+    def complete_questionnaire(self):
+        """Complete the standard debriefing form."""
+        pass
+
     def sign_off(self):
         """Submit questionnaire and finish."""
         try:
             feedback = WebDriverWait(self.driver, 10).until(
                 EC.element_to_be_clickable((By.ID, 'submit-questionnaire')))
+            self.complete_questionnaire()
             feedback.click()
             logger.info("Clicked submit questionnaire button.")
             self.driver.switch_to_window(self.driver.window_handles[0])

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -74,7 +74,9 @@ class BotBase(object):
                 EC.element_to_be_clickable((By.CLASS_NAME, 'btn-primary')))
             begin.click()
             logger.info("Clicked begin experiment button.")
-            self.driver.switch_to_window('Popup')
+            WebDriverWait(self.driver, 10).until(
+                lambda d: len(d.window_handles) == 2)
+            self.driver.switch_to_window(self.driver.window_handles[-1])
             self.driver.set_window_size(1024, 768)
             logger.info("Switched to experiment popup.")
             consent = WebDriverWait(self.driver, 10).until(

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -1,7 +1,7 @@
 """Bots."""
 
 import logging
-from urlparse import urlparse
+from urlparse import urlparse, parse_qs
 
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -46,7 +46,14 @@ class BotBase(object):
             raise ValueError(
                 'Unsupported webdriver_type: {}'.format(driver_type))
         self.driver.set_window_size(1024, 768)
+
+        parts = urlparse(URL)
+        query = parse_qs(parts.query)
+        if not assignment_id:
+            assignment_id = query.get('assignmentId', [''])[0]
         self.assignment_id = assignment_id
+        if not worker_id:
+            worker_id = query.get('workerId', [''])[0]
         self.worker_id = worker_id
         self.unique_id = worker_id + ':' + assignment_id
         logger.info("Started PhantomJs webdriver.")
@@ -106,7 +113,7 @@ class BotBase(object):
                                        status,
                                        self.unique_id)
         tmp_driver.get(complete_url)
-        logger.error("Forced call to %s: %s" % (status, complete_url))
+        logger.info("Forced call to %s: %s" % (status, complete_url))
         tmp_driver.quit()
 
     def run_experiment(self):

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -11,6 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from dallinger.config import get_config
 config = get_config()
 
+logging.basicConfig()
 logger = logging.getLogger(__file__)
 
 

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -103,11 +103,13 @@ class BotBase(object):
         self.participate()
         if not self.sign_off():
             # phantomjs error, but need to call complete or recruiting stops
+            tmp_driver = webdriver.PhantomJS()
             url = self.driver.current_url
             p = urlparse(url)
             complete_url = '%s://%s/worker_failed?uniqueId=%s'
             complete_url = complete_url % (p.scheme, p.netloc, self.unique_id)
-            self.driver.get(complete_url)
+            tmp_driver.get(complete_url)
             logger.error("Forced call to worker_failed: %s" % complete_url)
-            logger.info(self.driver.page_source)
+            logger.info(self.driver.current_url)
+            tmp_driver.quit()
         self.driver.quit()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -11,7 +11,7 @@ from selenium.webdriver.support import expected_conditions as EC
 from dallinger.config import get_config
 config = get_config()
 
-logging.basicConfig()
+logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__file__)
 
 
@@ -98,3 +98,4 @@ class BotBase(object):
         self.sign_up()
         self.participate()
         self.sign_off()
+        self.driver.quit()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -115,7 +115,7 @@ class BotBase(object):
         self.sign_up()
         self.participate()
         if self.sign_off():
-            complete_experiment('worker_complete')
+            self.complete_experiment('worker_complete')
         else:
-            complete_experiment('worker_failed')
+            self.complete_experiment('worker_failed')
         self.driver.quit()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -48,7 +48,6 @@ class BotBase(object):
 
     def sign_up(self):
         """Accept HIT, give consent and start experiment."""
-        print self.URL
         try:
             self.driver.get(self.URL)
             logger.info("Loaded ad page.")
@@ -93,6 +92,8 @@ class BotBase(object):
             return False
 
     def run_experiment(self):
+        self.driver = webdriver.PhantomJS()
+        self.driver.set_window_size(1024, 768)
         self.sign_up()
         self.participate()
         self.sign_off()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -109,4 +109,5 @@ class BotBase(object):
             complete_url = complete_url % (p.scheme, p.netloc, self.unique_id)
             self.driver.get(complete_url)
             logger.error("Error. Forced call to worker_failed.")
+            logger.info(self.driver.page_source)
         self.driver.quit()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -1,7 +1,7 @@
 """Bots."""
 
 import logging
-from lazy import lazy
+from cached_property import cached_property
 from urlparse import urlparse, parse_qs
 
 from selenium import webdriver
@@ -32,10 +32,12 @@ class BotBase(object):
         self.worker_id = worker_id
         self.unique_id = worker_id + ':' + assignment_id
 
-    @lazy
+    @cached_property
     def driver(self):
         from dallinger.config import get_config
         config = get_config()
+        if not config.ready:
+            config.load()
         driver_url = config.get('webdriver_url', None)
         driver_type = config.get('webdriver_type', 'phantomjs').lower()
 
@@ -122,8 +124,6 @@ class BotBase(object):
         tmp_driver.quit()
 
     def run_experiment(self):
-        self.driver = webdriver.PhantomJS()
-        self.driver.set_window_size(1024, 768)
         self.sign_up()
         self.participate()
         if self.sign_off():

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -48,7 +48,7 @@ class BotBase(object):
         self.driver.set_window_size(1024, 768)
         self.assignment_id = assignment_id
         self.worker_id = worker_id
-        self.uniqueId = worker_id + ':' + assignment_id
+        self.unique_id = worker_id + ':' + assignment_id
         logger.info("Started PhantomJs webdriver.")
 
     def sign_up(self):

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -19,7 +19,7 @@ class BotBase(object):
 
     """A bot."""
 
-    def __init__(self, URL, recruiter=None):
+    def __init__(self, URL):
         logger.info("Starting up bot with URL: %s." % URL)
         self.URL = URL
         driver_url = config.get('webdriver_url', None)
@@ -45,6 +45,7 @@ class BotBase(object):
             raise ValueError(
                 'Unsupported webdriver_type: {}'.format(driver_type))
         self.driver.set_window_size(1024, 768)
+        self.recruiter = recruiter
         self.recruiter = recruiter
         logger.info("Started PhantomJs webdriver.")
 
@@ -91,9 +92,6 @@ class BotBase(object):
             return True
         except TimeoutException:
             logger.error("Error during experiment sign off.")
-            # Complete was not called, so try again
-            if self.recruiter is not None:
-                self.recruiter.recruit_participants(n=1)
             return False
 
     def run_experiment(self):

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -19,7 +19,7 @@ class BotBase(object):
 
     """A bot."""
 
-    def __init__(self, URL):
+    def __init__(self, URL, recruiter=None):
         logger.info("Starting up bot with URL: %s." % URL)
         self.URL = URL
         driver_url = config.get('webdriver_url', None)
@@ -45,6 +45,7 @@ class BotBase(object):
             raise ValueError(
                 'Unsupported webdriver_type: {}'.format(driver_type))
         self.driver.set_window_size(1024, 768)
+        self.recruiter = recruiter
         logger.info("Started PhantomJs webdriver.")
 
     def sign_up(self):
@@ -90,6 +91,9 @@ class BotBase(object):
             return True
         except TimeoutException:
             logger.error("Error during experiment sign off.")
+            # Complete was not called, so try again
+            if self.recruiter is not None:
+                self.recruiter.recruit_participants(n=1)
             return False
 
     def run_experiment(self):

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -84,7 +84,7 @@ class BotBase(object):
     def sign_off(self):
         """Submit questionnaire and finish."""
         try:
-            feedback = WebDriverWait(self.driver, 10).until(
+            feedback = WebDriverWait(self.driver, 15).until(
                 EC.element_to_be_clickable((By.ID, 'submit-questionnaire')))
             feedback.click()
             logger.info("Clicked submit questionnaire button.")
@@ -108,6 +108,6 @@ class BotBase(object):
             complete_url = '%s://%s/worker_failed?uniqueId=%s'
             complete_url = complete_url % (p.scheme, p.netloc, self.unique_id)
             self.driver.get(complete_url)
-            logger.error("Error. Forced call to worker_failed.")
+            logger.error("Forced call to worker_failed: %s" % complete_url)
             logger.info(self.driver.page_source)
         self.driver.quit()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -118,7 +118,6 @@ class BotBase(object):
             return False
 
     def complete_experiment(self, status):
-        tmp_driver = webdriver.PhantomJS()
         url = self.driver.current_url
         p = urlparse(url)
         complete_url = '%s://%s/%s?uniqueId=%s'
@@ -126,15 +125,16 @@ class BotBase(object):
                                        p.netloc,
                                        status,
                                        self.unique_id)
-        tmp_driver.get(complete_url)
+        self.driver.get(complete_url)
         logger.info("Forced call to %s: %s" % (status, complete_url))
-        tmp_driver.quit()
 
     def run_experiment(self):
-        self.sign_up()
-        self.participate()
-        if self.sign_off():
-            self.complete_experiment('worker_complete')
-        else:
-            self.complete_experiment('worker_failed')
-        self.driver.quit()
+        try:
+            self.sign_up()
+            self.participate()
+            if self.sign_off():
+                self.complete_experiment('worker_complete')
+            else:
+                self.complete_experiment('worker_failed')
+        finally:
+            self.driver.quit()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -344,11 +344,28 @@ def debug(verbose, bot, exp_config=None):
                         url = match.group(1)
                         webbrowser.open(url, new=1, autoraise=True)
 
-                # Is recruitment over? We can end this debug session.
+                # Is recruitment over? We can end the loop, and check
+                # experiment status
                 match = re.search('Close recruitment.$', line)
                 if match:
                     log('Recruitment is complete.')
                     break
+
+            # Check status url
+            status_url = base_url + '/summary'
+            while True:
+                time.sleep(30)
+                data = {}
+                try:
+                    resp = requests.get(status_url)
+                    data = resp.json()
+                except (ValueError, requests.exceptions.RequestException):
+                    error('Error fetching experiment status.')
+                log('Current application state: {}'.format(data))
+                if data.get('completed', False):
+                    log('Experiment completed, all nodes filled.')
+                    break
+
     finally:
         try:
             # It seems we need to explicitly kill all subprocesses with a SIGINT

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -297,7 +297,9 @@ def debug(verbose, bot, exp_config=None):
     port = config.get('port')
     try:
         p = subprocess.Popen(
-            ['heroku', 'local', 'web=2,worker=8', '-p', str(port)],
+            ['heroku', 'local', '-p', str(port),
+             "web={},worker={}".format(config.get('num_dynos_web', 1),
+                                       config.get('num_dynos_worker', 1))],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -379,6 +379,18 @@ def debug(verbose, bot):
     finally:
         p.kill()
 
+                # Check for unexpected bot hangs
+                match = re.search('Ignoring EPIPE', line)
+                if participant and match:
+                    epipe = epipe + 1
+                    if epipe >= 2:
+                        error("The experiment finished but recruitment was not closed.")
+                        participant.driver.quit()
+                        break
+
+    finally:
+        p.kill()
+
     log("Completed debugging of experiment with id " + id)
     os.chdir(cwd)
 

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -344,6 +344,7 @@ def debug(verbose, bot, exp_config=None):
 
                 # start checking for completion status
                 if closed:
+                    time.sleep(10)
                     try:
                         resp = requests.get(status_url)
                         exp_data = resp.json()
@@ -353,7 +354,6 @@ def debug(verbose, bot, exp_config=None):
                     if exp_data.get('completed', False):
                         log('Experiment completed, all nodes filled.')
                         break
-                    time.sleep(10)
                     continue
 
                 # Open browser for new participants

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -355,14 +355,14 @@ def debug(verbose, bot, exp_config=None):
             # Check status url
             status_url = base_url + '/summary'
             while True:
-                time.sleep(30)
+                time.sleep(10)
                 data = {}
                 try:
                     resp = requests.get(status_url)
                     data = resp.json()
                 except (ValueError, requests.exceptions.RequestException):
                     error('Error fetching experiment status.')
-                log('Current application state: {}'.format(data))
+                log('Experiment summary: {}'.format(data))
                 if data.get('completed', False):
                     log('Experiment completed, all nodes filled.')
                     break

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -275,7 +275,7 @@ def debug(verbose, bot, exp_config=None):
     if bot:
         exp_config["recruiter"] = u"bots"
 
-    (id, tmp) = setup_experiment(debug=True, verbose=verbose, exp_config=exp_config)
+    (id, tmp) = setup_experiment(verbose=verbose, exp_config=exp_config)
 
     # Switch to the temporary directory.
     cwd = os.getcwd()
@@ -284,15 +284,17 @@ def debug(verbose, bot, exp_config=None):
     # Set the mode to debug.
     config = get_config()
     logfile = config.get('logfile')
-    if logfile != '-':
+    if logfile and logfile != '-':
         logfile = os.path.join(cwd, logfile)
+        config.extend({'logfile': logfile})
+        config.write()
 
     # Drop all the tables from the database.
     db.init_db(drop_all=True)
 
     # Start up the local server
     log("Starting up the server...")
-    port = config.get('port', 22362)
+    port = config.get('port')
     try:
         p = subprocess.Popen(
             ['heroku', 'local', '-p', str(port)],
@@ -338,11 +340,10 @@ def debug(verbose, bot, exp_config=None):
                     sys.stdout.write(line)
 
                 # Open browser for new participants
-                if not bot:
-                    match = re.search('New participant requested: (.*)$', line)
-                    if match:
-                        url = match.group(1)
-                        webbrowser.open(url, new=1, autoraise=True)
+                match = re.search('New participant requested: (.*)$', line)
+                if match:
+                    url = match.group(1)
+                    webbrowser.open(url, new=1, autoraise=True)
 
                 # Is recruitment over? We can end the loop, and check
                 # experiment status

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -297,7 +297,7 @@ def debug(verbose, bot, exp_config=None):
     port = config.get('port')
     try:
         p = subprocess.Popen(
-            ['heroku', 'local', '-p', str(port)],
+            ['heroku', 'local', 'web=2,worker=8', '-p', str(port)],
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
         )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -268,9 +268,6 @@ def debug(verbose, bot):
     """Run the experiment locally."""
     (id, tmp) = setup_experiment(debug=True, verbose=verbose)
 
-    # Drop all the tables from the database.
-    db.init_db(drop_all=True)
-
     # Switch to the temporary directory.
     cwd = os.getcwd()
     os.chdir(tmp)
@@ -287,9 +284,12 @@ def debug(verbose, bot):
     })
     config.write()
 
+    # Drop all the tables from the database.
+    db.init_db(drop_all=True)
+
     # Start up the local server
     log("Starting up the server...")
-    port = config.get('port')
+    port = config.get('port', 22362)
     try:
         p = subprocess.Popen(
             ['heroku', 'local', '-p', str(port)],

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -191,9 +191,6 @@ class Configuration(object):
         self.extend(os.environ, cast_types=True)
 
     def load(self):
-        if self.ready:
-            raise ValueError("Already loaded")
-
         # Apply extra parameters before loading the configs
         self.register_extra_parameters()
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -138,7 +138,7 @@ class Configuration(object):
         except KeyError:
             raise AttributeError
 
-    def __dict__(self):
+    def as_dict(self):
         d = {}
         for key in self.types:
             if key not in self.sensitive:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -138,6 +138,16 @@ class Configuration(object):
         except KeyError:
             raise AttributeError
 
+    def __dict__(self):
+        d = {}
+        for key in self.types:
+            if key not in self.sensitive:
+                try:
+                    d[key] = self.get(key)
+                except KeyError:
+                    pass
+        return d
+
     def register(self, key, type_, synonyms=None, sensitive=False):
         if synonyms is None:
             synonyms = set()

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -161,7 +161,11 @@ def export(id, local=False, scrub_pii=False):
 
     print("Preparing to export the data...")
 
-    copy_heroku_to_local(id)
+    if local:
+        db_name = 'dallinger'
+    else:
+        db_name = heroku.app_name(id)
+        copy_heroku_to_local(id)
 
     # Create the data package if it doesn't already exist.
     subdata_path = os.path.join("data", id, "data")
@@ -173,7 +177,7 @@ def export(id, local=False, scrub_pii=False):
             raise
 
     # Copy in the data.
-    copy_local_to_csv(heroku.app_name(id), subdata_path, scrub_pii=scrub_pii)
+    copy_local_to_csv(db_name, subdata_path, scrub_pii=scrub_pii)
 
     # Copy the experiment code into a code/ subdirectory.
     try:

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -23,6 +23,7 @@ except ImportError:
     pass
 
 from dallinger import heroku
+from dallinger.db import db_url
 
 
 table_names = [
@@ -162,7 +163,7 @@ def export(id, local=False, scrub_pii=False):
     print("Preparing to export the data...")
 
     if local:
-        db_name = 'dallinger'
+        db_name = db_url
     else:
         db_name = heroku.app_name(id)
         copy_heroku_to_local(id)

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -287,7 +287,7 @@ class Table(object):
     def __init__(self, path):
 
         self.odo_resource = odo.resource(path)
-        self.tablib_dataset = tablib.Dataset().load(open(path).read())
+        self.tablib_dataset = tablib.Dataset().load(open(path).read(), "csv")
 
     @property
     def csv(self):

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -10,6 +10,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError
 
 
 logger = logging.getLogger('dallinger.db')

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -10,7 +10,6 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.exc import OperationalError
-from sqlalchemy.exc import DBAPIError
 
 
 logger = logging.getLogger('dallinger.db')

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -455,13 +455,14 @@ class Experiment(object):
         bot = kwargs.get('bot')
         if bot:
             del kwargs['bot']
+            kwargs['recruiter'] = 'bots'
 
         if kwargs:
             self.exp_config.update(kwargs)
 
         if self.exp_config.get('mode') == u'debug':
             dlgr.command_line.debug.callback(verbose=True,
-                                             bot=bot)
+                                             exp_config=self.exp_config)
         else:
             dlgr.command_line.deploy_sandbox_shared_setup(
                 app=app_id,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -459,8 +459,11 @@ class Experiment(object):
             self.exp_config.update(kwargs)
 
         if self.exp_config.get('mode') == u'debug':
-            dlgr.command_line.debug.callback(verbose=True,
-                                             exp_config=self.exp_config)
+            dlgr.command_line.debug.callback(
+                verbose=True,
+                bot=bot,
+                exp_config=self.exp_config
+            )
         else:
             dlgr.command_line.deploy_sandbox_shared_setup(
                 app=app_id,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -236,7 +236,9 @@ class Experiment(object):
 
     def create_node(self, participant, network):
         """Create a node for a participant."""
-        return Node(network=network, participant=participant)
+        node = Node(network=network, participant=participant)
+        self.session.commit()
+        return node
 
     def add_node_to_network(self, node, network):
         """Add a node to a network.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -437,7 +437,7 @@ class Experiment(object):
         self.fail_participant(participant)
 
     @exp_class_working_dir
-    def run(self, exp_config=None, app_id=None, **kwargs):
+    def run(self, exp_config=None, app_id=None, bot=False, **kwargs):
         """Deploy and run an experiment.
 
         The exp_config object is either a dictionary or a
@@ -452,9 +452,7 @@ class Experiment(object):
         self.app_id = app_id
         self.exp_config = exp_config or {}
 
-        bot = kwargs.get('bot')
         if bot:
-            del kwargs['bot']
             kwargs['recruiter'] = 'bots'
 
         if kwargs:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -479,8 +479,7 @@ class Experiment(object):
             while self.experiment_completed() is False:
                 time.sleep(30)
             self.end_experiment()
-        data = self.retrieve_data()
-        return (self.app_id, data, self.exp_config)
+        return self.retrieve_data()
 
     def experiment_completed(self):
         """Checks the current state of the experiment to see whether it has

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -236,9 +236,7 @@ class Experiment(object):
 
     def create_node(self, participant, network):
         """Create a node for a participant."""
-        node = Node(network=network, participant=participant)
-        self.session.commit()
-        return node
+        return Node(network=network, participant=participant)
 
     def add_node_to_network(self, node, network):
         """Add a node to a network.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1283,12 +1283,17 @@ def check_for_duplicate_assignments(participant):
 @db.scoped_session_decorator
 def worker_complete():
     """Complete worker."""
-    if 'uniqueId' not in request.args:
+    if not request.args.get('uniqueId'):
         status = "bad request"
     else:
-        participant = models.Participant.query.filter_by(
+        participants = models.Participant.query.filter_by(
             unique_id=request.args['uniqueId'],
-        ).all()[0]
+        ).all()
+        if not len(participants):
+            return error_response(error_type='UniqueId not found: {}'.format(
+                request.args['uniqueId']
+            ))
+        participant = participants[0]
         participant.end_time = datetime.now()
         session.add(participant)
         session.commit()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -4,7 +4,6 @@ from datetime import datetime
 import gevent
 from json import dumps
 from operator import attrgetter
-import json
 import re
 import traceback
 import user_agents

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1433,14 +1433,21 @@ def worker_function(event_type, assignment_id, participant_id):
     elif event_type == 'BotAssignmentSubmitted':
         exp.log("Received bot submission.", key)
         participant.end_time = datetime.now()
-        participant.status = "submitted"
-        session.commit()
 
         # No checks for bot submission
         exp.recruiter().approve_hit(assignment_id)
         participant.status = "approved"
         exp.submission_successful(participant=participant)
         session.commit()
+        exp.recruit()
+
+    elif event_type == 'BotAssignmentRejected':
+        exp.log("Received rejected bot submission.", key)
+        participant.end_time = datetime.now()
+        participant.status = "rejected"
+        session.commit()
+
+        # We go back to recruiting immediately
         exp.recruit()
 
     elif event_type == "NotificationMissing":

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -49,9 +49,6 @@ q = Queue(connection=redis)
 WAITING_ROOM_CHANNEL = 'quorum'
 
 app = Flask('Experiment_Server')
-# This might only be necessary for Flask-SocketIO:
-secret = hashlib.sha256(config.get("aws_secret_access_key")).hexdigest()
-app.config["SECRET_KEY"] = secret
 
 Experiment = experiment.load()
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -362,7 +362,7 @@ def summary():
     else:
         for net in unfilled_nets:
             node_count = models.Node.query.filter_by(
-                network_id=net.id
+                network_id=net.id, failed=False,
             ).with_entities(func.count(models.Node.id)).scalar()
             net_size = net.max_size
             required_nodes += net_size

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -209,6 +209,13 @@ def shutdown_session(_=None):
     db.logger.debug('Closing Dallinger DB session at flask request end')
 
 
+"""Inject the experiment variable into the template context."""
+@app.context_processor
+def inject_experiment():
+    exp = Experiment(session)
+    return dict(experiment=exp)
+
+
 """Define routes for managing an experiment and the participants."""
 
 
@@ -219,11 +226,6 @@ def launch():
     exp.log("Launching experiment...", "-----")
     url_info = exp.recruiter().open_recruitment(n=exp.initial_recruitment_size)
     session.commit()
-
-    """Inject the experiment variable into the template context."""
-    @app.context_processor
-    def inject_experiment():
-        return dict(experiment=exp)
 
     for task in exp.background_tasks:
         gevent.spawn(task)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1300,7 +1300,6 @@ def worker_complete():
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
         )
-    print config.get('recruiter', 'mturk')
     if config.get('recruiter', 'mturk') == 'bots':
         # Trigger notification directly
         # Handled same as debug, but added separetely for clarity
@@ -1308,6 +1307,10 @@ def worker_complete():
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
         )
+    _debug_notify(
+        assignment_id=participant.assignment_id,
+        participant_id=participant.id,
+    )
     return success_response(field="status",
                             data=status,
                             request_type="worker complete")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1298,20 +1298,20 @@ def worker_complete():
         session.add(participant)
         session.commit()
         status = "success"
-    if config.get('mode') == "debug":
-        # Trigger notification directly in debug mode,
-        # because there won't be one from MTurk
-        _debug_notify(
-            assignment_id=participant.assignment_id,
-            participant_id=participant.id,
-        )
-    if config.get('recruiter', 'mturk') == 'bots':
+    if config.get('recruiter', 'mturk') == u'bots':
         # Trigger notification directly
         # Bot submissions skip all attention and bonus checks
         _debug_notify(
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
             event_type='BotAssignmentSubmitted',
+        )
+    elif config.get('mode') == "debug":
+        # Trigger notification directly in debug mode,
+        # because there won't be one from MTurk
+        _debug_notify(
+            assignment_id=participant.assignment_id,
+            participant_id=participant.id,
         )
     return success_response(field="status",
                             data=status,

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -49,6 +49,9 @@ q = Queue(connection=redis)
 WAITING_ROOM_CHANNEL = 'quorum'
 
 app = Flask('Experiment_Server')
+# This might only be necessary for Flask-SocketIO:
+secret = hashlib.sha256(config.get("aws_secret_access_key")).hexdigest()
+app.config["SECRET_KEY"] = secret
 
 Experiment = experiment.load()
 
@@ -1457,4 +1460,5 @@ def insert_mode(page_html, mode):
             page_html[match.end():]
         return new_html
     else:
+        traceback.print_exc()
         raise ExperimentError("insert_mode_failed")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1300,7 +1300,8 @@ def worker_complete():
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
         )
-    if config.get('recruiter', None) == "bots":
+    print config.get('recruiter', 'mturk')
+    if config.get('recruiter', 'mturk') == 'bots':
         # Trigger notification directly
         # Handled same as debug, but added separetely for clarity
         _debug_notify(

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import gevent
 from json import dumps
 from operator import attrgetter
+import json
 import re
 import traceback
 import user_agents

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1302,15 +1302,12 @@ def worker_complete():
         )
     if config.get('recruiter', 'mturk') == 'bots':
         # Trigger notification directly
-        # Handled same as debug, but added separetely for clarity
+        # Bot submissions skip all attention and bonus checks
         _debug_notify(
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
+            event_type='BotAssignmentSubmitted',
         )
-    _debug_notify(
-        assignment_id=participant.assignment_id,
-        participant_id=participant.id,
-    )
     return success_response(field="status",
                             data=status,
                             request_type="worker complete")
@@ -1432,6 +1429,14 @@ def worker_function(event_type, assignment_id, participant_id):
                     exp.submission_successful(participant=participant)
                     session.commit()
                     exp.recruit()
+
+    elif event_type == 'BotAssignmentSubmitted':
+        # No checks for bot submission
+        exp.log("Received bot submission.", key)
+        participant.status = "approved"
+        exp.submission_successful(participant=participant)
+        session.commit()
+        exp.recruit()
 
     elif event_type == "NotificationMissing":
         if participant.status == "working":

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1431,8 +1431,13 @@ def worker_function(event_type, assignment_id, participant_id):
                     exp.recruit()
 
     elif event_type == 'BotAssignmentSubmitted':
-        # No checks for bot submission
         exp.log("Received bot submission.", key)
+        participant.end_time = datetime.now()
+        participant.status = "submitted"
+        session.commit()
+
+        # No checks for bot submission
+        exp.recruiter().approve_hit(assignment_id)
         participant.status = "approved"
         exp.submission_successful(participant=participant)
         session.commit()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1457,5 +1457,4 @@ def insert_mode(page_html, mode):
             page_html[match.end():]
         return new_html
     else:
-        traceback.print_exc()
         raise ExperimentError("insert_mode_failed")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1300,6 +1300,13 @@ def worker_complete():
             assignment_id=participant.assignment_id,
             participant_id=participant.id,
         )
+    if config.get('recruiter', None) == "bots":
+        # Trigger notification directly
+        # Handled same as debug, but added separetely for clarity
+        _debug_notify(
+            assignment_id=participant.assignment_id,
+            participant_id=participant.id,
+        )
     return success_response(field="status",
                             data=status,
                             request_type="worker complete")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -209,9 +209,9 @@ def shutdown_session(_=None):
     db.logger.debug('Closing Dallinger DB session at flask request end')
 
 
-"""Inject the experiment variable into the template context."""
 @app.context_processor
 def inject_experiment():
+    """Inject the experiment variable into the template context."""
     exp = Experiment(session)
     return dict(experiment=exp)
 

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -40,7 +40,6 @@ class ChatBackend(object):
 
     def subscribe(self, client, channel=None):
         """Register a new client to receive messages."""
-        app.logger.debug('{} subscribing to channel {}'.format(client, channel))
         if channel is not None:
             self.clients[channel].append(client)
             if channel not in self.pubsub.channels:
@@ -61,7 +60,6 @@ class ChatBackend(object):
 
         Automatically discards invalid connections.
         """
-        app.logger.debug('sending {} to client {}'.format(data, client))
         try:
             client.send(data)
         except socket.error:

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -40,6 +40,7 @@ class ChatBackend(object):
 
     def subscribe(self, client, channel=None):
         """Register a new client to receive messages."""
+        app.logger.debug('{} subscribing to channel {}'.format(client, channel))
         if channel is not None:
             self.clients[channel].append(client)
             if channel not in self.pubsub.channels:
@@ -60,6 +61,7 @@ class ChatBackend(object):
 
         Automatically discards invalid connections.
         """
+        app.logger.debug('sending {} to client {}'.format(data, client))
         try:
             client.send(data)
         except socket.error:

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -72,7 +72,7 @@ class ChatBackend(object):
         """Listens for new messages in redis, and sends them to clients."""
         for message in self.pubsub.listen():
             data = message.get('data')
-            if message['type'] == 'message':
+            if message['type'] == 'message' and data != 'None':
                 channel = message['channel']
                 count = len(self.clients[channel])
                 if count:

--- a/dallinger/experiments/__init__.py
+++ b/dallinger/experiments/__init__.py
@@ -3,7 +3,12 @@ with a ``setuptools`` ``entry_point`` for the ``dallinger.experiments`` group.
 """
 import logging
 from pkg_resources import iter_entry_points
+
+from ..config import get_config
 from ..experiment import Experiment
+
+config = get_config()
+config.load()
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -13,11 +13,11 @@ var getUrlParameter = function getUrlParameter(sParam) {
         }
     }
 };
-hit_id = getUrlParameter("hit_id");
-worker_id = getUrlParameter("worker_id");
-assignment_id = getUrlParameter("assignment_id");
-mode = getUrlParameter("mode");
-participant_id = getUrlParameter("participant_id");
+var hit_id = getUrlParameter("hit_id");
+var worker_id = getUrlParameter("worker_id");
+var assignment_id = getUrlParameter("assignment_id");
+var mode = getUrlParameter("mode");
+var participant_id = getUrlParameter("participant_id");
 
 // stop people leaving the page
 window.onbeforeunload = function() {
@@ -27,17 +27,17 @@ window.onbeforeunload = function() {
 };
 
 // allow actions to leave the page
-allow_exit = function() {
+var allow_exit = function() {
     window.onbeforeunload = function() {};
 };
 
 // advance the participant to a given html page
-go_to_page = function(page) {
+var go_to_page = function(page) {
     window.location = "/" + page + "?participant_id=" + participant_id;
 };
 
 // report assignment complete
-submitAssignment = function() {
+var submitAssignment = function() {
     reqwest({
         url: "/participant/" + participant_id,
         method: "get",
@@ -47,7 +47,7 @@ submitAssignment = function() {
             hit_id = resp.participant.hit_id;
             assignment_id = resp.participant.assignment_id;
             worker_id = resp.participant.worker_id;
-            worker_complete = '/worker_complete';
+            var worker_complete = '/worker_complete';
             reqwest({
                 url: worker_complete,
                 method: "get",
@@ -61,7 +61,7 @@ submitAssignment = function() {
                 },
                 error: function (err) {
                     console.log(err);
-                    errorResponse = JSON.parse(err.response);
+                    var errorResponse = JSON.parse(err.response);
                     $("body").html(errorResponse.html);
                 }
             });
@@ -69,13 +69,13 @@ submitAssignment = function() {
     });
 };
 
-submit_assignment = function () {
+var submit_assignment = function () {
     submitAssignment();
 };
 
 // make a new participant
-create_participant = function() {
-
+var create_participant = function() {
+    var url;
     // check if the local store is available, and if so, use it.
     if (typeof store != "undefined") {
         url = "/participant/" +
@@ -95,40 +95,44 @@ create_participant = function() {
     if (participant_id !== undefined && participant_id !== 'undefined') {
         deferred.resolve();
     } else {
-        reqwest({
-            url: url,
-            method: "post",
-            type: "json",
-            success: function(resp) {
-                console.log(resp);
-                participant_id = resp.participant.id;
-                deferred.resolve();
-            },
-            error: function (err) {
-                errorResponse = JSON.parse(err.response);
-                $("body").html(errorResponse.html);
-            }
+        $(function () {
+            $('.btn-success').prop('disabled', 'disabled');
+            reqwest({
+                url: url,
+                method: "post",
+                type: "json",
+                success: function(resp) {
+                    console.log(resp);
+                    participant_id = resp.participant.id;
+                    $('.btn-success').prop('disabled', null);
+                    deferred.resolve();
+                },
+                error: function (err) {
+                    var errorResponse = JSON.parse(err.response);
+                    $("body").html(errorResponse.html);
+                }
+            });
         });
     }
     return deferred;
 };
 
-lock = false;
+var lock = false;
 
-submitResponses = function () {
+var submitResponses = function () {
     submitNextResponse(0);
     submitAssignment();
 };
 
-submit_responses = function () {
+var submit_responses = function () {
     submitResponses();
     submitAssignment();
 };
 
-submitNextResponse = function (n) {
+var submitNextResponse = function (n) {
 
     // Get all the ids.
-    ids = $("form .question select, input, textarea").map(
+    var ids = $("form .question select, input, textarea").map(
         function () {
             return $(this).attr("id");
         }
@@ -149,7 +153,7 @@ submitNextResponse = function (n) {
             }
         },
         error: function (err) {
-            errorResponse = JSON.parse(err.response);
+            var errorResponse = JSON.parse(err.response);
             if (errorResponse.hasOwnProperty("html")) {
                 $("body").html(errorResponse.html);
             }
@@ -177,7 +181,7 @@ waitForQuorum = function (onOpen) {
     return deferred;
 };
 
-numReady = function(summary) {
+var numReady = function(summary) {
     for (var i = 0; i < summary.length; i++) {
         if (summary[i][0] == "working") {
             return summary[i][1];

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -9,7 +9,6 @@ import requests
 
 import dallinger
 from dallinger import db
-from dallinger.experiment_server.experiment_server import worker_function
 from dallinger.models import Participant
 from dallinger.heroku.messages import NullHITMessager
 
@@ -45,7 +44,6 @@ def run_check(config, mturk, participants, session, reference_time):
                 # Bot somehow did not finish (phantomjs?). Just get rid of it.
                 p.status = "rejected"
                 session.commit()
-                worker_function('BotAssignmentRejected', assignment_id, None)
                 return
 
             # ask amazon for the status of the assignment

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -39,6 +39,19 @@ def run_check(config, mturk, participants, session, reference_time):
             # get their assignment
             assignment_id = p.assignment_id
 
+            # First see if we have a bot participant
+            if config.get('recruiter', 'mturk') == 'bots':
+                # Bot somehow did not finish (phantomjs error?)
+                # Get rid of it and continue recruiting more bots
+                args = {
+                    'Event.1.EventType': 'BotAssignmentRejected',
+                    'Event.1.AssignmentId': assignment_id
+                }
+                requests.post(
+                    "http://" + config.get('host') + '/notifications',
+                    data=args)
+                return
+
             # ask amazon for the status of the assignment
             try:
                 assignment = mturk.get_assignment(assignment_id)[0]

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -201,7 +201,7 @@ class BotRecruiter(object):
         ad_parameters = 'assignmentId={}&hitId={}&workerId={}&mode=sandbox'
         ad_parameters = ad_parameters.format(assignment, hit, worker)
         url = '{}/ad?{}'.format(base_url, ad_parameters)
-        bot = Bot(url, recruiter=self)
+        bot = Bot(url)
         job = q.enqueue(bot.run_experiment)
         logger.info("Created job with id {} for url {}.".format(job.id, url))
         return job

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -169,7 +169,7 @@ class MTurkRecruiter(object):
         This does nothing, because the fact that this is called means
         that all MTurk HITs that were created were already completed.
         """
-        pass
+        logger.info("Close recruitment.")
 
 
 class BotRecruiter(object):
@@ -214,4 +214,4 @@ class BotRecruiter(object):
 
         This does nothing at this time.
         """
-        pass
+        logger.info("Close recruitment.")

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -195,16 +195,17 @@ class BotRecruiter(object):
         """Recruit n new participant bots to the queue"""
         from dallinger_experiment import Bot
         base_url = get_base_url()
-        worker = generate_random_id()
-        hit = generate_random_id()
-        assignment = generate_random_id()
-        ad_parameters = 'assignmentId={}&hitId={}&workerId={}&mode=sandbox'
-        ad_parameters = ad_parameters.format(assignment, hit, worker)
-        url = '{}/ad?{}'.format(base_url, ad_parameters)
-        bot = Bot(url, assignment_id=assignment, worker_id=worker)
-        job = q.enqueue(bot.run_experiment)
-        logger.info("Created job with id {} for url {}.".format(job.id, url))
-        return job
+
+        for _ in range(n):
+            worker = generate_random_id()
+            hit = generate_random_id()
+            assignment = generate_random_id()
+            ad_parameters = 'assignmentId={}&hitId={}&workerId={}&mode=sandbox'
+            ad_parameters = ad_parameters.format(assignment, hit, worker)
+            url = '{}/ad?{}'.format(base_url, ad_parameters)
+            bot = Bot(url, assignment_id=assignment, worker_id=worker)
+            job = q.enqueue(bot.run_experiment)
+            logger.info("Created job {} for url {}.".format(job.id, url))
 
     def approve_hit(self, assignment_id):
         return True

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -204,7 +204,7 @@ class BotRecruiter(object):
             ad_parameters = ad_parameters.format(assignment, hit, worker)
             url = '{}/ad?{}'.format(base_url, ad_parameters)
             bot = Bot(url, assignment_id=assignment, worker_id=worker)
-            job = q.enqueue(bot.run_experiment)
+            job = q.enqueue(bot.run_experiment, timeout=60*20)
             logger.info("Created job {} for url {}.".format(job.id, url))
 
     def approve_hit(self, assignment_id):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -201,7 +201,7 @@ class BotRecruiter(object):
         ad_parameters = 'assignmentId={}&hitId={}&workerId={}&mode=sandbox'
         ad_parameters = ad_parameters.format(assignment, hit, worker)
         url = '{}/ad?{}'.format(base_url, ad_parameters)
-        bot = Bot(url)
+        bot = Bot(url, assignment_id=assignment, worker_id=worker)
         job = q.enqueue(bot.run_experiment)
         logger.info("Created job with id {} for url {}.".format(job.id, url))
         return job

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -201,7 +201,7 @@ class BotRecruiter(object):
         ad_parameters = 'assignmentId={}&hitId={}&workerId={}&mode=sandbox'
         ad_parameters = ad_parameters.format(assignment, hit, worker)
         url = '{}/ad?{}'.format(base_url, ad_parameters)
-        bot = Bot(url)
+        bot = Bot(url, recruiter=self)
         job = q.enqueue(bot.run_experiment)
         logger.info("Created job with id {} for url {}.".format(job.id, url))
         return job

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -207,7 +207,6 @@ class BotRecruiter(object):
         return job
 
     def approve_hit(self, assignment_id):
-        logger.info("Do we even get here ever.")
         return True
 
     def close_recruitment(self):

--- a/demos/2048/experiment.py
+++ b/demos/2048/experiment.py
@@ -11,10 +11,11 @@ def extra_parameters():
 class TwentyFortyEight(dallinger.experiments.Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Initialize the experiment."""
         super(TwentyFortyEight, self).__init__(session)
         self.experiment_repeats = 1
         N = config.get("n")
         self.initial_recruitment_size = N
-        self.setup()
+        if session:
+            self.setup()

--- a/demos/bartlett1932/experiment.py
+++ b/demos/bartlett1932/experiment.py
@@ -1,7 +1,6 @@
 """Bartlett's transmission chain experiment from Remembering (1932)."""
 
 import logging
-import time
 
 from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException

--- a/demos/bartlett1932/experiment.py
+++ b/demos/bartlett1932/experiment.py
@@ -33,7 +33,8 @@ class Bartlett1932(Experiment):
         import models
         self.models = models
         self.experiment_repeats = 1
-        self.setup()
+        if session:
+            self.setup()
 
     def setup(self):
         """Setup the networks.

--- a/demos/bartlett1932/experiment.py
+++ b/demos/bartlett1932/experiment.py
@@ -56,8 +56,10 @@ class Bartlett1932(Experiment):
     def add_node_to_network(self, node, network):
         """Add node to the chain and receive transmissions."""
         network.add_node(node)
-        parent = node.neighbors(direction="from")[0]
-        parent.transmit()
+        parents = node.neighbors(direction="from")
+        if len(parents):
+            parent = parents[0]
+            parent.transmit()
         node.receive()
 
     def recruit(self):
@@ -75,8 +77,6 @@ class Bot(BotBase):
         """Finish reading and send text"""
         try:
             logger.info("Entering participate method")
-            self.driver.execute_script("create_agent")
-            time.sleep(10)
             ready = WebDriverWait(self.driver, 10).until(
                 EC.element_to_be_clickable((By.ID, 'finish-reading')))
             stimulus = self.driver.find_element_by_id('stimulus')

--- a/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/bartlett1932/static/scripts/experiment.js
@@ -1,3 +1,5 @@
+var my_node_id;
+
 // Consent to the experiment.
 $(document).ready(function() {
 
@@ -21,7 +23,7 @@ $(document).ready(function() {
     // Consent to the experiment.
     $("#no-consent").click(function() {
         allow_exit();
-        self.close();
+        window.close();
     });
 
     // Consent to the experiment.
@@ -46,7 +48,7 @@ $(document).ready(function() {
         $("#submit-response").addClass('disabled');
         $("#submit-response").html('Sending...');
 
-        response = $("#reproduction").val();
+        var response = $("#reproduction").val();
 
         $("#reproduction").val("");
 
@@ -70,7 +72,7 @@ $(document).ready(function() {
 });
 
 // Create the agent.
-create_agent = function() {
+var create_agent = function() {
     reqwest({
         url: "/node/" + participant_id,
         method: 'post',
@@ -92,14 +94,14 @@ create_agent = function() {
     });
 };
 
-get_info = function() {
+var get_info = function() {
     reqwest({
         url: "/node/" + my_node_id + "/received_infos",
         method: 'get',
         type: 'json',
         success: function (resp) {
-            story = resp.infos[0].contents;
-            storyHTML = markdown.toHTML(story);
+            var story = resp.infos[0].contents;
+            var storyHTML = markdown.toHTML(story);
             $("#story").html(storyHTML);
             $("#stimulus").show();
             $("#response-form").hide();
@@ -107,13 +109,13 @@ get_info = function() {
         },
         error: function (err) {
             console.log(err);
-            errorResponse = JSON.parse(err.response);
+            var errorResponse = JSON.parse(err.response);
             $('body').html(errorResponse.html);
         }
     });
 };
 
-create_agent_failsafe = function() {
+var create_agent_failsafe = function() {
     if ($("#story").html == '<< loading >>') {
         create_agent();
     }

--- a/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/bartlett1932/static/scripts/experiment.js
@@ -73,11 +73,13 @@ $(document).ready(function() {
 
 // Create the agent.
 var create_agent = function() {
+    $('#finish-reading').attr('disabled', 'disabled');
     reqwest({
         url: "/node/" + participant_id,
         method: 'post',
         type: 'json',
         success: function (resp) {
+            $('#finish-reading').attr('disabled', null);
             my_node_id = resp.node.id;
             get_info(my_node_id);
         },

--- a/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/bartlett1932/static/scripts/experiment.js
@@ -73,13 +73,13 @@ $(document).ready(function() {
 
 // Create the agent.
 var create_agent = function() {
-    $('#finish-reading').attr('disabled', 'disabled');
+    $('#finish-reading').prop('disabled', true);
     reqwest({
         url: "/node/" + participant_id,
         method: 'post',
         type: 'json',
         success: function (resp) {
-            $('#finish-reading').attr('disabled', null);
+            $('#finish-reading').prop('disabled', false);
             my_node_id = resp.node.id;
             get_info(my_node_id);
         },

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -15,7 +15,7 @@ def extra_parameters():
 class CoordinationChatroom(dlgr.experiments.Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Initialize the experiment."""
         super(CoordinationChatroom, self).__init__(session)
         self.experiment_repeats = 1
@@ -27,7 +27,8 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
         self.config = config
         if not self.config.ready:
             self.config.load()
-        self.setup()
+        if session:
+            self.setup()
 
     def create_network(self):
         """Create a new network by reading the configuration file."""

--- a/demos/concentration/experiment.py
+++ b/demos/concentration/experiment.py
@@ -7,7 +7,7 @@ import dallinger as dlgr
 class ConcentrationGame(dlgr.experiments.Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Initialize the experiment."""
         config = ConfigParser.ConfigParser()
         config.read("config.txt")
@@ -16,4 +16,5 @@ class ConcentrationGame(dlgr.experiments.Experiment):
         self.experiment_repeats = 1
         N = config.get("Experiment", "num_participants")
         self.initial_recruitment_size = N
-        self.setup()
+        if session:
+            self.setup()

--- a/demos/function-learning/experiment.py
+++ b/demos/function-learning/experiment.py
@@ -7,7 +7,7 @@ from dallinger.networks import Chain
 class FunctionLearning(Experiment):
     """A function-learning experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         The models module is imported here because it must be imported at
@@ -21,7 +21,8 @@ class FunctionLearning(Experiment):
         import models
         self.models = models
         self.experiment_repeats = 1
-        self.setup()
+        if session:
+            self.setup()
 
     def setup(self):
         """Setup does stuff only if there are no networks.

--- a/demos/iterated-drawing/experiment.py
+++ b/demos/iterated-drawing/experiment.py
@@ -7,7 +7,7 @@ from dallinger.experiments import Experiment
 class IteratedDrawing(Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         The models module is imported here because it must be imported at
@@ -21,7 +21,8 @@ class IteratedDrawing(Experiment):
         import models
         self.models = models
         self.experiment_repeats = 1
-        self.setup()
+        if session:
+            self.setup()
 
     def setup(self):
         """Setup the networks.

--- a/demos/mcmcp/experiment.py
+++ b/demos/mcmcp/experiment.py
@@ -11,7 +11,7 @@ from operator import attrgetter
 class MCMCP(Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         The models module is imported here because it must be imported at
@@ -26,7 +26,8 @@ class MCMCP(Experiment):
         self.models = models
         self.experiment_repeats = 1
         self.trials_per_participant = 10
-        self.setup()
+        if session:
+            self.setup()
 
     def create_node(self, network, participant):
         """Create a node for a participant."""

--- a/demos/rogers/experiment.py
+++ b/demos/rogers/experiment.py
@@ -13,7 +13,7 @@ import random
 class RogersExperiment(Experiment):
     """The experiment class."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         The models module is imported here because it must be imported at
@@ -39,7 +39,7 @@ class RogersExperiment(Experiment):
         self.initial_recruitment_size = self.generation_size
         self.known_classes["LearningGene"] = self.models.LearningGene
 
-        if not self.networks():
+        if session and not self.networks():
             self.setup()
         self.save()
 

--- a/demos/sheep-market/experiment.py
+++ b/demos/sheep-market/experiment.py
@@ -16,7 +16,7 @@ import json
 class SheepMarket(Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         A few properties are then overwritten.
@@ -25,7 +25,8 @@ class SheepMarket(Experiment):
         super(SheepMarket, self).__init__(session)
         self.experiment_repeats = 1
         self.initial_recruitment = 10000
-        self.setup()
+        if session:
+            self.setup()
 
     def create_network(self):
         """Return a new network."""

--- a/demos/snake/experiment.py
+++ b/demos/snake/experiment.py
@@ -11,9 +11,10 @@ def extra_parameters():
 class SnakeGame(dlgr.experiments.Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Initialize the experiment."""
         super(SnakeGame, self).__init__(session)
         self.experiment_repeats = 1
         self.initial_recruitment_size = config.get("n")
-        self.setup()
+        if session:
+            self.setup()

--- a/demos/vox-populi/experiment.py
+++ b/demos/vox-populi/experiment.py
@@ -7,7 +7,7 @@ from dallinger.experiments import Experiment
 class VoxPopuli(Experiment):
     """Define the structure of the experiment."""
 
-    def __init__(self, session):
+    def __init__(self, session=None):
         """Call the same function in the super (see experiments.py in dallinger).
 
         A few properties are then overwritten.
@@ -16,7 +16,8 @@ class VoxPopuli(Experiment):
         super(VoxPopuli, self).__init__(session)
         self.experiment_repeats = 1
         self.initial_recruitment = 20
-        self.setup()
+        if session:
+            self.setup()
 
     def create_network(self):
         """Return a new network."""

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,4 +20,3 @@ tablib==0.11.4
 ua-parser==0.3.6
 user-agents==0.2.0
 psutil==5.2.0
-lazy==1.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ SQLAlchemy==1.1.7
 tablib==0.11.4
 ua-parser==0.3.6
 user-agents==0.2.0
+psutil==5.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,3 +20,4 @@ tablib==0.11.4
 ua-parser==0.3.6
 user-agents==0.2.0
 psutil==5.2.0
+lazy==1.3

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ setup_args = dict(
         ],
         'dallinger.experiments': [
             'Bartlett1932 = demos.bartlett1932.experiment:Bartlett1932',
-            'Griduniverse = demos.Griduniverse.experiment:Griduniverse',
         ],
     },
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup_args = dict(
         ],
         'dallinger.experiments': [
             'Bartlett1932 = demos.bartlett1932.experiment:Bartlett1932',
+            'Griduniverse = demos.Griduniverse.experiment:Griduniverse',
         ],
     },
     extras_require={

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -10,7 +10,8 @@ class TestExperiment(Experiment):
     def __init__(self, session=None):
         super(TestExperiment, self).__init__(session)
         self.experiment_repeats = 1
-        self.setup()
+        if session:
+            self.setup()
 
     @property
     def public_properties(self):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -200,7 +200,6 @@ class TestDebugServer(object):
     #         p.read()
 
 
-
 class TestHeader(object):
     def test_header_contains_version_number(self):
         # Make sure header contains the version number.

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -133,60 +133,72 @@ class TestDebugServer(object):
         """Set up the environment by moving to the demos directory."""
         self.orig_dir = os.getcwd()
         os.chdir("demos/bartlett1932")
+        # Heroku requires a home directory to start up
+        # We create a fake one using tempfile and set it into the
+        # environment to handle sandboxes on CI servers
+        self.fake_home = tempfile.mkdtemp()
+
+        self.environ = os.environ.copy()
+        self.environ.update({'HOME': self.fake_home})
 
     def teardown(self):
+        shutil.rmtree(self.fake_home, ignore_errors=True)
         os.chdir(self.orig_dir)
 
     def test_startup(self):
-        # Heroku requires a home directory to start up
-        # We create a fake one using tempfile and set it into the
-        # environment to handle sandboxes on CI servers
-        fake_home = tempfile.mkdtemp()
         # Make sure debug server starts without error
+        p = pexpect.spawn(
+            'dallinger',
+            ['debug', '--verbose'],
+            env=self.environ,
+        )
+        p.logfile = sys.stdout
         try:
-            environ = os.environ.copy()
-            environ.update({'HOME': fake_home})
-            p = pexpect.spawn(
-                'dallinger',
-                ['debug', '--verbose'],
-                env=environ,
-            )
-            p.logfile = sys.stdout
             p.expect_exact('Server is running', timeout=120)
+        finally:
             p.sendcontrol('c')
             p.read()
-        finally:
-            shutil.rmtree(fake_home, ignore_errors=True)
 
     def test_warning_if_no_heroku_present(self):
-        # Heroku requires a home directory to start up
-        # We create a fake one using tempfile and set it into the
-        # environment to handle sandboxes on CI servers
-        fake_home = tempfile.mkdtemp()
-        # Make sure debug server starts without error
+        environ = self.environ.copy()
+        # Remove the path item that has heroku in it
+        path_items = environ['PATH'].split(':')
+        path_items = [
+            item for item in path_items
+            if not os.path.exists(os.path.join(item, 'heroku'))
+        ]
+        environ.update({
+            'PATH': ':'.join(path_items)
+        })
+        p = pexpect.spawn(
+            'dallinger',
+            ['debug', '--verbose'],
+            env=environ,
+        )
+        p.logfile = sys.stdout
         try:
-            environ = os.environ.copy()
-            # Remove the path item that has heroku in it
-            path_items = environ['PATH'].split(':')
-            path_items = [
-                item for item in path_items
-                if not os.path.exists(os.path.join(item, 'heroku'))
-            ]
-            environ.update({
-                'HOME': fake_home,
-                'PATH': ':'.join(path_items)
-            })
-            p = pexpect.spawn(
-                'dallinger',
-                ['debug', '--verbose'],
-                env=environ,
-            )
-            p.logfile = sys.stdout
             p.expect_exact("Couldn't start Heroku for local debugging", timeout=120)
+        finally:
             p.sendcontrol('c')
             p.read()
-        finally:
-            shutil.rmtree(fake_home)
+
+    # def test_debug_bots(self):
+    #     # Make sure debug server runs to completion with bots
+    #     p = pexpect.spawn(
+    #         'dallinger',
+    #         ['debug', '--verbose', '--bot'],
+    #         env=self.environ,
+    #     )
+    #     p.logfile = sys.stdout
+    #     try:
+    #         p.expect_exact('Server is running', timeout=120)
+    #         p.expect_exact('Recruitment is complete', timeout=300)
+    #         p.expect_exact('Experiment completed', timeout=120)
+    #         p.expect_exact('Local Heroku process terminated', timeout=10)
+    #     finally:
+    #         p.sendcontrol('c')
+    #         p.read()
+
 
 
 class TestHeader(object):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

As an experimenter I can run Dallinger using a bot recruiter that will run bots as participants in Heroku. The bot recruiter can also, optionally, be used from within debug mode which is now available from the high-level API.

## Description
<!--- Describe your changes in detail -->
If `recruiter=bots` is specified in the configuration or directly in code, the dallinger sandbox and deploy commands will use the bot recruiter to recruit participants, and put them in a queue in the same heroku app. The experiment will begin automatically once the app is launched.

Additionally, when the `dallinger debug` command is run with the `--bot` flag, the bot recruiter will be used to complete the experiment automatically. Finally, the high-level API supports calls like the following to run an experiment in debug mode with bots:

    from dallinger.experiments import Bartlett1932
    exp = Bartlett1932()
    exp.run(mode=u'debug', recruiter=u'bots')

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These features were required by stories 173 and 152 in ScrumDo.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested using both debug and sandbox modes with the bartlett1932 demo.
