### PR TITLE
Better error handling in command line calls to /launch

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -69,7 +69,7 @@ def log(msg, delay=0.5, chevrons=True, verbose=True):
     """Log a message to stdout."""
     if verbose:
         if chevrons:
-            click.echo("\n❯❯ " + msg)
+            click.echo(u"\n❯❯ " + msg)
         else:
             click.echo(msg)
         time.sleep(delay)
@@ -79,7 +79,7 @@ def error(msg, delay=0.5, chevrons=True, verbose=True):
     """Log a message to stdout."""
     if verbose:
         if chevrons:
-            click.secho("\n❯❯ " + msg, err=True, fg='red')
+            click.secho(u"\n❯❯ " + msg, err=True, fg='red')
         else:
             click.secho(msg, err=True, fg='red')
         time.sleep(delay)
@@ -338,13 +338,16 @@ def debug(verbose, bot, exp_config=None):
             try:
                 launch_data = launch_request.json()
             except ValueError:
-                error("Error parsing response from /launch: {}".format(launch_request.content))
+                error(
+                    u"Error parsing response from /launch, check web dyno logs for details: "
+                    + launch_request.text
+                )
                 raise
 
             if not launch_request.ok:
                 error('Experiment launch failed, check web dyno logs for details.')
                 if launch_data.get('message'):
-                    error(str(launch_data['message']))
+                    error(launch_data['message'])
                 launch_request.raise_for_status()
 
             closed = False
@@ -549,7 +552,10 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
     try:
         launch_data = launch_request.json()
     except ValueError:
-        error("Error parsing response from /launch: {}".format(launch_request.content))
+        error(
+            "Error parsing response from /launch, check web dyno logs for details: "
+            + launch_request.text
+        )
         raise
 
     if not launch_request.ok:

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -261,6 +261,25 @@ def summary(app):
         click.echo("\nYield: {:.2%}".format(1.0 * num_101s / num_10xs))
 
 
+def _handle_launch_data(url):
+    launch_request = requests.post(url)
+    try:
+        launch_data = launch_request.json()
+    except ValueError:
+        error(
+            u"Error parsing response from /launch, check web dyno logs for details: "
+            + launch_request.text
+        )
+        raise
+
+    if not launch_request.ok:
+        error('Experiment launch failed, check web dyno logs for details.')
+        if launch_data.get('message'):
+            error(launch_data['message'])
+        launch_request.raise_for_status()
+    return launch_data
+
+
 @dallinger.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
 @click.option('--bot', is_flag=True, flag_value=True,
@@ -334,21 +353,7 @@ def debug(verbose, bot, exp_config=None):
             # Call endpoint to launch the experiment
             log("Launching the experiment...")
             time.sleep(4)
-            launch_request = requests.post('{}/launch'.format(base_url))
-            try:
-                launch_data = launch_request.json()
-            except ValueError:
-                error(
-                    u"Error parsing response from /launch, check web dyno logs for details: "
-                    + launch_request.text
-                )
-                raise
-
-            if not launch_request.ok:
-                error('Experiment launch failed, check web dyno logs for details.')
-                if launch_data.get('message'):
-                    error(launch_data['message'])
-                launch_request.raise_for_status()
+            _handle_launch_data('{}/launch'.format(base_url))
 
             closed = False
             status_url = base_url + '/summary'
@@ -548,22 +553,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
     # Launch the experiment.
     log("Launching the experiment on MTurk...")
 
-    launch_request = requests.post('https://{}.herokuapp.com/launch'.format(app_name(id)))
-    try:
-        launch_data = launch_request.json()
-    except ValueError:
-        error(
-            "Error parsing response from /launch, check web dyno logs for details: "
-            + launch_request.text
-        )
-        raise
-
-    if not launch_request.ok:
-        error('Experiment launch failed, check web dyno logs for details.')
-        if launch_data.get('message'):
-            error(str(launch_data['message']))
-        launch_request.raise_for_status()
-
+    launch_data = _handle_launch_data('https://{}.herokuapp.com/launch'.format(app_name(id)))
     log("URLs:")
     log("App home: https://{}.herokuapp.com/".format(app_name(id)), chevrons=False)
     log("Initial recruitment: {}".format(launch_data.get('recruitment_url', None)), chevrons=False)

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -137,6 +137,9 @@ class Experiment(object):
             debug_mode = False
 
         recruiter = config.get('recruiter', None)
+        if recruiter == 'bogus':
+            # For forcing failures in tests
+            raise NotImplementedError
         if debug_mode and recruiter != 'bots':
             return HotAirRecruiter
         if recruiter == 'bots':

--- a/demos/bartlett1932/config.txt
+++ b/demos/bartlett1932/config.txt
@@ -1,6 +1,7 @@
 [Experiment]
 mode = sandbox
 auto_recruit = true
+webdriver_type = phantomjs
 
 [MTurk]
 title = War of the Ghosts

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,3 +69,5 @@ def pytest_addoption(parser):
     parser.addoption("--webdriver", nargs="?", action="store",
                      help="URL of selenium server including /wd/hub to run remote tests against",
                      metavar='URL')
+    parser.addoption("--runbot", action="store_true",
+                     help="Run an experiment using a bot during tests")


### PR DESCRIPTION
## Description
This branch implements explicit error handling and logging in the experiment server's `/launch` route. In addition, it adds some additional error handling and logging to the command line's `deploy_sandbox_shared_setup` call to the experiment `/launch`

## Motivation and Context
These changes are intended to address the problem described in issue #480.

## How Has This Been Tested?
Automated tests have been added for the experiment server `/launch` route in success and failure conditions. The automated test suite runs successfully with these changes.