### PR TITLE
Add documentation on bots

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -33,7 +33,7 @@ class BotBase(object):
 
     @cached_property
     def driver(self):
-        """Returns a Selenium Webdriver instance of the type requested in the
+        """Returns a Selenium WebDriver instance of the type requested in the
         configuration."""
         from dallinger.config import get_config
         config = get_config()

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -15,8 +15,7 @@ logger = logging.getLogger(__file__)
 
 
 class BotBase(object):
-
-    """A bot."""
+    """A base class for Bots that works with the built-in demos."""
 
     def __init__(self, URL, assignment_id='', worker_id=''):
         logger.info("Creating bot with URL: %s." % URL)
@@ -34,6 +33,8 @@ class BotBase(object):
 
     @cached_property
     def driver(self):
+        """Returns a Selenium Webdriver instance of the type requested in the
+        configuration."""
         from dallinger.config import get_config
         config = get_config()
         if not config.ready:
@@ -133,6 +134,8 @@ class BotBase(object):
         logger.info("Forced call to %s: %s" % (status, complete_url))
 
     def run_experiment(self):
+        """Sign up, run the ``participate`` method, then sign off and close
+        the driver."""
         try:
             self.sign_up()
             self.participate()

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -10,6 +10,15 @@ verify
 
 Verify that a directory is a Dallinger-compatible app.
 
+.. _dallinger-bot:
+
+bot
+^^^
+
+Spawn a bot and attach it to the specified application. The ``--debug`` flag
+connects the bot to the locally running instance of Dallinger. Alternatively
+an instance on Heroku may be specified using the ``--app`` parameter.
+
 debug
 ^^^^^
 

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -16,8 +16,8 @@ bot
 ^^^
 
 Spawn a bot and attach it to the specified application. The ``--debug`` flag
-connects the bot to the locally running instance of Dallinger. Alternatively
-an instance on Heroku may be specified using the ``--app`` parameter.
+connects the bot to the locally running instance of Dallinger. Alternatively,
+the ``--app <app>`` flag specifies a live experiment by its id.
 
 debug
 ^^^^^
@@ -35,7 +35,9 @@ deploy
 ^^^^^^
 
 Runs the experiment live on MTurk using Heroku as a server. An optional
-``--verbose`` flag prints more detailed logs to the command line.
+``--verbose`` flag prints more detailed logs to the command line. An optional
+``--bot`` flag forces the bot recruiter to be used, rather than the configured
+recruiter.
 
 logs
 ^^^^

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -11,6 +11,7 @@ Laboratory automation for the behavioral and social sciences.
     dallinger_with_anaconda
     aws_etc_keys
     demoing_dallinger
+    running_bots
     learning_to_use_dallinger
     monitoring_a_live_experiment
     postico_and_postgres

--- a/docs/source/running_bots.rst
+++ b/docs/source/running_bots.rst
@@ -1,0 +1,109 @@
+Running bots as participants
+============================
+
+Dallinger supports writing bots using the Selenium framework that participate in
+an experiment. Not all experiments have bots available, currently :doc:`demos/bartlett1932/index`
+and :doc:`demos/chatroom/index` have bots available.
+
+Writing a bot
+^^^^^^^^^^^^^
+
+In your ``experiment.py`` you will need to create a subclass of BotBase called Bot. 
+This class should implement the ``participate`` method, which will be called once
+the bot has navigated to the main experiment. Note, the BotBase class makes some
+assumptions about HTML structure, based on the demo experiments. If your HTML
+differs significantly you may need to override other methods too.
+
+
+.. currentmodule:: dallinger.bots
+
+.. autoclass:: BotBase
+  :members:
+
+Running bots locally
+^^^^^^^^^^^^^^^^^^^^
+
+You must set the configuration value ``recruiter='bots'`` to run an experiment using its
+bot. As usual, this can be set in local or global configurations, as an
+environment variable or as a keyword argument to :py:meth:`~dallinger.experiments.Experiment.run`.
+You should also set ``max_participants`` to the number of bots you want to run at once,
+``num_dynos_worker`` should be more than that number, as a bot takes up a worker
+processes. In addition, you may want to increase `num_dynos_web` to improve
+performance.
+
+Dallinger uses Selenium to run bots locally. By default, it will try to run
+phantomJS directly, however it supports using Firefox and Chrome through
+configuration variables.
+
+.. code-block:: ini
+
+    webdriver_type = firefox
+
+You can also provide a URL to a Selenium Webdriver hub, which is recommended if
+you're planning on running a large number of simultaneous bots. The hub does not
+need to be on the same computer as Dallinger, but it does need to be able to access
+the computer running Dallinger directly by its IP address.
+
+We recommend using FireFox when writing bots, as it allows you to visually see
+its output and allows you to attach the development console directly to the
+bot's browser session.
+
+Running an experiment with the API may look like:
+
+.. code-block:: python
+
+    participants = 4
+    data = experiment.run(
+        mode=u'debug',
+        recruiter=u'bots',
+        max_participants=participants,
+        num_dynos_web=int(participants/4),
+        num_dynos_worker=participants,
+        workers=participants+5,
+    )
+
+Running a single bot
+********************
+
+If you want to run a single bot as part of a wider experiment, you can use
+the :ref:`bot <dallinger-bot>` command. This is useful for testing a single
+bot's behavior as part of a longer-running experiment, and allows easy access 
+to the Python pdb debugger.
+
+Scaling bots locally
+********************
+
+For example, you may want to run a dedicated computer on your lab network to host
+bots, without slowing down experimenter computers. It is recommended that you 
+run Selenium in a hub configuration, as a single selenium instance will limit 
+the number of concurrent sessions. 
+
+Download the latest ``selenium-server-standalone.jar`` file from `SeleniumHQ <http://www.seleniumhq.org/download/>`_
+and run a hub using:
+
+::
+
+    java -jar selenium-server-standalone-3.3.1.jar -role hub
+
+and attach multiple nodes by running:
+
+::
+
+    java -jar selenium-server-standalone-3.3.1.jar -role node -hub http://hubcomputer.example.com:4444/grid/register
+
+These nodes may be on other computers on the local network or on the same host
+machine. If they are on the same host you will need to add ``-port 4446`` (for 
+some port number) such that each selenium node on the same server is listening
+on a different port.
+
+You will also need to set up the browser interfaces on each computer that's running
+a node. This requires being able to run the browser and having the correct driver
+available in the system path, so the selenium server can run it.
+
+We recommend using Chrome when running large numbers of bots, as it is more
+feature-complete than PhantomJS but with better performance at scale than Firefox. It
+is best to run at most three Firefox sessions on commodity hardware, so for best
+results 16 bots should be run over 6 selenium servers. This will depend on how
+processor intensive your experiment is, it may be possible to run more sessions
+without performance degradation.
+

--- a/docs/source/running_bots.rst
+++ b/docs/source/running_bots.rst
@@ -1,9 +1,9 @@
 Running bots as participants
 ============================
 
-Dallinger supports writing bots using the Selenium framework that participate in
-an experiment. Not all experiments have bots available, currently :doc:`demos/bartlett1932/index`
-and :doc:`demos/chatroom/index` have bots available.
+Dallinger supports using the Selenium framework to write bots that participate in
+experiments. Not all experiments will have bots available; the :doc:`demos/bartlett1932/index`
+and :doc:`demos/chatroom/index` demos are the only built-in experiments that do.
 
 Writing a bot
 ^^^^^^^^^^^^^
@@ -26,9 +26,9 @@ Running bots locally
 You must set the configuration value ``recruiter='bots'`` to run an experiment using its
 bot. As usual, this can be set in local or global configurations, as an
 environment variable or as a keyword argument to :py:meth:`~dallinger.experiments.Experiment.run`.
-You should also set ``max_participants`` to the number of bots you want to run at once,
-``num_dynos_worker`` should be more than that number, as a bot takes up a worker
-processes. In addition, you may want to increase `num_dynos_web` to improve
+You should also set ``max_participants`` to the number of bots you want to run at once.
+``num_dynos_worker`` should be more than ``max_participants``, as a bot takes up a worker
+process while it is running. In addition, you may want to increase `num_dynos_web` to improve
 performance.
 
 Dallinger uses Selenium to run bots locally. By default, it will try to run
@@ -39,12 +39,8 @@ configuration variables.
 
     webdriver_type = firefox
 
-You can also provide a URL to a Selenium Webdriver hub, which is recommended if
-you're planning on running a large number of simultaneous bots. The hub does not
-need to be on the same computer as Dallinger, but it does need to be able to access
-the computer running Dallinger directly by its IP address.
 
-We recommend using FireFox when writing bots, as it allows you to visually see
+We recommend using Firefox when writing bots, as it allows you to visually see
 its output and allows you to attach the development console directly to the
 bot's browser session.
 
@@ -57,7 +53,7 @@ Running an experiment with the API may look like:
         mode=u'debug',
         recruiter=u'bots',
         max_participants=participants,
-        num_dynos_web=int(participants/4),
+        num_dynos_web=int(participants/4) + 1,
         num_dynos_worker=participants,
         workers=participants+5,
     )
@@ -65,7 +61,7 @@ Running an experiment with the API may look like:
 Running a single bot
 ********************
 
-If you want to run a single bot as part of a wider experiment, you can use
+If you want to run a single bot as part of an ongoing experiment, you can use
 the :ref:`bot <dallinger-bot>` command. This is useful for testing a single
 bot's behavior as part of a longer-running experiment, and allows easy access 
 to the Python pdb debugger.
@@ -73,13 +69,27 @@ to the Python pdb debugger.
 Scaling bots locally
 ********************
 
-For example, you may want to run a dedicated computer on your lab network to host
+For example you may want to run a dedicated computer on your lab network to host
 bots, without slowing down experimenter computers. It is recommended that you 
-run Selenium in a hub configuration, as a single selenium instance will limit 
+run Selenium in a hub configuration, as a single Selenium instance will limit 
 the number of concurrent sessions. 
 
-Download the latest ``selenium-server-standalone.jar`` file from `SeleniumHQ <http://www.seleniumhq.org/download/>`_
-and run a hub using:
+You can also provide a URL to a Selenium WebDriver instance using the
+``webdriver_url`` configuration setting. This is required if you're running 
+Selenium in a hub configuration. The hub does not need to be on the same computer
+as Dallinger, but it does need to be able to access the computer running
+Dallinger directly by its IP address.
+
+On Apple macOS, we recommend using homebrew to install and run selenium, using:
+
+::
+
+    brew install selenium-server-standalone
+    selenium-server -port 4444
+
+
+On other platforms, download the latest ``selenium-server-standalone.jar`` file 
+from `SeleniumHQ <http://www.seleniumhq.org/download/>`_ and run a hub using:
 
 ::
 
@@ -93,17 +103,17 @@ and attach multiple nodes by running:
 
 These nodes may be on other computers on the local network or on the same host
 machine. If they are on the same host you will need to add ``-port 4446`` (for 
-some port number) such that each selenium node on the same server is listening
+some port number) such that each Selenium node on the same server is listening
 on a different port.
 
 You will also need to set up the browser interfaces on each computer that's running
 a node. This requires being able to run the browser and having the correct driver
-available in the system path, so the selenium server can run it.
+available in the system path, so the Selenium server can run it.
 
 We recommend using Chrome when running large numbers of bots, as it is more
 feature-complete than PhantomJS but with better performance at scale than Firefox. It
 is best to run at most three Firefox sessions on commodity hardware, so for best
-results 16 bots should be run over 6 selenium servers. This will depend on how
-processor intensive your experiment is, it may be possible to run more sessions
+results 16 bots should be run over 6 Selenium servers. This will depend on how
+processor intensive your experiment is. It may be possible to run more sessions
 without performance degradation.
 

--- a/docs/source/running_bots.rst
+++ b/docs/source/running_bots.rst
@@ -80,7 +80,7 @@ Selenium in a hub configuration. The hub does not need to be on the same compute
 as Dallinger, but it does need to be able to access the computer running
 Dallinger directly by its IP address.
 
-On Apple macOS, we recommend using homebrew to install and run selenium, using:
+On Apple macOS, we recommend using Homebrew to install and run selenium, using:
 
 ::
 

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -41,6 +41,7 @@ js
 Kalish
 Kegl
 Lewandowsky
+macOS
 md
 Meme
 microfluidics
@@ -79,7 +80,7 @@ virtualization
 Vox
 walkthrough
 walkthroughs
-Webdriver
+WebDriver
 Webhook
 webpage
 Wikipedia

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -21,6 +21,7 @@ dallingerconfig
 dyno
 dynos
 et
+Firefox
 frontend
 GitHub
 Google
@@ -48,6 +49,7 @@ neighbour
 ons
 pandoc
 Papertrail
+phantomJS
 Populi
 Postgres
 PostgreSQL
@@ -77,6 +79,7 @@ virtualization
 Vox
 walkthrough
 walkthroughs
+Webdriver
 Webhook
 webpage
 Wikipedia

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -83,6 +83,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: recruit
 
+  .. automethod:: run
+
   .. automethod:: save
 
   .. automethod:: setup


### PR DESCRIPTION
## Description
Provides initial documentation on how to implement and run bots in Dallinger, including scaling concerns.

## Motivation and Context
The Griduniverse experiment is rather processor and RAM intensive on the client side. Some changes were made to increase performance, however other changes regarding how to run the Selenium server cannot be included in the code. This PR formalises the discussions we've been having in development about how to run bots, and includes specific advice for choice of browser and performance.

## How Has This Been Tested?
There are no code changes, only documentation. They need a test reader for style and substance.
