### PR TITLE
Create JS module namespace with a questionnaire submitter

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -16,6 +16,25 @@ var getUrlParameter = function getUrlParameter(sParam) {
 
 var Dallinger = (function () {
   var dlgr = {};
+
+  participantId = getUrlParameter("participant_id") || -1;
+
+  dlgr.submitQuestionnaire = function (name, callback) {
+    formSerialized = $("form").serializeArray();
+    formDict = formSerialized.reduce(
+      function(m,o){ m[o.name] = o.value; return m; }, {}
+    );
+    $.ajax({
+      type: "POST",
+      url: "/question/" + participantId,
+      data: {
+        question: name || "questionnaire",
+        number: 1,
+        response: JSON.stringify(formDict),
+      },
+      success: callback,
+    });
+  };
   return dlgr;
 })();
 

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -17,7 +17,7 @@ var getUrlParameter = function getUrlParameter(sParam) {
 var Dallinger = (function () {
   var dlgr = {};
 
-  participantId = getUrlParameter("participant_id") || -1;
+  participantId = getUrlParameter("participant_id");
 
   dlgr.submitQuestionnaire = function (name, callback) {
     formSerialized = $("form").serializeArray();

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -21,9 +21,10 @@ var Dallinger = (function () {
 
   dlgr.submitQuestionnaire = function (name, callback) {
     formSerialized = $("form").serializeArray();
-    formDict = formSerialized.reduce(
-      function(m,o){ m[o.name] = o.value; return m; }, {}
-    );
+    var formDict = {};
+    formSerialized.forEach(function (field) {
+        formDict[field.name] = field.value;
+    });
     $.ajax({
       type: "POST",
       url: "/question/" + participantId,

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -13,6 +13,12 @@ var getUrlParameter = function getUrlParameter(sParam) {
         }
     }
 };
+
+var Dallinger = (function () {
+  var dlgr = {};
+  return dlgr;
+})();
+
 var hit_id = getUrlParameter("hit_id");
 var worker_id = getUrlParameter("worker_id");
 var assignment_id = getUrlParameter("assignment_id");


### PR DESCRIPTION
This creates `Dallinger`, a new JS module provided by `dallinger.js`. Eventually, this should hold all the experiment-agnostic code. For now it contains only one function, `Dallinger.submitQuestionnaire`, which serializes the entire form on `questionnaire.html` and submits the responses as a single entry in the Question table. None of the in-Dallinger demos have been modified to use this. I figured we'd wait until a 4.0 release that puts everything inside a `Dallinger` module that has more than just one function. This was created for the purposes of https://github.com/Dallinger/Griduniverse/pull/69, which has a 20-item survey that is not well-served using the existing form submission tools.