### PR TITLE
Refactor and fix retrieve_data bug

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -556,7 +556,7 @@ class Experiment(object):
         # experiment status
         if self.exp_config.get('mode') != 'debug':
             self.log("Waiting for experiment to complete.", "")
-            while self.experiment_completed() is False:
+            while not self.experiment_completed():
                 time.sleep(30)
         return True
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -483,7 +483,10 @@ class Experiment(object):
                 verbose=self.verbose,
                 exp_config=self.exp_config
             )
-        return self._finish_experiment()
+        self._await_completion()
+        data = self.retrieve_data()
+        self.end_experiment()
+        return data
 
     def collect(self, app_id, exp_config=None, bot=False, **kwargs):
         """Collect data for the provided experiment id.

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -10,6 +10,23 @@ class TestNetworks(object):
         net = models.Network()
         assert isinstance(net, models.Network)
 
+    def test_has_a_big_default_max_size(self, a):
+        assert a.network().max_size > 100000
+
+    def test_not_full_with_zero_nodes(self, a):
+        net = a.network(max_size=1)
+        assert not net.full
+
+    def test_not_full_if_nodes_fewer_than_max_size(self, a):
+        net = a.network(max_size=2)
+        nodes.Agent(network=net)
+        assert not net.full
+
+    def test_full_if_nodes_equal_max_size(self, a):
+        net = a.network(max_size=1)
+        nodes.Agent(network=net)
+        assert net.full
+
     def test_node_failure(self, db_session):
         net = networks.Network()
         db_session.add(net)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix `retrieve_data` to be called after the loop ends but before the experiment is destroyed... See: 
https://github.com/Dallinger/Dallinger/pull/866/files

## Problem
The high level api is unable to work in sandbox/live mode because the experiment gets destroyed after it is finished. Is there a reason this line is in the code or is it a bug?