### PR TITLE
Handle chat via a single websocket connection

### DIFF
--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -118,5 +118,6 @@ def chat(ws):
 
         # Publish messages from client
         message = ws.receive()
-        channel, data = message.split(':', 1)
-        conn.publish(channel, data)
+        if message is not None:
+            channel, data = message.split(':', 1)
+            conn.publish(channel, data)

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -176,9 +176,9 @@ var submitNextResponse = function (n) {
 
 waitForQuorum = function () {
     var ws_scheme = (window.location.protocol === "https:") ? 'wss://' : 'ws://';
-    var inbox = new ReconnectingWebSocket(ws_scheme + location.host + "/receive_chat");
+    var socket = new ReconnectingWebSocket(ws_scheme + location.host + "/chat");
     var deferred = $.Deferred();
-    inbox.onmessage = function (msg) {
+    socket.onmessage = function (msg) {
         if (msg.data.indexOf('quorum:') !== 0) { return; }
         var data = JSON.parse(msg.data.substring(7));
         var n = data.n;

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -96,13 +96,14 @@ var create_participant = function() {
         deferred.resolve();
     } else {
         $(function () {
-            $('.btn-success').prop('disabled', 'disabled');
+            $('.btn-success').prop('disabled', true);
             reqwest({
                 url: url,
                 method: "post",
                 type: "json",
                 success: function(resp) {
                     console.log(resp);
+                    $('.btn-success').prop('disabled', false);
                     participant_id = resp.participant.id;
                     if (resp.quorum) {
                         if (resp.quorum.n === resp.quorum.q) {

--- a/demos/chatroom/experiment.py
+++ b/demos/chatroom/experiment.py
@@ -13,7 +13,7 @@ def extra_parameters():
     config.register('n', int)
 
 
-class CoordinationChatroom(dlgr.experiments.Experiment):
+class CoordinationChatroom(dlgr.experiment.Experiment):
     """Define the structure of the experiment."""
 
     def __init__(self, session=None):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -93,25 +93,25 @@ class TestChatBackend:
 
         assert chat.age[client] == 0
 
-    def test_outbox_subscribes_to_default_channel(self, sockets):
+    def test_chat_subscribes_to_default_channel(self, sockets):
         ws = Mock()
         sockets.request = Mock()
-        sockets.request.args.get.return_value = None
-        sockets.outbox(ws)
+        sockets.request.args = {}
+        sockets.chat(ws)
 
         ws.closed = True
         gevent.wait()
 
         assert ws in sockets.chat_backend.clients['quorum']
 
-    def test_outbox_subscribes_to_requested_channel(self, sockets):
+    def test_chat_subscribes_to_requested_channel(self, sockets):
         ws = Mock()
         sockets.request = Mock()
         sockets.request.args.get.return_value = 'special'
-        sockets.outbox(ws)
+        sockets.chat(ws)
         assert ws in sockets.chat_backend.clients['special']
 
-    def test_inbox_publishes_message_to_requested_channel(self, sockets):
+    def test_chat_publishes_message_to_requested_channel(self, sockets):
         class MockSocket(Mock):
             """We need a property that returns False the first time
             and True after that. Doesn't seem possible with Mock.
@@ -126,11 +126,10 @@ class TestChatBackend:
                 return False
 
         ws = MockSocket()
-        ws.receive.return_value = 'incoming message!'
+        ws.receive.return_value = 'special:incoming message!'
         sockets.request = Mock()
         sockets.conn = Mock()
-        sockets.request.args.get.return_value = 'special'
-        sockets.inbox(ws)
+        sockets.chat(ws)
         sockets.conn.publish.assert_called_once_with(
             'special', 'incoming message!'
         )


### PR DESCRIPTION
## Description
This changes the Flask route used for handling websockets so there is just one route used for both receiving and sending. It also updates the waiting room javascript to use that endpoint. I'll open a related pull request to make a similar change for Griduniverse.

## Motivation and Context
This avoids a possible race condition where the client fails to receive a response to a message that it sends because the other connection hasn't opened yet.

## How Has This Been Tested?
I tested by running the chatroom and griduniverse demos in debug mode, and the automated tests are passing locally. I may need to debug the tests on travis after opening the pull request.