### PR TITLE
Replay server state

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ before_script:
 - bundle exec danger
 - createuser dallinger --createdb
 - createdb -O dallinger dallinger
+- createdb -O dallinger dallinger-import
 env:
   global:
   - DATABASE_URL=postgresql://dallinger@localhost/dallinger

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from collections import deque
+from contextlib import contextmanager
 from ConfigParser import SafeConfigParser
 import distutils.util
 import imp
@@ -129,6 +130,12 @@ class Configuration(object):
                 )
             normalized_mapping[key] = value
         self.data.extendleft([normalized_mapping])
+
+    @contextmanager
+    def override(self, *args, **kwargs):
+        self.extend(*args, **kwargs)
+        yield self
+        self.data.popleft()
 
     def get(self, key, default=marker):
         if not self.ready:

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -86,12 +86,12 @@ def scoped_session_decorator(func):
     return wrapper
 
 
-def init_db(drop_all=False):
+def init_db(drop_all=False, bind=engine):
     """Initialize the database, optionally dropping existing tables."""
     try:
         if drop_all:
-            Base.metadata.drop_all(bind=engine)
-        Base.metadata.create_all(bind=engine)
+            Base.metadata.drop_all(bind=bind)
+        Base.metadata.create_all(bind=bind)
     except OperationalError as err:
         msg = 'password authentication failed for user "dallinger"'
         if msg in err.message:

--- a/tests/test_replay_state.py
+++ b/tests/test_replay_state.py
@@ -1,0 +1,67 @@
+"""Tests for the data module."""
+
+from datetime import datetime
+import os
+import mock
+import shutil
+
+import pytest
+
+
+@pytest.fixture
+def zip_path():
+    return os.path.join(
+        "tests",
+        "datasets",
+        "test_export.zip"
+    )
+
+
+class TestReplayState(object):
+
+    @pytest.fixture
+    def cleanup(self):
+        yield
+        shutil.rmtree('data')
+
+    @pytest.fixture
+    def experiment(self):
+        from dlgr.demos.bartlett1932.experiment import Bartlett1932
+        yield Bartlett1932()
+
+    bartlett_export = os.path.join(
+        "tests",
+        "datasets",
+        "bartlett_bots.zip"
+    )
+
+    @pytest.fixture
+    def scrubber(self, experiment, db_session):
+        with experiment.restore_state_from_replay(
+            'bartlett-test',
+            session=db_session,
+            zip_path=self.bartlett_export,
+        ) as scrubber:
+            yield scrubber
+
+    def test_scrub_forwards(self, scrubber):
+        target = datetime(2017, 6, 23, 12, 0, 29, 941148)
+        with mock.patch(
+            'dlgr.demos.bartlett1932.experiment.Bartlett1932.replay_event'
+        ) as replay_event:
+            replay_event.assert_not_called()
+            scrubber(target)
+            assert replay_event.call_count == 4
+            scrubber(datetime.now())
+            assert replay_event.call_count == 5
+
+    def test_cannot_scrub_backwards(self, scrubber):
+        target = datetime(2017, 6, 23, 12, 0, 29, 941148)
+        with mock.patch(
+            'dlgr.demos.bartlett1932.experiment.Bartlett1932.replay_event'
+        ) as replay_event:
+            replay_event.assert_not_called()
+            scrubber(datetime.now())
+            assert replay_event.call_count == 5
+            with pytest.raises(NotImplementedError):
+                scrubber(target)


### PR DESCRIPTION
## Description
This is story 294. It is part of the wider group of stories to enable better jupyter interaction with experiment data. This story allows the user to instantiate an experiment and provide it with data from a previous run, scrubbing forwards so the experiment is effectively paused at various points in the previous run.

## Motivation and Context
Until now, it's only been possible to replay an experiment in real-time, interacting with it as the replay runs through the web server, or to load the full set of data wholesale and introspect it manually. This provides a generic framework to get the data an experiment had at a given time and progress through it at your own pace.

## How Has This Been Tested?
Basic unit tests, included in the commit
Manual testing with GridUniverse where the _state event was introspected
