### PR TITLE
Add CLI command for monitoring

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -858,9 +858,7 @@ def export(app, local, no_scrub):
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 def logs(app):
     """Show the logs."""
-    subprocess.check_call([
-        "heroku", "addons:open", "papertrail", "--app", app_name(app)
-    ])
+    heroku.open_logs(app)
 
 
 @dallinger.command()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -359,16 +359,22 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 def summary(app):
     """Print a summary of a deployed app's status."""
+    click.echo(get_summary(app))
+
+
+def get_summary(app):
     r = requests.get('https://{}.herokuapp.com/summary'.format(app_name(app)))
     summary = r.json()['summary']
-    click.echo("\nstatus \t| count")
-    click.echo("----------------")
+    out = []
+    out.append("\nstatus \t| count")
+    out.append("----------------")
     for s in summary:
-        click.echo("{}\t| {}".format(s[0], s[1]))
+        out.append("{}\t| {}".format(s[0], s[1]))
     num_101s = sum([s[1] for s in summary if s[0] == 101])
     num_10xs = sum([s[1] for s in summary if s[0] >= 100])
     if num_10xs > 0:
-        click.echo("\nYield: {:.2%}".format(1.0 * num_101s / num_10xs))
+        out.append("\nYield: {:.2%}".format(1.0 * num_101s / num_10xs))
+    return "\n".join(out)
 
 
 def _handle_launch_data(url):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -868,6 +868,27 @@ def logs(app):
 
 
 @dallinger.command()
+@click.option('--app', default=None, callback=verify_id, help='Experiment id')
+def monitor(app):
+    """Set up application monitoring."""
+    if app is None:
+        raise TypeError("Select an experiment using the --app flag.")
+
+    dash_url = "https://dashboard.heroku.com/apps/{}".format(app_name(app))
+    webbrowser.open(dash_url)
+    webbrowser.open("https://requester.mturk.com/mturk/manageHITs")
+    heroku.open_logs(app)
+    subprocess.call(["open", heroku.db_uri(app)])
+    while True:
+        summary = get_summary(app)
+        click.clear()
+        click.echo(header)
+        click.echo("\nExperiment {}\n".format(app))
+        click.echo(summary)
+        time.sleep(10)
+
+
+@dallinger.command()
 @click.option('--app', default=None, help='Experiment id')
 @click.option('--debug', default=None,
               help='Local debug recruitment url')

--- a/dallinger/heroku/__init__.py
+++ b/dallinger/heroku/__init__.py
@@ -2,6 +2,7 @@
 
 from tools import (
     app_name,
+    db_uri,
     auth_token,
     log_in,
     open_logs,
@@ -11,6 +12,7 @@ from tools import (
 __all__ = (
     "app_name",
     "auth_token",
+    "db_uri",
     "log_in",
     "open_logs",
     "scale_up_dynos"

--- a/dallinger/heroku/__init__.py
+++ b/dallinger/heroku/__init__.py
@@ -4,6 +4,7 @@ from tools import (
     app_name,
     auth_token,
     log_in,
+    open_logs,
     scale_up_dynos
 )
 
@@ -11,5 +12,6 @@ __all__ = (
     "app_name",
     "auth_token",
     "log_in",
+    "open_logs",
     "scale_up_dynos"
 )

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -1,6 +1,7 @@
 """Miscellaneous tools for Heroku."""
 
 import pexpect
+import re
 import subprocess
 
 from dallinger.config import get_config
@@ -27,6 +28,17 @@ def open_logs(app):
     subprocess.check_call([
         "heroku", "addons:open", "papertrail", "--app", app_name(app)
     ])
+
+
+def db_uri(app):
+    output = subprocess.check_output([
+        "heroku",
+        "pg:credentials",
+        "DATABASE",
+        "--app", app_name(app)
+    ])
+    match = re.search('(postgres://.*)$', output)
+    return match.group(1)
 
 
 def scale_up_dynos(app):

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -23,6 +23,12 @@ def log_in():
     p.interact()
 
 
+def open_logs(app):
+    subprocess.check_call([
+        "heroku", "addons:open", "papertrail", "--app", app_name(app)
+    ])
+
+
 def scale_up_dynos(app):
     """Scale up the Heroku dynos."""
     config = get_config()


### PR DESCRIPTION
`dallinger monitor` opens the Heroku dashboard to the launched app,
opens the MTurk console, opens the Papertrail logs, connects to the
database using Postico, and then runs a loop that prints the summary
every 10 seconds.