### PR TITLE
Disable "begin experiment" button on click

### DIFF
--- a/demos/dlgr/demos/bartlett1932/templates/ad.html
+++ b/demos/dlgr/demos/bartlett1932/templates/ad.html
@@ -65,18 +65,21 @@
                                 By clicking the following URL link, you will be taken to the experiment,
                                 including complete instructions and an informed consent agreement.
                             </p>
-                            <script>
-                                function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                }
-                            </script>
+
                             <div class="alert alert-warning">
                                 <b>Warning</b>: Please disable pop-up blockers before continuing.
                             </div>
 
-                            <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                            <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                               Begin Experiment
                             </button>
+                            <script>
+                                function openwindow(event) {
+                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    event.target.setAttribute("disabled", "");
+                                }
+                                document.getElementById("begin-button").onclick = openwindow;
+                            </script>                            
                         {% endif %}
                     </div>
                 </div>

--- a/demos/dlgr/demos/chatroom/templates/ad.html
+++ b/demos/dlgr/demos/chatroom/templates/ad.html
@@ -65,18 +65,20 @@
                                 By clicking the following URL link, you will be taken to the experiment,
                                 including complete instructions and an informed consent agreement.
                             </p>
-                            <script>
-                                function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                  }
-                            </script>
                             <div class="alert alert-warning">
                                 <b>Warning</b>: Please disable pop-up blockers before continuing.
                             </div>
 
-                            <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                            <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                               Begin Experiment
                             </button>
+                            <script>
+                                function openwindow(event) {
+                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    event.target.setAttribute("disabled", "");
+                                }
+                                document.getElementById("begin-button").onclick = openwindow;
+                            </script>                                
                         {% endif %}
                     </div>
             </div>

--- a/demos/dlgr/demos/concentration/templates/ad.html
+++ b/demos/dlgr/demos/concentration/templates/ad.html
@@ -65,18 +65,20 @@
                                 By clicking the following URL link, you will be taken to the experiment,
                                 including complete instructions and an informed consent agreement.
                             </p>
-                            <script>
-                                function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                }
-                            </script>
                             <div class="alert alert-warning">
                                 <b>Warning</b>: Please disable pop-up blockers before continuing.
                             </div>
 
-                            <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                            <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                               Begin Experiment
                             </button>
+                            <script>
+                                function openwindow(event) {
+                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    event.target.setAttribute("disabled", "");
+                                }
+                                document.getElementById("begin-button").onclick = openwindow;
+                            </script>   
                         {% endif %}
                     </div>
                 </div>

--- a/demos/dlgr/demos/function_learning/templates/ad.html
+++ b/demos/dlgr/demos/function_learning/templates/ad.html
@@ -112,20 +112,19 @@
                                     By clicking the following URL link, you will be taken to the experiment,
                                     including complete instructions and an informed consent agreement.
                                 </p>
-                                <script>
-                                    function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                    }
-                                </script>
                                 <div class="alert alert-warning">
                                     <b>Warning</b>: Please disable pop-up blockers before continuing.
                                 </div>
-
-                                <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                                <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                                   Begin Experiment
                                 </button>
-
-
+                                <script>
+                                    function openwindow(event) {
+                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        event.target.setAttribute("disabled", "");
+                                    }
+                                    document.getElementById("begin-button").onclick = openwindow;
+                                </script>   
                             {% endif %}
                             <!--
                                 endif

--- a/demos/dlgr/demos/iterated_drawing/templates/ad.html
+++ b/demos/dlgr/demos/iterated_drawing/templates/ad.html
@@ -112,19 +112,19 @@
                                     By clicking the following URL link, you will be taken to the experiment,
                                     including complete instructions and an informed consent agreement.
                                 </p>
-                                <script>
-                                    function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                    }
-                                </script>
                                 <div class="alert alert-warning">
                                     <b>Warning</b>: Please disable pop-up blockers before continuing.
                                 </div>
-
-                                <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                                <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                                   Begin Experiment
                                 </button>
-
+                                <script>
+                                    function openwindow(event) {
+                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        event.target.setAttribute("disabled", "");
+                                    }
+                                    document.getElementById("begin-button").onclick = openwindow;
+                                </script>
 
                             {% endif %}
                             <!--

--- a/demos/dlgr/demos/mcmcp/templates/ad.html
+++ b/demos/dlgr/demos/mcmcp/templates/ad.html
@@ -112,19 +112,19 @@
                                     By clicking the following URL link, you will be taken to the experiment,
                                     including complete instructions and an informed consent agreement.
                                 </p>
-                                <script>
-                                    function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                    }
-                                </script>
                                 <div class="alert alert-warning">
                                     <b>Warning</b>: Please disable pop-up blockers before continuing.
                                 </div>
-
-                                <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                                <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                                   Begin Experiment
                                 </button>
-
+                                <script>
+                                    function openwindow(event) {
+                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        event.target.setAttribute("disabled", "");
+                                    }
+                                    document.getElementById("begin-button").onclick = openwindow;
+                                </script>
 
                             {% endif %}
                             <!--

--- a/demos/dlgr/demos/rogers/templates/ad.html
+++ b/demos/dlgr/demos/rogers/templates/ad.html
@@ -113,18 +113,19 @@
                                     By clicking the following URL link, you will be taken to the experiment,
                                     including complete instructions and an informed consent agreement.
                                 </p>
-                                <script>
-                                    function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                    }
-                                </script>
                                 <div class="alert alert-warning">
                                     <b>Warning</b>: Please disable pop-up blockers before continuing.
                                 </div>
-
-                                <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                                <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                                   Begin Experiment
                                 </button>
+                                <script>
+                                    function openwindow(event) {
+                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        event.target.setAttribute("disabled", "");
+                                    }
+                                    document.getElementById("begin-button").onclick = openwindow;
+                                </script>
 
 
                             {% endif %}

--- a/demos/dlgr/demos/sheep_market/templates/ad.html
+++ b/demos/dlgr/demos/sheep_market/templates/ad.html
@@ -111,19 +111,21 @@
                                     By clicking the following URL link, you will be taken to the experiment,
                                     including complete instructions and an informed consent agreement.
                                 </p>
-                                <script>
-                                    function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                    }
-                                </script>
+
                                 <div class="alert alert-warning">
                                     <b>Warning</b>: Please disable pop-up blockers before continuing.
                                 </div>
 
-                                <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                                <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                                   Begin Experiment
                                 </button>
-
+                                <script>
+                                    function openwindow(event) {
+                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        event.target.setAttribute("disabled", "");
+                                    }
+                                    document.getElementById("begin-button").onclick = openwindow;
+                                </script>
 
                             {% endif %}
                             <!--

--- a/demos/dlgr/demos/snake/templates/ad.html
+++ b/demos/dlgr/demos/snake/templates/ad.html
@@ -65,18 +65,20 @@
                                 By clicking the following URL link, you will be taken to the experiment,
                                 including complete instructions and an informed consent agreement.
                             </p>
-                            <script>
-                                function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                }
-                            </script>
+
                             <div class="alert alert-warning">
                                 <b>Warning</b>: Please disable pop-up blockers before continuing.
                             </div>
-
-                            <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                            <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                               Begin Experiment
                             </button>
+                            <script>
+                                function openwindow(event) {
+                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    event.target.setAttribute("disabled", "");
+                                }
+                                document.getElementById("begin-button").onclick = openwindow;
+                            </script>
                         {% endif %}
                     </div>
                 </div>

--- a/demos/dlgr/demos/twentyfortyeight/templates/ad.html
+++ b/demos/dlgr/demos/twentyfortyeight/templates/ad.html
@@ -70,18 +70,20 @@
                                 By clicking the following URL link, you will be taken to the experiment,
                                 including complete instructions and an informed consent agreement.
                             </p>
-                            <script>
-                                function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
-                                }
-                            </script>
                             <div class="alert alert-warning">
                                 <b>Warning</b>: Please disable pop-up blockers before continuing.
                             </div>
 
-                            <button type="button" class="btn btn-primary btn-lg" onClick="openwindow();">
+                            <button type="button" id="begin-button" class="btn btn-primary btn-lg">
                               Begin Experiment
                             </button>
+                            <script>
+                                function openwindow(event) {
+                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    event.target.setAttribute("disabled", "");
+                                }
+                                document.getElementById("begin-button").onclick = openwindow;
+                            </script>
 
                         {% endif %}
                     </div>


### PR DESCRIPTION
Relates to issue #407 

## Description
As proposed by @suchow in the ticket, simply disable the "Begin experiment" button when it's initially clicked.

## How Has This Been Tested?
Tested manually in the Bartlett1932 and Chatroom experiments.

