### PR TITLE
More sustainable MTurk testing

### DIFF
--- a/Dangerfile
+++ b/Dangerfile
@@ -43,3 +43,9 @@ end
 if release && !git.modified_files.include?("CHANGELOG.md")
     fail("Please update the change log for this release.")
 end
+
+mturk_changed = git.modified_files.include?("dallinger/mturk.py")
+mturk_tests_changed = git.modified_files.include?("test/test_mturk.py")
+if mturk_changed || mturk_tests_changed
+    warn("MTurk code has changed, please test it using `pytest --mturkfull`.")
+end

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -315,12 +315,14 @@ class MTurkService(object):
         try:
             self.mturk.extend_hit(hit_id, expiration_increment=duration_as_secs)
         except MTurkRequestError:
-            logger.exception("Failed to extend time until expiration of HIT")
+            raise MTurkServiceException(
+                "Failed to extend time until expiration of HIT")
 
         try:
             self.mturk.extend_hit(hit_id, assignments_increment=number)
         except MTurkRequestError:
-            logger.exception("Error: failed to add {} assignments to HIT".format(number))
+            raise MTurkServiceException(
+                "Error: failed to add {} assignments to HIT".format(number))
 
         updated_hit = self.mturk.get_hit(hit_id)[0]
 
@@ -352,10 +354,11 @@ class MTurkService(object):
                 self.mturk.grant_bonus(worker_id, assignment_id, amount, reason)
             )
         except MTurkRequestError:
-            logger.exception("Failed to pay assignment {} bonus of {}".format(
+            error = "Failed to pay assignment {} bonus of {}".format(
                 assignment_id,
                 amount
-            ))
+            )
+            raise MTurkServiceException(error)
 
     def _translate_hit(self, hit):
         translated = {
@@ -391,6 +394,6 @@ class MTurkService(object):
         try:
             self.mturk.approve_assignment(assignment_id, feedback=None)
         except MTurkRequestError:
-            logger.exception(
+            raise MTurkServiceException(
                 "Failed to approve assignment {}".format(assignment_id))
         return True

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -222,7 +222,7 @@ class MTurkRecruiter(Recruiter):
         try:
             return self.mturkservice.grant_bonus(assignment_id, amount, reason)
         except MTurkServiceException as ex:
-            logger.exception((ex.message))
+            logger.exception(ex.message)
 
     @property
     def is_in_progress(self):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -6,6 +6,7 @@ from dallinger.heroku.worker import conn
 from dallinger.models import Participant
 from dallinger.mturk import MTurkService
 from dallinger.mturk import DuplicateQualificationNameError
+from dallinger.mturk import MTurkServiceException
 from dallinger.mturk import QualificationNotFoundException
 from dallinger.utils import get_base_url
 from dallinger.utils import generate_random_id
@@ -193,11 +194,14 @@ class MTurkRecruiter(Recruiter):
             logger.info('no HIT in progress: recruitment aborted')
             return
 
-        return self.mturkservice.extend_hit(
-            hit_id,
-            number=n,
-            duration_hours=self.config.get('duration')
-        )
+        try:
+            return self.mturkservice.extend_hit(
+                hit_id,
+                number=n,
+                duration_hours=self.config.get('duration')
+            )
+        except MTurkServiceException as ex:
+            logger.exception(ex.message)
 
     def notify_recruited(self, participant):
         """Assign a Qualification to the Participant for the experiment ID,
@@ -215,7 +219,10 @@ class MTurkRecruiter(Recruiter):
 
     def reward_bonus(self, assignment_id, amount, reason):
         """Reward the Turker for a specified assignment with a bonus."""
-        return self.mturkservice.grant_bonus(assignment_id, amount, reason)
+        try:
+            return self.mturkservice.grant_bonus(assignment_id, amount, reason)
+        except MTurkServiceException as ex:
+            logger.exception((ex.message))
 
     @property
     def is_in_progress(self):
@@ -229,7 +236,10 @@ class MTurkRecruiter(Recruiter):
             return str(any_participant_record.hit_id)
 
     def approve_hit(self, assignment_id):
-        return self.mturkservice.approve_assignment(assignment_id)
+        try:
+            return self.mturkservice.approve_assignment(assignment_id)
+        except MTurkServiceException as ex:
+            logger.exception(ex.message)
 
     def close_recruitment(self):
         """Clean up once the experiment is complete.

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -64,6 +64,11 @@ To run all tests except those that require a MTurk Worker ID, run::
 
 	pytest -m "not mturkworker"
 
+To run the complete, comprehensive suite of tests which interact Mechanical Turk,
+add the ``mturkfull`` option when running the tests::
+
+  pytest --mturkfull
+
 To build documentation::
 
 	tox -e docs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -199,5 +199,7 @@ def pytest_addoption(parser):
                      help="Run an experiment using a bot during tests")
     parser.addoption("--manual", action="store_true",
                      help="Run manual interactive tests during test run")
+    parser.addoption("--mturkfull", action="store_true",
+                     help="Run comprehensive MTurk integration tests during test run")
     parser.addoption("--heroku", action="store_true",
                      help="Run tests requiring heroku login")


### PR DESCRIPTION
## Run fewer full system MTurk tests by default

We currently have a large suite of tests which run against the live MTurk service. These tests provide a lot of confidence, but they are not only slow, but also non-deterministic, since occasionally the service is unavailable. The more calls we make, the more likely to hit non-responsive moment and see a spurious test failure. 

There is also a large degree of redundancy between tests, because so many of the same preconditions exist across different tests. This can cause a single regression to trigger failures in a large number of tests, making debugging difficult.

This PR:

- completes, as much as possible, isolation tests for the MTurkService class
- adds one new full-system test which hits 75% of the MTurkService class code
- configures the comprehensive integration tests so they are only run when an option flag (`--mturkfull`) is specified when running tests
