### PR TITLE
Make sure each web worker listens for redis channel messages

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -212,7 +212,7 @@ var submitNextResponse = function (n) {
 
 waitForQuorum = function () {
     var ws_scheme = (window.location.protocol === "https:") ? 'wss://' : 'ws://';
-    var socket = new ReconnectingWebSocket(ws_scheme + location.host + "/chat");
+    var socket = new ReconnectingWebSocket(ws_scheme + location.host + "/chat?channel=quorum");
     var deferred = $.Deferred();
     socket.onmessage = function (msg) {
         if (msg.data.indexOf('quorum:') !== 0) { return; }


### PR DESCRIPTION
This fixes a problem where only the web worker which handled the `/launch` request would start a greenlet to receive messages from redis. That had the side effect of causing some clients to not receive messages meant for them (see https://github.com/Dallinger/Griduniverse/issues/71 for one example).

There are a couple of minor semi-related changes:
- Log the process id and greenlet id for each log entry from sockets.py to help with debugging what's going on.
- No longer subscribe to the `quorum` channel by default.

Tested with the automated tests and by running locally and confirming that I don't see the problem I did before.