### PR TITLE
Idle Heroku application email

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import webbrowser
 
+import signal
 import click
 from dallinger.config import get_config
 import psycopg2
@@ -33,6 +34,7 @@ from collections import Counter
 from dallinger import data
 from dallinger import db
 from dallinger import heroku
+from dallinger.heroku.messages import EmailingHITMessager
 from dallinger.heroku.worker import conn
 from dallinger.heroku.tools import HerokuLocalWrapper
 from dallinger.heroku.tools import HerokuApp
@@ -46,6 +48,7 @@ from dallinger.utils import GitClient
 from dallinger.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
+start = time.time()
 
 header = """
     ____        ____
@@ -79,6 +82,12 @@ def error(msg, delay=0.5, chevrons=True, verbose=True):
         else:
             click.secho(msg, err=True, fg='red')
         time.sleep(delay)
+
+
+def idle_handler(signal, frame):
+    """If time exceeds 6 hours"""
+    EmailingHITMessager()
+    log("Sending email...")
 
 
 def verify_id(ctx, param, app):
@@ -424,6 +433,10 @@ def debug(verbose, bot, proxy, exp_config=None):
 
 def deploy_sandbox_shared_setup(verbose=True, app=None, exp_config=None):
     """Set up Git, push to Heroku, and launch the app."""
+
+    signal.signal(signal.SIGALRM, idle_handler)
+    signal.alarm.timeout(21600)
+
     if verbose:
         out = None
     else:

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -98,9 +98,10 @@ def report_idle_after(seconds):
                         "dallinger_email_key": config["dallinger_email_password"],
                         "whimsical": False
                     }
+                    app_id = config["id"]
                     email = EmailingHITMessager(when=time, assignment_id=None,
                                                 hit_duration=seconds, time_active=seconds,
-                                                config=heroku_config)
+                                                config=heroku_config, app_id=app_id)
                     log("Sending email...")
                     email.send_idle_experiment()
                 except KeyError:

--- a/dallinger/heroku/messages.py
+++ b/dallinger/heroku/messages.py
@@ -111,8 +111,7 @@ Time since participant started: {minutes_so_far}
 idle_template = """Dear experimenter,
 
 This is an automated email from Dallinger. You are receiving this email because
-your dyno has been running for over {minutes_so_far}. You can destroy your app
-using the command `dallinger destroy --app {uuid}.`
+your dyno has been running for over {minutes_so_far} minutes.`
 
 Best,
 
@@ -128,7 +127,7 @@ Time since participant started: {minutes_so_far}
 
 class EmailingHITMessager(object):
 
-    def __init__(self, when, assignment_id, hit_duration, time_active, config, server=None, uuid=None):
+    def __init__(self, when, assignment_id, hit_duration, time_active, config, server=None):
         self.when = when
         self.assignment_id = assignment_id
         self.duration = round(hit_duration / 60)
@@ -165,6 +164,7 @@ class EmailingHITMessager(object):
             'message': template.format(**self.__dict__),
             'subject': "Idle Experiment."
         }
+        self._send(data)
         return data
 
     def _build_resubmitted_msg(self):

--- a/dallinger/heroku/messages.py
+++ b/dallinger/heroku/messages.py
@@ -108,10 +108,27 @@ Allowed time: {duration}
 Time since participant started: {minutes_so_far}
 """
 
+idle_template = """Dear experimenter,
+
+This is an automated email from Dallinger. You are receiving this email because
+your dyno has been running for over {minutes_so_far}. You can destroy your app
+using the command `dallinger destroy --app {uuid}.`
+
+Best,
+
+The Dallinger dev. team.
+
+Error details:
+Assignment: {assignment_id}
+
+Allowed time: {duration}
+Time since participant started: {minutes_so_far}
+"""
+
 
 class EmailingHITMessager(object):
 
-    def __init__(self, when, assignment_id, hit_duration, time_active, config, server=None):
+    def __init__(self, when, assignment_id, hit_duration, time_active, config, server=None, uuid=None):
         self.when = when
         self.assignment_id = assignment_id
         self.duration = round(hit_duration / 60)
@@ -140,6 +157,14 @@ class EmailingHITMessager(object):
     def send_hit_cancelled_msg(self):
         data = self._build_hit_cancelled_msg()
         self._send(data)
+        return data
+
+    def send_idle_experiment(self):
+        template = idle_template
+        data = {
+            'message': template.format(**self.__dict__),
+            'subject': "Idle Experiment."
+        }
         return data
 
     def _build_resubmitted_msg(self):

--- a/dallinger/heroku/messages.py
+++ b/dallinger/heroku/messages.py
@@ -113,21 +113,21 @@ idle_template = """Dear experimenter,
 This is an automated email from Dallinger. You are receiving this email because
 your dyno has been running for over {minutes_so_far} minutes.`
 
-Best,
+The application id is: {app_id}
+
+To see the logs, use the command "dallinger logs --app {app_id}"
+To pause the app, use the command "dallinger hibernate --app {app_id}"
+To destroy the app, use the command "dallinger destroy --app {app_id}"
+
 
 The Dallinger dev. team.
-
-Error details:
-Assignment: {assignment_id}
-
-Allowed time: {duration}
-Time since participant started: {minutes_so_far}
 """
 
 
 class EmailingHITMessager(object):
 
-    def __init__(self, when, assignment_id, hit_duration, time_active, config, server=None):
+    def __init__(self, when, assignment_id, hit_duration, time_active, config,
+                 server=None, app_id=None):
         self.when = when
         self.assignment_id = assignment_id
         self.duration = round(hit_duration / 60)
@@ -139,6 +139,7 @@ class EmailingHITMessager(object):
         self.toaddr = config.get('contact_email_on_error')
         self.email_password = config.get("dallinger_email_key")
         self.server = server or SMTP('smtp.gmail.com:587')
+        self.app_id = app_id
 
     def _send(self, data):
         msg = MIMEText(data['message'])

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -7,15 +7,18 @@ import pytest
 import re
 import subprocess
 import sys
+from time import sleep
 from uuid import UUID
 from click.testing import CliRunner
 from ConfigParser import NoOptionError, SafeConfigParser
+from smtplib import SMTPAuthenticationError
 
 import pexpect
 from pytest import raises
 
 import dallinger.command_line
 from dallinger.command_line import verify_package
+from dallinger.command_line import timeout
 from dallinger.compat import unicode
 from dallinger.config import get_config
 from dallinger import recruiters
@@ -119,6 +122,18 @@ class TestCommandLine(object):
     def test_setup(self):
         subprocess.check_call(["dallinger", "setup"])
         subprocess.check_call(["dallinger", "setup"])
+
+    def test_email_with_no_credentials(self):
+            @timeout(1)
+            def test_smpt():
+                config = get_config()
+                config.extend({'dallinger_email_address': u'email',
+                               'contact_email_on_error': u'email',
+                               'dallinger_email_password': u'password'})
+                sleep(5)
+
+            with raises(SMTPAuthenticationError):
+                test_smpt()
 
 
 @pytest.mark.usefixtures('bartlett_dir', 'active_config')

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -123,9 +123,14 @@ class TestCommandLine(object):
         subprocess.check_call(["dallinger", "setup"])
         subprocess.check_call(["dallinger", "setup"])
 
-    def test_email_with_no_credentials(self):
+    def test_email_with_no_credentials(self, active_config):
             @report_idle_after(1)
             def test_smpt():
+                active_config.extend({
+                    'dallinger_email_address': u'email',
+                    'contact_email_on_error': u'email',
+                    'dallinger_email_password': u'password'
+                })
                 sleep(5)
 
             with raises(SMTPAuthenticationError):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -18,7 +18,7 @@ from pytest import raises
 
 import dallinger.command_line
 from dallinger.command_line import verify_package
-from dallinger.command_line import timeout
+from dallinger.command_line import report_idle_after
 from dallinger.compat import unicode
 from dallinger.config import get_config
 from dallinger import recruiters
@@ -124,12 +124,8 @@ class TestCommandLine(object):
         subprocess.check_call(["dallinger", "setup"])
 
     def test_email_with_no_credentials(self):
-            @timeout(1)
+            @report_idle_after(1)
             def test_smpt():
-                config = get_config()
-                config.extend({'dallinger_email_address': u'email',
-                               'contact_email_on_error': u'email',
-                               'dallinger_email_password': u'password'})
                 sleep(5)
 
             with raises(SMTPAuthenticationError):

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -326,6 +326,10 @@ class TestEmailingHITMessager(object):
         assert data['subject'] == 'Dallinger automated email - major error.'
         assert 'Allowed time: 1.0' in data['message']
 
+    def test_send_idle_experiment(self, nonwhimsical):
+        data = nonwhimsical.send_idle_experiment()
+        assert data['subject'] == 'Idle Experiment.'
+
 
 class TestHerokuUtilFunctions(object):
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Email experimenters after app is left running for 6+ hours.

## Motivation and Context
Heroku applications are often left running by experimenters without them knowing. This is costly. Experimenters should be notified if there app is left running for a certain amount of time.

## How Has This Been Tested?
Tested using my email credentials in the config, entering the following keys:
`dallinger_email_address`, `contact_email_on_error`, `dallinger_email_password`
