### PR TITLE
Fix participant_id bug

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -29,6 +29,7 @@ class BotBase(object):
         self.assignment_id = assignment_id
         if not worker_id:
             worker_id = query.get('worker_id', [''])[0]
+        self.participant_id = participant_id
         self.worker_id = worker_id
         self.unique_id = worker_id + ':' + assignment_id
 


### PR DESCRIPTION
Small bug fix in bots.py

## Description
Make `participant_id` an attribute. 

## Motivation and Context
`participant_id` isn't being saved to the Bots object, so there's errors on looping bot.

## How Has This Been Tested?
Using interactive evolutionary algo on GU 