### PR TITLE
Fix test failure caused by MTurk service behavior change

### DIFF
--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -314,15 +314,21 @@ class MTurkService(object):
         duration_as_secs = int(duration_hours * 3600)
         try:
             self.mturk.extend_hit(hit_id, expiration_increment=duration_as_secs)
-        except MTurkRequestError:
+        except MTurkRequestError as ex:
             raise MTurkServiceException(
-                "Failed to extend time until expiration of HIT")
+                "Failed to extend time until expiration of HIT: {}".format(
+                    ex.message
+                )
+            )
 
         try:
             self.mturk.extend_hit(hit_id, assignments_increment=number)
-        except MTurkRequestError:
+        except MTurkRequestError as ex:
             raise MTurkServiceException(
-                "Error: failed to add {} assignments to HIT".format(number))
+                "Error: failed to add {} assignments to HIT: {}".format(
+                    number, ex.message
+                )
+            )
 
         updated_hit = self.mturk.get_hit(hit_id)[0]
 


### PR DESCRIPTION
MTurk now has a short delay between the time a HIT is created and when it can be extended. This PR updates the tests to account for this. Once on master this should be cherry-picked or rebased into development.