### PR TITLE
Fix fingerprint in deploy mode

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -589,7 +589,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     except MultipleResultsFound:
         fingerprint_found = True
 
-    if fingerprint_found:
+    if fingerprint_hash and fingerprint_found:
         db.logger.warning("Same browser fingerprint detected.")
 
         if mode == 'live':

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -155,21 +155,29 @@ var dallinger = (function () {
   };
 
   // make a new participant
-  dlgr.createParticipant = function() {
+var create_participant = function() {
     var url;
+
+    new Fingerprint2().get(function(result){
+      fingerprint_hash = result;
+      store.set("fingerprint_hash", fingerprint_hash)
+    });
+
     // check if the local store is available, and if so, use it.
-    if (typeof store !== "undefined") {
-      url = "/participant/" +
-        store.get("worker_id") + "/" +
-        store.get("hit_id") + "/" +
-        store.get("assignment_id") + "/" +
-        store.get("mode");
+    if (typeof store != "undefined") {
+        url = "/participant/" +
+            store.get("worker_id") + "/" +
+            store.get("hit_id") + "/" +
+            store.get("assignment_id") + "/" +
+            store.get("mode") + "?fingerprint_hash=" +
+            store.get("fingerprint_hash");
     } else {
-      url = "/participant/" +
-        dlgr.identity.workerId + "/" +
-        dlgr.identity.hitId + "/" +
-        dlgr.identity.assignmentId + "/" +
-        dlgr.identity.mode;
+        url = "/participant/" +
+            worker_id + "/" +
+            hit_id + "/" +
+            assignment_id + "/" +
+            mode + "?fingerprint_hash=" +
+            fingerprint_hash;
     }
 
     var deferred = $.Deferred();

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -173,10 +173,10 @@ var create_participant = function() {
             store.get("fingerprint_hash");
     } else {
         url = "/participant/" +
-            worker_id + "/" +
-            hit_id + "/" +
-            assignment_id + "/" +
-            mode + "?fingerprint_hash=" +
+            dlgr.identity.worker_id + "/" +
+            dlgr.identity.hit_id + "/" +
+            dlgr.identity.assignment_id + "/" +
+            dlgr.identity.mode + "?fingerprint_hash=" +
             fingerprint_hash;
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
See issue #827. Participants in deploy mode with null fingerprints are getting marked as the same fingerprint. 
