### PR TITLE
Balance web locally

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,7 +9,10 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
   end
 
-  config.vm.network "forwarded_port", guest: 5000, host: 5000, auto_correct: true
+
+
+  config.vm.network "public_network",
+    use_dhcp_assigned_default_route: true
 
   config.vm.provision "shell", privileged: false, inline: <<-SHELL
     sudo apt-get update
@@ -28,6 +31,7 @@ Vagrant.configure("2") do |config|
     # Virtual environment
     echo 'source ~/venv/bin/activate' >> ~/.bashrc
     echo 'cd /vagrant' >> ~/.bashrc
+    echo 'export HOST=`ifconfig | grep Ethernet -A1 | grep addr: | tail -n1 | cut -d: -f2 | cut -d " " -f1`' >> ~/.bashrc
     sudo pip install virtualenv
     virtualenv --no-site-packages ~/venv
     source ~/venv/bin/activate

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,8 @@ Vagrant.configure("2") do |config|
   config.vm.provider "virtualbox" do |vb|
       vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
       vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.cpus = 2
+      vb.memory = 4096
   end
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -194,9 +194,9 @@ class BotRecruiter(object):
     def recruit_participants(self, n=1):
         """Recruit n new participant bots to the queue"""
         from dallinger_experiment import Bot
-        base_url = get_base_url()
 
         for _ in range(n):
+            base_url = get_base_url()
             worker = generate_random_id()
             hit = generate_random_id()
             assignment = generate_random_id()

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -11,8 +11,10 @@ def get_base_url():
         base_url = "https://{}".format(host)
     else:
         # debug mode
+        base_port = config.get('port')
+        port_range = range(base_port, base_port + config.get('num_dynos_web', 1))
         base_url = "http://{}:{}".format(
-            host, config.get("port")
+            host, random.choice(port_range)
         )
     return base_url
 


### PR DESCRIPTION
## Description
Automatically load balances between all ports exposed by local web processes. This improves bot performance, in conjunction with changes already on development.

## Motivation and Context
Previously, all users would connect to web.1, which would cause significant delays when spawning large numbers of bots, as well as increased load for web sockets.

## How Has This Been Tested?
Tested while on `bot_queue` branch manually with Griduniverse
