### PR TITLE
Fix sort order issue in MCMCP demo

### DIFF
--- a/demos/mcmcp/static/scripts/experiment.js
+++ b/demos/mcmcp/static/scripts/experiment.js
@@ -29,8 +29,13 @@ get_infos = function() {
         success: function (resp) {
             sides_switched = Math.random() < 0.5;
 
-            animal_0 = JSON.parse(resp.infos[0].contents);
-            animal_1 = JSON.parse(resp.infos[1].contents);
+            if (resp.infos[0].id > resp.infos[1].id) {
+                animal_0 = JSON.parse(resp.infos[0].contents);
+                animal_1 = JSON.parse(resp.infos[1].contents);
+            } else {
+                animal_0 = JSON.parse(resp.infos[1].contents);
+                animal_1 = JSON.parse(resp.infos[0].contents);
+            }
 
             if (sides_switched === false) {
                 drawAnimal(animal_0, "left");


### PR DESCRIPTION
When running a long chain, @jcpeterson noticed that every so often the
mapping between the "left" and "right" buttons flipped. The error was
non-deterministic and hard to predict. After a long debugging session,
we realized that the order of infos returned by the
`node/<node_id>/infos` route is non-deterministic (or at least not
always sequential in node id). This is a fix that behaves properly no
matter what order the returned infos are sorted in.

Closes #570.