### PR TITLE
Issues/823 info post details part b

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1068,30 +1068,19 @@ def info_post(node_id):
     # get the parameters and validate them
     contents = request_parameter(parameter="contents")
     details = request_parameter(parameter="details", optional=True)
-    if details:
-        details = loads(details)
-
-    # Special case for TrackingEvents. TODO: moveme
-    if request_parameter(parameter="info_type") == 'TrackingEvent':
-        db.logger.debug('rq: Queueing %s with for node: %s for worker_function',
-                        'TrackingEvent', node_id)
-        q.enqueue(worker_function, 'TrackingEvent', None, None,
-                  node_id=node_id, details=details)
-        return success_response()
-
-    # Get info_type again, and this time, validate it along with the other
-    # parameters:
     info_type = request_parameter(parameter="info_type",
                                   parameter_type="known_class",
                                   default=models.Info)
     for x in [contents, details, info_type]:
         if type(x) == Response:
             return x
-
     # check the node exists
     node = models.Node.query.get(node_id)
     if node is None:
         return error_response(error_type="/info POST, node does not exist")
+
+    if details:
+        details = loads(details)
 
     exp = Experiment(session)
     try:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1065,8 +1065,6 @@ def info_post(node_id):
         if type(x) == Response:
             return x
 
-    if details:
-        details = loads(details)
     # check the node exists
     node = models.Node.query.get(node_id)
     if node is None:

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -715,16 +715,6 @@ class TestInfoRoutePOST(object):
         data = json.loads(resp.data)
         assert u'info' in data
 
-    def test_queues_tracking_event(self, a, webapp):
-        node = a.node()
-        data = {'contents': 'foo', 'info_type': 'TrackingEvent'}
-        resp = webapp.post(
-            '/info/{}'.format(node.id),
-            data=data
-        )
-        data = json.loads(resp.data)
-        assert data == {u'status': u'success'}
-
     def test_loads_details_json_value(self, a, webapp):
         node = a.node()
         data = {

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -758,6 +758,32 @@ class TestInfoRoutePOST(object):
         assert '/info POST server error' in resp.data
 
 
+@pytest.mark.usefixtures('experiment_dir', 'db_session')
+class TestTrackingEventRoutePOST(object):
+
+    def test_invalid_node_id_returns_error(self, webapp):
+        nonexistent_node_id = 999
+        data = {'details': '{"key": "value"}'}
+        resp = webapp.post(
+            '/tracking_event/{}'.format(nonexistent_node_id),
+            data=data
+        )
+        data = json.loads(resp.data)
+        assert data['status'] == 'error'
+        assert 'node does not exist' in data['html']
+
+    def test_loads_and_returns_details(self, a, webapp):
+        node = a.node()
+        data = {'details': '{"key": "value"}'}
+        resp = webapp.post(
+            '/tracking_event/{}'.format(node.id),
+            data=data
+        )
+        data = json.loads(resp.data)
+        assert data['status'] == u'success'
+        assert data['details'] == {u'key': u'value'}
+
+
 @pytest.mark.usefixtures('experiment_dir')
 class TestNodeNeighbors(object):
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -691,6 +691,52 @@ class TestNodeRoutePOST(object):
         assert 'recipient Node does not exist' in data['html']
 
 
+@pytest.mark.usefixtures('experiment_dir', 'db_session')
+class TestInfoRoutePOST(object):
+
+    def test_info_post_works_with_details_json_value(self, a, webapp):
+        node = a.node()
+        data = {
+            'contents': 'foo',
+            'info_type': 'Info',
+            'details': '{"key": "value"}'
+        }
+        resp = webapp.post(
+            '/info/{}'.format(node.id),
+            data=data
+        )
+        data = json.loads(resp.data)
+        assert data['info']['details'] == {u'key': u'value'}
+
+    def test_info_post_invalid_node_id_returns_error(self, webapp):
+        nonexistent_node_id = 999
+        data = {
+            'contents': 'foo',
+            'info_type': 'Info',
+            'details': '{"key": "value"}'
+        }
+        resp = webapp.post(
+            '/info/{}'.format(nonexistent_node_id),
+            data=data
+        )
+        data = json.loads(resp.data)
+        assert data['status'] == 'error'
+        assert 'node does not exist' in data['html']
+
+    def test_info_post_works_without_details_json_value(self, a, webapp):
+        node = a.node()
+        data = {
+            'contents': 'foo',
+            'info_type': 'Info',
+        }
+        resp = webapp.post(
+            '/info/{}'.format(node.id),
+            data=data
+        )
+        data = json.loads(resp.data)
+        assert data['info']['contents'] == u'foo'
+
+
 @pytest.mark.usefixtures('experiment_dir')
 class TestNodeNeighbors(object):
 


### PR DESCRIPTION
## Description
The TrackingEvent functionality is just bolted onto the side of the /info/ route, and shares almost nothing with the rest of the code in there. In the case when the info_type is "TrackingEvent", the route doesn't even create an Info object. This PR moves the TrackingEvent enqueuing functionality to a new route.

## How Has This Been Tested?
Automated tests only
