### PR TITLE
Echo git output from Heroku in verbose mode

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -65,8 +65,6 @@ class GitError(Exception):
 class GitClient(object):
     """Minimal wrapper, mostly for mocking"""
 
-    _sp_out = subprocess.PIPE
-
     def __init__(self, output=None):
         if output is None:
             self.out = sys.stdout

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -265,10 +265,11 @@ class TestGitClient(object):
         assert ex_info.match('Not a git repository')
 
     def test_can_use_alternate_output(self, git):
-        out = mock.Mock(spec=file)
-        git.out = out
+        import tempfile
+        git.out = tempfile.NamedTemporaryFile()
         git.init()
-        out.write.assert_called()
+        git.out.seek(0)
+        assert "git init" in git.out.read()
 
 
 @pytest.fixture


### PR DESCRIPTION
Restore verbose Git output from sandbox and production deployment.

## Motivation and Context
Errors which occur during experiment startup (debug, sandbox, or production deployment) can be very mysterious and hard to debug unless printed error information is specific and related to the actual problem.

A previous change improved error handling of Git commands by capturing the error output and including it in an exception message during deployment. However, a side-effect of this change was to suppress the vast amount of standard output from this command, leading to confusion about whether the command was actually processing, or hung.

This PR attempts to restore the output stream while retaining the improved exception handling.

## How Has This Been Tested?
* automated tests
* ran `dallinger sandbox --verbose` with Griduniverse, and verified the verbose output from the `git push` command:
```
❯❯ Pushing code to Heroku...
GitClient: "git push heroku HEAD:master"
Counting objects: 75, done.
Delta compression using up to 4 threads.
Compressing objects: 100% (67/67), done.
Writing objects: 100% (75/75), 709.26 KiB | 0 bytes/s, done.
Total 75 (delta 4), reused 0 (delta 0)
remote: Compressing source files... done.
remote: Building source:
remote:
remote: -----> Python app detected
remote: -----> Installing runtime (python-2.7.13)
remote: -----> Installing dependencies with pip
...
```
* commented out the `git init` command from `deploy_sandbox_shared_setup` and ran `dallinger sandbox --verbose` to verify that the useful exception message was still present when `git push` is later called without a repository present:

```
...
  File "/Users/jesses/py_dev/Dallinger2/dallinger/command_line.py", line 509, in deploy_sandbox_shared_setup
    git.add("config.txt")
  File "/Users/jesses/py_dev/Dallinger2/dallinger/utils.py", line 83, in add
    self._run(["git", "add", what])
  File "/Users/jesses/py_dev/Dallinger2/dallinger/utils.py", line 97, in _run
    raise GitError(e.message)
dallinger.utils.GitError: Command: "git add config.txt": Error: "fatal: Not a git repository (or any of the parent directories): .git"
```

## Notes
The PR solves the problem by attempting to first run `subprocess.check_call()`, which writes output to the provided file handle in real time, and then if this fails, runs the same command with `subprocess.Popen()`, which returns error information. This relies on an assumption that the call to `Popen()` will always fail for the same reason that `check_call()` did. The double call feels hacky, but I wasn't able to find an alternative solution.
