### PR TITLE
Avoid adblocker

### DIFF
--- a/dallinger/default_configs/.dallingerconfig
+++ b/dallinger/default_configs/.dallingerconfig
@@ -6,3 +6,7 @@ aws_region = us-east-1
 [Email Access]
 dallinger_email_address = ???
 dallinger_email_password = ???
+
+[Server]
+host = 0.0.0.0
+port = 5000

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -6,7 +6,7 @@ database_url = postgresql://postgres@localhost/dallinger
 
 [Server]
 host = localhost
-port = 22362
+port = 5000
 logfile = server.log
 loglevel = 0
 threads = auto

--- a/demos/2048/templates/ad.html
+++ b/demos/2048/templates/ad.html
@@ -20,7 +20,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -34,7 +34,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/bartlett1932/templates/ad.html
+++ b/demos/bartlett1932/templates/ad.html
@@ -18,7 +18,7 @@
 			    padding: 2px;
 			    border: none;
 			}
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -32,7 +32,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 			<div id="ad">
 				<div class="row">
 					<div class="col-xs-2">

--- a/demos/chatroom/templates/ad.html
+++ b/demos/chatroom/templates/ad.html
@@ -18,7 +18,7 @@
                 padding: 2px;
                 border: none;
             }
-            #container-ad {
+            #container-not-an-ad {
                 position: absolute;
                 top: 0px; /* Header Height */
                 bottom: 0px; /* Footer Height */
@@ -32,7 +32,7 @@
         </style>
     </head>
     <body>
-        <div id="container-ad">
+        <div id="container-not-an-ad">
             <div id="ad">
                 <div class="row">
                     <div class="col-xs-2">

--- a/demos/concentration/templates/ad.html
+++ b/demos/concentration/templates/ad.html
@@ -18,7 +18,7 @@
 			    padding: 2px;
 			    border: none;
 			}
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -32,7 +32,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 			<div id="ad">
 				<div class="row">
 					<div class="col-xs-2">

--- a/demos/function-learning/templates/ad.html
+++ b/demos/function-learning/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/iterated-drawing/templates/ad.html
+++ b/demos/iterated-drawing/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/mcmcp/templates/ad.html
+++ b/demos/mcmcp/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/rogers/templates/ad.html
+++ b/demos/rogers/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/sheep-market/templates/ad.html
+++ b/demos/sheep-market/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">

--- a/demos/snake/templates/ad.html
+++ b/demos/snake/templates/ad.html
@@ -18,7 +18,7 @@
 			    padding: 2px;
 			    border: none;
 			}
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -32,7 +32,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 			<div id="ad">
 				<div class="row">
 					<div class="col-xs-2">

--- a/demos/vox-populi/templates/ad.html
+++ b/demos/vox-populi/templates/ad.html
@@ -40,7 +40,7 @@
 			    border: none;
 			}
 
-			#container-ad {
+			#container-not-an-ad {
 			    position: absolute;
 			    top: 0px; /* Header Height */
 			    bottom: 0px; /* Footer Height */
@@ -54,7 +54,7 @@
 		</style>
 	</head>
 	<body>
-		<div id="container-ad">
+		<div id="container-not-an-ad">
 
 			<div id="ad">
 				<div class="row">


### PR DESCRIPTION
Google’s Ad-Blocker currently blocks demos because of “container-ad” in “ad.html”. 

For all demos, “container-ad” was changed to “container-not-an-ad” which bypasses the adblocker.

Addresses issue 441: https://github.com/Dallinger/Dallinger/issues/441