### PR TITLE
Ignore snapshots everywhere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 *.egg-info/
 *.db-journal
 demos/*/data/*
-demos/*/snapshots/*
+**/snapshots/*
 docs/source/demos
 docs/source/_static/*.zip
 .env


### PR DESCRIPTION
.gitignore pattern for ignoring snapshots no longer working since the layout move to use the /dlgr/ directory. This pattern matches more aggressively, and covers the tests/experiment snapshot directory also.

