### PR TITLE
Freeze requirements before deploy

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -170,6 +170,10 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     cwd = os.getcwd()
     os.chdir(dst)
 
+    # Freeze the Python requirements
+    with open(os.path.join(dst, 'requirements.txt'), 'w') as file:
+        subprocess.check_call(['pip', 'freeze'], stdout=file)
+
     # Write the custom config
     if exp_config:
         config.extend(exp_config)
@@ -196,8 +200,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
         os.path.join(dst, "dallinger_experiment.py"))
 
     # Get dallinger package location.
-    from pkg_resources import get_distribution
-    dist = get_distribution('dallinger')
+    dist = pkg_resources.get_distribution('dallinger')
     src_base = os.path.join(dist.location, dist.project_name)
 
     heroku_files = [

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -171,8 +171,40 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     os.chdir(dst)
 
     # Freeze the Python requirements
+    log('Freezing Python requirements...')
+    blacklist = (
+        # Dev dependencies
+        'alabaster',
+        'coverage',
+        'coverage_pth',
+        'codecov',
+        'flake8',
+        'mock',
+        'pyenchant',
+        'pytest',
+        'Sphinx',
+        'sphinxcontrib-spelling',
+        'tox',
+        # Data analysis tools
+        'datashape',
+        'networkx',
+        'numpy',
+        'odo',
+        'pandas',
+        'tablib',
+        # Obsolete
+        'psiturk-dallinger',
+    )
     with open(os.path.join(dst, 'requirements.txt'), 'w') as file:
-        subprocess.check_call(['pip', 'freeze'], stdout=file)
+        for line in subprocess.check_output(['pip', 'freeze']).splitlines():
+            if line.startswith(blacklist):
+                continue
+            # Access github anonymously
+            line = line.replace(
+                'git+git@github.com:', 'git+https://github.com/')
+            click.echo(line)
+            file.write(line)
+            file.write('\n')
 
     # Write the custom config
     if exp_config:


### PR DESCRIPTION
This calls `pip freeze` to generate requirements.txt before deploying to Heroku.

(Some packages such as dev-only dependencies and data analysis tools are filtered out to avoid trying to install them on heroku.)

## Motivation and Context
This solves at least two problems:
1. Makes sure that heroku runs the same revision of dallinger that you have locally if you are working with a git clone of dallinger. (Note: any changes must obviously be committed and pushed to be available to heroku.)
2. Makes sure that if you're deploying an experiment that was installed as a separate Python distribution, it will also be importable with the same package name on heroku.

## How Has This Been Tested?
I deployed the chatroom demo to a sandbox using `dallinger sandbox --verbose` and confirmed that it installed the same revision of Dallinger that I have locally.
