### PR TITLE
WIP: Compatibility between export .zip format and format expected by Data class

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -223,7 +223,9 @@ def archive_data(id, src, dst):
     with ZipFile(dst, 'w', ZIP_DEFLATED, allowZip64=True) as zf:
         for root, dirs, files in os.walk(src):
             for file in files:
-                zf.write(os.path.join(root, file))
+                filename = os.path.join(root, file)
+                arcname = filename.replace(src, '').lstrip('/')
+                zf.write(filename, arcname)
     shutil.rmtree(src)
     print("Done. Data available in {}-data.zip".format(id))
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -129,3 +129,7 @@ class TestData(object):
         path = dallinger.data.export("12345-12345-12345-12345", local=True)
         archive = ZipFile(path)
         assert 'data/info.csv' in archive.namelist()
+
+    def test_export_compatible_with_data(self):
+        path = dallinger.data.export("12345-12345-12345-12345", local=True)
+        data = dallinger.data.Data(path)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -123,3 +123,9 @@ class TestData(object):
         dallinger.data.export("12345-12345-12345-12345", local=True)
         assert os.path.isfile("data/12345-12345-12345-12345-data.zip")
         shutil.rmtree('data')
+
+    def test_export_directory_format(self):
+        from zipfile import ZipFile
+        path = dallinger.data.export("12345-12345-12345-12345", local=True)
+        archive = ZipFile(path)
+        assert 'data/info.csv' in archive.namelist()


### PR DESCRIPTION
Currently you can not load a file created with `export()` with the `Data` class, because the zipped folder structures differ.

## Description
Structure expected by `Data`:
```
12eee6c6-f37f-4963-b684-da585acd77f1-data
├── 12eee6c6-f37f-4963-b684-da585acd77f1-code.zip
├── data
│   ├── info.csv
│   ├── network.csv
│   ├── node.csv
│   ├── notification.csv
│   ├── participant.csv
│   ├── question.csv
│   ├── questiontransformation.csv
│   ├── transformation.csv
│   ├── transmission.csv
│   └── vector.csv
├── experiment_id.md
└── server_logs.md

1 directory, 13 files
```

Structure created by `export`:
```
data
└── test_export
    ├── data
    │   ├── info.csv
    │   ├── network.csv
    │   ├── node.csv
    │   ├── notification.csv
    │   ├── participant.csv
    │   ├── question.csv
    │   ├── transformation.csv
    │   ├── transmission.csv
    │   └── vector.csv
    └── experiment_id.md

2 directories, 10 files
```

## Motivation and Context
You should be able to export an experiment and the use the zip with `Data`

## How Has This Been Tested?
Work in progress; failing test only.

