### PR TITLE
Fixing file compression error when data is too large

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -204,7 +204,6 @@ def export(id, local=False, scrub_pii=False):
     src = os.path.join("data", id)
     dst = os.path.join("data", id + "-data.zip")
     archive_data(id, src, dst)
-    shutil.rmtree(src)
 
     cwd = os.getcwd()
     data_filename = '{}-data.zip'.format(id)
@@ -220,12 +219,11 @@ def export(id, local=False, scrub_pii=False):
 
 def archive_data(id, src, dst):
     print("Zipping up the package...")
-    if not os.path.isdir(src):
-        IOError("File not found.")
     with ZipFile(dst, 'w', ZIP_DEFLATED, allowZip64=True) as zf:
         for root, dirs, files in os.walk(src):
             for file in files:
                 zf.write(os.path.join(root, file))
+    shutil.rmtree(src)
     print("Done. Data available in {}-data.zip".format(id))
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -126,11 +126,3 @@ class TestData(object):
         os.mkdir(src)
         dallinger.data.archive_data(id, src, dst)
         assert os.path.isfile(dst)
-
-    def test_archive_data_error(self):
-        export_dir = tempfile.mkdtemp()
-        id = "12345-12345-12345-12345"
-        src = os.path.join(id)
-        dst = os.path.join(id + "-data.zip")
-        with pytest.raises(IOError):
-            os.path.isfile(dst)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -117,3 +117,12 @@ class TestData(object):
             reader = csv.reader(f, delimiter=',')
             header = next(reader)
             assert "creation_time" in header
+
+    def test_export_archive(self):
+        export_dir = tempfile.mkdtemp()
+        id = "12345-12345-12345-12345"
+        src = os.path.join(export_dir, id)
+        dst = os.path.join(export_dir, id + "-data.zip")
+        os.mkdir(src)
+        dallinger.data.archive_data(id, src, dst)
+        assert os.path.isfile(dst)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -118,7 +118,7 @@ class TestData(object):
             header = next(reader)
             assert "creation_time" in header
 
-    def test_export_archive(self):
+    def test_archive_data(self):
         export_dir = tempfile.mkdtemp()
         id = "12345-12345-12345-12345"
         src = os.path.join(export_dir, id)
@@ -126,3 +126,11 @@ class TestData(object):
         os.mkdir(src)
         dallinger.data.archive_data(id, src, dst)
         assert os.path.isfile(dst)
+
+    def test_archive_data_error(self):
+        export_dir = tempfile.mkdtemp()
+        id = "12345-12345-12345-12345"
+        src = os.path.join(id)
+        dst = os.path.join(id + "-data.zip")
+        with pytest.raises(IOError):
+            os.path.isfile(dst)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Replace the shutil.make_archive() function with a ZipFile function that does the same compression of the archive, except it allows you to pass the arguments `Zip64=True` for large files.

## Motivation and Context
Issue #588 discovers a bug where shutil does not zip data that is too large (>800mb).

## How Has This Been Tested?
Tested with 2.5 gigs of data inserted in the local database table, then exported with `dallinger export`
