### PR TITLE
Allow more than 10 assignments on Mechanical Turk

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -138,6 +138,7 @@ class Experiment(object):
         last part could (should) be made pluggable.
         """
         from dallinger.recruiters import HotAirRecruiter
+        from dallinger.recruiters import MTurkLargeRecruiter
         from dallinger.recruiters import MTurkRecruiter
         from dallinger.recruiters import BotRecruiter
 
@@ -156,6 +157,8 @@ class Experiment(object):
             return HotAirRecruiter
         if recruiter == 'bots':
             return BotRecruiter.from_current_config
+        if recruiter == 'mturklarge':
+            return MTurkLargeRecruiter.from_current_config
         return MTurkRecruiter.from_current_config
 
     def send(self, raw_message):

--- a/dallinger/networks.py
+++ b/dallinger/networks.py
@@ -7,6 +7,26 @@ from .models import Network
 from .nodes import Source
 
 
+class DelayedChain(Network):
+    """Source -> Node -> Node -> Node -> ...
+
+    The source is optional, but must be added first.
+    """
+
+    __mapper_args__ = {"polymorphic_identity": "delayed_chain"}
+
+    def add_node(self, node):
+        """Add an agent, connecting it to the previous node."""
+        other_nodes = [n for n in self.nodes() if n.id != node.id]
+        if node.id > 11:
+            parents = [max(other_nodes, key=attrgetter('creation_time'))]
+        else:
+            parents = [n for n in other_nodes if isinstance(n, Source)]
+
+        for parent in parents:
+            parent.connect(whom=node)
+
+
 class Chain(Network):
     """Source -> Node -> Node -> Node -> ...
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -279,7 +279,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         to_recruit = max(n, 10)
         return super(MTurkLargeRecruiter, self).open_recruitment(to_recruit)
 
-    def recruit_participants(self, n=1):
+    def recruit(self, n=1):
         if not self.config.get('auto_recruit', False):
             logger.info('auto_recruit is False: recruitment suppressed')
             return
@@ -294,7 +294,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         else:
              conn.incr('num_recruited', n)
         if to_recruit:
-            return super(MTurkLargeRecruiter, self).recruit_participants(to_recruit)
+            return super(MTurkLargeRecruiter, self).recruit(to_recruit)
 
 
 class BotRecruiter(Recruiter):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -266,6 +266,7 @@ class MTurkRecruiter(Recruiter):
             except DuplicateQualificationNameError:
                 pass
 
+
 class MTurkLargeRecruiter(MTurkRecruiter):
     def __init__(self, *args, **kwargs):
         conn.set('num_recruited', 0)
@@ -292,7 +293,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
             else:
                 to_recruit = 0
         else:
-             conn.incr('num_recruited', n)
+            conn.incr('num_recruited', n)
         if to_recruit:
             return super(MTurkLargeRecruiter, self).recruit(to_recruit)
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -266,6 +266,39 @@ class MTurkRecruiter(Recruiter):
             except DuplicateQualificationNameError:
                 pass
 
+class MTurkLargeRecruiter(MTurkRecruiter):
+    def __init__(self, *args, **kwargs):
+        super(MTurkLargeRecruiter, self).__init__(*args, **kwargs)
+        self.num_recruited = 0
+
+    def open_recruitment(self, n=1):
+        if self.is_in_progress:
+            # Already started... do nothing.
+            return None
+        self.num_recruited += n
+        if n < 10:
+            to_recruit = 10
+        else:
+            to_recruit = n
+        return super(MTurkLargeRecruiter, self).open_recruitment(to_recruit)
+
+    def recruit_participants(self, n=1):
+        if not self.config.get('auto_recruit', False):
+            logger.info('auto_recruit is False: recruitment suppressed')
+            return
+        to_recruit = n
+        if self.num_recruited < 10:
+            self.num_recruited += n
+            logger.info('Recruited participant from preallocated pool')
+            if self.num_recruited > 10:
+                to_recruit = self.num_recruited - 10
+            else:
+                to_recruit = 0
+        else:
+            self.num_recruited += n
+        if to_recruit:
+            return super(MTurkLargeRecruiter, self).recruit_participants(to_recruit)
+
 
 class BotRecruiter(Recruiter):
     """Recruit bot participants using a queue"""

--- a/demos/dlgr/demos/bartlett1932/config.txt
+++ b/demos/dlgr/demos/bartlett1932/config.txt
@@ -2,6 +2,7 @@
 mode = sandbox
 auto_recruit = true
 webdriver_type = phantomjs
+recruiter = mturklarge
 
 [MTurk]
 title = War of the Ghosts

--- a/demos/dlgr/demos/bartlett1932/config.txt
+++ b/demos/dlgr/demos/bartlett1932/config.txt
@@ -2,7 +2,6 @@
 mode = sandbox
 auto_recruit = true
 webdriver_type = phantomjs
-recruiter = mturklarge
 
 [MTurk]
 title = War of the Ghosts

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -34,7 +34,7 @@ class Bartlett1932(Experiment):
         import models
         self.models = models
         self.experiment_repeats = 1
-        self.initial_recruitment_size = 10
+        self.initial_recruitment_size = 1
         if session:
             self.setup()
 

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -8,8 +8,9 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from dallinger.bots import BotBase
-from dallinger.networks import Chain
+from dallinger.networks import DelayedChain
 from dallinger.experiment import Experiment
+from dallinger.models import Participant
 
 
 logger = logging.getLogger(__file__)
@@ -32,6 +33,7 @@ class Bartlett1932(Experiment):
         import models
         self.models = models
         self.experiment_repeats = 1
+        self.initial_recruitment_size = 10
         if session:
             self.setup()
 
@@ -50,7 +52,7 @@ class Bartlett1932(Experiment):
 
     def create_network(self):
         """Return a new network."""
-        return Chain(max_size=5)
+        return DelayedChain()
 
     def add_node_to_network(self, node, network):
         """Add node to the chain and receive transmissions."""
@@ -64,7 +66,14 @@ class Bartlett1932(Experiment):
     def recruit(self):
         """Recruit one participant at a time until all networks are full."""
         if self.networks(full=False):
-            self.recruiter().recruit(n=1)
+
+            participants = Participant.query\
+                .filter_by(status="approved")\
+                .all()
+
+            if len(participants) >= 10:
+                self.recruiter().recruit(n=1)
+
         else:
             self.recruiter().close_recruitment()
 

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -53,7 +53,7 @@ class Bartlett1932(Experiment):
 
     def create_network(self):
         """Return a new network."""
-        return DelayedChain()
+        return DelayedChain(max_size=5)
 
     def add_node_to_network(self, node, network):
         """Add node to the chain and receive transmissions."""

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -6,6 +6,7 @@ from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
+from sqlalchemy import not_
 
 from dallinger.bots import BotBase
 from dallinger.networks import DelayedChain
@@ -68,10 +69,10 @@ class Bartlett1932(Experiment):
         if self.networks(full=False):
 
             participants = Participant.query\
-                .filter_by(status="approved")\
+                .filter_by(not_(status="working"))\
                 .all()
 
-            if len(participants) >= 10:
+            if len(participants) >= self.initial_recruitment_size:
                 self.recruiter().recruit(n=1)
 
         else:

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -8,7 +8,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
 
 from dallinger.bots import BotBase
-from dallinger.networks import DelayedChain
+from dallinger.networks import Chain
 from dallinger.experiment import Experiment
 
 
@@ -51,7 +51,7 @@ class Bartlett1932(Experiment):
 
     def create_network(self):
         """Return a new network."""
-        return DelayedChain(max_size=5)
+        return Chain(max_size=5)
 
     def add_node_to_network(self, node, network):
         """Add node to the chain and receive transmissions."""

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -67,13 +67,7 @@ class Bartlett1932(Experiment):
     def recruit(self):
         """Recruit one participant at a time until all networks are full."""
         if self.networks(full=False):
-
-            participants = Participant.query\
-                .filter_by(not_(status="working"))\
-                .all()
-
-            if len(participants) >= self.initial_recruitment_size:
-                self.recruiter().recruit(n=1)
+            self.recruiter().recruit(n=1)
 
         else:
             self.recruiter().close_recruitment()

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -6,12 +6,10 @@ from selenium.webdriver.common.by import By
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.support.ui import WebDriverWait
 from selenium.webdriver.support import expected_conditions as EC
-from sqlalchemy import not_
 
 from dallinger.bots import BotBase
 from dallinger.networks import DelayedChain
 from dallinger.experiment import Experiment
-from dallinger.models import Participant
 
 
 logger = logging.getLogger(__file__)

--- a/demos/dlgr/demos/iterated_drawing/templates/questionnaire.html
+++ b/demos/dlgr/demos/iterated_drawing/templates/questionnaire.html
@@ -65,7 +65,7 @@
             <div class="col-xs-7">
             </div>
             <div class="col-xs-3">
-                <button type="button" class="btn btn-primary btn-lg continue" onClick="submitResponses();">
+                <button type="button" id="submit-questionnaire" class="btn btn-primary btn-lg continue" onClick="submitResponses();">
                     Continue</span>
                 </button>
             </div>

--- a/demos/dlgr/demos/mcmcp/experiment.py
+++ b/demos/dlgr/demos/mcmcp/experiment.py
@@ -12,7 +12,7 @@ from selenium.common.exceptions import TimeoutException
 from dallinger.bots import BotBase
 from dallinger.experiment import Experiment
 from dallinger import db
-from dallinger.networks import DelayedChain
+from dallinger.networks import Chain
 
 
 class MCMCP(Experiment):
@@ -49,7 +49,7 @@ class MCMCP(Experiment):
 
     def create_network(self):
         """Create a new network."""
-        return DelayedChain(max_size=100)
+        return Chain(max_size=100)
 
     def get_network_for_participant(self, participant):
         if len(participant.nodes(failed="all")) < self.trials_per_participant:

--- a/demos/dlgr/demos/mcmcp/templates/consent.html
+++ b/demos/dlgr/demos/mcmcp/templates/consent.html
@@ -42,7 +42,7 @@
                 <hr>
                 <h4>Do you understand and consent to these terms?</h4>
                 <br>
-                <button type="button" class="btn btn-primary btn-lg" onClick="allow_exit();window.location='/instructions/instruct-ready?hit_id={{ hit_id }}&assignment_id={{ assignment_id }}&worker_id={{ worker_id }}&mode={{ mode }}';" style="float: left;">I agree
+                <button type="button" class="btn btn-primary btn-lg" id="consent" onClick="allow_exit();window.location='/instructions/instruct-ready?hit_id={{ hit_id }}&assignment_id={{ assignment_id }}&worker_id={{ worker_id }}&mode={{ mode }}';" style="float: left;">I agree
                 </button>
                 <button type="button" class="btn btn-danger btn-lg" onClick="allow_exit();self.close();" style="float: right;">No thanks (exit HIT)
                 </button>

--- a/demos/dlgr/demos/mcmcp/templates/exp.html
+++ b/demos/dlgr/demos/mcmcp/templates/exp.html
@@ -16,8 +16,8 @@
             <div id="stimulus">
                 <h1>Which one is a dog?</h1>
                 <div>
-                    <button type="button" class="btn btn-primary submit-response" onClick="submit_response(0);">Left</button>
-                    <button type="button" class="btn btn-primary submit-response" onClick="submit_response(1);">Right</button>
+                    <button type="button" class="btn btn-primary submit-response" id="left_button" onClick="submit_response(0);">Left</button>
+                    <button type="button" class="btn btn-primary submit-response" id="right_button" onClick="submit_response(1);">Right</button>
                 </div>
             </div>
         </div>

--- a/demos/dlgr/demos/mcmcp/templates/instructions/instruct-ready.html
+++ b/demos/dlgr/demos/mcmcp/templates/instructions/instruct-ready.html
@@ -1,6 +1,7 @@
 <head>
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
+    <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
     <script src="/static/scripts/dallinger.js" type="text/javascript"> </script>
 </head>
@@ -23,7 +24,7 @@
         <div class="row">
             <div class="col-xs-10"></div>
             <div class="col-xs-2">
-                <button type="button" class="btn btn-success btn-lg" onClick="allow_exit();go_to_page('exp');">
+                <button type="button" id="begin" class="btn btn-success btn-lg" onClick="allow_exit();go_to_page('exp');">
                 Begin</button>
             </div>
         </div>

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -238,6 +238,21 @@ class TestNetworks(object):
             "0 infos, 0 transmissions and 0 transformations>"
         )
 
+    def test_create_delayed_chain(self, db_session):
+        net = networks.DelayedChain()
+        db_session.add(net)
+        db_session.commit()
+
+        source = nodes.RandomBinaryStringSource(network=net)
+        net.add_node(source)
+
+        for i in range(15):
+            agent = nodes.Agent(network=net)
+            net.add_node(agent)
+
+        source_ids = [node.vectors()[0].origin.id for node in net.nodes()]
+        assert source_ids == [15, 14, 13, 12, 11, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+
     def test_create_fully_connected(self, db_session):
         net = networks.FullyConnected()
         db_session.add(net)

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -396,4 +396,3 @@ class TestMTurkLargeRecruiter(object):
             duration_hours=1.0,
             number=6
         )
-

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -396,3 +396,11 @@ class TestMTurkLargeRecruiter(object):
             duration_hours=1.0,
             number=6
         )
+
+    def test_recruit_auto_recruit_off_does_not_extend_hit(self, recruiter):
+        recruiter.config['auto_recruit'] = False
+        fake_hit_id = 'fake HIT id'
+        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+        recruiter.recruit()
+
+        assert not recruiter.mturkservice.extend_hit.called


### PR DESCRIPTION
## Description
This creates a recruiter that can get more than 10 participants on mechanical turk, and a chain implementation that handles the initial glut of participants. It also adds a bot for MCMCP to assist with testing this.


## Motivation and Context
Mechanical turk's pricing increases if you need more than 10 assignments, so if your initial recruitment size is less than 10 it will fail on extending past that limit. This pre-allocates 10 participants and introduces a chain and a recruiter type to make it compatible with experiments without them needing to specifically code for the mturk limitations.

## How Has This Been Tested?
Unit tests only, at this stage.