### PR TITLE
Pin networkx version, since odo doesn't

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup_args = dict(
     },
     extras_require={
         'data': [
+            "networkx==1.11",
             "odo==0.5.0",
             "tablib==0.11.3"
         ],


### PR DESCRIPTION
`master` and related branches are broken since new release of `networkx` package on 9/20/2017.
https://pypi.python.org/pypi/networkx/

## Description
```
dallinger/data.py:418: in df
    return odo.odo(self.odo_resource, pd.DataFrame)
.tox/py27/lib/python2.7/site-packages/odo/odo.py:91: in odo
    return into(target, source, **kwargs)
.tox/py27/lib/python2.7/site-packages/multipledispatch/dispatcher.py:164: in __call__
    return func(*args, **kwargs)
.tox/py27/lib/python2.7/site-packages/odo/into.py:43: in wrapped
    return f(*args, **kwargs)
.tox/py27/lib/python2.7/site-packages/odo/into.py:53: in into_type
    return convert(a, b, dshape=dshape, **kwargs)
.tox/py27/lib/python2.7/site-packages/odo/core.py:44: in __call__
    return _transform(self.graph, *args, **kwargs)
.tox/py27/lib/python2.7/site-packages/odo/core.py:57: in _transform
    ooc_types=ooc_types)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
graph = <networkx.classes.digraph.DiGraph object at 0x7f3646642d10>
source = <class 'odo.backends.csv.CSV'>
target = <class 'pandas.core.frame.DataFrame'>, excluded_edges = set([])
ooc_types = set([<class '_abcoll.Iterator'>, <class 'sqlalchemy.sql.schema.Table'>, <class 'pandas.io.pytables.AppendableFrameTable'>, <class 'odo.chunks.Chunks'>, <class 'odo.backends.csv.CSV'>, <class 'odo.backends.json.JSONLines'>])
    def path(graph, source, target, excluded_edges=None, ooc_types=ooc_types):
        """ Path of functions between two types """
        if not isinstance(source, type):
            source = type(source)
        if not isinstance(target, type):
            target = type(target)
    
        if source not in graph:
            for cls in valid_subclasses:
                if issubclass(source, cls):
                    source = cls
                    break
    
        # If both source and target are Out-Of-Core types then restrict ourselves
        # to the graph of out-of-core types
        if ooc_types:
            oocs = tuple(ooc_types)
            if issubclass(source, oocs) and issubclass(target, oocs):
                graph = graph.subgraph([n for n in graph.nodes()
                                        if issubclass(n, oocs)])
        with without_edges(graph, excluded_edges) as g:
            pth = nx.shortest_path(g, source=source, target=target, weight='cost')
            result = [(src, tgt, graph.edge[src][tgt]['func'])
>                     for src, tgt in zip(pth, pth[1:])]
E           AttributeError: 'DiGraph' object has no attribute 'edge'
```

## Motivation and Context
`odo` does not pin `networkx` to a specific known version. The simplest (though perhaps not the best?) fix is to pin the version in dallinger.

## How Has This Been Tested?
Automated tests
