### PR TITLE
Issues/sandbox host fix

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -9,7 +9,12 @@ def get_base_url():
     config = get_config()
     host = os.getenv('HOST', config.get('host'))
     if 'herokuapp.com' in host:
-        base_url = "https://{}".format(host)
+        if host.startswith('https://'):
+            base_url = host
+        elif host.startswith('http://'):
+            base_url = host.replace('http://', 'https://')
+        else:
+            base_url = "https://{}".format(host)
     else:
         # debug mode
         base_port = config.get('base_port')

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -186,3 +186,45 @@ worldwide = false
             config.load_from_file(LOCAL_CONFIG)
         finally:
             os.chdir('../..')
+
+    def test_local_base_url(self):
+        from dallinger.utils import get_base_url
+        config = get_config()
+        config.ready = True
+        os.chdir('tests/experiment')
+        try:
+            config.register_extra_parameters()
+            config.load_from_file(LOCAL_CONFIG)
+            config.set(u'host', u'localhost')
+            config.set(u'base_port', 5000)
+            assert(get_base_url() == 'http://localhost:5000')
+        finally:
+            os.chdir('../..')
+
+    def test_remote_base_url(self):
+        from dallinger.utils import get_base_url
+        config = get_config()
+        config.ready = True
+        orig_host = os.environ.get('HOST')
+        try:
+            os.environ['HOST'] = 'https://dlgr-bogus.herokuapp.com'
+            assert(get_base_url() == 'https://dlgr-bogus.herokuapp.com')
+        finally:
+            if orig_host:
+                os.environ['HOST'] = orig_host
+            else:
+                del os.environ['HOST']
+
+    def test_remote_base_url_always_ssl(self):
+        from dallinger.utils import get_base_url
+        config = get_config()
+        config.ready = True
+        orig_host = os.environ.get('HOST')
+        try:
+            os.environ['HOST'] = 'http://dlgr-bogus.herokuapp.com'
+            assert(get_base_url() == 'https://dlgr-bogus.herokuapp.com')
+        finally:
+            if orig_host:
+                os.environ['HOST'] = orig_host
+            else:
+                del os.environ['HOST']

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-import mock
 from tempfile import NamedTemporaryFile
 
 import pexpect
@@ -191,16 +190,16 @@ worldwide = false
         config.set(u'base_port', 5000)
         assert(get_base_url() == 'http://localhost:5000')
 
-    @mock.patch.dict(os.environ, {'HOST': 'https://dlgr-bogus.herokuapp.com'})
     def test_remote_base_url(self):
         from dallinger.utils import get_base_url
         config = get_config()
         config.ready = True
+        config.set(u'host', u'https://dlgr-bogus.herokuapp.com')
         assert(get_base_url() == 'https://dlgr-bogus.herokuapp.com')
 
-    @mock.patch.dict(os.environ, {'HOST': 'http://dlgr-bogus.herokuapp.com'})
     def test_remote_base_url_always_ssl(self):
         from dallinger.utils import get_base_url
         config = get_config()
         config.ready = True
+        config.set(u'host', u'http://dlgr-bogus.herokuapp.com')
         assert(get_base_url() == 'https://dlgr-bogus.herokuapp.com')


### PR DESCRIPTION
## Description
Fixes sandbox runs by ensuring protocol isn't doubled.

## How Has This Been Tested?
Includes new tests for `utils.get_base_url()` method and has been tested with sandbox deploys.

