### PR TITLE
Tests cleanup and speedup

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,6 +56,9 @@ def aws_creds():
 @pytest.fixture
 def db_session():
     import dallinger.db
+    # The drop_all call can hang without this; see:
+    # https://stackoverflow.com/questions/13882407/sqlalchemy-blocked-on-dropping-tables
+    dallinger.db.session.close()
     session = dallinger.db.init_db(drop_all=True)
     yield session
     session.rollback()

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -1,36 +1,24 @@
-from dallinger import nodes, db, information, models
+from dallinger import nodes, information, models
 
 
 class TestEnvironments(object):
 
-    def setup(self):
-        """Set up the environment by resetting the tables."""
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def add(self, *args):
-        self.db.add_all(args)
-        self.db.commit()
-
-    def test_create_environment(self):
+    def test_create_environment(self, db_session):
         """Create an environment"""
         net = models.Network()
-        self.db.add(net)
+        db_session.add(net)
         environment = nodes.Environment(network=net)
         information.State(origin=environment, contents="foo")
-        self.db.commit()
+        db_session.commit()
 
         assert isinstance(environment.id, int)
         assert environment.type == "environment"
         assert environment.creation_time
         assert environment.state().contents == "foo"
 
-    def test_create_environment_get_observed(self):
+    def test_create_environment_get_observed(self, db_session):
         net = models.Network()
-        self.db.add(net)
+        db_session.add(net)
         environment = nodes.Environment(network=net)
         information.State(origin=environment, contents="foo")
 
@@ -42,12 +30,12 @@ class TestEnvironments(object):
 
         assert agent.infos()[0].contents == "foo"
 
-    def test_environment_update(self):
+    def test_environment_update(self, db_session):
         net = models.Network()
-        self.db.add(net)
+        db_session.add(net)
         environment = nodes.Environment(network=net)
         environment.update("some content")
-        self.db.commit()
+        db_session.commit()
 
         state = environment.state()
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -14,10 +14,6 @@ class TestExamples(object):
     def teardown(self):
         os.chdir("..")
 
-    def add(self, *args):
-        self.db.add_all(args)
-        self.db.commit()
-
     def verify_demo(self, demo):
         os.chdir(demo)
         is_passing = dallinger.command_line.verify_package()

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -57,7 +57,7 @@ class TestClockScheduler(object):
         jobs = self.clock.scheduler.get_jobs()
         with pytest.raises(RuntimeError) as excinfo:
             jobs[0].func()
-        assert excinfo.value.message == 'Config not loaded'
+        assert excinfo.match('Config not loaded')
 
     def test_launch_loads_config(self):
         original_start = self.clock.scheduler.start

--- a/tests/test_information.py
+++ b/tests/test_information.py
@@ -1,36 +1,24 @@
-from dallinger import models, information, db
+from dallinger import models, information
 
 
 class TestInformation(object):
 
-    def setup(self):
-        """Set up the environment by resetting the tables."""
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def add(self, *args):
-        self.db.add_all(args)
-        self.db.commit()
-
-    def test_create_genome(self):
+    def test_create_genome(self, db_session):
         net = models.Network()
-        self.db.add(net)
+        db_session.add(net)
         node = models.Node(network=net)
         info = information.Gene(origin=node)
-        self.db.commit()
+        db_session.commit()
 
         assert info.type == "gene"
         assert info.contents is None
 
-    def test_create_memome(self):
+    def test_create_memome(self, db_session):
         net = models.Network()
-        self.db.add(net)
+        db_session.add(net)
         node = models.Node(network=net)
         info = information.Meme(origin=node)
-        self.db.commit()
+        db_session.commit()
 
         assert info.type == "meme"
         assert info.contents is None

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -1,4 +1,4 @@
-from dallinger import networks, nodes, db, models
+from dallinger import networks, nodes, models
 import random
 import pytest
 from collections import defaultdict
@@ -6,21 +6,14 @@ from collections import defaultdict
 
 class TestNetworks(object):
 
-    def setup(self):
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def test_create_network(self):
+    def test_create_network(self, db_session):
         net = models.Network()
         assert isinstance(net, models.Network)
 
-    def test_node_failure(self):
+    def test_node_failure(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for _ in range(5):
             nodes.Agent(network=net)
@@ -36,10 +29,10 @@ class TestNetworks(object):
         assert len(net.nodes(failed="all")) == 6
         assert len(net.nodes(failed=True)) == 1
 
-    def test_network_agents(self):
+    def test_network_agents(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         assert len(net.nodes(type=nodes.Agent)) == 0
 
@@ -48,20 +41,20 @@ class TestNetworks(object):
         assert net.nodes(type=nodes.Agent) == [agent]
         assert isinstance(net, models.Network)
 
-    def test_network_base_add_node_not_implemented(self):
+    def test_network_base_add_node_not_implemented(self, db_session):
         net = models.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
         node = models.Node(network=net)
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
         with pytest.raises(NotImplementedError):
             net.add_node(node)
 
-    def test_network_sources(self):
+    def test_network_sources(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         assert len(net.nodes(type=nodes.Source)) == 0
 
@@ -69,10 +62,10 @@ class TestNetworks(object):
 
         assert net.nodes(type=nodes.Source) == [source]
 
-    def test_network_nodes(self):
+    def test_network_nodes(self, db_session):
         net = models.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         node1 = models.Node(network=net)
         node2 = models.Node(network=net)
@@ -91,10 +84,10 @@ class TestNetworks(object):
         assert set(net.nodes(failed=True)) == set([node1, agent1])
         assert set(net.nodes(type=nodes.Agent, failed="all")) == set([agent1, agent2, agent3])
 
-    def test_network_vectors(self):
+    def test_network_vectors(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         assert len(net.vectors()) == 0
 
@@ -107,10 +100,10 @@ class TestNetworks(object):
         assert net.vectors()[0].origin == agent1
         assert net.vectors()[0].destination == agent2
 
-    def test_network_degrees(self):
+    def test_network_degrees(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         agent1 = nodes.Agent(network=net)
         agent2 = nodes.Agent(network=net)
@@ -122,14 +115,14 @@ class TestNetworks(object):
         assert 1 in [len(n.vectors(direction="outgoing")) for n in net.nodes()]
         assert 0 in [len(n.vectors(direction="outgoing")) for n in net.nodes()]
 
-    def test_network_add_source_global(self):
+    def test_network_add_source_global(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         agent1 = nodes.Agent(network=net)
         nodes.Agent(network=net)
-        # self.db.commit()
+        # db_session.commit()
 
         source = nodes.RandomBinaryStringSource(network=net)
         source.connect(whom=net.nodes(type=nodes.Agent))
@@ -140,10 +133,10 @@ class TestNetworks(object):
         assert [len(n.vectors(direction="outgoing")) for n in net.nodes(type=nodes.Agent)] == [0, 0]
         assert len(net.nodes(type=nodes.Source)[0].vectors(direction="outgoing")) == 2
 
-    def test_network_add_source_local(self):
+    def test_network_add_source_local(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         nodes.Agent(network=net)
         nodes.Agent(network=net)
@@ -155,10 +148,10 @@ class TestNetworks(object):
         assert [len(n.vectors(direction="outgoing")) for n in net.nodes(type=nodes.Agent)] == [0, 0]
         assert len(net.nodes(type=nodes.Source)[0].vectors(direction="outgoing")) == 1
 
-    def test_network_add_node(self):
+    def test_network_add_node(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         nodes.Agent(network=net)
         nodes.Agent(network=net)
@@ -168,10 +161,10 @@ class TestNetworks(object):
         assert len(net.vectors()) == 0
         assert len(net.nodes(type=nodes.Source)) == 0
 
-    def test_network_downstream_nodes(self):
+    def test_network_downstream_nodes(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         node1 = models.Node(network=net)
         node2 = models.Node(network=net)
@@ -193,10 +186,10 @@ class TestNetworks(object):
 
         pytest.raises(ValueError, node1.neighbors, direction="ghbhfgjd")
 
-    def test_network_repr(self):
+    def test_network_repr(self, db_session):
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         nodes.Agent(network=net)
         nodes.Agent(network=net)
@@ -209,10 +202,10 @@ class TestNetworks(object):
             "0 infos, 0 transmissions and 0 transformations>"
         )
 
-    def test_create_chain(self):
+    def test_create_chain(self, db_session):
         net = networks.Chain()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         source = nodes.RandomBinaryStringSource(network=net)
         net.add_node(source)
@@ -227,10 +220,10 @@ class TestNetworks(object):
         assert net.nodes(type=nodes.Agent)[0].network == net
         assert net.nodes(type=nodes.Source)[0].network == net
 
-    def test_chain_repr(self):
+    def test_chain_repr(self, db_session):
         net = networks.Chain()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         source = nodes.RandomBinaryStringSource(network=net)
         net.add_node(source)
@@ -238,17 +231,17 @@ class TestNetworks(object):
         for i in range(4):
             agent = nodes.ReplicatorAgent(network=net)
             net.add_node(agent)
-        self.db.commit()
+        db_session.commit()
 
         assert repr(net) == (
             "<Network-" + str(net.id) + "-chain with 5 nodes, 4 vectors, "
             "0 infos, 0 transmissions and 0 transformations>"
         )
 
-    def test_create_fully_connected(self):
+    def test_create_fully_connected(self, db_session):
         net = networks.FullyConnected()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for i in range(4):
             agent = nodes.Agent(network=net)
@@ -261,11 +254,11 @@ class TestNetworks(object):
             for n in net.nodes(type=nodes.Agent)
         ] == [3, 3, 3, 3]
 
-    def test_create_empty(self):
+    def test_create_empty(self, db_session):
         """Empty networks should have nodes, but no edges."""
         net = networks.Empty()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for i in range(10):
             agent = nodes.Agent(network=net)
@@ -274,11 +267,11 @@ class TestNetworks(object):
         assert len(net.nodes(type=nodes.Agent)) == 10
         assert len(net.vectors()) == 0
 
-    def test_create_empty_with_source(self):
+    def test_create_empty_with_source(self, db_session):
         """A sourced empty network should have nodes and an edge for each."""
         net = networks.Empty()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for i in range(10):
             agent = nodes.Agent(network=net)
@@ -290,10 +283,10 @@ class TestNetworks(object):
         assert len(net.nodes(type=nodes.Agent)) == 10
         assert len(net.vectors()) == 10
 
-    def test_fully_connected_repr(self):
+    def test_fully_connected_repr(self, db_session):
         net = networks.FullyConnected()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
         for i in range(4):
             agent = nodes.Agent(network=net)
             net.add_node(agent)
@@ -303,12 +296,12 @@ class TestNetworks(object):
             "0 infos, 0 transmissions and 0 transformations>"
         )
 
-    def test_create_scale_free(self):
+    def test_create_scale_free(self, db_session):
         m0 = 4
         m = 4
         net = networks.ScaleFree(m0=m0, m=m)
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for i in range(m0):
             agent = nodes.Agent(network=net)
@@ -327,10 +320,10 @@ class TestNetworks(object):
         assert len(net.nodes(type=nodes.Agent)) == m0 + 2
         assert len(net.vectors()) == m0 * (m0 - 1) + 2 * 2 * m
 
-    def test_scale_free_repr(self):
+    def test_scale_free_repr(self, db_session):
         net = networks.ScaleFree(m0=4, m=4)
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         for i in range(6):
             agent = nodes.Agent(network=net)
@@ -341,11 +334,11 @@ class TestNetworks(object):
             "0 infos, 0 transmissions and 0 transformations>"
         )
 
-    def test_create_sequential_microsociety(self):
+    def test_create_sequential_microsociety(self, db_session):
         """Create a sequential microsociety."""
         net = networks.SequentialMicrosociety(n=3)
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         net.add_node(nodes.RandomBinaryStringSource(network=net))
 
@@ -406,13 +399,28 @@ class GenerationalAgent(nodes.Agent):
 
 class TestDiscreteGenerational(TestNetworks):
 
-    def _make_one(self, n_gens, gen_size, initial_source):
+    n_gens = 4
+    gen_size = 4
+
+    @pytest.fixture
+    def net_init_src_true(self, db_session):
         net = networks.DiscreteGenerational(
-            generations=n_gens,
-            generation_size=gen_size,
-            initial_source=initial_source)
-        self.db.add(net)
-        self.db.commit()
+            generations=self.n_gens,
+            generation_size=self.gen_size,
+            initial_source=True)
+        db_session.add(net)
+        db_session.commit()
+
+        return net
+
+    @pytest.fixture
+    def net_init_src_false(self, db_session):
+        net = networks.DiscreteGenerational(
+            generations=self.n_gens,
+            generation_size=self.gen_size,
+            initial_source=False)
+        db_session.add(net)
+        db_session.commit()
 
         return net
 
@@ -427,25 +435,21 @@ class TestDiscreteGenerational(TestNetworks):
 
         return by_gen
 
-    def test_initial_source_attr_true(self):
-        net = self._make_one(1, 1, initial_source=True)
-        assert net.initial_source
+    def test_initial_source_attr_true(self, net_init_src_true):
+        assert net_init_src_true.initial_source
 
-    def test_initial_source_attr_false(self):
-        net = self._make_one(1, 1, initial_source=False)
+    def test_initial_source_attr_false(self, net_init_src_false):
+        net = net_init_src_false
         assert not net.initial_source
 
-    def test_add_node_with_initial_source_true(self):
-        n_gens = 4
-        gen_size = 4
-
-        net = self._make_one(n_gens, gen_size, initial_source=True)
+    def test_add_node_with_initial_source_true(self, net_init_src_true):
+        net = net_init_src_true
         source = nodes.RandomBinaryStringSource(network=net)
 
         by_gen = self._fill(net)
 
         assert len(net.nodes(type=nodes.Source)) == 1
-        assert len(net.nodes(type=nodes.Agent)) == n_gens * gen_size
+        assert len(net.nodes(type=nodes.Agent)) == self.n_gens * self.gen_size
 
         first_generation = by_gen[0]
         subsequent_generations = {gen: by_gen[gen] for gen in by_gen.keys() if gen > 0}
@@ -462,16 +466,14 @@ class TestDiscreteGenerational(TestNetworks):
                 assert len(parents) == 1
                 assert parents[0] in by_gen[agent.generation - 1]
 
-    def test_add_node_with_initial_source_false(self):
-        n_gens = 4
-        gen_size = 4
-        net = self._make_one(n_gens, gen_size, initial_source=False)
+    def test_add_node_with_initial_source_false(self, net_init_src_false):
+        net = net_init_src_false
         source = nodes.RandomBinaryStringSource(network=net)
 
         by_gen = self._fill(net)
 
         assert len(net.nodes(type=nodes.Source)) == 1
-        assert len(net.nodes(type=nodes.Agent)) == n_gens * gen_size
+        assert len(net.nodes(type=nodes.Agent)) == self.n_gens * self.gen_size
 
         first_generation = by_gen[0]
 

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,21 +1,14 @@
-from dallinger import processes, networks, nodes, db, models
+from dallinger import processes, networks, nodes, models
 from dallinger.nodes import Agent
 
 
 class TestProcesses(object):
 
-    def setup(self):
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def test_random_walk_from_source(self):
+    def test_random_walk_from_source(self, db_session):
 
         net = models.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         agent1 = nodes.ReplicatorAgent(network=net)
         agent2 = nodes.ReplicatorAgent(network=net)
@@ -45,17 +38,17 @@ class TestProcesses(object):
 
         assert msg == agent3.infos()[0].contents
 
-    def test_moran_process_cultural(self):
+    def test_moran_process_cultural(self, db_session):
 
         # Create a fully-connected network.
         net = models.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         agent1 = nodes.ReplicatorAgent(network=net)
         agent2 = nodes.ReplicatorAgent(network=net)
         agent3 = nodes.ReplicatorAgent(network=net)
-        self.db.commit()
+        db_session.commit()
 
         agent1.connect(whom=agent2)
         agent1.connect(whom=agent3)
@@ -92,12 +85,12 @@ class TestProcesses(object):
             max(agent1.infos(), key=attrgetter('creation_time')).contents
         )
 
-    def test_moran_process_sexual(self):
+    def test_moran_process_sexual(self, db_session):
 
         # Create a fully-connected network.
         net = networks.Network()
-        self.db.add(net)
-        self.db.commit()
+        db_session.add(net)
+        db_session.commit()
 
         agent1 = nodes.ReplicatorAgent(network=net)
         agent2 = nodes.ReplicatorAgent(network=net)

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -1,7 +1,6 @@
 import mock
 import os
 import pytest
-from dallinger import db
 
 
 class TestRecruiters(object):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -79,7 +79,7 @@ class TestBotRecruiter(object):
         recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
 
 
-def stub_config(**kwargs):
+def stub_config():
     defaults = {
         'auto_recruit': True,
         'aws_access_key_id': 'fake key',
@@ -98,43 +98,28 @@ def stub_config(**kwargs):
         'description': 'fake HIT description',
         'keywords': ['kw1', 'kw2', 'kw3'],
     }
-    defaults.update(kwargs)
 
-    return defaults
+    return defaults.copy()
 
 
+@pytest.mark.usefixtures('experiment_dir')
 class TestMTurkRecruiterAssumesConfigFileInCWD(object):
-
-    def setup(self):
-        self.db = db.init_db(drop_all=True)
-        os.chdir(os.path.join("demos", "bartlett1932"))
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-        os.chdir("../..")
 
     def test_instantiation_from_current_config(self):
         from dallinger.recruiters import MTurkRecruiter
         recruiter = MTurkRecruiter.from_current_config()
-        assert recruiter.config.get('title') == 'War of the Ghosts'
+        assert recruiter.config.get('title') == 'Stroop task'
 
 
 class TestMTurkRecruiter(object):
 
-    def setup(self):
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def make_one(self, **kwargs):
+    @pytest.fixture
+    def recruiter(self):
         from dallinger.mturk import MTurkService
         from dallinger.recruiters import MTurkRecruiter
         mockservice = mock.create_autospec(MTurkService)
         r = MTurkRecruiter(
-            config=stub_config(**kwargs),
+            config=stub_config(),
             hit_domain='fake-domain',
             ad_url='http://fake-domain/ad'
         )
@@ -145,30 +130,26 @@ class TestMTurkRecruiter(object):
         }
         return r
 
-    def test_config_passed_to_constructor(self):
-        recruiter = self.make_one()
+    def test_config_passed_to_constructor(self, recruiter):
         assert recruiter.config.get('title') == 'fake experiment title'
 
-    def test_open_recruitment_raises_if_no_external_hit_domain_configured(self):
+    def test_open_recruitment_raises_if_no_external_hit_domain_configured(self, recruiter):
         from dallinger.recruiters import MTurkRecruiterException
-        recruiter = self.make_one()
         recruiter.hit_domain = None
         with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment(n=1)
 
-    def test_open_recruitment_raises_in_debug_mode(self):
+    def test_open_recruitment_raises_in_debug_mode(self, recruiter):
         from dallinger.recruiters import MTurkRecruiterException
-        recruiter = self.make_one(mode='debug')
+        recruiter.config['mode'] = 'debug'
         with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment()
 
-    def test_open_recruitment_check_creds_before_calling_create_hit(self):
-        recruiter = self.make_one()
+    def test_open_recruitment_check_creds_before_calling_create_hit(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.check_credentials.assert_called_once()
 
-    def test_open_recruitment_single_recruitee(self):
-        recruiter = self.make_one()
+    def test_open_recruitment_single_recruitee(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
             ad_url='http://fake-domain/ad',
@@ -184,32 +165,27 @@ class TestMTurkRecruiter(object):
             us_only=True
         )
 
-    def test_open_recruitment_is_noop_if_experiment_in_progress(self):
+    def test_open_recruitment_is_noop_if_experiment_in_progress(self, recruiter, db_session):
         from dallinger.models import Participant
         participant = Participant(
             worker_id='1', hit_id='1', assignment_id='1', mode="test")
-        self.db.add(participant)
-        recruiter = self.make_one()
+        db_session.add(participant)
         recruiter.open_recruitment()
 
         recruiter.mturkservice.check_credentials.assert_not_called()
 
-    def test_current_hit_id_with_active_experiment(self):
+    def test_current_hit_id_with_active_experiment(self, recruiter, db_session):
         from dallinger.models import Participant
         participant = Participant(
             worker_id='1', hit_id='the hit!', assignment_id='1', mode="test")
-        self.db.add(participant)
-        recruiter = self.make_one()
+        db_session.add(participant)
 
         assert recruiter.current_hit_id() == 'the hit!'
 
-    def test_current_hit_id_with_no_active_experiment(self):
-        recruiter = self.make_one()
-
+    def test_current_hit_id_with_no_active_experiment(self, recruiter):
         assert recruiter.current_hit_id() is None
 
-    def test_recruit_participants_auto_recruit_on_recruits_for_current_hit(self):
-        recruiter = self.make_one()
+    def test_recruit_participants_auto_recruit_on_recruits_for_current_hit(self, recruiter):
         fake_hit_id = 'fake HIT id'
         recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
         recruiter.recruit_participants()
@@ -220,23 +196,21 @@ class TestMTurkRecruiter(object):
             duration_hours=1.0
         )
 
-    def test_recruit_participants_auto_recruit_off_does_not_extend_hit(self):
-        recruiter = self.make_one(auto_recruit=False)
+    def test_recruit_participants_auto_recruit_off_does_not_extend_hit(self, recruiter):
+        recruiter.config['auto_recruit'] = False
         fake_hit_id = 'fake HIT id'
         recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
         recruiter.recruit_participants()
 
         assert not recruiter.mturkservice.extend_hit.called
 
-    def test_recruit_participants_no_current_hit_does_not_extend_hit(self):
-        recruiter = self.make_one()
+    def test_recruit_participants_no_current_hit_does_not_extend_hit(self, recruiter):
         recruiter.current_hit_id = mock.Mock(return_value=None)
         recruiter.recruit_participants()
 
         assert not recruiter.mturkservice.extend_hit.called
 
-    def test_reward_bonus_is_simple_passthrough(self):
-        recruiter = self.make_one()
+    def test_reward_bonus_is_simple_passthrough(self, recruiter):
         recruiter.reward_bonus(
             assignment_id='fake assignment id',
             amount=2.99,
@@ -249,14 +223,12 @@ class TestMTurkRecruiter(object):
             reason='well done!'
         )
 
-    def test_approve_hit(self):
-        recruiter = self.make_one()
+    def test_approve_hit(self, recruiter):
         fake_id = 'fake assignment id'
         recruiter.approve_hit(fake_id)
 
         recruiter.mturkservice.approve_assignment.assert_called_once_with(fake_id)
 
-    def test_close_recruitment(self):
-        recruiter = self.make_one()
+    def test_close_recruitment(self, recruiter):
         recruiter.close_recruitment()
         # This test is for coverage; the method doesn't do anything.

--- a/tests/test_sources.py
+++ b/tests/test_sources.py
@@ -1,67 +1,59 @@
-from dallinger import nodes, db, models
+from dallinger import nodes, models
 
 
 class TestSources(object):
 
-    def setup(self):
-        """Set up the environment by resetting the tables."""
-        self.db = db.init_db(drop_all=True)
+    def add(self, session, *args):
+        session.add_all(args)
+        session.commit()
 
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def add(self, *args):
-        self.db.add_all(args)
-        self.db.commit()
-
-    def test_create_random_binary_string_source(self):
+    def test_create_random_binary_string_source(self, db_session):
         net = models.Network()
-        self.add(net)
+        self.add(db_session, net)
         source = nodes.RandomBinaryStringSource(network=net)
-        self.add(source)
+        self.add(db_session, source)
 
         assert source
 
-    def test_transmit_random_binary_string_source(self):
+    def test_transmit_random_binary_string_source(self, db_session):
         net = models.Network()
-        self.add(net)
+        self.add(db_session, net)
         source = nodes.RandomBinaryStringSource(network=net)
         agent = nodes.ReplicatorAgent(network=net)
-        self.db.add(source)
-        self.db.add(agent)
-        self.db.commit()
+        db_session.add(source)
+        db_session.add(agent)
+        db_session.commit()
 
         source.connect(whom=agent)
-        self.add(source, agent)
+        self.add(db_session, source, agent)
 
         source.transmit(to_whom=agent)
-        self.db.commit()
+        db_session.commit()
 
         agent.receive()
-        self.db.commit()
+        db_session.commit()
 
         assert agent.infos()[0].contents in ["00", "01", "10", "11"]
 
-    def test_broadcast_random_binary_string_source(self):
+    def test_broadcast_random_binary_string_source(self, db_session):
         net = models.Network()
-        self.add(net)
+        self.add(db_session, net)
         source = nodes.RandomBinaryStringSource(network=net)
         agent1 = nodes.ReplicatorAgent(network=net)
         agent2 = nodes.ReplicatorAgent(network=net)
-        self.db.add(agent1)
-        self.db.add(agent2)
-        self.db.commit()
+        db_session.add(agent1)
+        db_session.add(agent2)
+        db_session.commit()
         source.connect(whom=agent1)
         source.connect(whom=agent2)
-        self.add(source, agent1, agent2)
+        self.add(db_session, source, agent1, agent2)
 
         source.transmit(what=source.create_information())
-        self.db.commit()
+        db_session.commit()
 
         agent1.receive()
         agent2.receive()
-        self.db.commit()
+        db_session.commit()
 
         assert agent1.infos()[0].contents in ["00", "01", "10", "11"]
         assert agent2.infos()[0].contents in ["00", "01", "10", "11"]

--- a/tests/test_transformations.py
+++ b/tests/test_transformations.py
@@ -1,57 +1,45 @@
-from dallinger import db, models
+from dallinger import models
 
 
 class TestTransformations(object):
 
-    def setup(self):
-        """Set up the environment by resetting the tables."""
-        self.db = db.init_db(drop_all=True)
-
-    def teardown(self):
-        self.db.rollback()
-        self.db.close()
-
-    def add(self, *args):
-        self.db.add_all(args)
-        self.db.commit()
-
-    def test_identity_transformation(self):
+    def test_identity_transformation(self, db_session):
         net = models.Network()
-        self.add(net)
+        db_session.add(net)
         node = models.Node(network=net)
-        self.db.add(node)
-        self.db.commit()
+        db_session.add(node)
+        db_session.commit()
 
         info_in = models.Info(origin=node, contents="foo")
-        self.db.add(info_in)
-        self.db.commit()
+        db_session.add(info_in)
+        db_session.commit()
 
         node.replicate(info_in)
 
         # # Create a new info based on the old one.
         # info_out = models.Info(origin=node, contents=info_in.contents)
-        # self.db.add(info_in)
-        # self.db.commit()
+        # db_session.add(info_in)
+        # db_session.commit()
 
         # # Register the transformation.
         # transformation = transformations.Replication(
         #     info_out=info_out,
         #     info_in=info_in)
 
-        # self.db.add(transformation)
-        # self.db.commit()
+        # db_session.add(transformation)
+        # db_session.commit()
 
         assert node.infos()[-1].contents == "foo"
         assert len(node.infos()) == 2
 
     # def test_shuffle_transformation(self):
     #     node = models.Node()
-    #     self.db.add(node)
-    #     self.db.commit()
+    #     db_session.add(node)
+    #     db_session.commit()
 
     #     info_in = models.Info(origin=node, contents="foo")
-    #     self.db.add(info_in)
-    #     self.db.commit()
+    #     db_session.add(info_in)
+    #     db_session.commit()
 
     #     # Create a new info based on the old one.
     #     shuffled_string = ''.join(
@@ -64,7 +52,7 @@ class TestTransformations(object):
     #         info_out=info_out,
     #         info_in=info_in)
 
-    #     self.db.add(transformation)
-    #     self.db.commit()
+    #     db_session.add(transformation)
+    #     db_session.commit()
 
     #     assert info_out.contents in ["foo", "ofo", "oof"]


### PR DESCRIPTION
Make use of the `db_session` fixture for tests which interact with the database session.

## Description
Refactor tests to use the existing test fixture.

## Motivation and Context
* Removes duplication
* Makes it easy to opt in or out of database setup/teardown on a test-by-test basis, rather than a class-by-class basis, allowing tests which don't need it to run faster.

## How Has This Been Tested?
No changes to production code. Test refactoring only.

