### PR TITLE
Remove test pypi upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,15 +57,6 @@ after_success:
 before_deploy:
 - pandoc --from=markdown --to=rst --output=README.rst README.md
 deploy:
-  - provider: pypi  # test pypi
-    distributions: sdist
-    server: https://test.pypi.org/legacy/
-    user: "suchow"
-    password:
-      secure: "A8nIC9tLyVV1X5020JbJwpBCSS7kQvuXP2pLIgu40CPB/ZfU3OOC5IyjfFWypIP/CCExM8o6Spb5UJccgLLUy7OLGMPaO/8Ne7BCyh75uvav5iX4KlP/j8eWih+CPGWPhO4pYsXnzpGi+GSQnwmhxdoPmllUbyLvmppsfI+vBf9pYGRpF8BgjIt0S3ffYRh030S6jFSQ1HCEz/JDIaHn4eh+nn/squVXKHMbejR8IaMnVc+Xus8mT7yzQhdIWn/jCV7GCq1uvBU1Jieh9lR18ohwT3FE51rnPZvVEGUmW0JaWmVYjwKRevXPfS9gbDSGBOAwMypVk5lPSoJlXhUpfuUEEbWvl/XpO+B9C3VGgtFSR3R+9zN7Vhg89FkVjxBIEVV6t5p+7RRtKYkyp08T9B72wzwG8Xq2XMFNb9/w1hJsx5YuZZVLQOHJlae64jstJOzAiQUXN0ZAsSU6lyH2MXJPLhgqc8Lfd05/5swnkrbj/PxchawbwwnmLps9DlyVVcxH8XdW3n8NYU4tzc+2NwM0/+AMhQQ7hQ5YTz1YSDiHNUTmFqFoawUzeDUT+5NDfy+DYk8SkIj8i6gWsEES1fPkckTvsuKrJUEy781Ff5dl/nb8xsX8UC3DhcEqYkYkr+3bgmKydMCOGGB9k+/2/p0AS67Rmu+/Vs5op6jGhp8="
-    on:
-      condition: $TRAVIS_PYTHON_VERSION = "2.7"
-    skip_cleanup: true
   - provider: pypi  # production pypi
     distributions: sdist
     server: https://pypi.org/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We agreed to remove the test server from continuously uploading versions of Dallinger to Pypi since this is not useful in a majority of cases. Should we need the test server to be uploaded to during testing, we will create a story in the future that may integrate inserting hashes to the version number to prevent duplicates from being uploaded.
