### PR TITLE
Add Sentry integration via Heroku addons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ README.rst
 htmlcov/*
 tests/config.py
 *.ipynb_checkpoints/
+.eggs/*

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -482,6 +482,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         ["heroku", "addons:create", "heroku-postgresql:{}".format(quote(database_size))],
         ["heroku", "addons:create", "heroku-redis:premium-0"],
         ["heroku", "addons:create", "papertrail"],
+        ["heroku", "addons:create", "sentry"],
     ]
     for cmd in cmds:
         subprocess.check_call(cmd + ["--app", app_name(id)], stdout=out)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -482,8 +482,11 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         ["heroku", "addons:create", "heroku-postgresql:{}".format(quote(database_size))],
         ["heroku", "addons:create", "heroku-redis:premium-0"],
         ["heroku", "addons:create", "papertrail"],
-        ["heroku", "addons:create", "sentry"],
     ]
+
+    if config["sentry"]:
+        cmds.append(["heroku", "addons:create", "sentry"])
+
     for cmd in cmds:
         subprocess.check_call(cmd + ["--app", app_name(id)], stdout=out)
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -66,6 +66,7 @@ default_keys = (
     ('webdriver_type', unicode, []),
     ('webdriver_url', unicode, []),
     ('whimsical', bool, []),
+    ('sentry', bool, []),
 )
 
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import gevent
 from json import dumps
 from operator import attrgetter
+import os
 import re
 import sys
 import user_agents
@@ -212,9 +213,12 @@ def shutdown_session(_=None):
 
 @app.context_processor
 def inject_experiment():
-    """Inject the experiment variable into the template context."""
+    """Inject experiment and enviroment variables into the template context."""
     exp = Experiment(session)
-    return dict(experiment=exp)
+    return dict(
+        experiment=exp,
+        env=os.environ,
+    )
 
 
 """Define routes for managing an experiment and the participants."""

--- a/tox.ini
+++ b/tox.ini
@@ -31,4 +31,4 @@ deps =
 whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt
-    make -C docs html spelling
+    make -C docs html


### PR DESCRIPTION
This adds Sentry as a Heroku add on and makes the resultant DSN, stored in an environment variable, available to templates via injection in the template context.

This should be evaluated in combination with `sentry` branch of Griduniverse.