### PR TITLE
use postgres defaults that work both on Linux and OsX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,11 @@ install:
 - gem install chandler
 before_script:
 - bundle exec danger
-- createdb dallinger -U postgres
+- createuser dallinger
+- createdb -O dallinger dallinger
 env:
   global:
-  - DATABASE_URL=postgresql://postgres@localhost/dallinger
+  - DATABASE_URL=postgresql://dallinger@localhost/dallinger
   - PORT=5000
   - threads=1
   - secure: isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg=

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -16,7 +16,7 @@ from sqlalchemy.exc import OperationalError
 
 logger = logging.getLogger('dallinger.db')
 
-db_url_default = "postgresql://postgres@localhost/dallinger"
+db_url_default = "postgresql://dallinger:dallinger@localhost/dallinger"
 db_url = os.environ.get("DATABASE_URL", db_url_default)
 engine = create_engine(db_url, pool_size=1000)
 session = scoped_session(sessionmaker(autocommit=False,

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -74,39 +74,29 @@ Create the Database
 -------------------
 
 After installing Postgres, you will need to create a database for your
-experiments to use. First, open the Postgres.app. Then, run the
-following command from the command line:
+experiments to use. It is recommended that you also create a database user.
+First, open the Postgres.app. Then, run the following commands from the
+command line:
 
 ::
 
-    psql -c 'create database dallinger;' -U postgres
+    createuser -P dallinger
+    (Password: dallinger)
+    createdb -O dallinger dallinger
 
-If you get the following error...
+The first command will create a user named ``dallinger`` and prompt you for a
+password. The seconf command will create the ``dallinger`` database, setting
+the newly created user as the owner.
+
+If you get an error like the following...
 
 ::
 
-    psql: could not connect to server: No such file or directory
+    createuser: could not connect to database postgres: could not connect to server:
         Is the server running locally and accepting
         connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
 
 ...then you probably did not start the app.
-
-If you get the following error...
-
-::
-
-    dyld: Library not loaded: /usr/local/opt/readline/lib/libreadline.6.dylib
-        Referenced from: /usr/local/bin/psql
-        Reason: image not found
-    Abort trap: 6
-
-... then type the following command into the command line:
-
-::
-
-    createdb -U postgres dallinger
-    
-(This error may arise if you are running Python 2.7 with Anaconda within a virtual environment.)
 
 Set up a virtual environment
 ----------------------------

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -85,7 +85,7 @@ command line:
     createdb -O dallinger dallinger
 
 The first command will create a user named ``dallinger`` and prompt you for a
-password. The seconf command will create the ``dallinger`` database, setting
+password. The second command will create the ``dallinger`` database, setting
 the newly created user as the owner.
 
 If you get an error like the following...


### PR DESCRIPTION
## Description
Use a database user with a password as default to have same settings in Linux and OsX.

## Motivation and Context
Issue 492.
