### PR TITLE
Bug fixes to config and submitResponses

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -237,16 +237,14 @@ var create_participant = function() {
 var lock = false;
 
 var submitResponses = function () {
-    submitNextResponse(0);
-    submitAssignment();
+    submitNextResponse(0, submitAssignment);
 };
 
 var submit_responses = function () {
     submitResponses();
-    submitAssignment();
 };
 
-var submitNextResponse = function (n) {
+var submitNextResponse = function (n, callback = function() {}) {
 
     // Get all the ids.
     var ids = $("form .question select, input, textarea").map(
@@ -267,6 +265,8 @@ var submitNextResponse = function (n) {
         success: function() {
             if (n <= ids.length) {
                 submitNextResponse(n + 1);
+            } else {
+                callback();
             }
         },
         error: function (err) {
@@ -274,6 +274,7 @@ var submitNextResponse = function (n) {
             if (errorResponse.hasOwnProperty("html")) {
                 $("body").html(errorResponse.html);
             }
+            callback();
         }
     });
 };

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -64,7 +64,7 @@ Built-in configuration parameters include:
 ``auto_recruit``
     Whether recruitment should be automatic.
 
-``group``
+``group_name``
     A string. *Unicode string*.
 
 ``loglevel``


### PR DESCRIPTION
Fixed typo in configuration.rst and fixed bug in submitResponses

## Description
Changed "group" to "group_name" per usage in https://github.com/Dallinger/Dallinger/pull/578

Added submitAssignment to a callback function in submitResponses

## Motivation and Context
Fixed typo

submitResponses used in the questionnaire was not working properly. The call to submitAssignment was not used in a callback function, so the page sometimes redirected before submitted all questions.

## How Has This Been Tested?
Jordan says config variable name was an error..

I have only tested my edits to submitResponses locally.


