### PR TITLE
Add payment check method

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -163,12 +163,12 @@ def verify_package(verbose=True):
     if base_pay <= 0:
         log("✗ base_payment must be positive value in config.txt.",
             delay=0, chevrons=False, verbose=verbose)
-        return False
+        is_passing = False
 
     if float(dollarFormat) != float(base_pay):
         log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
             "{0} to {1}.".format(base_pay, dollarFormat), delay=0, chevrons=False, verbose=verbose)
-        return False
+        is_passing = False
 
     # Check front-end files do not exist
     files = [

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -153,6 +153,23 @@ def verify_package(verbose=True):
         log("✓ README is OK",
             delay=0, chevrons=False, verbose=verbose)
 
+    # Check base_payment is correct
+    config = get_config()
+    if not config.ready:
+        config.load()
+    base_pay = config.get('base_payment')
+    dollarFormat = "{:.2f}".format(base_pay)
+
+    if base_pay <= 0:
+        log("✗ base_payment must be positive value in config.txt.",
+            delay=0, chevrons=False, verbose=verbose)
+        return False
+
+    if float(dollarFormat) != float(base_pay):
+        log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
+            "{0} to {1}.".format(base_pay, dollarFormat), delay=0, chevrons=False, verbose=verbose)
+        return False
+
     # Check front-end files do not exist
     files = [
         os.path.join("templates", "complete.html"),

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -92,6 +92,7 @@ def verify_id(ctx, param, app):
     elif app[0:5] == "dlgr-":
         raise ValueError("The --app flag requires the full "
                          "UUID beginning with {}-...".format(app[5:13]))
+    return app
 
 
 def verify_package(verbose=True):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -356,10 +356,9 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
 
 @dallinger.command()
-@click.option('--app', default=None, help='ID of the deployed experiment')
+@click.option('--app', default=None, callback=verify_id, help='Experiment id')
 def summary(app):
     """Print a summary of a deployed app's status."""
-    verify_id(app)
     r = requests.get('https://{}.herokuapp.com/summary'.format(app_name(app)))
     summary = r.json()['summary']
     click.echo("\nstatus \t| count")
@@ -677,10 +676,13 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
 
 @dallinger.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
-@click.option('--app', default=None, callback=verify_id, help='Experiment id')
+@click.option('--app', default=None, help='Experiment id')
 def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
     # Load configuration.
+    if app:
+        verify_id(None, None, app)
+
     config = get_config()
     config.load()
 
@@ -699,6 +701,9 @@ def sandbox(verbose, app):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
+    if app:
+        verify_id(None, None, app)
+
     # Load configuration.
     config = get_config()
     config.load()
@@ -865,7 +870,7 @@ def logs(app):
 def bot(app, debug):
     """Run the experiment bot."""
     if debug is None:
-        verify_id(app)
+        verify_id(None, None, app)
 
     (id, tmp) = setup_experiment()
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -103,7 +103,7 @@ class Configuration(object):
                 except ValueError:
                     pass
             if not isinstance(value, expected_type):
-                raise ValueError(
+                raise TypeError(
                     'Got {value} for {key}, expected {expected_type}'
                     .format(
                         value=repr(value),
@@ -154,7 +154,7 @@ class Configuration(object):
         if key in self.types:
             raise KeyError('Config key {} is already registered'.format(key))
         if type_ not in self.SUPPORTED_TYPES:
-            raise ValueError(
+            raise TypeError(
                 '{type} is not a supported type'.format(
                     type=type_
                 )

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -32,12 +32,20 @@ class TestCommandLine(object):
         output = subprocess.check_output(["dallinger"])
         assert("Usage: dallinger [OPTIONS] COMMAND [ARGS]" in output)
 
-    def test_dlgr_id(self):
+    def test_log_empty(self):
         id = "dlgr-3b9c2aeb"
         assert ValueError, subprocess.call(["dallinger", "logs", "--app", id])
 
-    def test_empty_id(self):
+    def test_log_no_flag(self):
         assert TypeError, subprocess.call(["dallinger", "logs"])
+
+    def test_deploy_empty(self):
+        id = "dlgr-3b9c2aeb"
+        assert ValueError, subprocess.call(["dallinger", "deploy", "--app", id])
+
+    def test_sandbox_empty(self):
+        id = "dlgr-3b9c2aeb"
+        assert ValueError, subprocess.call(["dallinger", "sandbox", "--app", id])
 
     def test_verify_id_short_fails(self):
         id = "dlgr-3b9c2aeb"

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -13,6 +13,7 @@ import pexpect
 from pytest import raises
 
 import dallinger.command_line
+from dallinger.command_line import verify_package
 from dallinger.compat import unicode
 from dallinger.config import LOCAL_CONFIG, get_config
 import dallinger.version
@@ -150,7 +151,7 @@ class TestSetupExperiment(object):
         config = get_config()
         config['base_payment'] = 1.2342
         assert(verify_package() is False)
-    
+
     def test_negative_payment(self):
         config = get_config()
         config['base_payment'] = -1.99

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -141,6 +141,21 @@ class TestSetupExperiment(object):
         with raises(NoOptionError):
             deploy_config.get('Parameters', 'something_sensitive')
 
+    def test_payment_type(self):
+        config = get_config()
+        with raises(TypeError):
+            config['base_payment'] = 12
+
+    def test_large_float_payment(self):
+        config = get_config()
+        config['base_payment'] = 1.2342
+        assert(verify_package() is False)
+    
+    def test_negative_payment(self):
+        config = get_config()
+        config['base_payment'] = -1.99
+        assert(verify_package() is False)
+
 
 class TestDebugServer(object):
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -26,13 +26,13 @@ class TestConfiguration(object):
 
     def test_register_unknown_type_raises(self):
         config = Configuration()
-        with raises(ValueError):
+        with raises(TypeError):
             config.register('num_participants', object)
 
     def test_type_mismatch(self):
         config = Configuration()
         config.register('num_participants', int)
-        with raises(ValueError):
+        with raises(TypeError):
             config.extend({'num_participants': 1.0})
 
     def test_type_mismatch_with_cast_types(self):
@@ -46,7 +46,7 @@ class TestConfiguration(object):
         config = Configuration()
         config.register('num_participants', int)
         config.ready = True
-        with raises(ValueError):
+        with raises(TypeError):
             config.extend({'num_participants': 'A NUMBER'}, cast_types=True)
 
     def test_get_before_ready_is_not_possible(self):


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Add payment check method, change ValueErrors to be TypeErrors

## Motivation and Context
#337 asked for better error checking on MTurk payment. While this was partially fixed in commit 3027f0f369df42686bf6974a9b17fdf3826a6697, there are still issues when submitting a config where `base_payment` is a negative number or a large float.

## How Has This Been Tested?
`dallinger verify` using an different `base_payment` values in `config.txt`
