### PR TITLE
Robust recruiter

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -228,8 +228,7 @@ class MTurkRecruiterException(Exception):
 
 
 class MTurkRecruiter(Recruiter):
-    """Recruit participants from Amazon Mechanical Turk
-    
+    """Recruit participants from Amazon Mechanical Turk.
     If fewer than 9 assignments are made initially, recruitment stops after 9 
     calls to recruit()"""
 
@@ -447,6 +446,7 @@ class MTurkRecruiter(Recruiter):
 class MTurkRobustRecruiter(MTurkRecruiter):
     """Accommodates more than 9 calls to recruit() without forcing
     a large initial recruitment"""
+
 
     def recruit(self, n=1):
         

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -443,6 +443,13 @@ class MTurkRecruiter(Recruiter):
             except DuplicateQualificationNameError:
                 pass
 
+# TODO: expiring HITs on shutdown becomes more complicated here
+# because we have to go back and find all the HITs that have been
+# created. One solution could be to expire the last HIT when creating
+# a new one, but then we would have to require n=1 recruitments, which
+# places a constraint on what experimental designs can be used.  E.g.,
+# might want multiple participants will different HITs going in
+# parallel
 class MTurkRobustRecruiter(MTurkRecruiter):
     """Accommodates more than 9 calls to recruit() without forcing
     a large initial recruitment and avoiding higher fees"""

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -454,10 +454,7 @@ class MTurkRobustRecruiter(MTurkRecruiter):
     """Accommodates more than 9 calls to recruit() without forcing
     a large initial recruitment and avoiding higher fees"""
 
-<<<<<<< HEAD
 
-=======
->>>>>>> Fixing style errors
     def recruit(self, n=1):
 
         if not self.config.get('auto_recruit', False):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -229,7 +229,7 @@ class MTurkRecruiterException(Exception):
 
 class MTurkRecruiter(Recruiter):
     """Recruit participants from Amazon Mechanical Turk.
-    If fewer than 9 assignments are made initially, recruitment stops after 9 
+    If fewer than 9 assignments are made initially, recruitment stops after 9
     calls to recruit()"""
 
     nickname = 'mturk'
@@ -447,13 +447,16 @@ class MTurkRobustRecruiter(MTurkRecruiter):
     """Accommodates more than 9 calls to recruit() without forcing
     a large initial recruitment"""
 
+<<<<<<< HEAD
 
+=======
+>>>>>>> Fixing style errors
     def recruit(self, n=1):
-        
+
         if not self.config.get('auto_recruit', False):
             logger.info('auto_recruit is False: recruitment suppressed')
             return
-        
+
         hit_request = {
             'max_assignments': n,
             'title': self.config.get('title'),
@@ -468,12 +471,7 @@ class MTurkRobustRecruiter(MTurkRecruiter):
             'us_only': self.config.get('us_only'),
             'blacklist': self._config_to_list('qualification_blacklist'),
         }
-        hit_info = self.mturkservice.create_hit(**hit_request)
-        if self.config.get('mode') == "sandbox":
-            lookup_url = "https://workersandbox.mturk.com/mturk/preview?groupId={type_id}"
-        else:
-            lookup_url = "https://worker.mturk.com/mturk/preview?groupId={type_id}"
-
+        self.mturkservice.create_hit(**hit_request)
         return
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -462,6 +462,11 @@ class MTurkRobustRecruiter(MTurkRecruiter):
             logger.info('auto_recruit is False: recruitment suppressed')
             return
 
+        hit_id = self.current_hit_id()
+        if hit_id is None:
+            logger.info('no HIT in progress: recruitment aborted')
+            return
+
         hit_request = {
             'max_assignments': n,
             'title': self.config.get('title'),
@@ -476,8 +481,10 @@ class MTurkRobustRecruiter(MTurkRecruiter):
             'us_only': self.config.get('us_only'),
             'blacklist': self._config_to_list('qualification_blacklist'),
         }
-        self.mturkservice.create_hit(**hit_request)
-        return
+        try:
+            self.mturkservice.create_hit(**hit_request)
+        except MTurkServiceException as ex:
+            logger.exception(ex.message)
 
 
 class MTurkLargeRecruiter(MTurkRecruiter):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -443,6 +443,7 @@ class MTurkRecruiter(Recruiter):
             except DuplicateQualificationNameError:
                 pass
 
+
 # TODO: expiring HITs on shutdown becomes more complicated here
 # because we have to go back and find all the HITs that have been
 # created. One solution could be to expire the last HIT when creating
@@ -471,7 +472,7 @@ class MTurkRobustRecruiter(MTurkRecruiter):
             'lifetime_days': self.config.get('lifetime'),
             'ad_url': self.ad_url,
             'notification_url': self.config.get('notification_url'),
-            'approve_requirement': self.config.get('approve_requirement'),
+            'approve_requirement': self.co>nfig.get('approve_requirement'),
             'us_only': self.config.get('us_only'),
             'blacklist': self._config_to_list('qualification_blacklist'),
         }

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -228,7 +228,10 @@ class MTurkRecruiterException(Exception):
 
 
 class MTurkRecruiter(Recruiter):
-    """Recruit participants from Amazon Mechanical Turk"""
+    """Recruit participants from Amazon Mechanical Turk
+    
+    If fewer than 9 assignments are made initially, recruitment stops after 9 
+    calls to recruit()"""
 
     nickname = 'mturk'
 
@@ -442,7 +445,9 @@ class MTurkRecruiter(Recruiter):
                 pass
 
 class MTurkRobustRecruiter(MTurkRecruiter):
-
+    """Accommodates more than 9 calls to recruit() without forcing 
+    a large initial recruitment"""
+    
     def recruit(self, n=1):
         
         if not self.config.get('auto_recruit', False):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -445,7 +445,7 @@ class MTurkRecruiter(Recruiter):
 
 class MTurkRobustRecruiter(MTurkRecruiter):
     """Accommodates more than 9 calls to recruit() without forcing
-    a large initial recruitment"""
+    a large initial recruitment and avoiding higher fees"""
 
 <<<<<<< HEAD
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -441,6 +441,36 @@ class MTurkRecruiter(Recruiter):
             except DuplicateQualificationNameError:
                 pass
 
+class MTurkRobustRecruiter(MTurkRecruiter):
+
+    def recruit(self, n=1):
+        
+        if not self.config.get('auto_recruit', False):
+            logger.info('auto_recruit is False: recruitment suppressed')
+            return
+        
+        hit_request = {
+            'max_assignments': n,
+            'title': self.config.get('title'),
+            'description': self.config.get('description'),
+            'keywords': self._config_to_list('keywords'),
+            'reward': self.config.get('base_payment'),
+            'duration_hours': self.config.get('duration'),
+            'lifetime_days': self.config.get('lifetime'),
+            'ad_url': self.ad_url,
+            'notification_url': self.config.get('notification_url'),
+            'approve_requirement': self.config.get('approve_requirement'),
+            'us_only': self.config.get('us_only'),
+            'blacklist': self._config_to_list('qualification_blacklist'),
+        }
+        hit_info = self.mturkservice.create_hit(**hit_request)
+        if self.config.get('mode') == "sandbox":
+            lookup_url = "https://workersandbox.mturk.com/mturk/preview?groupId={type_id}"
+        else:
+            lookup_url = "https://worker.mturk.com/mturk/preview?groupId={type_id}"
+
+        return
+
 
 class MTurkLargeRecruiter(MTurkRecruiter):
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -445,9 +445,9 @@ class MTurkRecruiter(Recruiter):
                 pass
 
 class MTurkRobustRecruiter(MTurkRecruiter):
-    """Accommodates more than 9 calls to recruit() without forcing 
+    """Accommodates more than 9 calls to recruit() without forcing
     a large initial recruitment"""
-    
+
     def recruit(self, n=1):
         
         if not self.config.get('auto_recruit', False):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -556,6 +556,74 @@ class TestMTurkRecruiter(object):
 
 
 @pytest.mark.usefixtures('active_config')
+class TestMTurkRobustRecruiter(TestMTurkRecruiter):
+
+    @pytest.fixture
+    def recruiter(self, active_config):
+        from dallinger.mturk import MTurkService
+        from dallinger.recruiters import MTurkRobustRecruiter
+        with mock.patch.multiple('dallinger.recruiters',
+                                 os=mock.DEFAULT,
+                                 get_base_url=mock.DEFAULT) as mocks:
+            mocks['get_base_url'].return_value = 'http://fake-domain'
+            mocks['os'].getenv.return_value = 'fake-host-domain'
+            mockservice = mock.create_autospec(MTurkService)
+            active_config.extend({'mode': u'sandbox'})
+            r = MTurkRobustRecruiter()
+            r.mturkservice = mockservice('fake key', 'fake secret')
+            r.mturkservice.check_credentials.return_value = True
+            r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
+            return r
+
+    def test_recruit_auto_recruit_on_recruits_for_current_hit(self, recruiter):
+        fake_hit_id = 'fake HIT id'
+        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+        recruiter.recruit()
+        recruiter.mturkservice.create_hit.assert_called_once_with(
+            ad_url='http://fake-domain/ad',
+            approve_requirement=95,
+            description=u'fake HIT description',
+            duration_hours=1.0,
+            keywords=[u'kw1', u'kw2', u'kw3'],
+            lifetime_days=1,
+            max_assignments=1,
+            notification_url=u'https://url-of-notification-route',
+            reward=0.01,
+            title=u'fake experiment title',
+            us_only=True,
+            blacklist=[],
+        )
+        assert not recruiter.mturkservice.extend_hit.called
+
+
+    def test_recruit_auto_recruit_off_does_not_extend_hit(self, recruiter):
+        recruiter.config['auto_recruit'] = False
+        fake_hit_id = 'fake HIT id'
+        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+        recruiter.recruit()
+
+        assert not recruiter.mturkservice.extend_hit.called
+        assert not recruiter.mturkservice.create_hit.called        
+
+    def test_recruit_no_current_hit_does_not_extend_hit(self, recruiter):
+        recruiter.current_hit_id = mock.Mock(return_value=None)
+        recruiter.recruit()
+
+        assert not recruiter.mturkservice.extend_hit.called
+        assert not recruiter.mturkservice.create_hit.called
+
+    def test_recruit_create_hit_error_is_logged_politely(self, recruiter):
+        from dallinger.mturk import MTurkServiceException
+        fake_hit_id = 'fake HIT id'
+        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+        recruiter.mturkservice.create_hit.side_effect = MTurkServiceException("Boom!")
+        with mock.patch('dallinger.recruiters.logger') as mock_logger:
+            recruiter.recruit()
+
+        mock_logger.exception.assert_called_once_with("Boom!")
+
+
+@pytest.mark.usefixtures('active_config')
 class TestMTurkLargeRecruiter(object):
 
     @pytest.fixture

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -595,7 +595,6 @@ class TestMTurkRobustRecruiter(TestMTurkRecruiter):
         )
         assert not recruiter.mturkservice.extend_hit.called
 
-
     def test_recruit_auto_recruit_off_does_not_extend_hit(self, recruiter):
         recruiter.config['auto_recruit'] = False
         fake_hit_id = 'fake HIT id'
@@ -603,7 +602,7 @@ class TestMTurkRobustRecruiter(TestMTurkRecruiter):
         recruiter.recruit()
 
         assert not recruiter.mturkservice.extend_hit.called
-        assert not recruiter.mturkservice.create_hit.called        
+        assert not recruiter.mturkservice.create_hit.called
 
     def test_recruit_no_current_hit_does_not_extend_hit(self, recruiter):
         recruiter.current_hit_id = mock.Mock(return_value=None)

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -611,7 +611,7 @@ class TestMTurkRobustRecruiter(TestMTurkRecruiter):
         assert not recruiter.mturkservice.extend_hit.called
         assert not recruiter.mturkservice.create_hit.called
 
-    def test_recruit_create_hit_error_is_logged_politely(self, recruiter):
+    def test_recruit_extend_hit_error_is_logged_politely(self, recruiter):
         from dallinger.mturk import MTurkServiceException
         fake_hit_id = 'fake HIT id'
         recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)


### PR DESCRIPTION
## Description
Added recruiter that can be initialized with fewer than 9 assignments but still recruit more than 9 times.

## Motivation and Context
On MTurk, if a HIT is initially created with fewer than 9 assignments it cannot be extended beyond a total of 9 assignments.  This limit leads recruiting with the MTurkRecruiter to silently fail in Dallinger 3.4.1 after 9 calls to recruit(), which as far as I can tell is undocumented and was very hard to debug.  This new recruiter avoids this issue by submitting new HITs instead of extending the initial HIT.

## How Has This Been Tested?
Tested locally in Dallinger 3.4.1 and in test_recruiters.py
