### PR TITLE
Bugfix for #840 (hibernate when clock is off)

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -685,8 +685,7 @@ def hibernate(app):
 
     log("Scaling down the web servers...")
     heroku_app = HerokuApp(app)
-    for process in ["web", "worker", "clock"]:
-        heroku_app.scale_down_dyno(process)
+    heroku_app.scale_down_dynos()
 
     log("Removing addons...")
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -83,6 +83,12 @@ class HerokuApp(object):
         self._run(cmd)
 
     @property
+    def clock_is_on(self):
+        cmd = ["heroku", "ps:scale", "--app", self.name]
+        output = self._result(cmd)
+        return "clock=1" in output
+
+    @property
     def dashboard_url(self):
         return u"https://dashboard.heroku.com/apps/{}".format(self.name)
 
@@ -179,6 +185,16 @@ class HerokuApp(object):
             "ps:scale", "{}=0".format(process),
             "--app", self.name
         ])
+
+    def scale_down_dynos(self):
+        """Turn off web and worker dynos, plus clock process if
+        there is one and it's active.
+        """
+        processes = ["web", "worker"]
+        if self.clock_is_on:
+            processes.append("clock")
+        for process in processes:
+            self.scale_down_dyno(process)
 
     def set(self, key, value):
         """Configure an app key/value pair"""

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -920,11 +920,7 @@ class TestHibernate(object):
             hibernate,
             ['--app', 'some-app-uid', ]
         )
-        heroku.scale_down_dyno.assert_has_calls([
-            mock.call('web'),
-            mock.call('worker'),
-            mock.call('clock')
-        ])
+        heroku.scale_down_dynos.assert_called_once()
 
     def test_kills_addons(self, hibernate, heroku, data):
         CliRunner().invoke(


### PR DESCRIPTION
Bugfix: Allow `dallinger hibernate` to work when app's `clock_on` setting is `false`

## Motivation and Context
`dallinger hibernate` raised an exception when trying to scale down a non-existent `clock` process if this process was not enabled in the experiment config. This PR updates the scaling down of dyno procedure to first check if the clock process is running.

## How Has This Been Tested?
* Automated tests
* Ran Bartlett experiment with `clock_on = false`, and successfully hibernated experiment:
```
dallinger hibernate --app fbf4efbd-4f68-0e9a-26f3-31884d40e534

❯❯ The database backup URL is...

❯❯ https://dallinger-f6dff828.s3.amazonaws.com/fbf4efbd-4f68-0e9a-26f3-31884d40e534.dump

❯❯ Scaling down the web servers...
Scaling dynos... done, now running web at 0:Standard-2X
Scaling dynos... done, now running worker at 0:Standard-2X

❯❯ Removing addons...
Destroying postgresql-asymmetrical-63937 on ⬢ dlgr-fbf4efbd... done
Destroying redis-animate-48683 on ⬢ dlgr-fbf4efbd... done
```
