### PR TITLE
Missed a spot when working on recruiter design earlier

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1381,16 +1381,12 @@ def _worker_complete(unique_id):
     session.add(participant)
     session.commit()
     config = _config()
-    recruiter = config.get('recruiter', 'mturk')
-    mode = config.get('mode')
-    if recruiter == 'mturk' and mode != 'debug':
-        # MTurk sends its own notifications
-        return
 
-    if recruiter == 'bots':
-        event_type = 'BotAssignmentSubmitted'
-    else:
-        event_type = 'AssignmentSubmitted'
+    recruiter = recruiters.from_config(config)
+    event_type = recruiter.submitted_event()
+
+    if event_type is None:
+        return
 
     _handle_worker_event(
         assignment_id=participant.assignment_id,

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -229,6 +229,11 @@ class MTurkRecruiter(Recruiter):
             self.config.get('aws_secret_access_key'),
             self.config.get('mode') != u"live"
         )
+        self._validate_conifg()
+
+    def _validate_conifg(self):
+        if self.config.get('mode') not in (u'sandbox', u'live'):
+            raise MTurkRecruiterException("Can't run an MTurk HIT in debug mode.")
 
     @property
     def external_submission_url(self):
@@ -255,8 +260,6 @@ class MTurkRecruiter(Recruiter):
             # Already started... do nothing.
             return None
 
-        if self.config.get('mode') == 'debug':
-            raise MTurkRecruiterException("Can't run a HIT in debug mode")
         if self.hit_domain is None:
             raise MTurkRecruiterException("Can't run a HIT from localhost")
 
@@ -338,12 +341,9 @@ class MTurkRecruiter(Recruiter):
             )
 
     def submitted_event(self):
-        """If we're in debug mode, we want to process an AssignmentSubmitted
-        event. Otherwise, MTurk will send its own notification when the worker
+        """MTurk will send its own notification when the worker
         completes the HIT on that service.
         """
-        if self.config.get('mode') == 'debug':
-            return 'AssignmentSubmitted'
         return None
 
     def reward_bonus(self, assignment_id, amount, reason):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -85,6 +85,13 @@ class Recruiter(object):
         """
         return None
 
+    def submitted_event(self):
+        """Return the appropriate event type to trigger when
+        an assignment is submitted. If no event should be processed,
+        return None.
+        """
+        return 'AssignmentSubmitted'
+
 
 class CLIRecruiter(Recruiter):
     """A recruiter which prints out /ad URLs to the console for direct
@@ -330,6 +337,15 @@ class MTurkRecruiter(Recruiter):
                 "on MTurk and can no longer submit the questionnaire"
             )
 
+    def submitted_event(self):
+        """If we're in debug mode, we want to process an AssignmentSubmitted
+        event. Otherwise, MTurk will send its own notification when the worker
+        completes the HIT on that service.
+        """
+        if self.config.get('mode') == 'debug':
+            return 'AssignmentSubmitted'
+        return None
+
     def reward_bonus(self, assignment_id, amount, reason):
         """Reward the Turker for a specified assignment with a bonus."""
         try:
@@ -464,6 +480,9 @@ class BotRecruiter(Recruiter):
         logger.info(
             "Bots don't get bonuses. Sorry, bots."
         )
+
+    def submitted_event(self):
+        return 'BotAssignmentSubmitted'
 
     def _get_bot_factory(self):
         # Must be imported at run-time

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -275,7 +275,7 @@ class TestBotRecruiter(object):
 class TestMTurkRecruiter(object):
 
     @pytest.fixture
-    def recruiter(self):
+    def recruiter(self, active_config):
         from dallinger.mturk import MTurkService
         from dallinger.recruiters import MTurkRecruiter
         with mock.patch.multiple('dallinger.recruiters',
@@ -284,11 +284,11 @@ class TestMTurkRecruiter(object):
             mocks['get_base_url'].return_value = 'http://fake-domain'
             mocks['os'].getenv.return_value = 'fake-host-domain'
             mockservice = mock.create_autospec(MTurkService)
+            active_config.extend({'mode': u'sandbox'})
             r = MTurkRecruiter()
             r.mturkservice = mockservice('fake key', 'fake secret')
             r.mturkservice.check_credentials.return_value = True
             r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
-            r.config.set('mode', u'sandbox')
             return r
 
     def test_config_passed_to_constructor_sandbox(self, recruiter):
@@ -318,12 +318,6 @@ class TestMTurkRecruiter(object):
         recruiter.hit_domain = None
         with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment(n=1)
-
-    def test_open_recruitment_raises_in_debug_mode(self, recruiter):
-        from dallinger.recruiters import MTurkRecruiterException
-        recruiter.config.set('mode', u'debug')
-        with pytest.raises(MTurkRecruiterException):
-            recruiter.open_recruitment()
 
     def test_open_recruitment_check_creds_before_calling_create_hit(self, recruiter):
         recruiter.open_recruitment(n=1)
@@ -392,13 +386,8 @@ class TestMTurkRecruiter(object):
 
         recruiter.mturkservice.check_credentials.assert_not_called()
 
-    def test_supresses_assignment_submitted_when_not_debug(self, recruiter):
-        recruiter.config.set('mode', u'anything but debug')
+    def test_supresses_assignment_submitted(self, recruiter):
         assert recruiter.submitted_event() is None
-
-    def test_returns_submission_event_type_when_in_debug(self, recruiter):
-        recruiter.config.set('mode', u'debug')
-        assert recruiter.submitted_event() is 'AssignmentSubmitted'
 
     def test_current_hit_id_with_active_experiment(self, a, recruiter):
         a.participant(hit_id=u'the hit!')
@@ -524,7 +513,7 @@ class TestMTurkRecruiter(object):
 class TestMTurkLargeRecruiter(object):
 
     @pytest.fixture
-    def recruiter(self):
+    def recruiter(self, active_config):
         from dallinger.mturk import MTurkService
         from dallinger.recruiters import MTurkLargeRecruiter
         with mock.patch.multiple('dallinger.recruiters',
@@ -533,11 +522,11 @@ class TestMTurkLargeRecruiter(object):
             mocks['get_base_url'].return_value = 'http://fake-domain'
             mocks['os'].getenv.return_value = 'fake-host-domain'
             mockservice = mock.create_autospec(MTurkService)
+            active_config.extend({'mode': u'sandbox'})
             r = MTurkLargeRecruiter()
             r.mturkservice = mockservice('fake key', 'fake secret')
             r.mturkservice.check_credentials.return_value = True
             r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
-            r.config.set('mode', u'sandbox')
             return r
 
     def test_open_recruitment_single_recruitee(self, recruiter):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -53,6 +53,13 @@ class TestModuleFunctions(object):
         r = mod.from_config(active_config)
         assert isinstance(r, mod.MTurkRecruiter)
 
+    def test_replay_setting_dictates_recruiter(self, mod, active_config):
+        active_config.extend(
+            {'replay': True, 'mode': u'sandbox', 'recruiter': u'CLIRecruiter'}
+        )
+        r = mod.from_config(active_config)
+        assert isinstance(r, mod.HotAirRecruiter)
+
     def test_unknown_recruiter_name_raises(self, mod, stub_config):
         stub_config.extend({'mode': u'sandbox', 'recruiter': u'bogus'})
         with pytest.raises(NotImplementedError):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -149,6 +149,9 @@ class TestCLIRecruiter(object):
         result = recruiter.open_recruitment()
         assert 'mode=new_mode' in result['items'][0]
 
+    def test_returns_standard_submission_event_type(self, recruiter):
+        assert recruiter.submitted_event() is 'AssignmentSubmitted'
+
 
 @pytest.mark.usefixtures('active_config')
 class TestHotAirRecruiter(object):
@@ -198,6 +201,9 @@ class TestHotAirRecruiter(object):
         result = recruiter.open_recruitment()
         assert 'mode=debug' in result['items'][0]
 
+    def test_returns_standard_submission_event_type(self, recruiter):
+        assert recruiter.submitted_event() is 'AssignmentSubmitted'
+
 
 class TestSimulatedRecruiter(object):
 
@@ -217,6 +223,9 @@ class TestSimulatedRecruiter(object):
 
     def test_open_recruitment_multiple_returns_empty_result(self, recruiter):
         assert recruiter.open_recruitment(n=3)['items'] == []
+
+    def test_returns_standard_submission_event_type(self, recruiter):
+        assert recruiter.submitted_event() is 'AssignmentSubmitted'
 
 
 class TestBotRecruiter(object):
@@ -257,6 +266,9 @@ class TestBotRecruiter(object):
 
     def test_reward_bonus(self, recruiter):
         recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
+
+    def test_returns_specific_submission_event_type(self, recruiter):
+        assert recruiter.submitted_event() is 'BotAssignmentSubmitted'
 
 
 @pytest.mark.usefixtures('active_config')
@@ -379,6 +391,14 @@ class TestMTurkRecruiter(object):
         recruiter.open_recruitment()
 
         recruiter.mturkservice.check_credentials.assert_not_called()
+
+    def test_supresses_assignment_submitted_when_not_debug(self, recruiter):
+        recruiter.config.set('mode', u'anything but debug')
+        assert recruiter.submitted_event() is None
+
+    def test_returns_submission_event_type_when_in_debug(self, recruiter):
+        recruiter.config.set('mode', u'debug')
+        assert recruiter.submitted_event() is 'AssignmentSubmitted'
 
     def test_current_hit_id_with_active_experiment(self, a, recruiter):
         a.participant(hit_id=u'the hit!')


### PR DESCRIPTION
Move forward a bit more on recruiter separation of concerns:

* experiment_server delegates to recruiter to know what kind of worker submission event to process
* running the MTurkRecruiter in debug mode isn't actually possible, so fail early if that's somehow attempted, and clean up code which later checked for that condition