### PR TITLE
Typo, duplicate summary text

### DIFF
--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -34,7 +34,6 @@ logs
 Open the app's logs in Papertrail. A required ``--app <app>`` flag specifies
 the experiment by its id.
 
-
 summary
 ^^^^^^^
 
@@ -48,12 +47,6 @@ Download the database and partial server logs to a zipped folder within
 the data directory of the experimental folder. Databases are stored in
 CSV format. A required ``--app <app>`` flag specifies
 the experiment by its id.
-
-summary
-^^^^^^^
-
-Print a summary of the participant table to the command line. A required
-``--app <app>`` flag specifies the experiment by its id.
 
 qualify
 ^^^^^^^


### PR DESCRIPTION
## Description
Remove duplicate 'summary' field in the docs.

## Motivation and Context
Fixing typo.