### PR TITLE
Better jupyter support

### DIFF
--- a/dallinger/__init__.py
+++ b/dallinger/__init__.py
@@ -15,12 +15,14 @@ from . import (
     heroku,
     registration
 )
+from .patches import patch
 
 import logging
 from logging import NullHandler
 logger = logging.getLogger(__name__)
 logger.addHandler(NullHandler())
 
+patch()
 
 __all__ = (
     "bots",

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -14,7 +14,6 @@ except ImportError:
     # Python >= 3.3
     from shlex import quote
 import shutil
-import subprocess
 import sys
 import tempfile
 import time
@@ -39,6 +38,7 @@ from dallinger.heroku.tools import HerokuLocalWrapper
 from dallinger.heroku.tools import HerokuApp
 from dallinger.mturk import MTurkService
 from dallinger import registration
+from dallinger.utils import check_call
 from dallinger.utils import generate_random_id
 from dallinger.utils import get_base_url
 from dallinger.utils import GitClient
@@ -904,7 +904,7 @@ def monitor(app):
     webbrowser.open(heroku_app.dashboard_url)
     webbrowser.open("https://requester.mturk.com/mturk/manageHITs")
     heroku_app.open_logs()
-    subprocess.call(["open", heroku_app.db_uri])
+    check_call(["open", heroku_app.db_uri])
     while _keep_running():
         summary = get_summary(app)
         click.clear()

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -14,6 +14,7 @@ import subprocess
 import traceback
 
 from dallinger.compat import unicode
+from dallinger.utils import check_call, check_output
 
 
 class HerokuApp(object):
@@ -177,11 +178,11 @@ class HerokuApp(object):
 
     def _run(self, cmd, pass_stderr=False):
         if pass_stderr:
-            return subprocess.check_call(cmd, stdout=self.out, stderr=self.out)
-        return subprocess.check_call(cmd, stdout=self.out)
+            return check_call(cmd, stdout=self.out, stderr=self.out)
+        return check_call(cmd, stdout=self.out)
 
     def _result(self, cmd):
-        return subprocess.check_output(cmd).decode(self.sys_encoding)
+        return check_output(cmd).decode(self.sys_encoding)
 
 
 def app_name(id):
@@ -191,13 +192,13 @@ def app_name(id):
 
 def auth_token():
     """A Heroku authenication token."""
-    return unicode(subprocess.check_output(["heroku", "auth:token"]).rstrip())
+    return unicode(check_output(["heroku", "auth:token"]).rstrip())
 
 
 def log_in():
     """Ensure that the user is logged in to Heroku."""
     try:
-        subprocess.check_output(["heroku", "auth:whoami"])
+        check_output(["heroku", "auth:whoami"])
     except Exception:
         raise Exception("You are not logged into Heroku.")
 

--- a/dallinger/patches.py
+++ b/dallinger/patches.py
@@ -1,0 +1,11 @@
+def patch_ipython():
+    try:
+        from ipykernel.iostream import OutStream
+    except ImportError:
+        return
+    else:
+        OutStream.writable = lambda self: True
+
+
+def patch():
+    patch_ipython()

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -1,8 +1,12 @@
 from dallinger.config import get_config
+import functools
+import io
 import os
 import random
 import string
 import subprocess
+import sys
+import tempfile
 
 
 def get_base_url():
@@ -48,3 +52,39 @@ class GitClient(object):
 
     def _run(self, cmd):
         subprocess.check_call(cmd, stdout=self.out, stderr=self.out)
+
+
+def wrap_subprocess_call(func, wrap_stdout=True):
+    @functools.wraps(func)
+    def wrapper(*popenargs, **kwargs):
+        out = kwargs.get('stdout', None)
+        err = kwargs.get('stderr', None)
+        replay_out = False
+        replay_err = False
+        if out is None and wrap_stdout:
+            try:
+                sys.stdout.fileno()
+            except io.UnsupportedOperation:
+                kwargs['stdout'] = tempfile.NamedTemporaryFile()
+                replay_out = True
+        if err is None:
+            try:
+                sys.stderr.fileno()
+            except io.UnsupportedOperation:
+                kwargs['stderr'] = tempfile.NamedTemporaryFile()
+                replay_err = True
+        try:
+            return func(*popenargs, **kwargs)
+        finally:
+            if replay_out:
+                kwargs['stdout'].seek(0)
+                sys.stdout.write(kwargs['stdout'].read())
+            if replay_err:
+                kwargs['stderr'].seek(0)
+                sys.stderr.write(kwargs['stderr'].read())
+    return wrapper
+
+
+check_call = wrap_subprocess_call(subprocess.check_call)
+call = wrap_subprocess_call(subprocess.call)
+check_output = wrap_subprocess_call(subprocess.check_output, wrap_stdout=False)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -925,9 +925,9 @@ class TestMonitor(object):
         return countdown
 
     @pytest.fixture
-    def subproc(self):
-        with mock.patch('dallinger.utils.subprocess') as sub:
-            yield sub
+    def command_line_check_call(self):
+        with mock.patch('dallinger.command_line.check_call') as call:
+            yield call
 
     @pytest.fixture
     def summary(self):
@@ -948,7 +948,7 @@ class TestMonitor(object):
         from dallinger.command_line import monitor
         return monitor
 
-    def test_opens_browsers(self, monitor, heroku, browser, subproc):
+    def test_opens_browsers(self, monitor, heroku, browser, command_line_check_call):
         heroku.dashboard_url = 'fake-dashboard-url'
         CliRunner().invoke(
             monitor,
@@ -959,15 +959,15 @@ class TestMonitor(object):
             mock.call('https://requester.mturk.com/mturk/manageHITs')
         ])
 
-    def test_calls_open_with_db_uri(self, monitor, heroku, browser, subproc):
+    def test_calls_open_with_db_uri(self, monitor, heroku, browser, command_line_check_call):
         heroku.db_uri = 'fake-db-uri'
         CliRunner().invoke(
             monitor,
             ['--app', 'some-app-uid', ]
         )
-        subproc.call.assert_called_once_with(['open', 'fake-db-uri'])
+        command_line_check_call.assert_called_once_with(['open', 'fake-db-uri'])
 
-    def test_shows_summary_in_output(self, monitor, heroku, browser, subproc):
+    def test_shows_summary_in_output(self, monitor, heroku, browser, command_line_check_call):
         heroku.db_uri = 'fake-db-uri'
         result = CliRunner().invoke(
             monitor,
@@ -976,7 +976,7 @@ class TestMonitor(object):
 
         assert len(re.findall('fake summary', result.output)) == 2
 
-    def test_raises_on_null_app_id(self, monitor, heroku, browser, subproc):
+    def test_raises_on_null_app_id(self, monitor, heroku, browser, command_line_check_call):
         heroku.db_uri = 'fake-db-uri'
         result = CliRunner().invoke(
             monitor,

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -926,7 +926,7 @@ class TestMonitor(object):
 
     @pytest.fixture
     def subproc(self):
-        with mock.patch('dallinger.command_line.subprocess') as sub:
+        with mock.patch('dallinger.utils.subprocess') as sub:
             yield sub
 
     @pytest.fixture

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -29,9 +29,14 @@ def run_check():
 
 
 @pytest.fixture
-def subproc():
-    with mock.patch('dallinger.heroku.tools.subprocess') as sp:
-        yield sp
+def check_call():
+    with mock.patch('dallinger.heroku.tools.check_call') as check_call:
+        yield check_call
+
+@pytest.fixture
+def check_output():
+    with mock.patch('dallinger.heroku.tools.check_output') as check_output:
+        yield check_output
 
 
 class TestHeroku(object):
@@ -328,16 +333,16 @@ class TestHerokuUtilFunctions(object):
         from dallinger.heroku import tools
         return tools
 
-    def test_auth_token(self, heroku, subproc):
-        subproc.check_output.return_value = 'some response '
+    def test_auth_token(self, heroku, check_output):
+        check_output.return_value = 'some response '
         assert heroku.auth_token() == u'some response'
 
-    def test_log_in_ok(self, heroku, subproc):
-        subproc.check_output.return_value = 'all good'
+    def test_log_in_ok(self, heroku, check_output):
+        check_output.return_value = 'all good'
         heroku.log_in()
 
-    def test_log_in_fails(self, heroku, subproc):
-        subproc.check_output.side_effect = Exception('boom!')
+    def test_log_in_fails(self, heroku, check_output):
+        check_output.side_effect = Exception('boom!')
         with pytest.raises(Exception) as excinfo:
             heroku.log_in()
         assert excinfo.match('You are not logged into Heroku.')
@@ -380,34 +385,34 @@ class TestHerokuApp(object):
     def test_dashboard_url(self, app):
         assert app.dashboard_url == u'https://dashboard.heroku.com/apps/dlgr-fake-uid'
 
-    def test_bootstrap_creates_app_with_team(self, app, subproc):
+    def test_bootstrap_creates_app_with_team(self, app, check_call):
         app.team = 'some-team'
         app.bootstrap()
-        subproc.check_call.assert_has_calls([
+        check_call.assert_has_calls([
             mock.call(['heroku', 'apps:create', 'dlgr-fake-uid', '--buildpack',
                        'https://github.com/thenovices/heroku-buildpack-scipy',
                        '--org', 'some-team'], stdout=None),
         ])
 
-    def test_bootstrap_sets_hostname(self, app, subproc):
+    def test_bootstrap_sets_hostname(self, app, check_call):
         app.team = 'some-team'
         app.bootstrap()
-        subproc.check_call.assert_has_calls([
+        check_call.assert_has_calls([
             mock.call(['heroku', 'config:set',
                        'HOST=https://dlgr-fake-uid.herokuapp.com',
                        '--app', 'dlgr-fake-uid'], stdout=None)
         ])
 
-    def test_addon(self, app, subproc):
+    def test_addon(self, app, check_call):
         app.addon('some-fake-addon')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "addons:create", "some-fake-addon", "--app", app.name],
             stdout=None
         )
 
-    def test_addon_destroy(self, app, subproc):
+    def test_addon_destroy(self, app, check_call):
         app.addon_destroy('some-fake-addon')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             [
                 "heroku",
                 "addons:destroy", 'some-fake-addon',
@@ -417,84 +422,84 @@ class TestHerokuApp(object):
             stdout=None
         )
 
-    def test_buildpack(self, app, subproc):
+    def test_buildpack(self, app, check_call):
         app.buildpack('some-fake-buildpack')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "buildpacks:add", "some-fake-buildpack", "--app", app.name],
             stdout=None
         )
 
-    def test_db_uri(self, app, subproc):
-        subproc.check_output.return_value = 'blahblahpostgres://foobar'
+    def test_db_uri(self, app, check_output):
+        check_output.return_value = 'blahblahpostgres://foobar'
         assert app.db_uri == u'postgres://foobar'
 
-    def test_db_url(self, app, subproc):
-        subproc.check_output.return_value = 'some url    '
+    def test_db_url(self, app, check_output, check_call):
+        check_output.return_value = 'some url    '
         assert app.db_url == u'some url'
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "pg:wait", "--app", app.name],
             stdout=None
         )
 
-    def test_backup_capture(self, app, subproc):
+    def test_backup_capture(self, app, check_call):
         app.backup_capture()
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "pg:backups:capture", "--app", app.name],
             stdout=None, stderr=None
         )
 
-    def test_backup_download(self, app, subproc):
+    def test_backup_download(self, app, check_call):
         app.backup_download()
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "pg:backups:download", "--app", app.name],
             stdout=None, stderr=None
         )
 
-    def test_destroy(self, app, subproc):
-        subproc.check_output.return_value = 'some response message'
+    def test_destroy(self, app, check_output):
+        check_output.return_value = 'some response message'
         assert app.destroy() == 'some response message'
-        subproc.check_output.assert_called_once_with(
+        check_output.assert_called_once_with(
             ["heroku", "apps:destroy", "--app", app.name, "--confirm", app.name],
         )
 
-    def test_get(self, app, subproc):
-        subproc.check_output.return_value = 'some value'
+    def test_get(self, app, check_output):
+        check_output.return_value = 'some value'
         assert app.get('some key') == u'some value'
-        subproc.check_output.assert_called_once_with(
+        check_output.assert_called_once_with(
             ["heroku", "config:get", "some key", "--app", app.name],
         )
 
-    def test_open_logs(self, app, subproc):
+    def test_open_logs(self, app, check_call):
         app.open_logs()
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "addons:open", "papertrail", "--app", app.name],
             stdout=None
         )
 
-    def test_pg_pull(self, app, subproc):
+    def test_pg_pull(self, app, check_call):
         app.pg_pull()
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "pg:pull", "DATABASE_URL", app.name, "--app", app.name],
             stdout=None
         )
 
-    def test_pg_wait(self, app, subproc):
+    def test_pg_wait(self, app, check_call):
         app.pg_wait()
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             ["heroku", "pg:wait", "--app", app.name],
             stdout=None
         )
 
-    def test_redis_url(self, app, subproc):
-        subproc.check_output.return_value = 'some url'
+    def test_redis_url(self, app, check_output):
+        check_output.return_value = 'some url'
         assert app.redis_url == u'some url'
-        subproc.check_output.assert_called_once_with(
+        check_output.assert_called_once_with(
             ["heroku", "config:get", "REDIS_URL", "--app", app.name],
         )
 
-    def test_restore(self, app, subproc):
+    def test_restore(self, app, check_call):
         app.restore('some url')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             [
                 "heroku",
                 "pg:backups:restore",
@@ -508,9 +513,9 @@ class TestHerokuApp(object):
             stdout=None
         )
 
-    def test_scale_up_dyno(self, app, subproc):
+    def test_scale_up_dyno(self, app, check_call):
         app.scale_up_dyno('some process', quantity=1, size='free')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             [
                 "heroku",
                 "ps:scale",
@@ -521,9 +526,9 @@ class TestHerokuApp(object):
             stdout=None
         )
 
-    def test_scale_down_dyno(self, app, subproc):
+    def test_scale_down_dyno(self, app, check_call):
         app.scale_down_dyno('some process')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             [
                 "heroku",
                 "ps:scale",
@@ -534,9 +539,9 @@ class TestHerokuApp(object):
             stdout=None
         )
 
-    def test_set(self, app, subproc):
+    def test_set(self, app, check_call):
         app.set('some key', 'some value')
-        subproc.check_call.assert_called_once_with(
+        check_call.assert_called_once_with(
             [
                 "heroku",
                 "config:set",

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -33,6 +33,7 @@ def check_call():
     with mock.patch('dallinger.heroku.tools.check_call') as check_call:
         yield check_call
 
+
 @pytest.fixture
 def check_output():
     with mock.patch('dallinger.heroku.tools.check_output') as check_output:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,76 @@
+import io
+import mock
+
+import pytest
+
+from dallinger import utils
+
+
+class TestSubprocessWrapper(object):
+
+    @pytest.fixture
+    def sys(self):
+        with mock.patch('dallinger.utils.sys') as sys:
+            yield sys
+
+    def test_writing_to_stdout_unaffected_by_default(self):
+        def sample(**kwargs):
+            assert kwargs['stdin'] is None
+            assert kwargs['stdout'] is None
+        utils.wrap_subprocess_call(sample)(stdin=None, stdout=None)
+
+    def test_writing_to_stdout_is_diverted_if_broken(self, sys):
+        def sample(**kwargs):
+            assert kwargs['stdin'] is None
+            assert kwargs['stdout'] is not None
+            assert kwargs['stdout'] is not sys.stdout
+        sys.stdout.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stdin=None, stdout=None)
+
+    def test_writing_to_stdout_is_not_diverted_if_wrapstdout_is_false(self, sys):
+        def sample(**kwargs):
+            assert kwargs['stdin'] is None
+            assert kwargs['stdout'] is None
+        sys.stdout.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample, wrap_stdout=False)(stdin=None, stdout=None)
+
+    def test_writing_to_stderr_is_diverted_if_broken(self, sys):
+        def sample(**kwargs):
+            assert kwargs['stderr'] is not None
+            assert kwargs['stderr'] is not sys.stdout
+        sys.stderr.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stderr=None)
+
+    def test_reading_from_stdin_is_not_diverted(self, sys):
+        def sample(**kwargs):
+            assert kwargs['stdin'] is None
+            assert kwargs['stdout'] is None
+        sys.stdin.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stdin=None, stdout=None)
+
+    def test_arbitrary_outputs_are_not_replaced_even_if_stdout_is_broken(self, sys):
+        output = io.StringIO()
+
+        def sample(**kwargs):
+            assert kwargs['stdin'] is None
+            assert kwargs['stdout'] is output
+        sys.stdout.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stdin=None, stdout=output)
+
+    def test_writing_to_broken_stdout_is_output_after_returning(self, sys):
+        def sample(**kwargs):
+            kwargs['stdout'].write('Output')
+            # The output isn't written until we return
+            sys.stdout.write.assert_not_called()
+        sys.stdout.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stdin=None, stdout=None)
+        sys.stdout.write.assert_called_once_with('Output')
+
+    def test_writing_to_broken_stderr_is_output_after_returning(self, sys):
+        def sample(**kwargs):
+            kwargs['stderr'].write('Output')
+            # The output isn't written until we return
+            sys.stderr.write.assert_not_called()
+        sys.stderr.fileno.side_effect = io.UnsupportedOperation
+        utils.wrap_subprocess_call(sample)(stderr=None)
+        sys.stderr.write.assert_called_once_with('Output')


### PR DESCRIPTION
## Description
This adds a patch for ipython's IO streams and wraps subprocess calls to make them more tolerant of the fact that jupyter does not allocate file descriptors for its streams. This allows experiments to be run through jupyter, albeit with the caveat that output is significantly laggier than using a console script.

## Motivation and Context
This allows the full range of functionality to be used in a Jupyter notebook, lowering the bar to entry.

## How Has This Been Tested?
Manual tests of bartlett1932/demo.ipynb only.
