### PR TITLE
Implement story 214, uuid generation method/commandline.

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -21,7 +21,6 @@ import sys
 import tempfile
 import time
 import traceback
-import uuid
 import webbrowser
 
 import click
@@ -242,7 +241,8 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
     pkg_resources.require(dependencies)
 
     # Generate a unique id for this experiment.
-    generated_uid = public_id = str(uuid.uuid4())
+    from dallinger.experiment import Experiment
+    generated_uid = public_id = Experiment.make_uuid()
 
     # If the user provided an app name, use it everywhere that's user-facing.
     if app:
@@ -351,6 +351,13 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 def summary(app):
     """Print a summary of a deployed app's status."""
     click.echo(get_summary(app))
+
+
+@dallinger.command()
+def uuid():
+    """Print a new UUID"""
+    from dallinger.experiment import Experiment
+    click.echo(Experiment.make_uuid())
 
 
 def get_summary(app):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -467,7 +467,7 @@ class Experiment(object):
         import dallinger as dlgr
 
         if app_id is None:
-            app_id = str(uuid.uuid4())
+            app_id = self.make_uuid()
 
         self.app_id = app_id
         self.exp_config = exp_config or {}
@@ -491,6 +491,11 @@ class Experiment(object):
                 exp_config=exp_config
             )
         return self._finish_experiment()
+
+    @classmethod
+    def make_uuid(cls):
+        """Returns a new uuid"""
+        return str(uuid.uuid4())
 
     def _finish_experiment(self):
         # Debug runs synchronously

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,16 @@
+"""Test python experiment API"""
+from uuid import UUID
+
+
+class TestAPI(object):
+
+    def test_uuid(self):
+        from dallinger.experiment import Experiment
+        exp_uuid = Experiment.make_uuid()
+        assert isinstance(UUID(exp_uuid, version=4), UUID)
+
+    def test_uuid_instance(self):
+        from dallinger.experiment import Experiment
+        exp = Experiment()
+        exp_uuid = exp.make_uuid()
+        assert isinstance(UUID(exp_uuid, version=4), UUID)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+from uuid import UUID
 from ConfigParser import NoOptionError, SafeConfigParser
 
 import pexpect
@@ -53,6 +54,10 @@ class TestCommandLine(object):
 
     def test_empty_id_fails_verification(self):
         assert ValueError, dallinger.commandline.verify_id(None)
+
+    def test_new_uuid(self):
+        output = subprocess.check_output(["dallinger", "uuid"])
+        assert isinstance(UUID(output.strip(), version=4), UUID)
 
 
 class TestSetupExperiment(object):


### PR DESCRIPTION
## Description
Provide an API method (`Experiment.make_uuid`) and commandline (`dallinger uuid`) to generate a new uuid for an experiment.

## Motivation and Context
This change is motivated by [ScrumDo Story 214](https://app.scrumdo.com/projects/story_permalink/1192298) which is in turn motivated by [ScrumDo Story 213](https://app.scrumdo.com/projects/story_permalink/1192296)

## How Has This Been Tested?
This has been tested by running the new `dallinger` command and the python API call. Additionally, new unit tests are included in this branch.
