### PR TITLE
Improve error message on invalid recruitment mode

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -232,8 +232,12 @@ class MTurkRecruiter(Recruiter):
         self._validate_conifg()
 
     def _validate_conifg(self):
-        if self.config.get('mode') not in (u'sandbox', u'live'):
-            raise MTurkRecruiterException("Can't run an MTurk HIT in debug mode.")
+        mode = self.config.get('mode')
+        if mode not in (u'sandbox', u'live'):
+            raise MTurkRecruiterException(
+                '"{}" is not a valid mode for MTurk recruitment. '
+                'The value of "mode" must be either "sandbox" or "live"'.format(mode)
+            )
 
     @property
     def external_submission_url(self):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -301,6 +301,14 @@ class TestMTurkRecruiter(object):
             r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
             return r
 
+    def test_instantiation_fails_with_invalid_mode(self, active_config):
+        from dallinger.recruiters import MTurkRecruiter
+        from dallinger.recruiters import MTurkRecruiterException
+        active_config.extend({'mode': u'nonsense'})
+        with pytest.raises(MTurkRecruiterException) as ex_info:
+            MTurkRecruiter()
+        assert ex_info.match('"nonsense" is not a valid mode')
+
     def test_config_passed_to_constructor_sandbox(self, recruiter):
         assert recruiter.config.get('title') == 'fake experiment title'
 


### PR DESCRIPTION
More specific error message when invoking the MTurkRecruiter with an invalid mode setting. See Dallinger/Griduniverse/pull/159.