### PR TITLE
Implement story 213, API method to retrieve data or run experiment.

### DIFF
--- a/dallinger/__init__.py
+++ b/dallinger/__init__.py
@@ -36,4 +36,5 @@ __all__ = (
     "experiment",
     "experiments",
     "registration",
+    "logger",
 )

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -77,14 +77,17 @@ class Configuration(object):
     }
 
     def __init__(self):
+        self._reset()
+
+    def set(self, key, value):
+        return self.extend({key: value})
+
+    def _reset(self):
         self.data = deque()
         self.types = {}
         self.synonyms = {}
         self.sensitive = set()
         self.ready = False
-
-    def set(self, key, value):
-        return self.extend({key: value})
 
     def extend(self, mapping, cast_types=False, strict=False):
         normalized_mapping = {}

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -41,7 +41,22 @@ table_names = [
 
 def load(id):
     """Load the data from wherever it is found."""
+    # Check locally first
+    cwd = os.getcwd()
     data_filename = '{}-data.zip'.format(id)
+    path_to_data = os.path.join(cwd, "data", data_filename)
+    if os.path.exists(path_to_data):
+        try:
+            return Data(path_to_data)
+        except IOError:
+            from dallinger import logger
+            logger.exception(
+                "Error reading local data file {}, checking remote.".format(
+                    path_to_data
+                )
+            )
+
+    # Get remote file instead
     path_to_data = os.path.join(tempfile.mkdtemp(), data_filename)
 
     buckets = [

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -304,7 +304,7 @@ def dallinger_s3_bucket():
 
 
 def registration_s3_bucket():
-    """The public `dallinger` S3 bucket."""
+    """The public write-only `dallinger-registration` S3 bucket."""
     conn = _s3_connection(dallinger_region=True)
     return conn.get_bucket("dallinger-registrations")
 

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -101,6 +101,27 @@ def backup(id):
     return url
 
 
+def registration_key(id):
+    return '{}.reg'.format(id)
+
+
+def register(id, url=None):
+    """Register a UUID key in the global S3 bucket."""
+    k = Key(registration_s3_bucket())
+    k.key = registration_key(id)
+    k.set_contents_from_string(url or 'missing')
+    reg_url = k.generate_url(expires_in=0, query_auth=False)
+    return reg_url
+
+
+def is_registered(id):
+    """Check if a UUID is already registered"""
+    # We can't use key.exists() unless the user has GET access,
+    # exists() would scale much better though.
+    key_names = set(k.key for k in list(registration_s3_bucket().list()))
+    return registration_key(id) in key_names
+
+
 def copy_heroku_to_local(id):
     """Copy a Heroku database locally."""
 
@@ -214,6 +235,10 @@ def export(id, local=False, scrub_pii=False):
         k = Key(user_s3_bucket())
         k.key = data_filename
         k.set_contents_from_filename(path_to_data)
+        url = k.generate_url(expires_in=0, query_auth=False)
+
+        # Register experiment UUID with dallinger
+        register(id, url)
 
     return path_to_data
 
@@ -239,10 +264,17 @@ def user_s3_bucket(canonical_user_id=None):
     s3_bucket_name = "dallinger-{}".format(
         hashlib.sha256(canonical_user_id).hexdigest()[0:8])
 
+    config = get_config()
+    location = config.get('aws_region')
+
+    # us-east-1 is the default and should not be included as location
+    if not location or location == u'us-east-1':
+        location = boto.s3.connection.Location.DEFAULT
+
     if not conn.lookup(s3_bucket_name):
         bucket = conn.create_bucket(
             s3_bucket_name,
-            location=boto.s3.connection.Location.DEFAULT
+            location=location
         )
     else:
         bucket = conn.get_bucket(s3_bucket_name)
@@ -252,18 +284,25 @@ def user_s3_bucket(canonical_user_id=None):
 
 def dallinger_s3_bucket():
     """The public `dallinger` S3 bucket."""
-    conn = _s3_connection()
+    conn = _s3_connection(dallinger_region=True)
     return conn.get_bucket("dallinger")
 
 
-def _s3_connection():
+def registration_s3_bucket():
+    """The public `dallinger` S3 bucket."""
+    conn = _s3_connection(dallinger_region=True)
+    return conn.get_bucket("dallinger-registrations")
+
+
+def _s3_connection(dallinger_region=False):
     """An S3 connection using the AWS keys in the config."""
     config = get_config()
     if not config.ready:
         config.load()
 
+    region = 'us-east-1' if dallinger_region else config.get('aws_region')
     return boto.s3.connect_to_region(
-        config.get('aws_region'),
+        region,
         aws_access_key_id=config.get('aws_access_key_id'),
         aws_secret_access_key=config.get('aws_secret_access_key'),
     )

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -46,6 +46,7 @@ def exp_class_working_dir(meth):
             config.load_from_file(LOCAL_CONFIG)
             return meth(self, *args, **kwargs)
         finally:
+            config._reset()
             os.chdir(orig_path)
     return new_meth
 
@@ -494,7 +495,16 @@ class Experiment(object):
             )
         return self._finish_experiment()
 
-    def retrieve(self, app_id, exp_config=None, bot=False, **kwargs):
+    def collect(self, app_id, exp_config=None, bot=False, **kwargs):
+        """Collect data for the provided experiment id.
+
+        The ``app_id`` parameter must be a valid UUID.
+        If an existing data file is found for the UUID it will
+        be returned, otherwise - if the UUID is not already registered -
+        the experiment will be run and data collected.
+
+        See ``run`` method above for other parameters
+        """
         try:
             orig_path = os.getcwd()
             new_path = os.path.dirname(
@@ -519,6 +529,11 @@ class Experiment(object):
                                u'but you do not have permission to access to the data')
         elif kwargs.get('mode') == u'debug' or exp_config.get('mode') == u'debug':
             raise RuntimeError(u'No remote or local data found for id {}'.format(app_id))
+
+        try:
+            assert isinstance(uuid.UUID(app_id, version=4), uuid.UUID)
+        except (ValueError, AssertionError):
+            raise ValueError('Invalid UUID supplied {}'.format(app_id))
 
         self.log(u'{} appears to be a new experiment id, running experiment.'.format(app_id),
                  key=u"Retrieve:")

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -496,6 +496,11 @@ class Experiment(object):
 
     def retrieve(self, app_id, exp_config=None, bot=False, **kwargs):
         try:
+            orig_path = os.getcwd()
+            new_path = os.path.dirname(
+                sys.modules[self.__class__.__module__].__file__
+            )
+            os.chdir(new_path)
             results = data_load(app_id)
             self.log(u'Data found for experiment {}, retrieving.'.format(app_id),
                      key=u"Retrieve:")
@@ -505,9 +510,15 @@ class Experiment(object):
                 u'Could not fetch data for id: {}, checking registry'.format(app_id),
                 key=u"Retrieve:"
             )
+        finally:
+            os.chdir(orig_path)
+
+        exp_config = exp_config or {}
         if is_registered(app_id):
             raise RuntimeError(u'The id {} is registered, '.format(app_id) +
                                u'but you do not have permission to access to the data')
+        elif kwargs.get('mode') == u'debug' or exp_config.get('mode') == u'debug':
+            raise RuntimeError(u'No remote or local data found for id {}'.format(app_id))
 
         self.log(u'{} appears to be a new experiment id, running experiment.'.format(app_id),
                  key=u"Retrieve:")

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -17,18 +17,18 @@ class TestAPI(object):
         exp_uuid = exp.make_uuid()
         assert isinstance(UUID(exp_uuid, version=4), UUID)
 
-    def test_retrieve(self):
+    def test_collect(self):
         from dallinger.experiments import Bartlett1932
         exp = Bartlett1932()
         existing_uuid = "12345-12345-12345-12345"
-        data = exp.retrieve(existing_uuid, recruiter=u'bots')
+        data = exp.collect(existing_uuid, recruiter=u'bots')
         assert isinstance(data, dallinger.data.Data)
 
-        dataless_uuid = "55555-55555-55555-55555"
+        dataless_uuid = "ed9e7ddd-3e97-452d-9e34-fee5d432258e"
         dallinger.data.register(dataless_uuid, 'https://bogus-url.com/something')
 
         try:
-            data = exp.retrieve(dataless_uuid, recruiter=u'bots')
+            data = exp.collect(dataless_uuid, recruiter=u'bots')
         except RuntimeError:
             # This is expected for an already registered UUID with no accessible data
             pass
@@ -36,11 +36,22 @@ class TestAPI(object):
             pytest.fail('Did not raise RuntimeError for existing UUID')
 
         # In debug mode an unknown UUID fails
-        unknown_uuid = "66666-66666-66666-66666"
+        unknown_uuid = "c85d5086-2fa7-4baf-9103-e142b9170cca"
         try:
-            data = exp.retrieve(unknown_uuid, mode=u'debug', recruiter=u'bots')
+            data = exp.collect(unknown_uuid, mode=u'debug', recruiter=u'bots')
         except RuntimeError:
             # This is expected for an already registered UUID with no accessible data
             pass
         else:
             pytest.fail('Did not raise RuntimeError for unknown debug UUID')
+
+    def test_collect_requires_valid_uuid(self):
+        from dallinger.experiments import Bartlett1932
+        exp = Bartlett1932()
+        existing_uuid = "totally-bogus-id"
+        try:
+            exp.collect(existing_uuid, recruiter=u'bots')
+        except ValueError:
+            pass
+        else:
+            pytest.fail('Did not raise error for invalid UUID')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -37,21 +37,12 @@ class TestAPI(object):
 
         # In debug mode an unknown UUID fails
         unknown_uuid = "c85d5086-2fa7-4baf-9103-e142b9170cca"
-        try:
+        with pytest.raises(RuntimeError):
             data = exp.collect(unknown_uuid, mode=u'debug', recruiter=u'bots')
-        except RuntimeError:
-            # This is expected for an already registered UUID with no accessible data
-            pass
-        else:
-            pytest.fail('Did not raise RuntimeError for unknown debug UUID')
 
     def test_collect_requires_valid_uuid(self):
         from dallinger.experiments import Bartlett1932
         exp = Bartlett1932()
         existing_uuid = "totally-bogus-id"
-        try:
+        with pytest.raises(ValueError):
             exp.collect(existing_uuid, recruiter=u'bots')
-        except ValueError:
-            pass
-        else:
-            pytest.fail('Did not raise error for invalid UUID')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 """Test python experiment API"""
+import dallinger
+import pytest
 from uuid import UUID
 
 
@@ -14,3 +16,21 @@ class TestAPI(object):
         exp = Experiment()
         exp_uuid = exp.make_uuid()
         assert isinstance(UUID(exp_uuid, version=4), UUID)
+
+    def test_retrieve(self):
+        from dallinger.experiments import Bartlett1932
+        exp = Bartlett1932()
+        existing_uuid = "12345-12345-12345-12345"
+        data = exp.retrieve(existing_uuid, mode=u'debug', recruiter=u'bots')
+        assert isinstance(data, dallinger.data.Data)
+
+        dataless_uuid = "55555-55555-55555-55555"
+        dallinger.data.register(dataless_uuid, 'https://bogus-url.com/something')
+
+        try:
+            data = exp.retrieve(dataless_uuid, mode=u'debug', recruiter=u'bots')
+        except RuntimeError:
+            # This is expected for an already registered UUID with no accessible data
+            pass
+        else:
+            pytest.fail('Did not raise RuntimeError for existing UUID')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,16 +21,26 @@ class TestAPI(object):
         from dallinger.experiments import Bartlett1932
         exp = Bartlett1932()
         existing_uuid = "12345-12345-12345-12345"
-        data = exp.retrieve(existing_uuid, mode=u'debug', recruiter=u'bots')
+        data = exp.retrieve(existing_uuid, recruiter=u'bots')
         assert isinstance(data, dallinger.data.Data)
 
         dataless_uuid = "55555-55555-55555-55555"
         dallinger.data.register(dataless_uuid, 'https://bogus-url.com/something')
 
         try:
-            data = exp.retrieve(dataless_uuid, mode=u'debug', recruiter=u'bots')
+            data = exp.retrieve(dataless_uuid, recruiter=u'bots')
         except RuntimeError:
             # This is expected for an already registered UUID with no accessible data
             pass
         else:
             pytest.fail('Did not raise RuntimeError for existing UUID')
+
+        # In debug mode an unknown UUID fails
+        unknown_uuid = "66666-66666-66666-66666"
+        try:
+            data = exp.retrieve(unknown_uuid, mode=u'debug', recruiter=u'bots')
+        except RuntimeError:
+            # This is expected for an already registered UUID with no accessible data
+            pass
+        else:
+            pytest.fail('Did not raise RuntimeError for unknown debug UUID')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -100,6 +100,13 @@ class TestData(object):
         assert data
         assert data.networks.csv
 
+    def test_local_data_loading(self):
+        local_data_id = "77777-77777-77777-77777"
+        dallinger.data.export(local_data_id, local=True)
+        data = dallinger.data.load(local_data_id)
+        assert data
+        assert data.networks.csv
+
     def test_export_of_nonexistent_database(self):
         nonexistent_local_db = str(uuid.uuid4())
         with pytest.raises(psycopg2.OperationalError):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,6 +3,7 @@
 from collections import OrderedDict
 import csv
 import os
+import requests
 import tempfile
 import uuid
 import shutil
@@ -133,3 +134,20 @@ class TestData(object):
     def test_export_compatible_with_data(self):
         path = dallinger.data.export("12345-12345-12345-12345", local=True)
         assert dallinger.data.Data(path)
+
+    def test_register_id(self):
+        new_uuid = "12345-12345-12345-12345"
+        url = dallinger.data.register(new_uuid, 'http://original-url.com/value')
+
+        # The registration creates a new file in the dallinger-registrations bucket
+        assert url.startswith('https://dallinger-registrations.')
+        assert new_uuid in url
+
+        # These files should be inaccessible to make it impossible to use the bucket
+        # as a file repository
+        res = requests.get(url)
+        assert res.status_code == 403
+
+        # We should be able to check that the UUID is registered
+        assert dallinger.data.is_registered(new_uuid) is True
+        assert dallinger.data.is_registered('bogus-uuid-value') is False


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Implements an `Experiment.retrieve()` method, which requires an experiment id, and accepts the configuration paramters that `run()` accepts. It will check to see if there is already data for the provided id, otherwise it will test if an experiment with that UUID has already completed and registered results, in which case it will fail with a `RuntimeError`, otherwise if the UUID is unknown it will run the experiment with the provided parameters and the specified id. This implementation includes a registry for experiment ids in a new `dallinger-registrations` bucket, all experiments runs that export data will also register their UUID in this bucket so it can be checked by the `retrieve()` method.

## Motivation and Context
This is the implementation of story 213, whose goal is to allow full repeatability of experiment results in the context of e.g. a Jupyter notebook.

## How Has This Been Tested?
I've manually tested the new methods, and provided automated tests for the registration mechanisms and the `retrieve()` method.
