### PR TITLE
Include bumpversion in dev dependencies

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 alabaster==0.7.9
+bumpversion==0.5.3
 coverage==4.5.1
 coverage_pth==0.0.2
 codecov==2.0.15


### PR DESCRIPTION

## Description
We use bumpversion to increment version numbers thoughout the codebase when cutting new releases. It should be included in dev-requirements.txt
