### PR TITLE
Verification fixes

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -92,6 +92,7 @@ def verify_id(ctx, param, app):
     elif app[0:5] == "dlgr-":
         raise ValueError("The --app flag requires the full "
                          "UUID beginning with {}-...".format(app[5:13]))
+    return app
 
 
 def verify_package(verbose=True):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -339,10 +339,9 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
 
 @dallinger.command()
-@click.option('--app', default=None, help='ID of the deployed experiment')
+@click.option('--app', default=None, callback=verify_id, help='Experiment id')
 def summary(app):
     """Print a summary of a deployed app's status."""
-    verify_id(app)
     r = requests.get('https://{}.herokuapp.com/summary'.format(app_name(app)))
     summary = r.json()['summary']
     click.echo("\nstatus \t| count")
@@ -660,10 +659,13 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
 
 @dallinger.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
-@click.option('--app', default=None, callback=verify_id, help='Experiment id')
+@click.option('--app', default=None, help='Experiment id')
 def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
     # Load configuration.
+    if app:
+        verify_id(None, None, app)
+
     config = get_config()
     config.load()
 
@@ -682,6 +684,9 @@ def sandbox(verbose, app):
 @click.option('--app', default=None, help='ID of the deployed experiment')
 def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
+    if app:
+        verify_id(None, None, app)
+
     # Load configuration.
     config = get_config()
     config.load()
@@ -848,7 +853,7 @@ def logs(app):
 def bot(app, debug):
     """Run the experiment bot."""
     if debug is None:
-        verify_id(app)
+        verify_id(None, None, app)
 
     (id, tmp) = setup_experiment()
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -31,12 +31,20 @@ class TestCommandLine(object):
         output = subprocess.check_output(["dallinger"])
         assert("Usage: dallinger [OPTIONS] COMMAND [ARGS]" in output)
 
-    def test_dlgr_id(self):
+    def test_log_empty(self):
         id = "dlgr-3b9c2aeb"
         assert ValueError, subprocess.call(["dallinger", "logs", "--app", id])
 
-    def test_empty_id(self):
+    def test_log_no_flag(self):
         assert TypeError, subprocess.call(["dallinger", "logs"])
+
+    def test_deploy_empty(self):
+        id = "dlgr-3b9c2aeb"
+        assert ValueError, subprocess.call(["dallinger", "deploy", "--app", id])
+
+    def test_sandbox_empty(self):
+        id = "dlgr-3b9c2aeb"
+        assert ValueError, subprocess.call(["dallinger", "sandbox", "--app", id])
 
     def test_verify_id_short_fails(self):
         id = "dlgr-3b9c2aeb"


### PR DESCRIPTION
PR #566 adds a verification check for app ids. I changed this to use Click's [callback feature](http://click.pocoo.org/5/advanced/#parameter-modifications), which broke a bunch of stuff by making the `--app` flag mandatory for deployment and sandboxing. This fixes those problems.