### PR TITLE
Do not backup to S3 when running with local=True

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -209,10 +209,11 @@ def export(id, local=False, scrub_pii=False):
     data_filename = '{}-data.zip'.format(id)
     path_to_data = os.path.join(cwd, "data", data_filename)
 
-    # Backup data on S3.
-    k = Key(user_s3_bucket())
-    k.key = data_filename
-    k.set_contents_from_filename(path_to_data)
+    # Backup data on S3 unless run locally
+    if not local:
+        k = Key(user_s3_bucket())
+        k.key = data_filename
+        k.set_contents_from_filename(path_to_data)
 
     return path_to_data
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -5,6 +5,7 @@ import csv
 import os
 import tempfile
 import uuid
+import shutil
 
 import pandas as pd
 import psycopg2
@@ -118,11 +119,7 @@ class TestData(object):
             header = next(reader)
             assert "creation_time" in header
 
-    def test_archive_data(self):
-        export_dir = tempfile.mkdtemp()
-        id = "12345-12345-12345-12345"
-        src = os.path.join(export_dir, id)
-        dst = os.path.join(export_dir, id + "-data.zip")
-        os.mkdir(src)
-        dallinger.data.archive_data(id, src, dst)
-        assert os.path.isfile(dst)
+    def test_export(self):
+        dallinger.data.export("12345-12345-12345-12345", local=True)
+        assert os.path.isfile("data/12345-12345-12345-12345-data.zip")
+        shutil.rmtree('data')


### PR DESCRIPTION
## Description
Do not backup when local==True. Allows us to test `dallinger.data.export` 