### PR TITLE
Fix malformed secure variables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,10 +41,10 @@ env:
   - DATABASE_URL=postgresql://dallinger@localhost/dallinger
   - PORT=5000
   - threads=1
-  - secure: isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg=
-  - secure: rWBAifHvKlQabe6gvz+edMEtjtDnpwI4RFHJB1ytYSNVKQ59s7fIk2q39IZc8K3Uix7ZtP3G7ws6ufQhOj44Pm4j1J+rbLnDjdMtmcDN5aiSnwb05JpltZXCNjUqAu/CBFZ44lnNenZp4uSLhU/kLVhB2Q+UPvyWNFgApEVoiHM=
-  - secure: fd4hFOH60UV8laBN4Mjva0w/EmVK3SVC5p/0O1oqPriPhUpoJ3eVVRvITbdvPctEJJgRR9t62rPk+Rv4EOXeRFfsjZK9gOfQqv/9VhJBebdQfOx2dwQLjDiGTrklkokDIDyfpyYOoJzZ/oP+6EneD403ilHnXC4fd/4EDQmaIRI=
-  - secure: 3rnkGugv5Hp71gjwQMUj5tup7/xk94p5IXEh0VItSXTziKn0pBY+yrCzAuIzlylbrl0baLaZOFGEFn2K+Jf+tr9mmN23X+zOUNsIqC4swlLLJx6hzH5AZaRmqzGjURM2gLISUayXGT9flOXyOKzzCGFELJKG9KlVyEOJ4fk04wQ=
+  - secure: "isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg="
+  - secure: "rWBAifHvKlQabe6gvz+edMEtjtDnpwI4RFHJB1ytYSNVKQ59s7fIk2q39IZc8K3Uix7ZtP3G7ws6ufQhOj44Pm4j1J+rbLnDjdMtmcDN5aiSnwb05JpltZXCNjUqAu/CBFZ44lnNenZp4uSLhU/kLVhB2Q+UPvyWNFgApEVoiHM="
+  - secure: "fd4hFOH60UV8laBN4Mjva0w/EmVK3SVC5p/0O1oqPriPhUpoJ3eVVRvITbdvPctEJJgRR9t62rPk+Rv4EOXeRFfsjZK9gOfQqv/9VhJBebdQfOx2dwQLjDiGTrklkokDIDyfpyYOoJzZ/oP+6EneD403ilHnXC4fd/4EDQmaIRI="
+  - secure: "3rnkGugv5Hp71gjwQMUj5tup7/xk94p5IXEh0VItSXTziKn0pBY+yrCzAuIzlylbrl0baLaZOFGEFn2K+Jf+tr9mmN23X+zOUNsIqC4swlLLJx6hzH5AZaRmqzGjURM2gLISUayXGT9flOXyOKzzCGFELJKG9KlVyEOJ4fk04wQ="
 script:
 - tox
 after_success:


### PR DESCRIPTION
## Description
travis allows encrypted variables in its .travis.yml file, however these must be enclosed
in quotes according to https://github.com/travis-ci/travis-ci/issues/747. This is shown
in our current travis output as (for example) export 4EDQmaIRI=[secure] and
"The previous command failed, possibly due to a malformed secure environment variable".

## Motivation and Context
I'm not sure if this has been causing failures in travis results, but it is causing spurious log output.
