### PR TITLE
Corrected error in configuration.rst: 'group' variable -> 'group_name' (2)

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -64,7 +64,7 @@ Built-in configuration parameters include:
 ``auto_recruit``
     Whether recruitment should be automatic.
 
-``group``
+``group_name``
     A string. *Unicode string*.
 
 ``loglevel``


### PR DESCRIPTION
I made a new PR because the tests were failing due to permission errors on @pkrafft's forked PR #797