### PR TITLE
Story 205: pay participant bonus

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -35,6 +35,10 @@ class Recruiter(object):
         """Throw an error."""
         raise NotImplementedError
 
+    def reward_bonus(self, assignment_id, amount, reason):
+        """Throw an error."""
+        raise NotImplementedError
+
 
 class HotAirRecruiter(object):
     """A dummy recruiter.
@@ -66,6 +70,13 @@ class HotAirRecruiter(object):
     def approve_hit(self, assignment_id):
         """Approve the HIT."""
         return True
+
+    def reward_bonus(self, assignment_id, amount, reason):
+        """Logging-only, Hot Air implementation"""
+        logger.info(
+            "Were this a real Recruiter, we'd be awarding ${} for assignment {}, "
+            'with reason "{}"'.format(amount, assignment_id, reason)
+        )
 
 
 class MTurkRecruiterException(Exception):
@@ -216,3 +227,9 @@ class BotRecruiter(object):
         This does nothing at this time.
         """
         logger.info("Close recruitment.")
+
+    def reward_bonus(self, assignment_id, amount, reason):
+        """Logging only. These are bots."""
+        logger.info(
+            "Bots don't get bonuses. Sorry, bots."
+        )

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -41,3 +41,14 @@ class TestEnvironments(object):
         agent.receive()
 
         assert agent.infos()[0].contents == "foo"
+
+    def test_environment_update(self):
+        net = models.Network()
+        self.db.add(net)
+        environment = nodes.Environment(network=net)
+        environment.update("some content")
+        self.db.commit()
+
+        state = environment.state()
+
+        assert state.contents == u'some content'

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -23,6 +23,10 @@ class TestRecruiters(object):
         with pytest.raises(NotImplementedError):
             recruiter.close_recruitment()
 
+    def test_reward_bonus(self, recruiter):
+        with pytest.raises(NotImplementedError):
+            recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
+
 
 class TestHotAirRecruiter(object):
 
@@ -49,6 +53,9 @@ class TestHotAirRecruiter(object):
     def test_approve_hit(self, recruiter):
         assert recruiter.approve_hit('any assignment id')
 
+    def test_reward_bonus(self, recruiter):
+        recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
+
 
 class TestBotRecruiter(object):
 
@@ -68,6 +75,9 @@ class TestBotRecruiter(object):
     @pytest.mark.xfail
     def test_close_recruitment(self, recruiter):
         recruiter.close_recruitment()
+
+    def test_reward_bonus(self, recruiter):
+        recruiter.reward_bonus()
 
 
 def stub_config(**kwargs):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -62,7 +62,7 @@ class TestBotRecruiter(object):
     @pytest.fixture
     def recruiter(self):
         from dallinger.recruiters import BotRecruiter
-        return BotRecruiter()
+        return BotRecruiter(config={})
 
     @pytest.mark.xfail
     def test_open_recruitment(self, recruiter):
@@ -72,12 +72,11 @@ class TestBotRecruiter(object):
     def test_recruit_participants(self, recruiter):
         recruiter.recruit_participants()
 
-    @pytest.mark.xfail
     def test_close_recruitment(self, recruiter):
         recruiter.close_recruitment()
 
     def test_reward_bonus(self, recruiter):
-        recruiter.reward_bonus()
+        recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
 
 
 def stub_config(**kwargs):


### PR DESCRIPTION
These changes support the ability to run experiments which calculate bonus payments for participants with Recruiters other than the MTurkRecruiter.

## Description
Upon experiment completion and submission, if an experiment returns a non-zero value from its `bonus()` method, the active recruiter's `reward_bonus()` method will be called. `reward_bonus()` is really part of the `Recruiter` interface and should be supported by all recruiter implementations.

## Motivation and Context
The Griduniverse demo will support participant payment, and it's helpful to test this using the `HotAirRecruiter`.

## How Has This Been Tested?
This has been testing with a combination of automated and manual tests.

