### PR TITLE
Tag builds not on master with their git commit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,16 @@
 
 import os
 from setuptools import setup
+import shlex
+from subprocess import check_output, CalledProcessError
+
+try:
+    GIT_HEAD_REV = check_output(shlex.split('git rev-parse HEAD')).strip()
+    GIT_MASTER_REV = check_output(shlex.split('git rev-parse HEAD')).strip()
+except CalledProcessError:
+    BUILD_TAG = ''
+else:
+    BUILD_TAG = 'dev_{}'.format(GIT_HEAD_REV)
 
 setup_args = dict(
     name='dallinger',
@@ -35,7 +45,12 @@ setup_args = dict(
             "odo==0.5.0",
             "tablib==0.11.3"
         ],
-    }
+    },
+    options={'egg_info': {
+        'tag_build': BUILD_TAG
+        }
+    },
+
 )
 
 # If not on Heroku, install setuptools-markdown.

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ extras =
 commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
-    pip install -e demos
+    pip install --no-deps -e demos
     coverage run {envbindir}/pytest {posargs}
     coverage combine
     coverage report


### PR DESCRIPTION
## Description
This is intended to prevent the automatic releases of every single
master commit to the test PyPI server from preempting the real
release of a tagged version. When running setup() the script will
attempt to find the commit hash of the current HEAD and of
origin/master. If they don't match the build will be tagged as dev
with the commit hash appended.

## Motivation and Context
Builds are current failing to deploy to test.pypi.org and bad packages are deployed there.

## How Has This Been Tested?
Local only, this also needs testing on travis but travis will only run this code on merged commits to master, not on PRs, I believe. Either way, I need to push it to find out.