### PR TITLE
Fix format error in experiment_completed()

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -534,7 +534,7 @@ class Experiment(object):
         """Checks the current state of the experiment to see whether it has
         completed"""
         heroku_app = HerokuApp(self.app_id)
-        status_url = '/summary'.format(heroku_app.url)
+        status_url = '{}/summary'.format(heroku_app.url)
         data = {}
         try:
             resp = requests.get(status_url)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Small bug in string formatting leaves `experiment_completed()` in an endless loop when running the high level api in debug mode.


## Motivation and Context
See GU PR [#159](https://github.com/Dallinger/Griduniverse/pull/159)
