### PR TITLE
Allow clients to configure lag in redis message delivery

### DIFF
--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -108,6 +108,7 @@ def chat(ws):
     """
     # Subscribe to messages on the specified channel.
     channel = request.args.get('channel')
+    lag_tolerance_secs = float(request.args.get('tolerance', 0.1))
     chat_backend.subscribe(ws, channel)
 
     # Send heartbeat ping every 30s
@@ -116,7 +117,7 @@ def chat(ws):
 
     while not ws.closed:
         # Sleep to prevent *constant* context-switches.
-        gevent.sleep(0.1)
+        gevent.sleep(lag_tolerance_secs)
 
         # Publish messages from client
         message = ws.receive()


### PR DESCRIPTION
## Description
Some contexts don't work well with any delay in message delivery (Griduniverse player movement, for example).

## Motivation and Context
See https://github.com/Dallinger/Griduniverse/pull/107

I'm hesitant to remove the `gevent.sleep()` call altogether, since the concept will then be lost and I don't fully understand the implications. The original idea came from the example code in this tutorial: https://devcenter.heroku.com/articles/python-websockets

## How Has This Been Tested?
Automated tests, and manual testing with Griduniverse game
