### PR TITLE
Stories/234 replay

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -832,6 +832,9 @@ class DebugSessionRunner(LocalSessionRunner):
 
 
 class LoadSessionRunner(LocalSessionRunner):
+    dispatch = {
+        'Replay ready: (.*)$': 'start_replay',
+    }
 
     def __init__(self, app_id, output, verbose, exp_config):
         self.app_id = app_id
@@ -866,9 +869,24 @@ class LoadSessionRunner(LocalSessionRunner):
         base_url = get_base_url()
         self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
 
+        if self.exp_config.get('replay', False):
+            self.out.log("Launching the experiment...")
+            time.sleep(4)
+            _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
+            heroku.monitor(listener=self.notify)
+
         # Just run until interrupted:
         while(self.keep_running()):
             time.sleep(1)
+
+    def start_replay(self, match):
+        """Dispatched to by notify(). If a recruitment request has been issued,
+        open a browser window for the a new participant (in this case the
+        person doing local debugging).
+        """
+        self.out.log("replay ready!")
+        url = match.group(1)
+        webbrowser.open(url, new=1, autoraise=True)
 
     def cleanup(self):
         self.out.log("Terminating dataset load for experiment {}".format(self.exp_id))
@@ -881,10 +899,14 @@ class LoadSessionRunner(LocalSessionRunner):
 @dallinger.command()
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
-def load(app, verbose, exp_config=None):
+@click.option('--replay', is_flag=True, flag_value=True, help='Replay mode')
+def load(app, verbose, replay, exp_config=None):
     """Import database state from an exported zip file and leave the server
     running until stopping the process with <control>-c.
     """
+    if replay:
+        exp_config = exp_config or {}
+        exp_config['replay'] = True
     loader = LoadSessionRunner(app, Output(), verbose, exp_config)
     loader.run()
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -60,6 +60,7 @@ default_keys = (
     ('port', int, ['PORT']),
     ('qualification_blacklist', unicode, []),
     ('recruiter', unicode, []),
+    ('replay', bool, []),
     ('threads', unicode, []),
     ('title', unicode, []),
     ('us_only', bool, []),

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -59,6 +59,7 @@ class Experiment(object):
     # method, since this is where messages from Redis will be sent.
     channel = None
     exp_config = None
+    replay_path = '/'
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
@@ -576,6 +577,19 @@ class Experiment(object):
     def end_experiment(self):
         """Terminates a running experiment"""
         HerokuApp(self.app_id).destroy()
+
+    def events_for_replay(self):
+        """Be default we return all infos in order for replay"""
+        return self.session.query(Info).order_by(Info.creation_time)
+
+    def replay_event(self, index, event):
+        pass
+
+    def replay_finish(self):
+        pass
+
+    def replay_started(self):
+        return True
 
 
 def load():

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -582,7 +582,7 @@ class Experiment(object):
         """Be default we return all infos in order for replay"""
         return self.session.query(Info).order_by(Info.creation_time)
 
-    def replay_event(self, index, event):
+    def replay_event(self, event):
         pass
 
     def replay_finish(self):

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -34,6 +34,7 @@ from dallinger.heroku.worker import conn as redis
 from dallinger.config import get_config
 from dallinger.recruiters import Recruiter
 
+from .replay import ReplayBackend
 from .worker_events import WorkerEvent
 from .utils import nocache
 
@@ -252,6 +253,17 @@ def launch():
         except Exception:
             return error_response(
                 error_text=u"Failed to spawn task on launch: {}, ".format(task) +
+                           u"check experiment server log for details",
+                status=500, simple=True
+            )
+
+    if config.get('replay', False):
+        try:
+            task = ReplayBackend(exp)
+            gevent.spawn(task)
+        except Exception:
+            return error_response(
+                error_text=u"Failed to launch replay task for experiment."
                            u"check experiment server log for details",
                 status=500, simple=True
             )

--- a/dallinger/experiment_server/replay.py
+++ b/dallinger/experiment_server/replay.py
@@ -1,0 +1,70 @@
+import gevent
+import logging
+import time
+from dallinger.utils import get_base_url
+
+
+logger = logging.getLogger(__file__)
+
+
+class ReplayBackend(object):
+    """Replay backend which replays `events` from a completed experiment run.
+
+    This is started during launch and delegates `event` selection and
+    publication to the experiment class. `Events` are any objects with a
+    creation_time attribute.
+    """
+
+    def __init__(self, experiment):
+        self.experiment = experiment
+
+    def __call__(self):
+        gevent.sleep(0.200)
+
+        logger.info('Replay ready: {}{}'.format(
+            get_base_url(), self.experiment.replay_path)
+        )
+
+        while not self.experiment.replay_started():
+            gevent.sleep(0.01)
+
+        self.experiment.log('Looping through replayable data', key='replay')
+        timestamp = self.timestamp
+        events = self.experiment.events_for_replay()
+
+        if not events.count():
+            return
+
+        first_timestamp = timestamp(events[0].creation_time)
+        self.experiment.log(
+            'Found {} messages to replay starting from {}'.format(
+                events.count(), events[0].creation_time
+            ), key='replay'
+        )
+        start = time.time()
+        for event in events:
+            event_offset = timestamp(event.creation_time) - first_timestamp
+            cur_offset = time.time() - start
+            if event_offset >= cur_offset:
+                if (event_offset - cur_offset) > 1:
+                    self.experiment.log(
+                        'Waiting {} seconds to replay {} {}'.format(
+                            event_offset - cur_offset, event.type, event.id
+                        ), key='replay'
+                    )
+                gevent.sleep(event_offset - cur_offset)
+            self.experiment.replay_event(event)
+
+        self.experiment.log(
+            'Replayed {} events in {} seconds (original duration {} seconds)'.format(
+                events.count(), time.time() - start,
+                timestamp(event.creation_time) - first_timestamp
+            ), key='replay'
+        )
+        self.experiment.replay_finish()
+        return
+
+    @staticmethod
+    def timestamp(dt):
+        """Generate a microsecond accurate timestamp from a datetime."""
+        return time.mktime(dt.timetuple()) + dt.microsecond / 1E6

--- a/dallinger/experiment_server/replay.py
+++ b/dallinger/experiment_server/replay.py
@@ -21,9 +21,13 @@ class ReplayBackend(object):
     def __call__(self):
         gevent.sleep(0.200)
 
-        logger.info('Replay ready: {}{}'.format(
-            get_base_url(), self.experiment.replay_path)
-        )
+        try:
+            logger.info('Replay ready: {}{}'.format(
+                get_base_url(), self.experiment.replay_path)
+            )
+        except RuntimeError:
+            # config not loaded, we may be in unit tests
+            pass
 
         while not self.experiment.replay_started():
             gevent.sleep(0.01)
@@ -33,6 +37,7 @@ class ReplayBackend(object):
         events = self.experiment.events_for_replay()
 
         if not events.count():
+            self.experiment.replay_finish()
             return
 
         first_timestamp = timestamp(events[0].creation_time)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -475,7 +475,7 @@ class TestLoad(object):
         os.remove(path)
 
     @pytest.fixture
-    def loader(self, db_session, env, output):
+    def loader(self, db_session, env, output, clear_workers):
         from dallinger.command_line import LoadSessionRunner
         from dallinger.heroku.tools import HerokuLocalWrapper
         loader = LoadSessionRunner(self.exp_id, output, verbose=True,
@@ -485,7 +485,7 @@ class TestLoad(object):
         yield loader
 
     @pytest.fixture
-    def replay_loader(self, db_session, env_with_home, output):
+    def replay_loader(self, db_session, env, output, clear_workers):
         from dallinger.command_line import LoadSessionRunner
         loader = LoadSessionRunner(self.exp_id, output, verbose=True,
                                    exp_config={'replay': True})
@@ -496,7 +496,6 @@ class TestLoad(object):
             from dallinger.heroku.tools import HerokuLocalWrapper
             loader.out.log("Launching replay browser...")
             return HerokuLocalWrapper.MONITOR_STOP
-
 
         loader.start_replay = mock.Mock(
             return_value=None,

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -478,9 +478,30 @@ class TestLoad(object):
     def loader(self, db_session, env, output):
         from dallinger.command_line import LoadSessionRunner
         from dallinger.heroku.tools import HerokuLocalWrapper
-        loader = LoadSessionRunner(self.exp_id, output, verbose=True, exp_config={})
+        loader = LoadSessionRunner(self.exp_id, output, verbose=True,
+                                   exp_config={})
         loader.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
 
+        yield loader
+
+    @pytest.fixture
+    def replay_loader(self, db_session, env_with_home, output):
+        from dallinger.command_line import LoadSessionRunner
+        loader = LoadSessionRunner(self.exp_id, output, verbose=True,
+                                   exp_config={'replay': True})
+        loader.keep_running = mock.Mock(return_value=False)\
+
+
+        def launch_and_finish(self):
+            from dallinger.heroku.tools import HerokuLocalWrapper
+            loader.out.log("Launching replay browser...")
+            return HerokuLocalWrapper.MONITOR_STOP
+
+
+        loader.start_replay = mock.Mock(
+            return_value=None,
+            side_effect=launch_and_finish
+        )
         yield loader
 
     def test_load_runs(self, loader, export):
@@ -501,6 +522,20 @@ class TestLoad(object):
         loader.keep_running = mock.Mock(return_value=False)
         with pytest.raises(IOError):
             loader.run()
+
+    def test_load_with_replay(self, replay_loader, export):
+        replay_loader.run()
+
+        replay_loader.out.log.assert_has_calls([
+            mock.call('Starting up the server...'),
+            mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
+            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
+            mock.call('Launching the experiment...'),
+            mock.call('Launching replay browser...'),
+            mock.call('Terminating dataset load for experiment some_experiment_id'),
+            mock.call('Cleaning up local Heroku process...'),
+            mock.call('Local Heroku process terminated.')
+        ])
 
 
 class TestOutput(object):

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -1,0 +1,103 @@
+from datetime import datetime
+import gevent
+import random
+
+
+class DummyEvent(object):
+    creation_time = None
+    type = 'event'
+    id = 1
+
+    def __init__(self, creation_time):
+        self.creation_time = creation_time
+
+
+class DummyEvents(list):
+
+    def count(self):
+        return len(self)
+
+
+class DummyExperiment(object):
+
+    replay_path = '/replay'
+    _events = DummyEvents()
+    replayed = []
+    finished = False
+    started = False
+
+    def log(self, *args, **kw):
+        pass
+
+    def replay_started(self):
+        return self.started
+
+    def events_for_replay(self):
+        return self._events
+
+    def replay_event(self, event):
+        self.replayed.append({
+            'orig_time': event.creation_time,
+            'replay_time': datetime.now()
+        })
+
+    def replay_finish(self):
+        self.finished = True
+
+
+class TestReplayBackend:
+
+    allowed_jitter = 0.05
+
+    def launch_replay_task(self, exp):
+        from dallinger.experiment_server.replay import ReplayBackend
+        task = ReplayBackend(exp)
+        gevent.spawn(task)
+        return task
+
+    def wait_to_finish(self, exp):
+        loop_count = 0
+        while exp.finished is False:
+            gevent.sleep(2)
+            loop_count += 1
+            if loop_count > 10:
+                raise RuntimeError('Replay did not finish in reasonable time')
+
+    def test_replay_waits_to_start(self):
+        exp = DummyExperiment()
+        assert exp.started is False
+        assert exp.finished is False
+
+        self.launch_replay_task(exp)
+
+        # Wait for task to `run` in background
+        gevent.sleep(2)
+        assert exp.finished is False
+
+        # Start the task
+        exp.started = True
+        gevent.sleep(2)
+        assert exp.finished is True
+
+    def test_replay_event_timing(self):
+        exp = DummyExperiment()
+
+        # 10 events ~ 1 second apart with some random jitter
+        exp._events = DummyEvents([
+            DummyEvent(datetime(2010, 1, 1, 0, 0, t, int(random.random() * 1000)))
+            for t in range(10)
+        ])
+
+        exp.started = True
+        self.launch_replay_task(exp)
+
+        self.wait_to_finish(exp)
+
+        replayed = exp.replayed
+        assert len(replayed) == 10
+
+        base_offset = (replayed[0]['replay_time'] - replayed[0]['orig_time']).total_seconds()
+
+        for rp in replayed:
+            time_diff = (rp['replay_time'] - rp['orig_time']).total_seconds()
+            assert abs(time_diff - base_offset) <= self.allowed_jitter


### PR DESCRIPTION
## Description
Implements support for replaying Griduniverse games, using the commandline. I recommend testing this by running a new Griduniverse game (older exports will be missing chat data):

    cd dlgr/griduniverse
    dallinger debug

Record the **experiment_id** and export the data:

    dallinger export --app **experiment_id** --local

Run the replay:

    dallinger load --app **experiment_id** --replay

## Motivation and Context
This, along with the [Griduniverse branch](https://github.com/Dallinger/Griduniverse/pull/127) implements generic replay support for experiments along with specific support for replaying Griduniverse games in a browser as described in [ScrumDo Story 234](https://app.scrumdo.com/projects/story_permalink/1268252)

## How Has This Been Tested?
This branch implements new unit tests for the replay handler module and integration tests for the command line `--replay` flag and loader. It has also been tested manually by running Griduniverse experiments, exporting them, and then loading them with the new `--replay` flag.
