### PR TITLE
allow reload or exit by default, but add a simple way to prevent exit

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -19,16 +19,25 @@ var assignment_id = getUrlParameter("assignment_id");
 var mode = getUrlParameter("mode");
 var participant_id = getUrlParameter("participant_id");
 
-// stop people leaving the page
-window.onbeforeunload = function() {
-    return "Warning: the study is not yet finished. " +
-    "Closing the window, refreshing the page or navigating elsewhere " +
-    "might prevent you from finishing the experiment.";
-};
+// stop people leaving the page, but only if desired by experiment
+var allow_exit_once = false;
+var prevent_exit = false;
+window.addEventListener('beforeunload', function(e) {
+    if (prevent_exit == true && allow_exit_once == false) {
+        var returnValue = "Warning: the study is not yet finished. " +
+        "Closing the window, refreshing the page or navigating elsewhere " +
+        "might prevent you from finishing the experiment.";
+        e.returnValue = returnValue;
+        return returnValue
+    } else {
+        allow_exit_once = false;
+        return undefined;
+    }
+});
 
 // allow actions to leave the page
 var allow_exit = function() {
-    window.onbeforeunload = function() {};
+    allow_exit_once = true;
 };
 
 // advance the participant to a given html page

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -28,7 +28,7 @@ window.addEventListener('beforeunload', function(e) {
         "Closing the window, refreshing the page or navigating elsewhere " +
         "might prevent you from finishing the experiment.";
         e.returnValue = returnValue;
-        return returnValue
+        return returnValue;
     } else {
         allow_exit_once = false;
         return undefined;

--- a/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/bartlett1932/static/scripts/experiment.js
@@ -3,6 +3,9 @@ var my_node_id;
 // Consent to the experiment.
 $(document).ready(function() {
 
+    // do not allow user to close or reload
+    prevent_exit = true;
+
     // Print the consent form.
     $("#print-consent").click(function() {
         console.log("hello");


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Allow experiments to prevent exit or reload from experiment pages by setting prevent_exit to true after dallinger.js is loaded.

## Motivation and Context
Story 188 calls for the removal of the prevent exit functionality, but was amended to make it configurable.

## How Has This Been Tested?
Tested with the Bartlett1932 demo. Experiments need to do nothing to get the default allow exit behavior.

