### PR TITLE
Corrected configuration.rst: 'group' variable -> 'group_name'

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -64,7 +64,7 @@ Built-in configuration parameters include:
 ``auto_recruit``
     Whether recruitment should be automatic.
 
-``group``
+``group_name``
     A string. *Unicode string*.
 
 ``loglevel``


### PR DESCRIPTION
Resubmitting pull request for group config edit

## Description
Changed "group" to "group_name" per usage in #578

## Motivation and Context
Fixed typo

## How Has This Been Tested?
Jordan says config variable name was an error.

