### PR TITLE
Document installing the `dlgr.demos` subpackage

### DIFF
--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -230,3 +230,18 @@ please see the special :doc:`dallinger_with_anaconda`.
 
 Next, you'll need :doc:`access keys for AWS, Heroku,
 etc. <aws_etc_keys>`.
+
+Install the dlgr.demos sub-package
+----------------------------------
+
+Both the test suite and the included demo experiments require installing the
+``dlgr.demos`` sub-package in order to run. Install this in "develop mode"
+with the ``-e`` option, so that any changes you make to a demo will be 
+immediately reflected on your next test or debug session.
+
+From the root ``Dallinger`` directory you created in the previous step, run the 
+installation command:
+
+::
+
+    pip install -e demos

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -21,6 +21,11 @@ The tests include:
   for the Python code is above the desired threshold.
 * Making sure the docs build without error.
 
+If you see ImportErrors related to demo packages, this most likely means you
+have not installed the ``dlgr.demos`` sub-package. See the 
+:doc:`Dallinger development installation instructions 
+<developing_dallinger_setup_guide>` for details.
+
 Amazon Mechanical Turk Integration Tests
 ----------------------------------------
 


### PR DESCRIPTION
## Description
Add installation of the demos sub-package to development setup documentation.

Addresses #699 