### PR TITLE
Improvements for repeatable test coverage

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -781,8 +781,8 @@ class LocalSessionRunner(object):
 class DebugSessionRunner(LocalSessionRunner):
 
     dispatch = {
-        '[^\"]{} (.*)$'.format(recruiters.NEW_RECRUIT_LOG_PREFIX): 'new_recruit',
-        '{}$'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
+        r'[^\"]{} (.*)$'.format(recruiters.NEW_RECRUIT_LOG_PREFIX): 'new_recruit',
+        r'{}$'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
     }
 
     def __init__(self, output, verbose, bot, proxy_port, exp_config):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -462,6 +462,15 @@ class TestDebugServer(object):
             with pytest.raises(OSError):
                 debugger.run()
 
+    def test_new_participant(self, debugger_unpatched):
+        from dallinger.config import get_config
+        debugger = debugger_unpatched
+        get_config().load()
+        debugger.new_recruit = mock.Mock(return_value=None)
+        assert not debugger.new_recruit.called
+        debugger.notify('New participant requested: http://example.com')
+        assert debugger.new_recruit.called
+
     def test_recruitment_closed(self, debugger_unpatched):
         from dallinger.heroku.tools import HerokuLocalWrapper
         debugger = debugger_unpatched

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -468,7 +468,7 @@ class TestDebugServer(object):
         get_config().load()
         debugger.new_recruit = mock.Mock(return_value=None)
         assert not debugger.new_recruit.called
-        debugger.notify('New participant requested: http://example.com')
+        debugger.notify(' New participant requested: http://example.com')
         assert debugger.new_recruit.called
 
     def test_recruitment_closed(self, debugger_unpatched):


### PR DESCRIPTION
## Description

This adds a test for another use of that function that
although still being ordering dependent will fix the partial coverage
of `dallinger.command_line.notify()` function in all cases.

## Motivation and Context
The `notify()` method of command_line.py is partially covered depending
on dictionary ordering, which causes spurious -0.19% test coverage deltas
in some builds. 

This is primarily to unblock spurious warnings on pyupbot PRs.

## How Has This Been Tested?
codecov on this PR