### PR TITLE
Fix encoding bug in ChatBackend

### DIFF
--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -63,7 +63,7 @@ class ChatBackend(object):
         Automatically discards invalid connections.
         """
         try:
-            client.send(data)
+            client.send(data.decode('utf-8'))
         except socket.error:
             for channel in self.clients:
                 self.unsubscribe(client, channel)


### PR DESCRIPTION

## Description
The ChatBackend.send method is given a UTF-8 encoded string, not a unicode string. Decode to utf-8 so the socket implementation can correctly encode this for transmission to the user.

## Motivation and Context
This allows non-latin content to be sent as part of chat messages, which otherwise would trigger a server error and a dropped transmission.

## How Has This Been Tested?
Manually, using the GridUniverse experiment and samples of non-latin and latin text.
