### PR TITLE
Fix waiting room bug

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -262,10 +262,6 @@ var dallinger = (function () {
       var n = data.n;
       var quorum = data.q;
       dlgr.updateProgressBar(n, quorum);
-      if (n >= quorum) {
-        if (n > quorum) dlgr.skip_experiment = true;
-        deferred.resolve();
-      }
     };
     return deferred;
   };

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -182,9 +182,9 @@ var dallinger = (function () {
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;
-          if (resp.quorum) {
-            if (resp.quorum.n === resp.quorum.q) {
-              if (resp.quorum.n > resp.quorum.q) skip_experiment = true;
+          if (resp.quorum && resp.quorum.n !== resp.quorum.q) {
+            if (resp.quorum.n > resp.quorum.q) {
+              dlgr.skip_experiment = true;
               // reached quorum; resolve immediately
               deferred.resolve();
             } else {
@@ -263,7 +263,7 @@ var dallinger = (function () {
       var quorum = data.q;
       dlgr.updateProgressBar(n, quorum);
       if (n >= quorum) {
-        if (n > quorum) skip_experiment = true;
+        if (n > quorum) dlgr.skip_experiment = true;
         deferred.resolve();
       }
     };

--- a/dallinger/frontend/templates/waiting.html
+++ b/dallinger/frontend/templates/waiting.html
@@ -18,7 +18,7 @@
           dallinger.allowExit();
           if (dallinger.skip_experiment) {
             $('.main_div').html('<p>The experiment has exceeded the maximum number of participants, your participation is not required. Click the button below to complete the HIT. You will be compensated as if you had completed the task.</p><button type="button" class="button btn-success">Complete</button>')
-            $('.main_div button').on('click', submit_assignment);
+            $('.main_div button').on('click', dallinger.submitAssignment);
           } else {
             dallinger.goToPage("exp");
           }


### PR DESCRIPTION
Fix small waiting room bug. Current behavior leaves over-recruited participants stuck in the waiting room. This fix attempts to make the intended behavior redirect over-recruited participants to the end of the experiment.

Tested with Griduniverse waiting room in debug mode.