### PR TITLE
Issues/747 monitor error

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -23,8 +23,14 @@ class HerokuApp(object):
         self.dallinger_uid = dallinger_uid
         self.out = output
         self.team = team
-        # Encoding of strings returned from subprocess calls:
-        self.sys_encoding = sys.stdout.encoding
+
+    @property
+    def sys_encoding(self):
+        # Encoding of strings returned from subprocess calls
+        if hasattr(sys.stdout, 'encoding'):
+            return sys.stdout.encoding
+
+        return sys.getdefaultencoding()
 
     def bootstrap(self):
         """Creates the heroku app and local git remote. Call this once you're

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -26,7 +26,10 @@ class HerokuApp(object):
 
     @property
     def sys_encoding(self):
-        # Encoding of strings returned from subprocess calls
+        # Encoding of strings returned from subprocess calls. The Click
+        # library overwrites sys.stdout in the context of its commands,
+        # so we need a fallback, which could possibly just be 'utf-8' instead
+        # of getdefaultencoding().
         if hasattr(sys.stdout, 'encoding'):
             return sys.stdout.encoding
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -82,7 +82,7 @@ class HerokuApp(object):
         """The connection URL for the remote database. For example:
         postgres://some-long-uid@ec2-52-7-232-59.compute-1.amazonaws.com:5432/d5fou154it1nvt
         """
-        output = self.get("DATABASE", subcommand="pg:credentials")
+        output = self.get("DATABASE", subcommand="pg:credentials:url")
         match = re.search('(postgres://.*)$', output)
         if match is None:
             raise NameError(

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -30,7 +30,7 @@ class HerokuApp(object):
         # library overwrites sys.stdout in the context of its commands,
         # so we need a fallback, which could possibly just be 'utf-8' instead
         # of getdefaultencoding().
-        return getattr(sys.stdout.encoding, sys.getdefaultencoding())
+        return getattr(sys.stdout, 'encoding', sys.getdefaultencoding())
 
     def bootstrap(self):
         """Creates the heroku app and local git remote. Call this once you're

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -30,10 +30,7 @@ class HerokuApp(object):
         # library overwrites sys.stdout in the context of its commands,
         # so we need a fallback, which could possibly just be 'utf-8' instead
         # of getdefaultencoding().
-        if hasattr(sys.stdout, 'encoding'):
-            return sys.stdout.encoding
-
-        return sys.getdefaultencoding()
+        return getattr(sys.stdout.encoding, sys.getdefaultencoding())
 
     def bootstrap(self):
         """Creates the heroku app and local git remote. Call this once you're

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -24,7 +24,7 @@ class HerokuApp(object):
         self.out = output
         self.team = team
         # Encoding of strings returned from subprocess calls:
-        self.sys_encoding = sys.getdefaultencoding()
+        self.sys_encoding = sys.stdout.encoding
 
     def bootstrap(self):
         """Creates the heroku app and local git remote. Call this once you're
@@ -79,9 +79,15 @@ class HerokuApp(object):
 
     @property
     def db_uri(self):
-        """Not sure what this returns"""
+        """The connection URL for the remote database. For example:
+        postgres://some-long-uid@ec2-52-7-232-59.compute-1.amazonaws.com:5432/d5fou154it1nvt
+        """
         output = self.get("DATABASE", subcommand="pg:credentials")
         match = re.search('(postgres://.*)$', output)
+        if match is None:
+            raise NameError(
+                "Could not retrieve the DB URI. Check for error output from "
+                "heroku above the stack trace.")
         return match.group(1)
 
     @property

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -428,6 +428,12 @@ class TestHerokuApp(object):
         subproc.check_output.return_value = 'blahblahpostgres://foobar'
         assert app.db_uri == u'postgres://foobar'
 
+    def test_db_uri_raises_if_no_match(self, app, subproc):
+        subproc.check_output.return_value = '└─ as DATABASE on ⬢ dlgr-da089b8f app'
+        with pytest.raises(NameError) as excinfo:
+            app.db_uri
+            assert excinfo.match("Could not retrieve the DB URI")
+
     def test_db_url(self, app, subproc):
         subproc.check_output.return_value = 'some url    '
         assert app.db_url == u'some url'


### PR DESCRIPTION
Fix for #747 

## Description
There were a couple layers here:
- The `heroku` command to get the URI for a database has changed from `pg:credentials` to `pg:credentials:url`
- The error message returned from `heroku` was a utf-8 encoded byte string, and we were trying to decode that using the encoding returned by `sys.getdefaultencoding()` which was the wrong thing to use, since this method generally returns `ascii` as the encoding

## How Has This Been Tested?
Automated and manual tests
