### PR TITLE
Avoid key collision on os.environ['PORT']

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ Vagrant.configure("2") do |config|
     # Dallinger install
     python setup.py develop
     dallinger setup
-    echo 'port = 5000' >> ~/.dallingerconfig
+    echo 'base_port = 5000' >> ~/.dallingerconfig
 
     # Heroku CLI installation
     sudo apt-get install software-properties-common

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -134,6 +134,17 @@ class Configuration(object):
             raise KeyError(key)
         return default
 
+    def by_layer(self, key, default=marker):
+        in_order = []
+        if not self.ready:
+            raise RuntimeError('Config not loaded')
+        for layer in self.data:
+            try:
+                in_order.append(layer[key])
+            except KeyError:
+                continue
+        return in_order
+
     def __getitem__(self, key):
         return self.get(key)
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -57,7 +57,6 @@ default_keys = (
     ('num_dynos_web', int, []),
     ('num_dynos_worker', int, []),
     ('organization_name', unicode, []),
-    ('port', int, ['PORT']),
     ('qualification_blacklist', unicode, []),
     ('recruiter', unicode, []),
     ('threads', unicode, []),
@@ -133,17 +132,6 @@ class Configuration(object):
         if default is marker:
             raise KeyError(key)
         return default
-
-    def by_layer(self, key, default=marker):
-        in_order = []
-        if not self.ready:
-            raise RuntimeError('Config not loaded')
-        for layer in self.data:
-            try:
-                in_order.append(layer[key])
-            except KeyError:
-                continue
-        return in_order
 
     def __getitem__(self, key):
         return self.get(key)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -32,7 +32,7 @@ default_keys = (
     ('aws_region', unicode, []),
     ('aws_secret_access_key', unicode, [], True),
     ('base_payment', float, []),
-    ('base_port', int, ['BASE_PORT']),
+    ('base_port', int, []),
     ('browser_exclude_rule', unicode, []),
     ('clock_on', bool, []),
     ('contact_email_on_error', unicode, []),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -32,6 +32,7 @@ default_keys = (
     ('aws_region', unicode, []),
     ('aws_secret_access_key', unicode, [], True),
     ('base_payment', float, []),
+    ('base_port', int, ['BASE_PORT']),
     ('browser_exclude_rule', unicode, []),
     ('clock_on', bool, []),
     ('contact_email_on_error', unicode, []),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -57,6 +57,7 @@ default_keys = (
     ('num_dynos_web', int, []),
     ('num_dynos_worker', int, []),
     ('organization_name', unicode, []),
+    ('port', int, ['PORT']),
     ('qualification_blacklist', unicode, []),
     ('recruiter', unicode, []),
     ('threads', unicode, []),

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -6,7 +6,7 @@ database_url = postgresql://postgres@localhost/dallinger
 
 [Server]
 host = localhost
-port = 5000
+base_port = 5000
 logfile = server.log
 loglevel = 0
 threads = auto

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import
 from gunicorn.app.base import Application
 from gunicorn import util
 import multiprocessing
+import os
 from dallinger.config import get_config
 import logging
 
@@ -32,6 +33,11 @@ class StandaloneServer(Application):
         self.load_user_config()
         self.do_load_config()
 
+    @property
+    def port(self):
+        """Heroku sets the port its running on as an environment variable"""
+        return os.environ.get('PORT')
+
     def init(self, *args):
         """init method
         Takes our custom options from self.options and creates a config
@@ -54,8 +60,7 @@ class StandaloneServer(Application):
             workers = str(multiprocessing.cpu_count() * 2 + 1)
 
         host = config.get("host")
-        port = config.get("port")
-        bind_address = "{}:{}".format(host, port)
+        bind_address = "{}:{}".format(host, self.port)
         self.options = {
             'bind': bind_address,
             'workers': workers,

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -199,16 +199,15 @@ class HerokuLocalWrapper(object):
                     'experiment may not behave correctly.'
                 )
 
-            if self.verbose:
-                continue  # we already logged everything
+            if self._worker_error(line) or self._startup_error(line):
+                if not self.verbose:
+                    self.out.error(
+                        'There was an error while starting the server. '
+                        'Run with --verbose for details.'
+                    )
+                    self.out.error("Sign of error found in line: ".format(line))
+                return False
 
-            if self._worker_error(line):
-                self.out.error(line)
-            if self._startup_error(line):
-                self.out.error(
-                    'There was an error while starting the server. '
-                    'Run with --verbose for details.'
-                )
         return False
 
     def _boot(self):

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -213,6 +213,8 @@ class HerokuLocalWrapper(object):
 
     def _boot(self):
         port = self.config.get('base_port')
+        self.out.log("In _boot(), port is: {}".format(port))
+        self.out.log("'port', by layer: {}".format(self.config.by_layer('base_port')))
         web_dynos = self.config.get('num_dynos_web', 1)
         worker_dynos = self.config.get('num_dynos_worker', 1)
         commands = [

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -213,8 +213,6 @@ class HerokuLocalWrapper(object):
 
     def _boot(self):
         port = self.config.get('base_port')
-        self.out.log("In _boot(), port is: {}".format(port))
-        self.out.log("'port', by layer: {}".format(self.config.by_layer('base_port')))
         web_dynos = self.config.get('num_dynos_web', 1)
         worker_dynos = self.config.get('num_dynos_worker', 1)
         commands = [

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -212,7 +212,7 @@ class HerokuLocalWrapper(object):
         return False
 
     def _boot(self):
-        port = self.config.get('port')
+        port = self.config.get('base_port')
         web_dynos = self.config.get('num_dynos_web', 1)
         worker_dynos = self.config.get('num_dynos_worker', 1)
         commands = [

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -67,7 +67,7 @@ class HotAirRecruiter(Recruiter):
         """Talk about recruiting participants."""
         for i in range(n):
             ad_url = "{}/ad?assignmentId=debug{}&hitId={}&workerId={}&mode=debug".format(
-                get_base_url(logger.info), generate_random_id(), generate_random_id(), generate_random_id(),
+                get_base_url(), generate_random_id(), generate_random_id(), generate_random_id(),
             )
             logger.info('New participant requested: {}'.format(ad_url))
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -67,7 +67,7 @@ class HotAirRecruiter(Recruiter):
         """Talk about recruiting participants."""
         for i in range(n):
             ad_url = "{}/ad?assignmentId=debug{}&hitId={}&workerId={}&mode=debug".format(
-                get_base_url(), generate_random_id(), generate_random_id(), generate_random_id(),
+                get_base_url(logger.info), generate_random_id(), generate_random_id(), generate_random_id(),
             )
             logger.info('New participant requested: {}'.format(ad_url))
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -4,7 +4,7 @@ import random
 import string
 
 
-def get_base_url():
+def get_base_url(log=None):
     config = get_config()
     host = os.getenv('HOST', config.get('host'))
     if 'herokuapp.com' in host:
@@ -13,6 +13,11 @@ def get_base_url():
         # debug mode
         base_port = config.get('base_port')
         port_range = range(base_port, base_port + config.get('num_dynos_web', 1))
+        if log is not None:
+            log("ENV (PORT): {}".format(os.getenv('PORT', 'no port')))
+            log("BY LAYER: {}".format(config.by_layer('base_port')))
+            log("BASE PORT: {}".format(base_port))
+            log("PORT RANGE: {}".format(port_range))
         base_url = "http://{}:{}".format(
             host, random.choice(port_range)
         )

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -11,7 +11,7 @@ def get_base_url():
         base_url = "https://{}".format(host)
     else:
         # debug mode
-        base_port = config.get('port')
+        base_port = config.get('base_port')
         port_range = range(base_port, base_port + config.get('num_dynos_web', 1))
         base_url = "http://{}:{}".format(
             host, random.choice(port_range)

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -4,7 +4,7 @@ import random
 import string
 
 
-def get_base_url(log=None):
+def get_base_url():
     config = get_config()
     host = os.getenv('HOST', config.get('host'))
     if 'herokuapp.com' in host:
@@ -13,14 +13,8 @@ def get_base_url(log=None):
         # debug mode
         base_port = config.get('base_port')
         port_range = range(base_port, base_port + config.get('num_dynos_web', 1))
-        if log is not None:
-            log("ENV (PORT): {}".format(os.getenv('PORT', 'no port')))
-            log("BY LAYER: {}".format(config.by_layer('base_port')))
-            log("BASE PORT: {}".format(base_port))
-            log("PORT RANGE: {}".format(port_range))
-        base_url = "http://{}:{}".format(
-            host, random.choice(port_range)
-        )
+        base_url = "http://{}:{}".format(host, random.choice(port_range))
+
     return base_url
 
 

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -366,6 +366,7 @@ class TestHerokuLocalWrapper(object):
 
     def test_quits_on_gunicorn_startup_error(self, heroku):
         from dallinger.heroku.tools import HerokuStartupError
+        heroku.verbose = False  # more coverage
         heroku._stream = mock.Mock(return_value=['[DONE] Killing all processes'])
         with pytest.raises(HerokuStartupError):
             heroku.start()

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -364,6 +364,12 @@ class TestHerokuLocalWrapper(object):
         with pytest.raises(HerokuTimeoutError):
             heroku.start(timeout_secs=1)
 
+    def test_quits_on_gunicorn_startup_error(self, heroku):
+        from dallinger.heroku.tools import HerokuStartupError
+        heroku._stream = mock.Mock(return_value=['[DONE] Killing all processes'])
+        with pytest.raises(HerokuStartupError):
+            heroku.start()
+
     def test_start_fails_if_stream_ends_without_matching_success_regex(self, heroku):
         from dallinger.heroku.tools import HerokuStartupError
         heroku._stream = mock.Mock(


### PR DESCRIPTION
Addresses issue #626 

## Description
When `heroku local` (I _think_ it's `heroku local`), starts, it sets an environment variable 'PORT' to whatever port the process's web worker is running on. This value is read by `load_from_environment()` when the process's `Configuration` object is initialized, and, prior to this fix, from that point on this value was treated as the base port by subsequent calls to `dallinger.utils.get_base_url()`, resulting in a miscalculation when defining a list of available ports. In order to preserve the original port number as the basis for calculating the port range, this PR introduces a new config variable `base_port`, which will not be overridden by heroku's writing to `os.environ`.

For now I left the old 'port/PORT' config value in place, and `dallinger.gunincorn.StandaloneServer.load_user_config()` still reads the environment variable through the config object. However, since the setting and reading of the process-specific port is really outside the dallinger application domain, I wonder if it might make more sense for `load_user_config()` to just read the port value directly from `os.environ`. This would allow us to remove `port` as a valid config value altogether, which might make sense, since the value should now only ever set by Heroku updating `os.environ`.
