### PR TITLE
Fix behavior when Sentry config missing

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -484,7 +484,7 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, web_procs=1, exp_config=
         ["heroku", "addons:create", "papertrail"],
     ]
 
-    if config["sentry"]:
+    if config.get("sentry", False):
         cmds.append(["heroku", "addons:create", "sentry"])
 
     for cmd in cmds:


### PR DESCRIPTION
Before this change, experiment launching breaks if the `sentry` config variable isn't provided.