### PR TITLE
Default port 5000

### DIFF
--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -6,7 +6,7 @@ database_url = postgresql://postgres@localhost/dallinger
 
 [Server]
 host = localhost
-port = 22362
+port = 5000
 logfile = server.log
 loglevel = 0
 threads = auto


### PR DESCRIPTION
This changes the default gunicorn port to 5000 (for consistency with some developers who already have it configured that way; we want a consistent port for browser-sync to proxy in Dallinger/Griduniverse#63
