### PR TITLE
Make waiting room handle filling multiple networks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ env:
   global:
   - DATABASE_URL=postgresql://postgres@localhost/dallinger
   - PORT=5000
+  - threads=1
   - secure: isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg=
   - secure: rWBAifHvKlQabe6gvz+edMEtjtDnpwI4RFHJB1ytYSNVKQ59s7fIk2q39IZc8K3Uix7ZtP3G7ws6ufQhOj44Pm4j1J+rbLnDjdMtmcDN5aiSnwb05JpltZXCNjUqAu/CBFZ44lnNenZp4uSLhU/kLVhB2Q+UPvyWNFgApEVoiHM=
   - secure: fd4hFOH60UV8laBN4Mjva0w/EmVK3SVC5p/0O1oqPriPhUpoJ3eVVRvITbdvPctEJJgRR9t62rPk+Rv4EOXeRFfsjZK9gOfQqv/9VhJBebdQfOx2dwQLjDiGTrklkokDIDyfpyYOoJzZ/oP+6EneD403ilHnXC4fd/4EDQmaIRI=

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ addons:
     - enchant
     - heroku-toolbelt
     - redis-server
+services:
+  - redis-server
 before_install:
 - rvm install 2.1.5
 - pip install --upgrade setuptools pip wheel

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -116,6 +116,10 @@ def after_soft_rollback(session, previous_transaction):
     session.info['outbox'] = []
 
 
+def queue_message(channel, message):
+    session.info['outbox'].append((channel, message))
+
+
 # Publish messages to redis after commit
 @event.listens_for(Session, 'after_commit')
 def after_commit(session):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -79,6 +79,11 @@ class Experiment(object):
         self.experiment_repeats = 0
 
         #: int, the number of participants
+        #: required to move from the waiting room to the experiment.
+        #: Default is 0 (no waiting room).
+        self.quorum = 0
+
+        #: int, the number of participants
         #: requested when the experiment first starts. Default is 1.
         self.initial_recruitment_size = 1
 
@@ -199,7 +204,8 @@ class Experiment(object):
 
         """
         key = participant.id
-        networks_with_space = Network.query.filter_by(full=False).all()
+        networks_with_space = Network.query.filter_by(
+            full=False).order_by(Network.id).all()
         networks_participated_in = [
             node.network_id for node in
             Node.query.with_entities(Node.network_id)
@@ -228,11 +234,14 @@ class Experiment(object):
                      "Assigning participant to practice network {}."
                      .format(chosen_network.id), key)
         else:
-            chosen_network = random.choice(legal_networks)
+            chosen_network = self.choose_network(legal_networks, participant)
             self.log("No practice networks available."
                      "Assigning participant to experiment network {}"
                      .format(chosen_network.id), key)
         return chosen_network
+
+    def choose_network(self, networks, participant):
+        return random.choice(networks)
 
     def create_node(self, participant, network):
         """Create a node for a participant."""

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -497,10 +497,6 @@ def assign_properties(thing):
     session.commit()
 
 
-def queue_message(channel, message):
-    session.info['outbox'].append((channel, message))
-
-
 @app.route("/participant/<worker_id>/<hit_id>/<assignment_id>/<mode>",
            methods=["POST"])
 @db.serialized
@@ -558,7 +554,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
             'q': experiment.quorum,
             'n': waiting_count,
         }
-        queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
+        db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
         result['quorum'] = quorum
 
     # return the data

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -105,7 +105,7 @@ var create_participant = function() {
                     console.log(resp);
                     participant_id = resp.participant.id;
                     if (resp.quorum) {
-                        if (resp.quorum && resp.quorum.n === resp.quorum.q) {
+                        if (resp.quorum.n === resp.quorum.q) {
                             // reached quorum; resolve immediately
                             deferred.resolve();
                         } else {

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -20,17 +20,8 @@
             </div>
         </div>
         <script type="text/javascript">
-            var creatingParticipant = $.Deferred();
-            var awaitingQuorum = waitForQuorum(function () {
-                // Send create participant request once the websocket is open
-                // so we'll be sure to receive our own quorum update
-                create_participant().done(function () {
-                    creatingParticipant.resolve();
-                });
-            });
-
-            // wait for quorum to be reached AND for participant to be created
-            $.when(awaitingQuorum, creatingParticipant).done(function () {
+            // wait for participant to be created and quorum to be reached
+            create_participant().done(function () {
                 allow_exit();
                 go_to_page("exp");
             });

--- a/demos/chatroom/config.txt
+++ b/demos/chatroom/config.txt
@@ -2,6 +2,7 @@
 mode = sandbox
 auto_recruit = true
 network = FullyConnected
+repeats = 2
 n = 2
 
 [MTurk]

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -9,6 +9,7 @@ config = get_config()
 
 def extra_parameters():
     config.register('network', unicode)
+    config.register('repeats', int)
     config.register('n', int)
 
 
@@ -18,12 +19,10 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
     def __init__(self, session=None):
         """Initialize the experiment."""
         super(CoordinationChatroom, self).__init__(session)
-        self.experiment_repeats = 1
-        self.num_participants = config.get('n')
-        self.initial_recruitment_size = self.num_participants
-        self.public_properties = {
-            'quorum': self.num_participants
-        }
+        self.experiment_repeats = repeats = config.get('repeats')
+        self.quorum = config.get('n')
+        # Recruit for all networks at once
+        self.initial_recruitment_size = repeats * self.quorum
         self.config = config
         if not self.config.ready:
             self.config.load()
@@ -36,7 +35,11 @@ class CoordinationChatroom(dlgr.experiments.Experiment):
             dlgr.networks,
             self.config.get('network')
         )
-        return class_(max_size=self.num_participants)
+        return class_(max_size=self.quorum)
+
+    def choose_network(self, networks, participant):
+        # Choose first available network rather than random
+        return networks[0]
 
     def info_post_request(self, node, info):
         """Run when a request to create an info is complete."""

--- a/demos/chatroom/static/scripts/experiment.js
+++ b/demos/chatroom/static/scripts/experiment.js
@@ -90,7 +90,7 @@ get_transmissions = function (my_node_id) {
                 console.log(transmissions[i]);
                 display_info(transmissions[i].info_id);
             }
-            get_transmissions(my_node_id);
+            setTimeout(function () { get_transmissions(my_node_id); }, 100);
         },
         error: function (err) {
             console.log(err);

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -10,6 +10,7 @@ class TestExperiment(Experiment):
     def __init__(self, session=None):
         super(TestExperiment, self).__init__(session)
         self.experiment_repeats = 1
+        self.quorum = 1
         if session:
             self.setup()
 
@@ -17,7 +18,6 @@ class TestExperiment(Experiment):
     def public_properties(self):
         return {
             'exists': True,
-            'quorum': 1,
         }
 
     def create_network(self):

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,3 +1,6 @@
+import mock
+
+
 def test_serialized(db_session):
     from dallinger.db import serialized
     from dallinger.models import Participant
@@ -37,3 +40,12 @@ def test_serialized(db_session):
     # Which we can check by making sure that `write`
     # calculated the count at least 3 times
     assert counts == [0, 0, 1]
+
+
+def test_after_commit_hook(db_session):
+    with mock.patch('dallinger.heroku.worker.conn') as redis:
+        from dallinger.db import queue_message
+        queue_message('test', 'test')
+        db_session.commit()
+
+        assert redis.called_once_with('test', 'test')


### PR DESCRIPTION
## Description
This is for Scrumdo story 176 (iteration 8). It makes it possible to use the waiting room to fill multiple equal-sized networks in sequence as participants arrive.

The chatroom demo is adjusted to support this. To fill multiple networks, set the `repeats` config setting to a value > 1. The recruiter will initially recruit `repeats * n` participants, where `n` is the number of participants per network.

Related changes:
- Delegate choosing the network for a new participant to a `choose_network` method on the experiment. This is so the chatroom experiment can fill networks sequentially rather than randomly.
- Adjust the `success_response` function in `experiment_server.py` to handle returning a response with an arbitrary number of key-value pairs.
- Make sure the websocket message with the quorum status is only sent after the commit to add a participant succeeds. This way if it conflicts and is retried due to the increased database isolation level, it won't cause multiple messages to be sent.
- Return the quorum status directly from the `create_participant` route to avoid race conditions i.e. where the websocket message was sent before the client that called `create_participant` was receiving messages.
- Delay .1s between requests to receive new chat messages to reduce the load on the server.

## Motivation and Context
This makes it possible to run an experiment with multiple groups of participants in parallel. It also makes the waiting room less prone to failure for the existing use case of filling a single network.

## How Has This Been Tested?
I tested by running the chatroom demo in debug mode with repeats = 2 and n = 2.
