### PR TITLE
Move experiment qualification to after waiting room

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -147,6 +147,12 @@ class Experiment(object):
         """
         return recruiters.from_config(get_config())
 
+    def is_overrecruited(self, waiting_count):
+        """Returns True if the number of people waiting is in excess of the
+        total number expected, indicating that this and subsequent users should
+        skip the experiment"""
+        return waiting_count > self.quorum
+
     def send(self, raw_message):
         """socket interface implementation, and point of entry for incoming
         Redis messages.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -752,9 +752,15 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
         quorum = {
             'q': exp.quorum,
             'n': waiting_count,
+            'overrecruited': exp.is_overrecruited(waiting_count),
         }
         db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
         result['quorum'] = quorum
+
+    if not result.get('quorum', {}).get('overrecruited', False):
+        # We either had no quorum or we have not overrecruited, inform the
+        # recruiter that this participant will be seeing the experiment
+        recruiters.for_experiment(exp).notify_using(participant)
 
     # return the data
     return success_response(**result)

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -231,7 +231,7 @@ var dallinger = (function () {
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;
           if (resp.quorum && resp.quorum.n !== resp.quorum.q) {
-            if (resp.quorum.n > resp.quorum.q) {
+            if (resp.quorum.overrecruited) {
               dlgr.skip_experiment = true;
               // reached quorum; resolve immediately
               deferred.resolve();

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -75,6 +75,12 @@ class Recruiter(object):
         """
         pass
 
+    def notify_using(self, participant):
+        """Allow the Recruiter to be notified when an recruited Participant
+        has been chosen to participate in an experiment they joined.
+        """
+        pass
+
     def rejects_questionnaire_from(self, participant):
         """Recruiters have different circumstances under which experiment
         questionnaires should be accepted or rejected.
@@ -317,6 +323,9 @@ class MTurkRecruiter(Recruiter):
             logger.exception(ex.message)
 
     def notify_recruited(self, participant):
+        pass
+
+    def notify_using(self, participant):
         """Assign a Qualification to the Participant for the experiment ID,
         and for the configured group_name, if it's been set.
         """

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -494,33 +494,33 @@ class TestMTurkRecruiter(object):
             fake_hit_id
         )
 
-    def test_notify_recruited_when_group_name_not_specified(self, recruiter):
+    def test_notify_using_when_group_name_not_specified(self, recruiter):
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
-        recruiter.notify_recruited(participant)
+        recruiter.notify_using(participant)
 
         recruiter.mturkservice.increment_qualification_score.assert_called_once_with(
             'some experiment uid',
             'some worker id',
         )
 
-    def test_notify_recruited_when_group_name_specified(self, recruiter):
+    def test_notify_using_when_group_name_specified(self, recruiter):
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
         recruiter.config.set('group_name', u'some existing group_name')
-        recruiter.notify_recruited(participant)
+        recruiter.notify_using(participant)
 
         recruiter.mturkservice.increment_qualification_score.assert_has_calls([
             mock.call('some experiment uid', 'some worker id'),
             mock.call('some existing group_name', 'some worker id')
         ], any_order=True)
 
-    def test_notify_recruited_nonexistent_qualification(self, recruiter):
+    def test_notify_using_nonexistent_qualification(self, recruiter):
         from dallinger.mturk import QualificationNotFoundException
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
         error = QualificationNotFoundException("Ouch!")
         recruiter.mturkservice.increment_qualification_score.side_effect = error
 
         # logs, but does not raise:
-        recruiter.notify_recruited(participant)
+        recruiter.notify_using(participant)
 
     def test_rejects_questionnaire_from_returns_none_if_working(self, recruiter):
         participant = mock.Mock(spec=Participant, status="working")


### PR DESCRIPTION
## Description
If an experiment is overrecruiting then the experiment qualification
should only be given to users who are actually shown the experiment.
If someone joins then is discarded by the waiting room they should
be unqualified. Assigning then removing the qualification causes
spurious emails to be generated by MTurk, so we change the way
overrecruitment is defined to be a python function rather than
comparing two elements of a JSON value in Javascript.

This lets
us assign the qualification in Python code and makes for a slightly
more standardised override story for experimenters.

## Motivation and Context
Incorrect qualifications were assigned during overrecruitment.

## How Has This Been Tested?
Automated tests