### PR TITLE
Fix error when running experiment multiple time from API

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -85,12 +85,18 @@ class Configuration(object):
     def set(self, key, value):
         return self.extend({key: value})
 
-    def _reset(self):
+    def clear(self):
         self.data = deque()
+        self.ready = False
+
+    def _reset(self, register_defaults=False):
+        self.clear()
         self.types = {}
         self.synonyms = {}
         self.sensitive = set()
-        self.ready = False
+        if register_defaults:
+            for registration in default_keys:
+                self.register(*registration)
 
     def extend(self, mapping, cast_types=False, strict=False):
         normalized_mapping = {}

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -46,7 +46,7 @@ def exp_class_working_dir(meth):
             config.load_from_file(LOCAL_CONFIG)
             return meth(self, *args, **kwargs)
         finally:
-            config._reset()
+            config.clear()
             os.chdir(orig_path)
     return new_meth
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ from pytest import raises
 import pexpect
 
 from dallinger.config import Configuration
+from dallinger.config import get_config, LOCAL_CONFIG
 
 
 class TestConfiguration(object):
@@ -170,4 +171,18 @@ worldwide = false
         finally:
             python.sendcontrol('d')
             python.read()
+            os.chdir('../..')
+
+    def test_reload_config(self):
+        # replicate the experiment API runner config loading
+        config = get_config()
+        os.chdir('tests/experiment')
+        try:
+            config.register_extra_parameters()
+            config.load_from_file(LOCAL_CONFIG)
+            # Failse with _reset()
+            config.clear()
+            config.register_extra_parameters()
+            config.load_from_file(LOCAL_CONFIG)
+        finally:
             os.chdir('../..')


### PR DESCRIPTION
## Description
Provide a softer reset of config between experiment runs.

## Motivation and Context
Fixes issue where the config reset between experiment runs using the API caused errors when reloading the config.

## How Has This Been Tested?
Includes an automated test to replicate the duplicate run issue.