### PR TITLE
Remove optional dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,6 @@ rq==0.8.1
 selenium==3.5.0
 SQLAlchemy==1.1.13
 sqlalchemy-postgres-copy==0.5.0
-tablib==0.12.0
 ua-parser==0.7.3
 user-agents==1.1.0
 psutil==5.2.2


### PR DESCRIPTION
The tablib library shouldn't be installed by default because it's an optional dependency. This is a fix for #728.