### PR TITLE
Pin flake8 version in for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ whitelist_externals =
 commands =
     flake8
 deps =
-    flake8
+    flake8 == 3.4.1
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
## Description
`flake8` version needs to be explicitly pinned in tox.ini, otherwise the newest available version is used.