### PR TITLE
Dev base payment

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -160,11 +160,12 @@ def verify_package(verbose=True):
     base_pay = config.get('base_payment')
     dollarFormat = "{:.2f}".format(base_pay)
     if base_pay <= 0:
-        log("✗ base_payment must be positive value in config.txt.")
+        log("✗ base_payment must be positive value in config.txt.",
+            delay=0, chevrons=False, verbose=verbose)
         return False
     if str(base_pay) != str(dollarFormat):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
-            "{0} to {1}.".format(base_pay, dollarFormat))
+            "{0} to {1}.".format(base_pay, dollarFormat), delay=0, chevrons=False, verbose=verbose)
         return False
 
     # Check front-end files do not exist

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -859,13 +859,13 @@ def verify_package(verbose=True):
     if not config.ready:
         config.load()
     base_pay = config.get('base_payment')
+    dollarFormat = "{:.2f}".format(base_pay)
     if base_pay <= 0:
-        log("✗ base_payment must be positive in config.txt.")
+        log("✗ base_payment must have positive value in config.txt.")
         return False
-
-    elif '.' not in str(base_pay):
+    if str(base_pay) != str(dollarFormat):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
-            "{0} to {1:.2f}.".format(base_pay, base_pay))
+            "{0} to {1}.".format(base_pay, dollarFormat))
         return False
 
     log("✓ no file conflicts", delay=0, chevrons=False, verbose=verbose)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -159,11 +159,13 @@ def verify_package(verbose=True):
         config.load()
     base_pay = config.get('base_payment')
     dollarFormat = "{:.2f}".format(base_pay)
+
     if base_pay <= 0:
         log("✗ base_payment must be positive value in config.txt.",
             delay=0, chevrons=False, verbose=verbose)
         return False
-    if str(base_pay) != str(dollarFormat):
+
+    if '.' not in str(base_pay):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
             "{0} to {1}.".format(base_pay, dollarFormat), delay=0, chevrons=False, verbose=verbose)
         return False
@@ -897,4 +899,3 @@ def rq_worker():
         # right now we care about low queue for bots
         worker = Worker('low')
         worker.work()
-

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -858,11 +858,11 @@ def verify_package(verbose=True):
     config = get_config()
     if not config.ready:
         config.load()
+
     base_pay = config.get('base_payment')
     if base_pay <= 0:
-        log("Payment must be positive.")
+        log("✗ base_payment must be positive in config.txt.")
         return False
-
     elif '.' not in str(base_pay):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
             "{0} to {1:.2f}.".format(base_pay, base_pay))

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -858,11 +858,11 @@ def verify_package(verbose=True):
     config = get_config()
     if not config.ready:
         config.load()
-
     base_pay = config.get('base_payment')
     if base_pay <= 0:
         log("✗ base_payment must be positive in config.txt.")
         return False
+
     elif '.' not in str(base_pay):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
             "{0} to {1:.2f}.".format(base_pay, base_pay))

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -896,3 +896,4 @@ def rq_worker():
         # right now we care about low queue for bots
         worker = Worker('low')
         worker.work()
+

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -854,6 +854,20 @@ def verify_package(verbose=True):
                 delay=0, chevrons=False, verbose=verbose)
             return False
 
+    # Check base_payment is correct
+    config = get_config()
+    if not config.ready:
+        config.load()
+    base_pay = config.get('base_payment')
+    if base_pay <= 0:
+        log("Payment must be positive.")
+        return False
+
+    elif '.' not in str(base_pay):
+        log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
+            "{0} to {1:.2f}.".format(base_pay, base_pay))
+        return False
+
     log("✓ no file conflicts", delay=0, chevrons=False, verbose=verbose)
 
     return is_passing

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -861,7 +861,7 @@ def verify_package(verbose=True):
     base_pay = config.get('base_payment')
     dollarFormat = "{:.2f}".format(base_pay)
     if base_pay <= 0:
-        log("✗ base_payment must have positive value in config.txt.")
+        log("✗ base_payment must be positive value in config.txt.")
         return False
     if str(base_pay) != str(dollarFormat):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -103,7 +103,7 @@ class Configuration(object):
                 except ValueError:
                     pass
             if not isinstance(value, expected_type):
-                raise ValueError(
+                raise TypeError(
                     'Got {value} for {key}, expected {expected_type}'
                     .format(
                         value=repr(value),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -154,7 +154,7 @@ class Configuration(object):
         if key in self.types:
             raise KeyError('Config key {} is already registered'.format(key))
         if type_ not in self.SUPPORTED_TYPES:
-            raise ValueError(
+            raise TypeError(
                 '{type} is not a supported type'.format(
                     type=type_
                 )

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -15,6 +15,7 @@ import dallinger.command_line
 from dallinger.compat import unicode
 from dallinger.config import LOCAL_CONFIG, get_config
 import dallinger.version
+from dallinger.command_line import verify_package
 
 
 class TestCommandLine(object):
@@ -125,6 +126,14 @@ class TestSetupExperiment(object):
             deploy_config.get('Parameters', 'a_password')
         with raises(NoOptionError):
             deploy_config.get('Parameters', 'something_sensitive')
+
+    def test_incorrect_payment(self):
+        config = get_config()
+        with raises(TypeError):
+            config['base_payment'] = 12
+
+    def test_default_config(self):
+        assert verify_package() is True
 
 
 class TestDebugServer(object):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,13 +26,13 @@ class TestConfiguration(object):
 
     def test_register_unknown_type_raises(self):
         config = Configuration()
-        with raises(ValueError):
+        with raises(TypeError):
             config.register('num_participants', object)
 
     def test_type_mismatch(self):
         config = Configuration()
         config.register('num_participants', int)
-        with raises(ValueError):
+        with raises(TypeError):
             config.extend({'num_participants': 1.0})
 
     def test_type_mismatch_with_cast_types(self):
@@ -46,7 +46,7 @@ class TestConfiguration(object):
         config = Configuration()
         config.register('num_participants', int)
         config.ready = True
-        with raises(ValueError):
+        with raises(TypeError):
             config.extend({'num_participants': 'A NUMBER'}, cast_types=True)
 
     def test_get_before_ready_is_not_possible(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
This fix creates a check during `dallinger verify` to inspect the `base_payment` key in config.txt is in the correct format. This fix also changes a few ValueErrors to TypeErrors, since they are errors concerning objects of incorrect types.

## Motivation and Context
Issue #337 describes an error during MTurk payment verification when using `dallinger deploy.` MTurk Payment fails at the end of running an experiment if the payment in the config is not in [dollar].[cents] format. 

## How Has This Been Tested?
Tested using `dallinger verify` after editing the `base_payment` in config.txt
