### PR TITLE
Change questionnaire bot

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -109,7 +109,7 @@ class BotBase(object):
         """Submit questionnaire and finish."""
         try:
             feedback = WebDriverWait(self.driver, 10).until(
-                EC.element_to_be_clickable((By.ID, 'submit-questionnaire')))
+                EC.presence_of_element_located((By.ID, 'submit-questionnaire')))
             self.complete_questionnaire()
             feedback.click()
             logger.info("Clicked submit questionnaire button.")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Griduniverse bot test fails due to new updates to the questionnaire requiring all questions to be filled out before submission. Changing the base bot class in order for this to work.

## How Has This Been Tested?
Tested with `python demo.py`