### PR TITLE
Redo pr 715

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -23,10 +23,12 @@ class BotBase(object):
         parts = urlparse(URL)
         query = parse_qs(parts.query)
         if not assignment_id:
-            assignment_id = query.get('assignmentId', [''])[0]
+            assignment_id = query.get('assignment_id', [''])[0]
+        if not participant_id:
+            participant_id = query.get('participant_id', [''])[0]
         self.assignment_id = assignment_id
         if not worker_id:
-            worker_id = query.get('workerId', [''])[0]
+            worker_id = query.get('worker_id', [''])[0]
         self.worker_id = worker_id
         self.unique_id = worker_id + ':' + assignment_id
 
@@ -124,11 +126,11 @@ class BotBase(object):
     def complete_experiment(self, status):
         url = self.driver.current_url
         p = urlparse(url)
-        complete_url = '%s://%s/%s?uniqueId=%s'
+        complete_url = '%s://%s/%s?participant_id=%s'
         complete_url = complete_url % (p.scheme,
                                        p.netloc,
                                        status,
-                                       self.unique_id)
+                                       self.participant_id)
         self.driver.get(complete_url)
         logger.info("Forced call to %s: %s" % (status, complete_url))
 

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__file__)
 class BotBase(object):
     """A base class for Bots that works with the built-in demos."""
 
-    def __init__(self, URL, assignment_id='', worker_id=''):
+    def __init__(self, URL, assignment_id='', worker_id='', participant_id=''):
         logger.info("Creating bot with URL: %s." % URL)
         self.URL = URL
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1353,7 +1353,7 @@ def check_for_duplicate_assignments(participant):
 @db.scoped_session_decorator
 def worker_complete():
     """Complete worker."""
-    participant_id = request.args.get('participantId')
+    participant_id = request.args.get('participant_id')
     if not participant_id:
         return error_response(
             error_type="bad request",
@@ -1396,7 +1396,7 @@ def _worker_complete(participant_id):
 @db.scoped_session_decorator
 def worker_failed():
     """Fail worker. Used by bots only for now."""
-    participant_id = request.args.get('participantId')
+    participant_id = request.args.get('participant_id')
     if not participant_id:
         return error_response(
             error_type="bad request",

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1353,7 +1353,7 @@ def check_for_duplicate_assignments(participant):
 @db.scoped_session_decorator
 def worker_complete():
     """Complete worker."""
-    participant_id = request.args.get('participant_id')
+    participant_id = request.args.get('participantId')
     if not participant_id:
         return error_response(
             error_type="bad request",
@@ -1396,7 +1396,7 @@ def _worker_complete(participant_id):
 @db.scoped_session_decorator
 def worker_failed():
     """Fail worker. Used by bots only for now."""
-    participant_id = request.args.get('participant_id')
+    participant_id = request.args.get('participantId')
     if not participant_id:
         return error_response(
             error_type="bad request",

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1353,23 +1353,23 @@ def check_for_duplicate_assignments(participant):
 @db.scoped_session_decorator
 def worker_complete():
     """Complete worker."""
-    unique_id = request.args.get('uniqueId')
-    if not unique_id:
+    participant_id = request.args.get('participantId')
+    if not participant_id:
         return error_response(
             error_type="bad request",
-            error_text=u'uniqueId parameter is required'
+            error_text=u'participantId parameter is required'
         )
 
     try:
-        _worker_complete(unique_id)
+        _worker_complete(participant_id)
     except KeyError:
-        return error_response(error_type='UniqueId not found: {}'.format(unique_id))
+        return error_response(error_type='ParticipantId not found: {}'.format(participant_id))
 
     return success_response(status="success")
 
 
-def _worker_complete(unique_id):
-    participants = models.Participant.query.filter_by(unique_id=unique_id).all()
+def _worker_complete(participant_id):
+    participants = models.Participant.query.filter_by(id=participant_id).all()
     if not participants:
         raise KeyError()
 
@@ -1396,26 +1396,26 @@ def _worker_complete(unique_id):
 @db.scoped_session_decorator
 def worker_failed():
     """Fail worker. Used by bots only for now."""
-    unique_id = request.args.get('uniqueId')
-    if not unique_id:
+    participant_id = request.args.get('participantId')
+    if not participant_id:
         return error_response(
             error_type="bad request",
-            error_text=u'uniqueId parameter is required'
+            error_text=u'participantId parameter is required'
         )
 
     try:
-        _worker_failed(unique_id)
+        _worker_failed(participant_id)
     except KeyError:
-        return error_response(error_type='UniqueId not found: {}'.format(unique_id))
+        return error_response(error_type='ParticipantId not found: {}'.format(participant_id))
 
     return success_response(field="status",
                             data="success",
                             request_type="worker failed")
 
 
-def _worker_failed(unique_id):
+def _worker_failed(participant_id):
     config = _config()
-    participants = models.Participant.query.filter_by(unique_id=unique_id).all()
+    participants = models.Participant.query.filter_by(id=participant_id).all()
     if not participants:
         raise KeyError()
 

--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -145,39 +145,23 @@ var go_to_page = function(page) {
 
 // report assignment complete
 var submitAssignment = function() {
-    var deferred = $.Deferred();
     reqwest({
-        url: "/participant/" + participant_id,
+        url: '/worker_complete',
         method: "get",
         type: "json",
+        data: {
+            "participantId": participant_id,
+        },
         success: function (resp) {
-            mode = resp.participant.mode;
-            hit_id = resp.participant.hit_id;
-            assignment_id = resp.participant.assignment_id;
-            worker_id = resp.participant.worker_id;
-            var worker_complete = '/worker_complete';
-            reqwest({
-                url: worker_complete,
-                method: "get",
-                type: "json",
-                data: {
-                    "uniqueId": worker_id + ":" + assignment_id
-                },
-                success: function (resp) {
-                    deferred.resolve();
-                    allow_exit();
-                    window.location = "/complete";
-                },
-                error: function (err) {
-                    deferred.reject();
-                    console.log(err);
-                    var errorResponse = JSON.parse(err.response);
-                    $("body").html(errorResponse.html);
-                }
-            });
+            allow_exit();
+            window.location = "/complete";
+        },
+        error: function (err) {
+            console.log(err);
+            var errorResponse = JSON.parse(err.response);
+            $("body").html(errorResponse.html);
         }
     });
-    return deferred;
 };
 
 var submit_assignment = function () {

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -140,7 +140,7 @@ var dallinger = (function () {
       dlgr.identity.workerId = resp.participant.worker_id;
       var workerComplete = '/worker_complete';
       dlgr.get('/worker_complete', {
-        'uniqueId': dlgr.identity.workerId + ":" + dlgr.identity.assignmentId
+        'participant_id': dlgr.identity.participantId
       }).done(function (resp) {
         deferred.resolve();
         dallinger.allowExit();

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -155,9 +155,7 @@ class Participant(Base, SharedMixin):
         return {
             "id": self.id,
             "type": self.type,
-            "worker_id": self.worker_id,
             "assignment_id": self.assignment_id,
-            "unique_id": self.unique_id,
             "hit_id": self.hit_id,
             "mode": self.mode,
             "end_time": self.end_time,

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -208,50 +208,50 @@ class TestWorkerComplete(object):
     def test_with_no_participant_id_returns_error(self, webapp):
         resp = webapp.get('/worker_complete')
         assert resp.status_code == 400
-        assert 'uniqueId parameter is required' in resp.data
+        assert 'participantId parameter is required' in resp.data
 
     def test_with_invalid_participant_id_returns_error(self, webapp):
-        resp = webapp.get('/worker_complete?uniqueId=nonsense')
+        resp = webapp.get('/worker_complete?participantId=-1')
         assert resp.status_code == 400
-        assert 'UniqueId not found: nonsense' in resp.data
+        assert 'ParticipantId not found: -1' in resp.data
 
     def test_with_valid_participant_id_returns_success(self, a, webapp):
-        resp = webapp.get('/worker_complete?uniqueId={}'.format(
-            a.participant().unique_id)
+        resp = webapp.get('/worker_complete?participantId={}'.format(
+            a.participant().id)
         )
         assert resp.status_code == 200
 
     def test_sets_end_time(self, a, webapp, db_session):
         participant = a.participant()
-        webapp.get('/worker_complete?uniqueId={}'.format(
-            participant.unique_id)
+        webapp.get('/worker_complete?participantId={}'.format(
+            participant.id)
         )
         assert db_session.merge(participant).end_time is not None
 
     def test_records_notification_if_debug_mode(self, a, webapp):
-        webapp.get('/worker_complete?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_complete?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
 
     def test_records_notification_if_bot_recruiter(self, a, webapp, active_config):
         active_config.extend({'recruiter': u'bots'})
-        webapp.get('/worker_complete?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_complete?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'BotAssignmentSubmitted'
 
     def test_records_no_notification_mturk_recruiter_and_nondebug(self, a, webapp, active_config):
         active_config.extend({'mode': u'sandbox'})
-        webapp.get('/worker_complete?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_complete?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.all() == []
 
     def test_records_notification_for_non_mturk_recruiter(self, a, webapp, active_config):
         active_config.extend({'mode': u'sandbox', 'recruiter': u'CLIRecruiter'})
-        webapp.get('/worker_complete?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_complete?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
 
@@ -262,36 +262,36 @@ class TestWorkerFailed(object):
     def test_with_no_participant_id_returns_error(self, webapp):
         resp = webapp.get('/worker_failed')
         assert resp.status_code == 400
-        assert 'uniqueId parameter is required' in resp.data
+        assert 'participantId parameter is required' in resp.data
 
     def test_with_invalid_participant_id_returns_error(self, webapp):
-        resp = webapp.get('/worker_failed?uniqueId=nonsense')
+        resp = webapp.get('/worker_failed?participantId=-1')
         assert resp.status_code == 400
-        assert 'UniqueId not found: nonsense' in resp.data
+        assert 'ParticipantId not found: -1' in resp.data
 
     def test_with_valid_participant_id_returns_success(self, a, webapp):
-        resp = webapp.get('/worker_failed?uniqueId={}'.format(
-            a.participant().unique_id)
+        resp = webapp.get('/worker_failed?participantId={}'.format(
+            a.participant().id)
         )
         assert resp.status_code == 200
 
     def test_sets_end_time(self, a, webapp, db_session):
         participant = a.participant()
-        webapp.get('/worker_failed?uniqueId={}'.format(
-            participant.unique_id)
+        webapp.get('/worker_failed?participantId={}'.format(
+            participant.id)
         )
         assert db_session.merge(participant).end_time is not None
 
     def test_records_notification_if_bot_recruiter(self, a, webapp, active_config):
         active_config.extend({'recruiter': u'bots'})
-        webapp.get('/worker_failed?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_failed?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'BotAssignmentRejected'
 
     def test_records_no_notification_if_mturk_recruiter(self, a, webapp):
-        webapp.get('/worker_failed?uniqueId={}'.format(
-            a.participant().unique_id)
+        webapp.get('/worker_failed?participantId={}'.format(
+            a.participant().id)
         )
         assert models.Notification.query.all() == []
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -211,46 +211,46 @@ class TestWorkerComplete(object):
         assert 'participantId parameter is required' in resp.data
 
     def test_with_invalid_participant_id_returns_error(self, webapp):
-        resp = webapp.get('/worker_complete?participantId=-1')
+        resp = webapp.get('/worker_complete?participant_id=-1')
         assert resp.status_code == 400
         assert 'ParticipantId not found: -1' in resp.data
 
     def test_with_valid_participant_id_returns_success(self, a, webapp):
-        resp = webapp.get('/worker_complete?participantId={}'.format(
+        resp = webapp.get('/worker_complete?participant_id={}'.format(
             a.participant().id)
         )
         assert resp.status_code == 200
 
     def test_sets_end_time(self, a, webapp, db_session):
         participant = a.participant()
-        webapp.get('/worker_complete?participantId={}'.format(
+        webapp.get('/worker_complete?participant_id={}'.format(
             participant.id)
         )
         assert db_session.merge(participant).end_time is not None
 
     def test_records_notification_if_debug_mode(self, a, webapp):
-        webapp.get('/worker_complete?participantId={}'.format(
+        webapp.get('/worker_complete?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
 
     def test_records_notification_if_bot_recruiter(self, a, webapp, active_config):
         active_config.extend({'recruiter': u'bots'})
-        webapp.get('/worker_complete?participantId={}'.format(
+        webapp.get('/worker_complete?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'BotAssignmentSubmitted'
 
     def test_records_no_notification_mturk_recruiter_and_nondebug(self, a, webapp, active_config):
         active_config.extend({'mode': u'sandbox'})
-        webapp.get('/worker_complete?participantId={}'.format(
+        webapp.get('/worker_complete?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.all() == []
 
     def test_records_notification_for_non_mturk_recruiter(self, a, webapp, active_config):
         active_config.extend({'mode': u'sandbox', 'recruiter': u'CLIRecruiter'})
-        webapp.get('/worker_complete?participantId={}'.format(
+        webapp.get('/worker_complete?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
@@ -265,32 +265,32 @@ class TestWorkerFailed(object):
         assert 'participantId parameter is required' in resp.data
 
     def test_with_invalid_participant_id_returns_error(self, webapp):
-        resp = webapp.get('/worker_failed?participantId=-1')
+        resp = webapp.get('/worker_failed?participant_id=-1')
         assert resp.status_code == 400
         assert 'ParticipantId not found: -1' in resp.data
 
     def test_with_valid_participant_id_returns_success(self, a, webapp):
-        resp = webapp.get('/worker_failed?participantId={}'.format(
+        resp = webapp.get('/worker_failed?participant_id={}'.format(
             a.participant().id)
         )
         assert resp.status_code == 200
 
     def test_sets_end_time(self, a, webapp, db_session):
         participant = a.participant()
-        webapp.get('/worker_failed?participantId={}'.format(
+        webapp.get('/worker_failed?participant_id={}'.format(
             participant.id)
         )
         assert db_session.merge(participant).end_time is not None
 
     def test_records_notification_if_bot_recruiter(self, a, webapp, active_config):
         active_config.extend({'recruiter': u'bots'})
-        webapp.get('/worker_failed?participantId={}'.format(
+        webapp.get('/worker_failed?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.one().event_type == u'BotAssignmentRejected'
 
     def test_records_no_notification_if_mturk_recruiter(self, a, webapp):
-        webapp.get('/worker_failed?participantId={}'.format(
+        webapp.get('/worker_failed?participant_id={}'.format(
             a.participant().id)
         )
         assert models.Notification.query.all() == []

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -707,3 +707,13 @@ class TestModels(object):
         assert len(participant.nodes(failed=True)) == 1
         assert len(participant.questions()) == 1
         assert participant.questions()[0].failed is True
+
+    def test_participant_json(self, db_session):
+        participant = models.Participant(
+            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+        db_session.add(participant)
+        db_session.commit()
+
+        # make sure private data is not in there
+        assert 'unique_id' not in participant.__json__()
+        assert 'worker_id' not in participant.__json__()


### PR DESCRIPTION
Created a new PR for story 47, because #715 was broken.

Description

Previously, worker_id and unique_id for any participant were visible in the public participant view. This PR removes that information from the view, while making sure other views that used that information continue to work as before.

Motivation and Context

Story 47.