### PR TITLE
Suppress pd future warning from odo

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -8,6 +8,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import warnings
 from zipfile import ZipFile, ZIP_DEFLATED
 
 import boto
@@ -16,16 +17,18 @@ import hashlib
 import postgres_copy
 import psycopg2
 
-try:
-    import odo
-    import pandas as pd
-    import tablib
-except ImportError:
-    pass
-
 from dallinger import heroku
 from dallinger import db
 from dallinger import models
+
+with warnings.catch_warnings():
+    warnings.simplefilter(action='ignore', category=FutureWarning)
+    try:
+        import odo
+        import pandas as pd
+        import tablib
+    except ImportError:
+        pass
 
 
 table_names = [

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -4,6 +4,7 @@ from config import get_config
 
 import csv
 import errno
+import logging
 import os
 import shutil
 import subprocess
@@ -21,6 +22,8 @@ from dallinger import heroku
 from dallinger import db
 from dallinger import models
 
+logger = logging.getLogger(__name__)
+
 with warnings.catch_warnings():
     warnings.simplefilter(action='ignore', category=FutureWarning)
     try:
@@ -28,7 +31,7 @@ with warnings.catch_warnings():
         import pandas as pd
         import tablib
     except ImportError:
-        pass
+        logger.debug("Failed to import odo, pandas, or tablib.")
 
 
 table_names = [


### PR DESCRIPTION
```
/Users/monica/.virtualenvs/dallinger/lib/python2.7/site-packages/odo/backends/pandas.py:94: FutureWarning: pandas.tslib is deprecated and will be removed in a future version.
You can access NaTType as type(pandas.NaT)
  @convert.register((pd.Timestamp, pd.Timedelta), (pd.tslib.NaTType, type(None)))
```