### PR TITLE
Don't use a fake HOME dir unless we're on Travis

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -26,15 +26,6 @@ def found_in(name, path):
 
 
 @pytest.fixture
-def env_with_home(env):
-    original_env = os.environ.copy()
-    if 'HOME' not in original_env:
-        os.environ.update(env)
-    yield
-    os.environ = original_env
-
-
-@pytest.fixture
 def output():
 
     class Output(object):
@@ -395,7 +386,7 @@ class Test_handle_launch_data(object):
 class TestDebugServer(object):
 
     @pytest.fixture
-    def debugger_unpatched(self, env_with_home, output, clear_workers):
+    def debugger_unpatched(self, env, output, clear_workers):
         from dallinger.command_line import DebugSessionRunner
         debugger = DebugSessionRunner(output, verbose=True, bot=False, exp_config={})
         return debugger
@@ -482,7 +473,7 @@ class TestLoad(object):
         os.remove(path)
 
     @pytest.fixture
-    def loader(self, db_session, env_with_home, output):
+    def loader(self, db_session, env, output):
         from dallinger.command_line import LoadSessionRunner
         from dallinger.heroku.tools import HerokuLocalWrapper
         loader = LoadSessionRunner(self.exp_id, output, verbose=True, exp_config={})

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     coverage report
     coverage xml
 passenv = 
+    CI
     DATABASE_URL PORT
     aws_access_key_id
     aws_secret_access_key


### PR DESCRIPTION
Speeds up tests which run `heroku local` by about 25 seconds each, by avoiding a full heroku CLI download and installation on each run.

I checked the "CI" environment variable on a few different CI servers (including AppVeyor) and it seems to be generally supported.

I have yet to figure out how to share a heroku cli installation across tests on Travis.
