### PR TITLE
Provide option for opening browser windows with alternate port

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -388,7 +388,9 @@ class TestDebugServer(object):
     @pytest.fixture
     def debugger_unpatched(self, env, output, clear_workers):
         from dallinger.command_line import DebugSessionRunner
-        debugger = DebugSessionRunner(output, verbose=True, bot=False, exp_config={})
+        debugger = DebugSessionRunner(
+            output, verbose=True, bot=False, proxy_port=None, exp_config={}
+        )
         return debugger
 
     @pytest.fixture


### PR DESCRIPTION
When debugging an experiment which uses the webpack BrowserSyncPlugin, it's really nice to avoid manually updating the port on multiple browser windows.

