### PR TITLE
Support for Packaged Experiments

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -112,36 +112,6 @@ def verify_package(verbose=True):
             log("✗ {} is MISSING".format(f), chevrons=False, verbose=verbose)
             is_passing = False
 
-    # Check the experiment file.
-    if os.path.exists("experiment.py"):
-
-        # Check if the experiment file has exactly one Experiment class.
-        tmp = tempfile.mkdtemp()
-        for f in ["experiment.py", "config.txt"]:
-            shutil.copyfile(f, os.path.join(tmp, f))
-
-        cwd = os.getcwd()
-        os.chdir(tmp)
-
-        open("__init__.py", "a").close()
-        exp = imp.load_source('experiment', os.path.join(tmp, "experiment.py"))
-
-        classes = inspect.getmembers(exp, inspect.isclass)
-        exps = [c for c in classes
-                if (c[1].__bases__[0].__name__ in "Experiment")]
-
-        if len(exps) == 0:
-            log("✗ experiment.py does not define an experiment class.",
-                delay=0, chevrons=False, verbose=verbose)
-            is_passing = False
-        elif len(exps) == 1:
-            log("✓ experiment.py defines 1 experiment",
-                delay=0, chevrons=False, verbose=verbose)
-        else:
-            log("✗ experiment.py defines more than one experiment class.",
-                delay=0, chevrons=False, verbose=verbose)
-        os.chdir(cwd)
-
     # Check base_payment is correct
     config = get_config()
     if not config.ready:

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -131,7 +131,6 @@ def verify_package(verbose=True):
         os.chdir(clone_dir)
         sys.path.append(clone_dir)
 
-        open("__init__.py", "a").close()
         exp = imp.load_source('experiment', os.path.join(clone_dir, "experiment.py"))
 
         classes = inspect.getmembers(exp, inspect.isclass)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -103,7 +103,6 @@ def verify_package(verbose=True):
     required_files = [
         "config.txt",
         "experiment.py",
-        "requirements.txt",
     ]
 
     for f in required_files:
@@ -142,17 +141,6 @@ def verify_package(verbose=True):
             log("✗ experiment.py defines more than one experiment class.",
                 delay=0, chevrons=False, verbose=verbose)
         os.chdir(cwd)
-
-    # Make sure there's a help file.
-    is_txt_readme = os.path.exists("README.md")
-    is_md_readme = os.path.exists("README.txt")
-    if (not is_md_readme) and (not is_txt_readme):
-        is_passing = False
-        log("✗ README.txt or README.md is MISSING.",
-            delay=0, chevrons=False, verbose=verbose)
-    else:
-        log("✓ README is OK",
-            delay=0, chevrons=False, verbose=verbose)
 
     # Check base_payment is correct
     config = get_config()

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -139,7 +139,7 @@ class Experiment(object):
         from dallinger.recruiters import BotRecruiter
 
         try:
-            debug_mode = config.get('mode') == 'debug'
+            debug_mode = config.get('mode', None) == 'debug'
         except RuntimeError:
             # Config not yet loaded
             debug_mode = False

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -40,6 +40,7 @@ def exp_class_working_dir(meth):
             )
             os.chdir(new_path)
             # Override configs
+            config.register_extra_parameters()
             config.load_from_file(LOCAL_CONFIG)
             return meth(self, *args, **kwargs)
         finally:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -113,6 +113,13 @@ class Experiment(object):
             # Guard against subclasses replacing this with a @property
             self.public_properties = {}
 
+        if session:
+            self.configure()
+
+    def configure(self):
+        """Load experiment configuration here"""
+        pass
+
     @property
     def background_tasks(self):
         """An experiment may define functions or methods to be started as

--- a/dallinger/experiments/__init__.py
+++ b/dallinger/experiments/__init__.py
@@ -4,11 +4,8 @@ with a ``setuptools`` ``entry_point`` for the ``dallinger.experiments`` group.
 import logging
 from pkg_resources import iter_entry_points
 
-from ..config import get_config
 from ..experiment import Experiment
 
-config = get_config()
-config.load()
 
 logger = logging.getLogger(__name__)
 logger.addHandler(logging.NullHandler())

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1,6 +1,11 @@
 import json
 import os
 import unittest
+from dallinger.config import get_config
+
+config = get_config()
+if not config.ready:
+    config.load()
 
 
 class FlaskAppTest(unittest.TestCase):
@@ -24,8 +29,7 @@ class FlaskAppTest(unittest.TestCase):
 
         import dallinger.db
         self.db = dallinger.db.init_db(drop_all=True)
-        from dallinger.config import get_config
-        self.exp_config = get_config()
+        self.exp_config = config
 
     def tearDown(self):
         self.db.rollback()


### PR DESCRIPTION
## Description

Experiments wrapped in python packages may not contain a requirements.txt file or a README in the same directory as the experiment.py. The command line tool (which is used to run the experiments in the python API) does not need to check for those files. Additionally, this branch removes a spurious import time config side-effect and ensures that custom config variables are registered in a timely manner.

## Motivation and Context

This is required for story DA-106, supporting Griduniverse as a PyPI package.

## How Has This Been Tested?

Automated tests ran successfully. I also manually ran the Griduniverse `packaged` branch through a debug session via the API.
