### PR TITLE
Fixed bug in submitResponses

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -258,7 +258,7 @@ var submit_responses = function () {
     submitResponses();
 };
 
-var submitNextResponse = function (n, callback = function(){}) {
+var submitNextResponse = function (n, callback) {
 
     // Get all the ids.
     var ids = $("form .question select, input, textarea").map(
@@ -280,7 +280,9 @@ var submitNextResponse = function (n, callback = function(){}) {
             if (n <= ids.length) {
                 submitNextResponse(n + 1, callback);
             } else {
-                callback();
+                if(callback) {
+                    callback();
+                }
             }
         },
         error: function (err) {
@@ -288,7 +290,9 @@ var submitNextResponse = function (n, callback = function(){}) {
             if (errorResponse.hasOwnProperty("html")) {
                 $("body").html(errorResponse.html);
             }
-            callback();
+            if(callback) {
+                callback();
+            }
         }
     });
 };

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -251,16 +251,14 @@ var create_participant = function() {
 var lock = false;
 
 var submitResponses = function () {
-    submitNextResponse(0);
-    submitAssignment();
+    submitNextResponse(0, submitAssignment);
 };
 
 var submit_responses = function () {
     submitResponses();
-    submitAssignment();
 };
 
-var submitNextResponse = function (n) {
+var submitNextResponse = function (n, callback = function(){}) {
 
     // Get all the ids.
     var ids = $("form .question select, input, textarea").map(
@@ -280,7 +278,9 @@ var submitNextResponse = function (n) {
         },
         success: function() {
             if (n <= ids.length) {
-                submitNextResponse(n + 1);
+                submitNextResponse(n + 1, callback);
+            } else {
+                callback();
             }
         },
         error: function (err) {
@@ -288,6 +288,7 @@ var submitNextResponse = function (n) {
             if (errorResponse.hasOwnProperty("html")) {
                 $("body").html(errorResponse.html);
             }
+            callback();
         }
     });
 };


### PR DESCRIPTION
Edited submitResponses function to remove incorrect asynchronous call to submitAssignment 

## Description
Added submitAssignment as a callback function in submitResponses

## Motivation and Context
submitResponses used in the questionnaire was not working properly. The call to submitAssignment was not used in a callback function, so the page sometimes redirected before submitted all questions.

## How Has This Been Tested?
Untested.. unless there are already tests for submitResponses?

