### PR TITLE
Add checks to catch failures to mark an info true

### DIFF
--- a/demos/mcmcp/experiment.py
+++ b/demos/mcmcp/experiment.py
@@ -58,6 +58,11 @@ class MCMCP(Experiment):
         parent.transmit()
         node.receive()
 
+    def data_check(self, participant):
+        """Make sure each trial contains exactly one chosen info."""
+        infos = participant.infos()
+        return len([info for info in infos if info.chosen])*2 == len(infos)
+
 
 extra_routes = Blueprint(
     'extra_routes',


### PR DESCRIPTION
In some cases, if request from the client-side are not received, both of the two infos on each mcmcp trial will remain marked as chosen=False. Creating a new node for that participant or a new participant is then impossible, and there is no mechanism to halt the assignment afterwards. 

## Description
A very simple data check using the standard function is added that checks that at least one info is marked as chosen=True. If not, the participant is failed in the usual manner.

## Motivation and Context
This happened to me twice in real experiments and it took a while to figure it out. It can randomly appear any time and make long MCMCP chains impossible, which are essential for using it in practice.

## How Has This Been Tested?
I've run about 1000 trials in a real experiment, and this does the trick. The rate of error before was about 2%, and no new cases have been seen.