### PR TITLE
Prevent experiment destroy function

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -527,8 +527,9 @@ class Experiment(object):
             self.log("Waiting for experiment to complete.", "")
             while self.experiment_completed() is False:
                 time.sleep(30)
-            # self.end_experiment()
-        return self.retrieve_data()
+            data = self.retrieve_data()
+            self.end_experiment()
+        return data
 
     def experiment_completed(self):
         """Checks the current state of the experiment to see whether it has

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -527,7 +527,7 @@ class Experiment(object):
             self.log("Waiting for experiment to complete.", "")
             while self.experiment_completed() is False:
                 time.sleep(30)
-            self.end_experiment()
+            # self.end_experiment()
         return self.retrieve_data()
 
     def experiment_completed(self):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -522,13 +522,8 @@ class Experiment(object):
         return str(uuid.UUID(int=random.getrandbits(128)))
 
     def _finish_experiment(self):
-        # Debug runs synchronously
-        if self.exp_config.get('mode') != 'debug':
-            self.log("Waiting for experiment to complete.", "")
-            while self.experiment_completed() is False:
-                time.sleep(30)
-            data = self.retrieve_data()
-            self.end_experiment()
+        data = self.retrieve_data()
+        self.end_experiment()
         return data
 
     def experiment_completed(self):
@@ -556,6 +551,11 @@ class Experiment(object):
 
     def end_experiment(self):
         """Terminates a running experiment"""
+        # Debug runs synchronously
+        if self.exp_config.get('mode') != 'debug':
+            self.log("Waiting for experiment to complete.", "")
+            while self.experiment_completed() is False:
+                time.sleep(30)
         HerokuApp(self.app_id).destroy()
 
     def events_for_replay(self):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -470,8 +470,9 @@ class Experiment(object):
                 verbose=self.verbose,
                 exp_config=self.exp_config
             )
+        data = self.retrieve_data()
         self.end_experiment()
-        return self.retrieve_data()
+        return data
 
     def collect(self, app_id, exp_config=None, bot=False, **kwargs):
         """Collect data for the provided experiment id.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -470,7 +470,8 @@ class Experiment(object):
                 verbose=self.verbose,
                 exp_config=self.exp_config
             )
-        return self._finish_experiment()
+        self.end_experiment()
+        return self.retrieve_data()
 
     def collect(self, app_id, exp_config=None, bot=False, **kwargs):
         """Collect data for the provided experiment id.
@@ -521,11 +522,6 @@ class Experiment(object):
         """Generate a new uuid."""
         return str(uuid.UUID(int=random.getrandbits(128)))
 
-    def _finish_experiment(self):
-        data = self.retrieve_data()
-        self.end_experiment()
-        return data
-
     def experiment_completed(self):
         """Checks the current state of the experiment to see whether it has
         completed"""
@@ -556,7 +552,8 @@ class Experiment(object):
             self.log("Waiting for experiment to complete.", "")
             while self.experiment_completed() is False:
                 time.sleep(30)
-        HerokuApp(self.app_id).destroy()
+            HerokuApp(self.app_id).destroy()
+        return True
 
     def events_for_replay(self):
         """Be default we return all infos in order for replay"""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Similar to #863. Fix all bugs that prevent high level api automation of experiments

## Motivation and Context
The high level api is unable to work in sandbox/live mode because the experiment gets destroyed after it is finished. Is there a reason this line is in the code or is it a bug?