### PR TITLE
Use random bits to form UUID

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -538,8 +538,8 @@ class Experiment(object):
 
     @classmethod
     def make_uuid(cls):
-        """Returns a new uuid"""
-        return str(uuid.uuid4())
+        """Generate a new uuid."""
+        return str(uuid.UUID(int=random.getrandbits(128)))
 
     def _finish_experiment(self):
         # Debug runs synchronously

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,7 +1,10 @@
 """Test python experiment API"""
-import dallinger
-import pytest
+import random
 from uuid import UUID
+
+import pytest
+
+import dallinger
 
 
 class TestAPI(object):
@@ -16,6 +19,18 @@ class TestAPI(object):
         exp = Experiment()
         exp_uuid = exp.make_uuid()
         assert isinstance(UUID(exp_uuid, version=4), UUID)
+
+    def test_uuid_reproducibility(self):
+        from dallinger.experiment import Experiment
+        exp = Experiment()
+        random.seed(1)
+        exp_uuid1 = exp.make_uuid()
+        exp_uuid2 = exp.make_uuid()
+        random.seed(1)
+        exp_uuid3 = exp.make_uuid()
+
+        assert exp_uuid1 != exp_uuid2
+        assert exp_uuid1 == exp_uuid3
 
     def test_collect(self):
         from dallinger.experiments import Bartlett1932


### PR DESCRIPTION
The default behavior of `uuid.uuid4()` uses random bits generated by the OS and is thus unresponsive to seeding the random number generator. Here, we generate the UUID using 128 pseudorandom bits. This helps with computational reproducibility — it'll use the OS source of randomness, unless the PRNG is seeded.