### PR TITLE
Features/662 better 'dallinger qualify'

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -616,8 +616,9 @@ def deploy(verbose, app):
 @click.option('--by_name', is_flag=True, flag_value=True,
               help='Use a qualification name, not an ID')
 @click.option('--notify', is_flag=True, flag_value=True, help='Notify worker by email')
+@click.option('--sandbox', is_flag=True, flag_value=True, help='Use the MTurk sandbox')
 @click.argument('workers', nargs=-1)
-def qualify(workers, qualification, value, by_name, notify):
+def qualify(workers, qualification, value, by_name, notify, sandbox):
     """Assign a qualification to 1 or more workers"""
     if not (workers and qualification and value):
         raise click.BadParameter(
@@ -629,7 +630,7 @@ def qualify(workers, qualification, value, by_name, notify):
     mturk = MTurkService(
         aws_access_key_id=config.get('aws_access_key_id'),
         aws_secret_access_key=config.get('aws_secret_access_key'),
-        sandbox=config.get('mode', 'sandbox') == "sandbox",
+        sandbox=sandbox,
     )
     if by_name:
         result = mturk.get_qualification_type_by_name(qualification)
@@ -642,7 +643,7 @@ def qualify(workers, qualification, value, by_name, notify):
         qid = qualification
 
     click.echo(
-        "Assigning qualification {} with value {} to {} worker {}...".format(
+        "Assigning qualification {} with value {} to {} worker{}...".format(
             qid,
             value,
             len(workers),

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -611,12 +611,12 @@ def deploy(verbose, app):
 
 
 @dallinger.command()
-@click.argument('workers', nargs=-1)
 @click.option('--qualification')
 @click.option('--value')
 @click.option('--notify', is_flag=True, flag_value=True, help='Notify worker by email')
+@click.argument('workers', nargs=-1)
 def qualify(workers, qualification, value, notify):
-    """Assign a qualification to a worker."""
+    """Assign a qualification to 1 or more workers"""
     config = get_config()
     config.load()
     mturk = MTurkService(
@@ -626,10 +626,11 @@ def qualify(workers, qualification, value, notify):
     )
 
     click.echo(
-        "Assigning qualification {} with value {} to {} workers...".format(
+        "Assigning qualification {} with value {} to {} worker{}...".format(
             qualification,
             value,
-            len(workers))
+            len(workers),
+            's' if len(workers) > 1 else '')
     )
     for worker in workers:
         if mturk.set_qualification_score(qualification, worker, value, notify=notify):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -617,8 +617,10 @@ def deploy(verbose, app):
 @click.argument('workers', nargs=-1)
 def qualify(workers, qualification, value, notify):
     """Assign a qualification to 1 or more workers"""
-    if not workers:
-        raise click.BadParameter('Must specify at least one worker ID')
+    if not (workers and qualification and value):
+        raise click.BadParameter(
+            'Must specify a qualification ID, value/score, and at least one worker ID'
+        )
 
     config = get_config()
     config.load()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -613,7 +613,8 @@ def deploy(verbose, app):
 @dallinger.command()
 @click.option('--qualification')
 @click.option('--value')
-@click.option('--by_name', is_flag=True, flag_value=True, help='Use a qualification name, not an ID')
+@click.option('--by_name', is_flag=True, flag_value=True,
+              help='Use a qualification name, not an ID')
 @click.option('--notify', is_flag=True, flag_value=True, help='Notify worker by email')
 @click.argument('workers', nargs=-1)
 def qualify(workers, qualification, value, by_name, notify):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -617,6 +617,9 @@ def deploy(verbose, app):
 @click.argument('workers', nargs=-1)
 def qualify(workers, qualification, value, notify):
     """Assign a qualification to 1 or more workers"""
+    if not workers:
+        raise click.BadParameter('Must specify at least one worker ID')
+
     config = get_config()
     config.load()
     mturk = MTurkService(

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -422,7 +422,7 @@ class TestQualify(object):
             ]
         )
         assert result.exit_code != 0
-        assert 'Must specify at least one worker ID' in result.output
+        assert 'at least one worker ID' in result.output
 
     def test_can_elect_to_notify_worker(self, qualify, stub_config, mturk):
         qual_value = 1

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -412,6 +412,21 @@ class TestQualify(object):
         )
         mturk.get_workers_with_qualification.assert_called_once_with('some qid')
 
+    def test_uses_mturk_sandbox_if_specified(self, qualify, stub_config):
+        qual_value = 1
+        with mock.patch('dallinger.command_line.MTurkService') as mock_mturk:
+            mock_mturk.return_value = mock.Mock()
+            CliRunner().invoke(
+                qualify,
+                [
+                    '--sandbox',
+                    '--qualification', 'some qid',
+                    '--value', qual_value,
+                    'some worker id',
+                ]
+            )
+            assert 'sandbox=True' in str(mock_mturk.call_args_list[0])
+
     def test_raises_with_no_worker(self, qualify, stub_config, mturk):
         qual_value = 1
         result = CliRunner().invoke(

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -412,6 +412,18 @@ class TestQualify(object):
         )
         mturk.get_workers_with_qualification.assert_called_once_with('some qid')
 
+    def test_raises_with_no_worker(self, qualify, stub_config, mturk):
+        qual_value = 1
+        result = CliRunner().invoke(
+            qualify,
+            [
+                '--qualification', 'some qid',
+                '--value', qual_value,
+            ]
+        )
+        assert result.exit_code != 0
+        assert 'Must specify at least one worker ID' in result.output
+
     def test_can_elect_to_notify_worker(self, qualify, stub_config, mturk):
         qual_value = 1
         result = CliRunner().invoke(

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -401,9 +401,9 @@ class TestQualify(object):
         result = CliRunner().invoke(
             qualify,
             [
-                'some worker id',
                 '--qualification', 'some qid',
                 '--value', qual_value,
+                'some worker id',
             ]
         )
         assert result.exit_code == 0
@@ -417,10 +417,10 @@ class TestQualify(object):
         result = CliRunner().invoke(
             qualify,
             [
-                'some worker id',
                 '--qualification', 'some qid',
                 '--value', qual_value,
-                '--notify'
+                '--notify',
+                'some worker id',
             ]
         )
         assert result.exit_code == 0
@@ -433,13 +433,12 @@ class TestQualify(object):
         result = CliRunner().invoke(
             qualify,
             [
-                'worker1', 'worker2',
                 '--qualification', 'some qid',
                 '--value', qual_value,
+                'worker1', 'worker2',
             ]
         )
         assert result.exit_code == 0
-        assert 'worker1 OK\nworker2 OK' in result.output
         mturk.set_qualification_score.assert_has_calls([
             mock.call(u'some qid', u'worker1', 1, notify=False),
             mock.call(u'some qid', u'worker2', 1, notify=False)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -7,6 +7,7 @@ import pytest
 import subprocess
 import sys
 from uuid import UUID
+from click.testing import CliRunner
 from ConfigParser import NoOptionError, SafeConfigParser
 
 import pexpect
@@ -376,3 +377,70 @@ class TestHeader(object):
     def test_header_contains_version_number(self):
         # Make sure header contains the version number.
         assert dallinger.version.__version__ in dallinger.command_line.header
+
+
+class TestQualify(object):
+
+    @pytest.fixture
+    def qualify(self):
+        from dallinger.command_line import qualify
+        return qualify
+
+    @pytest.fixture
+    def mturk(self):
+        with mock.patch('dallinger.command_line.MTurkService') as mock_mturk:
+            mock_results = [{'id': 'some qid', 'score': 1}]
+            mock_instance = mock.Mock()
+            mock_instance.get_workers_with_qualification.return_value = mock_results
+            mock_mturk.return_value = mock_instance
+
+            yield mock_instance
+
+    def test_qualify_single_worker(self, qualify, stub_config, mturk):
+        qual_value = 1
+        result = CliRunner().invoke(
+            qualify,
+            [
+                'some worker id',
+                '--qualification', 'some qid',
+                '--value', qual_value,
+            ]
+        )
+        assert result.exit_code == 0
+        mturk.set_qualification_score.assert_called_once_with(
+            'some qid', 'some worker id', qual_value, notify=False
+        )
+        mturk.get_workers_with_qualification.assert_called_once_with('some qid')
+
+    def test_can_elect_to_notify_worker(self, qualify, stub_config, mturk):
+        qual_value = 1
+        result = CliRunner().invoke(
+            qualify,
+            [
+                'some worker id',
+                '--qualification', 'some qid',
+                '--value', qual_value,
+                '--notify'
+            ]
+        )
+        assert result.exit_code == 0
+        mturk.set_qualification_score.assert_called_once_with(
+            'some qid', 'some worker id', qual_value, notify=True
+        )
+
+    def test_qualify_multiple_workers(self, qualify, stub_config, mturk):
+        qual_value = 1
+        result = CliRunner().invoke(
+            qualify,
+            [
+                'worker1', 'worker2',
+                '--qualification', 'some qid',
+                '--value', qual_value,
+            ]
+        )
+        assert result.exit_code == 0
+        assert 'worker1 OK\nworker2 OK' in result.output
+        mturk.set_qualification_score.assert_has_calls([
+            mock.call(u'some qid', u'worker1', 1, notify=False),
+            mock.call(u'some qid', u'worker2', 1, notify=False)
+        ])


### PR DESCRIPTION
More flexible version of `dallinger qualify` CLI command

## Description
Based on the work I did with @mongates on #662, this PR enhances the `dallinger qualify` command in several ways:

1. Supports the option to notify workers via a `--notify` option, whereas previously workers were always notified
2. Supports qualifying more than one worker at a time
3. Supports specifying a qualification name rather than an ID with the `--by_name` option

## Motivation and Context
Now that we support blacklisting MTurk workers based on qualifications, a more flexible tool will be useful.

## How Has This Been Tested?
Automated tests

