### PR TITLE
Send subprocess output do dev/null when setting sensitive keys

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -14,6 +14,7 @@ import subprocess
 import traceback
 
 from dallinger.compat import unicode
+from dallinger.config import SENSITIVE_KEY_NAMES
 
 
 class HerokuApp(object):
@@ -23,6 +24,7 @@ class HerokuApp(object):
         self.dallinger_uid = dallinger_uid
         self.out = output
         self.team = team
+        self.out_muted = open(os.devnull, 'w')
 
     @property
     def sys_encoding(self):
@@ -185,12 +187,26 @@ class HerokuApp(object):
             "{}={}".format(key, quote(str(value))),
             "--app", self.name
         ]
-        self._run(cmd)
+        if self._is_sensitive_key(key):
+            self._run_quiet(cmd)
+        else:
+            self._run(cmd)
+
+    def _is_sensitive_key(self, key):
+        for sensitive in SENSITIVE_KEY_NAMES:
+            if sensitive in key:
+                return True
+
+        return False
 
     def _run(self, cmd, pass_stderr=False):
         if pass_stderr:
             return subprocess.check_call(cmd, stdout=self.out, stderr=self.out)
         return subprocess.check_call(cmd, stdout=self.out)
+
+    def _run_quiet(self, cmd):
+        # make sure subprocess output doesn't echo secrets to the terminal
+        return subprocess.check_call(cmd, stdout=self.out_muted)
 
     def _result(self, cmd):
         return subprocess.check_output(cmd).decode(self.sys_encoding)

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -193,11 +193,7 @@ class HerokuApp(object):
             self._run(cmd)
 
     def _is_sensitive_key(self, key):
-        for sensitive in SENSITIVE_KEY_NAMES:
-            if sensitive in key:
-                return True
-
-        return False
+        return any([s in key for s in SENSITIVE_KEY_NAMES])
 
     def _run(self, cmd, pass_stderr=False):
         if pass_stderr:

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -557,7 +557,7 @@ class TestHerokuApp(object):
         app.set('some_nonsensitive_key', 'some value')
         assert subproc.check_call.call_args_list[0][-1]['stdout'] is app.out
 
-    def test_set_called_with_sensitive_key_surpresses_stdoutput(self, app, subproc):
+    def test_set_called_with_sensitive_key_suppresses_stdoutput(self, app, subproc):
         app.set('aws_secret_access_key', 'some value')
         assert subproc.check_call.call_args_list[0][-1]['stdout'] is app.out_muted
 

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -553,6 +553,14 @@ class TestHerokuApp(object):
             stdout=None
         )
 
+    def test_set_called_with_nonsensitive_key_uses_stdoutput(self, app, subproc):
+        app.set('some_nonsensitive_key', 'some value')
+        assert subproc.check_call.call_args_list[0][-1]['stdout'] is app.out
+
+    def test_set_called_with_sensitive_key_surpresses_stdoutput(self, app, subproc):
+        app.set('aws_secret_access_key', 'some value')
+        assert subproc.check_call.call_args_list[0][-1]['stdout'] is app.out_muted
+
     @pytest.mark.skipif(not pytest.config.getvalue("heroku"),
                         reason="--heroku was not specified")
     def test_full_monty(self, full_app, temp_repo):


### PR DESCRIPTION
Fix for #750 

## Description
Currently, running `sandbox` or `deploy` in verbose mode echos sensitive keys to the terminal. This PR suppresses this output.

## Motivation and Context
Bug report #750 

## How Has This Been Tested?
Automated tests and test with the Bartlett1932 experiment

Before (problem):
```
Setting whimsical and restarting ⬢ dlgr-2428dd53... done, v5
whimsical: True
Setting aws_region and restarting ⬢ dlgr-2428dd53... done, v6
aws_region: us-east-1
Setting auto_recruit and restarting ⬢ dlgr-2428dd53... done, v8
auto_recruit: True
Setting aws_secret_access_key and restarting ⬢ dlgr-2428dd53... done, v9
aws_secret_access_key: [redacted]
Setting dallinger_email_key and restarting ⬢ dlgr-2428dd53... done, v10
dallinger_email_key: '???'
Setting aws_access_key_id and restarting ⬢ dlgr-2428dd53... done, v11
aws_access_key_id: [redacted]
```

After (cleaned up):
```
Setting whimsical and restarting ⬢ dlgr-ef330bb6... done, v5
whimsical: True
Setting aws_region and restarting ⬢ dlgr-ef330bb6... done, v6
aws_region: us-east-1
Setting auto_recruit and restarting ⬢ dlgr-ef330bb6... done, v8
auto_recruit: True
Setting aws_secret_access_key and restarting dlgr-ef330bb6... done, v9
Setting dallinger_email_key and restarting ⬢ dlgr-ef330bb6... done, v10
dallinger_email_key: '???'
Setting aws_access_key_id and restarting dlgr-ef330bb6... done, v11
Setting dallinger_email_username and restarting ⬢ dlgr-ef330bb6... done, v12
dallinger_email_username: jesse@rasikaconsulting.com
```
