### PR TITLE
Story #291: Better Error Handling

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -19,6 +19,7 @@ import tempfile
 import time
 import webbrowser
 
+from datetime import datetime
 from functools import wraps
 import signal
 import click
@@ -121,7 +122,7 @@ def report_idle_after(seconds):
                         "whimsical": False
                     }
                     app_id = config["id"]
-                    email = EmailingHITMessager(when=time, assignment_id=None,
+                    email = EmailingHITMessager(when=datetime.now(), assignment_id=None,
                                                 hit_duration=seconds, time_active=seconds,
                                                 config=heroku_config, app_id=app_id)
                     log("Sending email...")

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -229,6 +229,7 @@ def verify_package(verbose=True):
     files = [
         os.path.join("templates", "complete.html"),
         os.path.join("templates", "error.html"),
+        os.path.join("templates", "error-complete.html"),
         os.path.join("templates", "launch.html"),
         os.path.join("templates", "thanks.html"),
         os.path.join("static", "css", "dallinger.css"),
@@ -393,6 +394,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
         os.path.join("static", "scripts", "spin.min.js"),
         os.path.join("static", "scripts", "tracker.js"),
         os.path.join("templates", "error.html"),
+        os.path.join("templates", "error-complete.html"),
         os.path.join("templates", "launch.html"),
         os.path.join("templates", "complete.html"),
         os.path.join("templates", "questionnaire.html"),

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -111,7 +111,8 @@ def error_response(error_type="Internal server error",
                    error_text='',
                    status=400,
                    participant=None,
-                   simple=False):
+                   simple=False,
+                   request_data=''):
     """Return a generic server error response."""
     last_exception = sys.exc_info()
     if last_exception[0]:
@@ -126,32 +127,30 @@ def error_response(error_type="Internal server error",
     else:
         data["html"] = error_page(error_text=error_text,
                                   error_type=error_type,
-                                  participant=participant).get_data().decode('utf-8')
+                                  participant=participant,
+                                  request_data=request_data).get_data().decode('utf-8')
     return Response(dumps(data), status=status, mimetype='application/json')
 
 
 def error_page(participant=None, error_text=None, compensate=True,
-               error_type="default"):
+               error_type="default", request_data=''):
     """Render HTML for error page."""
     config = _config()
+
     if error_text is None:
-
         error_text = """There has been an error and so you are unable to
-        continue, sorry! If possible, please return the assignment so someone
-        else can work on it."""
-
-    if compensate:
-        error_text += """ Please use the information below to contact us
-        about compensation"""
+        continue, sorry!"""
 
     if participant is not None:
         hit_id = participant.hit_id,
         assignment_id = participant.assignment_id,
         worker_id = participant.worker_id
+        participant_id = participant.id
     else:
-        hit_id = 'unknown'
-        assignment_id = 'unknown'
-        worker_id = 'unknown'
+        hit_id = request.form.get('hit_id', '')
+        assignment_id = request.form.get('assignment_id', '')
+        worker_id = request.form.get('worker_id', '')
+        participant_id = request.form.get('participant_id', '')
 
     return make_response(
         render_template(
@@ -162,7 +161,9 @@ def error_page(participant=None, error_text=None, compensate=True,
             error_type=error_type,
             hit_id=hit_id,
             assignment_id=assignment_id,
-            worker_id=worker_id
+            worker_id=worker_id,
+            request_data=request_data,
+            participant_id=participant_id
         ),
         500,
     )
@@ -230,6 +231,85 @@ def inject_experiment():
     return dict(
         experiment=exp,
         env=os.environ,
+    )
+
+
+@app.route('/error-page', methods=['POST', 'GET'])
+def render_error():
+    request_data = request.form.get("request_data")
+    participant_id = request.form.get("participant_id")
+    participant = None
+    if participant_id:
+        participant = models.Participant.query.get(participant_id)
+    return error_page(
+        participant=participant,
+        request_data=request_data,
+    )
+
+
+@app.route('/handle-error', methods=['POST'])
+def handle_error():
+    config = _config()
+    request_data = request.form.get("request_data")
+    error_feedback = request.form.get("error_feedback")
+    error_type = request.form.get("error_type")
+    error_text = request.form.get("error_text")
+    worker_id = request.form.get("worker_id")
+    assignment_id = request.form.get("assignment_id")
+    participant_id = request.form.get("participant_id")
+    hit_id = request.form.get("hit_id")
+    participant = None
+
+    completed = False
+    details = {}
+
+    if request_data:
+        request_data = loads(request_data)
+        details['request_data'] = request_data
+        if not participant_id and 'participant_id' in request_data:
+            participant_id = request_data['participant_id']
+        if not worker_id and 'worker_id' in request_data:
+            participant_id = request_data['worker_id']
+        if not assignment_id and 'assignment_id' in request_data:
+            participant_id = request_data['assignment_id']
+
+    details['feedback'] = error_feedback
+    details['error_type'] = error_type
+    details['error_text'] = error_text
+
+    if worker_id and not participant_id:
+        participants = models.Participant.query.filter_by(
+            worker_id=worker_id
+        ).all()
+        if participants:
+            participant = participants[0]
+
+    if assignment_id and not participant_id:
+        participants = models.Participant.query.filter_by(
+            worker_id=assignment_id
+        ).all()
+        if participants:
+            participant = participants[0]
+
+    if participant and not participant_id:
+        participant_id = participant.id
+
+    if participant_id:
+        _worker_complete(participant_id)
+        completed = True
+
+    notif = models.Notification(
+        assignment_id=assignment_id or 'unknown',
+        event_type=u'ExperimentError', details=details
+    )
+    session.add(notif)
+    session.commit()
+
+    return render_template(
+        'error-complete.html',
+        completed=completed,
+        contact_address=config.get('contact_email_on_error', ''),
+        hit_id=hit_id
     )
 
 
@@ -1483,13 +1563,13 @@ def worker_function(event_type, assignment_id, participant_id, node_id=None, det
     if event_type == 'TrackingEvent':
         node = None
         if node_id:
-            node = models.Node.query.filter_by(id=node_id).all()[0]
+            node = models.Node.query.get(node_id)
         if not node:
             participant = None
             if participant_id:
                 # Lookup assignment_id to create notifications
                 participant = models.Participant.query\
-                    .filter_by(id=participant_id).all()[0]
+                    .get(participant_id)
             elif assignment_id:
                 participants = models.Participant.query\
                     .filter_by(assignment_id=assignment_id)\

--- a/dallinger/frontend/templates/error-complete.html
+++ b/dallinger/frontend/templates/error-complete.html
@@ -1,0 +1,25 @@
+{% extends "layout.html" %}
+
+{% block body %}
+	<div id="container">
+        <div>
+            <h1>Thank you!</h1>
+            <hr>
+            <div>
+                <h1>Your feedback has been submitted.</h1>
+                {% if completed %}
+                <p>The HIT has been marked as completed.
+                    You should be compensated automatically.</p>
+                <p>To enquire about compensation, please contact the researcher at
+                    <a href="mailto:{{contact_address}}">{{contact_address}}
+                        and include your HIT ID: {{hit_id}}</a></p>
+                {% else %}
+                <p><b>We were not able to mark this HIT as completed.</b></p>
+                <p>Please contact the researcher at
+                    <a href="mailto:{{contact_address}}">{{contact_address}}
+                        and include your HIT ID: {{hit_id}}</a></p>
+                {% endif %}
+            </div>
+        </div>
+	</div>
+{% endblock %}

--- a/dallinger/frontend/templates/error.html
+++ b/dallinger/frontend/templates/error.html
@@ -6,8 +6,24 @@
             <h1>Error!</h1>
             <hr>
             <div>
-                <p>{{ error_text }}</p>
+                <p id="error-text">{{ error_text }}</p>
+                <p>Please let us know how you encountered this error using the form below.</p>
+                <form id="error-response" action="/handle-error" method="POST">
+                    <input type="hidden" name="error_type" value="{{ error_type }}" />
+                    <input type="hidden" name="error_text" value="{{ error_text }}" />
+                    {% if hit_id %}
+                    <input type="hidden" name="hit_id" value="{{ hit_id }}" />
+                    <input type="hidden" name="assignment_id" value="{{ assignment_id }}" />
+                    <input type="hidden" name="worker_id" value="{{ worker_id }}" />
+                    {% endif %}
+                    {% if request_data %}
+                    <input type="hidden" name="request_data" value="{{ request_data }}" />
+                    {% endif %}
+                    <textarea name="error_feedback"></textarea>
+                    <input type="submit" value="SUBMIT" />
+                </form>
                 {% if compensate == True %}
+                <p>This HIT will be marked as completed and you should be compensated automatically once the above form is submitted.</p>
                 <p>To enquire about compensation, please contact the researcher at <a href="mailto:{{contact_address}}">{{contact_address}}</a> and quote the following information.</p>
                 <p>
                     Error type: {{ error_type }}<br>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import mock
 import os
 import pytest
 import shutil
@@ -371,6 +372,15 @@ def db_session():
     yield session
     session.rollback()
     session.close()
+
+
+@pytest.fixture
+def dummy_mailer():
+    from smtplib import SMTP
+    from dallinger.heroku import messages
+    server = mock.create_autospec(SMTP)
+    messages.get_email_server = lambda: server
+    return server
 
 
 def pytest_addoption(parser):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -379,8 +379,10 @@ def dummy_mailer():
     from smtplib import SMTP
     from dallinger.heroku import messages
     server = mock.create_autospec(SMTP)
+    orig_server = messages.get_email_server
     messages.get_email_server = lambda: server
-    return server
+    yield server
+    messages.get_email_server = orig_server
 
 
 def pytest_addoption(parser):

--- a/tests/experiment/templates/error-complete.html
+++ b/tests/experiment/templates/error-complete.html
@@ -1,0 +1,26 @@
+<html>
+<head></head>
+<body>
+	<div id="container">
+        <div>
+            <h1>Thank you!</h1>
+            <hr>
+            <div>
+                <h1>Your feedback has been submitted.</h1>
+                {% if completed %}
+                <p>The HIT has been marked as completed.
+                    You should be compensated automatically.</p>
+                <p>To enquire about compensation, please contact the researcher at
+                    <a href="mailto:{{contact_address}}">{{contact_address}}
+                        and include your HIT ID: {{hit_id}}</a></p>
+                {% else %}
+                <p><b>We were not able to mark this HIT as completed.</b></p>
+                <p>Please contact the researcher at
+                    <a href="mailto:{{contact_address}}">{{contact_address}}
+                        and include your HIT ID: {{hit_id}}</a></p>
+                {% endif %}
+            </div>
+        </div>
+    </div>
+</body>
+</html>

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -210,6 +210,7 @@ class TestSetupExperiment(object):
         assert found_in(os.path.join("static", "scripts", "spin.min.js"), dst)
         assert found_in(os.path.join("static", "robots.txt"), dst)
         assert found_in(os.path.join("templates", "error.html"), dst)
+        assert found_in(os.path.join("templates", "error-complete.html"), dst)
         assert found_in(os.path.join("templates", "launch.html"), dst)
         assert found_in(os.path.join("templates", "complete.html"), dst)
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -268,7 +268,7 @@ class TestHandleError(object):
         assert notifications[0].event_type == u'AssignmentSubmitted'
         assert notifications[1].event_type == u'ExperimentError'
 
-    def test_saves_error_without_participant(self, a, webapp, db_session):
+    def test_saves_error_without_participant(self, a, webapp):
         webapp.post('/handle-error',
                     data={'request_data': json.dumps({'a': 'b'}),
                           'error_feedback': 'Some feedback'})
@@ -278,7 +278,7 @@ class TestHandleError(object):
         assert notifi.details['request_data']['a'] == 'b'
         assert notifi.details['feedback'] == 'Some feedback'
 
-    def test_looks_up_participant_from_assignment(self, a, webapp, db_session):
+    def test_looks_up_participant_from_assignment(self, a, webapp):
         participant = a.participant()
         assignment_id = participant.assignment_id
         participant_id = participant.id
@@ -292,7 +292,7 @@ class TestHandleError(object):
         assert notifications[1].assignment_id == assignment_id
         assert notifications[1].details['request_data']['participant_id'] == participant_id
 
-    def test_looks_up_participant_from_worker(self, a, webapp, db_session):
+    def test_looks_up_participant_from_worker(self, a, webapp):
         participant = a.participant()
         assignment_id = participant.assignment_id
         participant_id = participant.id
@@ -306,7 +306,7 @@ class TestHandleError(object):
         assert notifications[1].assignment_id == assignment_id
         assert notifications[1].details['request_data']['participant_id'] == participant_id
 
-    def test_looks_up_hit_in_request_data(self, a, webapp, db_session):
+    def test_looks_up_hit_in_request_data(self, a, webapp):
         participant = a.participant()
         assignment_id = participant.assignment_id
         worker_id = participant.worker_id
@@ -326,7 +326,7 @@ class TestHandleError(object):
         assert notifications[1].assignment_id == assignment_id
         assert notifications[1].details['request_data']['participant_id'] == participant_id
 
-    def test_sends_email(self, a, webapp, db_session, active_config, dummy_mailer):
+    def test_sends_email(self, a, webapp, active_config, dummy_mailer):
         active_config.extend({'dallinger_email_address': u'test_error',
                               'dallinger_email_password': u'secret'})
         webapp.post('/handle-error', data={})

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -256,7 +256,7 @@ class TestWorkerComplete(object):
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
 
 
-@pytest.mark.usefixtures('experiment_dir', 'db_session')
+@pytest.mark.usefixtures('experiment_dir', 'db_session', 'dummy_mailer')
 class TestHandleError(object):
 
     def test_completes_assignment(self, a, webapp):
@@ -278,6 +278,63 @@ class TestHandleError(object):
         assert notifi.details['request_data']['a'] == 'b'
         assert notifi.details['feedback'] == 'Some feedback'
 
+    def test_looks_up_participant_from_assignment(self, a, webapp, db_session):
+        participant = a.participant()
+        assignment_id = participant.assignment_id
+        participant_id = participant.id
+        webapp.post('/handle-error',
+                    data={'assignment_id': assignment_id})
+
+        notifications = models.Notification.query.all()
+        assert len(notifications) == 2
+        assert notifications[0].event_type == u'AssignmentSubmitted'
+        assert notifications[1].event_type == u'ExperimentError'
+        assert notifications[1].assignment_id == assignment_id
+        assert notifications[1].details['request_data']['participant_id'] == participant_id
+
+    def test_looks_up_participant_from_worker(self, a, webapp, db_session):
+        participant = a.participant()
+        assignment_id = participant.assignment_id
+        participant_id = participant.id
+        webapp.post('/handle-error',
+                    data={'worker_id': participant.worker_id})
+
+        notifications = models.Notification.query.all()
+        assert len(notifications) == 2
+        assert notifications[0].event_type == u'AssignmentSubmitted'
+        assert notifications[1].event_type == u'ExperimentError'
+        assert notifications[1].assignment_id == assignment_id
+        assert notifications[1].details['request_data']['participant_id'] == participant_id
+
+    def test_looks_up_hit_in_request_data(self, a, webapp, db_session):
+        participant = a.participant()
+        assignment_id = participant.assignment_id
+        worker_id = participant.worker_id
+        hit_id = participant.hit_id
+        participant_id = participant.id
+        webapp.post('/handle-error',
+                    data={'request_data': json.dumps({
+                        'worker_id': worker_id,
+                        'hit_id': hit_id,
+                        'assignment_id': assignment_id
+                    })})
+
+        notifications = models.Notification.query.all()
+        assert len(notifications) == 2
+        assert notifications[0].event_type == u'AssignmentSubmitted'
+        assert notifications[1].event_type == u'ExperimentError'
+        assert notifications[1].assignment_id == assignment_id
+        assert notifications[1].details['request_data']['participant_id'] == participant_id
+
+    def test_sends_email(self, a, webapp, db_session, active_config, dummy_mailer):
+        active_config.extend({'dallinger_email_address': u'test_error',
+                              'dallinger_email_password': u'secret'})
+        webapp.post('/handle-error', data={})
+
+        dummy_mailer.login.assert_called_once()
+        dummy_mailer.starttls.assert_called_once()
+        dummy_mailer.sendmail.assert_called_once()
+        assert dummy_mailer.sendmail.call_args[0][0] == u'test_error@gmail.com'
 
 @pytest.mark.usefixtures('experiment_dir', 'db_session')
 class TestWorkerFailed(object):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -336,6 +336,7 @@ class TestHandleError(object):
         dummy_mailer.sendmail.assert_called_once()
         assert dummy_mailer.sendmail.call_args[0][0] == u'test_error@gmail.com'
 
+
 @pytest.mark.usefixtures('experiment_dir', 'db_session')
 class TestWorkerFailed(object):
 

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -254,21 +254,18 @@ class TestHerokuClockTasks(object):
 
 
 def emailing_messager(whimsical):
-    from smtplib import SMTP
     config = {
         'whimsical': whimsical,
         'dallinger_email_username': 'test',
         'contact_email_on_error': 'contact@example.com',
         'dallinger_email_key': 'email secret key'
     }
-    mock_smtp = mock.create_autospec(SMTP)
     messager = EmailingHITMessager(
         when='the time',
         assignment_id='some assignment id',
         hit_duration=60,
         time_active=120,
-        config=config,
-        server=mock_smtp
+        config=config
     )
 
     return messager
@@ -284,6 +281,7 @@ def nonwhimsical():
     return emailing_messager(whimsical=False)
 
 
+@pytest.mark.usefixtures('dummy_mailer')
 class TestEmailingHITMessager(object):
 
     def test_send_resubmitted_msg_whimsical(self, whimsical):
@@ -329,6 +327,15 @@ class TestEmailingHITMessager(object):
     def test_send_idle_experiment(self, nonwhimsical):
         data = nonwhimsical.send_idle_experiment()
         assert data['subject'] == 'Idle Experiment.'
+
+    def test_send_hit_error(self, nonwhimsical, dummy_mailer):
+        data = nonwhimsical.send_hit_error()
+        assert data['subject'] == 'Error during HIT.'
+
+        dummy_mailer.login.assert_called_once()
+        dummy_mailer.starttls.assert_called_once()
+        dummy_mailer.sendmail.assert_called_once()
+        assert dummy_mailer.sendmail.call_args[0][0] == u'test@gmail.com'
 
 
 class TestHerokuUtilFunctions(object):


### PR DESCRIPTION
This pull request implements [ScrumDo Story 291](https://app.scrumdo.com/projects/story_permalink/1459239).

## Description
This PR implements a new error handler for failed AJAX requests. It makes some modifications to the default error page to include a response form, with hidden fields containing all available information about the failed request. It also implements a new route to handle the error form post which attempts to complete the HIT, and adds a `Notification` to the database associated with the `assignment_id` that includes all available information about the error, including the user feedback. Additionally, it sends an email to the experimenter notifying them of the error so that they can verify completion, etc.

## Motivation and Context
See This pull request implements [ScrumDo Story 291](https://app.scrumdo.com/projects/story_permalink/1459239).

## How Has This Been Tested?
There are some new automated tests of the error handler view. Additionally it has been manually tested by forcing the participant creation route to fail for a run of GridUniverse and running through the experiment.

Currently, a HIT cannot be always be completed and paid using the current worker implementation because that process expects and requires a participant. If there is a failure before the participant is created, then the HIT will not be submitted, but the issue will still be logged in the database as a `Notification`.
