### PR TITLE
Fix database user to match documented setup instructions

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -173,7 +173,7 @@ def copy_local_to_csv(local_db, path, scrub_pii=False):
     if "postgresql://" in local_db:
         conn = psycopg2.connect(dsn=local_db)
     else:
-        conn = psycopg2.connect(database=local_db, user="postgres")
+        conn = psycopg2.connect(database=local_db, user="dallinger")
     cur = conn.cursor()
     for table in table_names:
         csv_path = os.path.join(path, "{}.csv".format(table))


### PR DESCRIPTION
After re-creating my dallinger database following the instructions in the Developer Setup Guide, I ran into test failures in `test_data.py` due to the user specified for the DB connection. An example:
```
local_db = 'dallinger', path = '/var/folders/pv/yvkdh0vx195bcssnd2pc3cn40000gp/T/tmphMwr24', scrub_pii = True

    def copy_local_to_csv(local_db, path, scrub_pii=False):
        """Copy a local database to a set of CSV files."""
        if "postgresql://" in local_db:
            conn = psycopg2.connect(dsn=local_db)
        else:
            conn = psycopg2.connect(database=local_db, user="postgres")
        cur = conn.cursor()
        for table in table_names:
            csv_path = os.path.join(path, "{}.csv".format(table))
            with open(csv_path, "w") as f:
                sql = "COPY {} TO STDOUT WITH CSV HEADER".format(table)
>               cur.copy_expert(sql, f)
E               ProgrammingError: permission denied for relation info

dallinger/data.py:182: ProgrammingError
```

## How Has This Been Tested?
Automated tests now pass
