### PR TITLE
Verify experiment ID

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -783,7 +783,7 @@ def verify_id(app):
     """Verify the experiment id."""
     if app is None:
         raise TypeError("Select an experiment using the --app flag.")
-    elif "dlgr-" == app[0:5]:
+    elif app[0:5] = "dlgr-":
         raise ValueError("The --app flag requires the full UUID beginning with {}.".format(app[5:13]))
 
 

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -249,6 +249,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def summary(app):
     """Print a summary of a deployed app's status."""
+    verify_id(app)
     r = requests.get('https://{}.herokuapp.com/summary'.format(app_name(app)))
     summary = r.json()['summary']
     click.echo("\nstatus \t| count")
@@ -624,6 +625,7 @@ def qualify(qualification, value, worker):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def hibernate(app):
     """Pause an experiment and remove costly resources."""
+    verify_id(app)
     log("The database backup URL is...")
     backup_url = data.backup(app)
     log(backup_url)
@@ -657,6 +659,7 @@ def hibernate(app):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def destroy(app):
     """Tear down an experiment server."""
+    verify_id(app)
     destroy_server(app)
 
 
@@ -716,6 +719,7 @@ def awaken(app, databaseurl):
               help='Scrub PII')
 def export(app, local, no_scrub):
     """Export the data."""
+    verify_id(app)
     log(header, chevrons=False)
     data.export(str(app), local=local, scrub_pii=(not no_scrub))
 
@@ -724,12 +728,13 @@ def export(app, local, no_scrub):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def logs(app):
     """Show the logs."""
-    if app is None:
-        raise TypeError("Select an experiment using the --app flag.")
-    else:
+    verify_id(app)
+    try:
         subprocess.check_call([
             "heroku", "addons:open", "papertrail", "--app", app_name(app)
         ])
+    except subprocess.CalledProcessError as e:
+        print("Invalid experiment ID. {}".format(e))
 
 
 @dallinger.command()
@@ -774,6 +779,14 @@ def rq_worker():
         # right now we care about low queue for bots
         worker = Worker('low')
         worker.work()
+
+
+def verify_id(app):
+    """Verify the experiment id."""
+    if app is None:
+        raise TypeError("Select an experiment using the --app flag.")
+    elif "dlgr-" in app:
+        raise ValueError("Remove the \"dlgr-\" prefix.")
 
 
 def verify_package(verbose=True):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -678,6 +678,7 @@ def destroy_server(app):
 @click.option('--databaseurl', default=None, help='URL of the database')
 def awaken(app, databaseurl):
     """Restore the database from a given url."""
+    verify_id(app)
     id = app
     config = get_config()
     config.load()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -734,7 +734,7 @@ def logs(app):
             "heroku", "addons:open", "papertrail", "--app", app_name(app)
         ])
     except subprocess.CalledProcessError as e:
-        print("Invalid experiment ID. {}".format(e))
+        raise ValueError("Invalid experiment ID. {}".format(e))
 
 
 @dallinger.command()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -730,12 +730,9 @@ def export(app, local, no_scrub):
 def logs(app):
     """Show the logs."""
     verify_id(app)
-    try:
-        subprocess.check_call([
-            "heroku", "addons:open", "papertrail", "--app", app_name(app)
-        ])
-    except subprocess.CalledProcessError as e:
-        raise ValueError("Invalid experiment ID. {}".format(e))
+    subprocess.check_call([
+        "heroku", "addons:open", "papertrail", "--app", app_name(app)
+    ])
 
 
 @dallinger.command()
@@ -786,8 +783,8 @@ def verify_id(app):
     """Verify the experiment id."""
     if app is None:
         raise TypeError("Select an experiment using the --app flag.")
-    elif "dlgr-" in app:
-        raise ValueError("Remove the \"dlgr-\" prefix.")
+    elif "dlgr-" == app[0:5]:
+        raise ValueError("The --app flag requires the full UUID beginning with {}.".format(app[5:13]))
 
 
 def verify_package(verbose=True):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -783,7 +783,7 @@ def verify_id(app):
     """Verify the experiment id."""
     if app is None:
         raise TypeError("Select an experiment using the --app flag.")
-    elif app[0:5] = "dlgr-":
+    elif app[0:5] == "dlgr-":
         raise ValueError("The --app flag requires the full UUID beginning with {}.".format(app[5:13]))
 
 


### PR DESCRIPTION

## Description
Add a verify_id() function to check if the experiment ID is provided by the user, check if it contains the string "dlgr-", and add better error messaging for an incorrect ID when using the logs command.

It does not simplify the general error messages for all the commands with incorrect application ID incase the full stack trace is helpful.

## Motivation and Context
Issue #406 asks for an enhancement to notify users when they enter ```dlgr-``` via the command line as an experiment ID. It also asks for better error messaging when using the ```logs``` command.

## How Has This Been Tested?
This code has been tested using the following dallinger commands: logs, hibernate, summary, export, deploy, awaken.
 
Example:
```
dallinger logs --app dlgr-XXXX
```