### PR TITLE
Log and ignore unsupported event types to avoid confusing tracebacks

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1627,6 +1627,11 @@ def worker_function(event_type, assignment_id, participant_id, node_id=None, det
         session.commit()
         return
 
+    runner_cls = WorkerEvent.for_name(event_type)
+    if not runner_cls:
+        exp.log("Event type {} is not supported... ignoring.".format(event_type))
+        return
+
     if assignment_id is not None:
         # save the notification to the notification table
         notif = models.Notification(
@@ -1661,12 +1666,10 @@ def worker_function(event_type, assignment_id, participant_id, node_id=None, det
 
     participant_id = participant.id
 
-    runner_cls = WorkerEvent.for_name(event_type)
-    if runner_cls:
-        runner = runner_cls(
-            participant, assignment_id, exp, session, _config(), datetime.now()
-        )
-        runner()
+    runner = runner_cls(
+        participant, assignment_id, exp, session, _config(), datetime.now()
+    )
+    runner()
     session.commit()
 
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1141,6 +1141,14 @@ class TestWorkerFunctionIntegration(object):
     def test_all_invalid_values(self, worker_func):
         worker_func('foo', 'bar', 'baz')
 
+    def test_ignores_unsupported_event_types(self, worker_func):
+        mock_exp = mock.Mock()
+        with mock.patch('dallinger.experiment_server.experiment_server.Experiment') as mock_Exp:
+            mock_Exp.return_value = mock_exp
+            worker_func(event_type='IgnoreMe', assignment_id=None, participant_id=None)
+        log_calls = mock_exp.log.call_args_list
+        assert mock.call('Event type IgnoreMe is not supported... ignoring.') in log_calls
+
     def test_uses_assignment_id(self, a, worker_func):
         participant = a.participant()
 


### PR DESCRIPTION
Log unsupported event notifications (HITReviewable, for example), rather than raising exceptions.

## Description

Currently unsupported event notifications can result in confusing tracebacks:
```
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  >>>> ----- Received an HITReviewable notification for assignment None, participant None 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  00:45:04 ValueError: Error: worker_function needs either an assignment_id or a participant_id, they cannot both be None 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  Traceback (most recent call last): 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/worker.py", line 789, in perform_job 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      rv = job.perform() 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 573, in perform 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      self._result = self._execute() 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 579, in _execute 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      return self.func(*self.args, **self.kwargs) 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/src/dallinger/dallinger/db.py", line 85, in wrapper 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      return func(*args, **kwargs) 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/src/dallinger/dallinger/experiment_server/experiment_server.py", line 1659, in worker_function 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      "Error: worker_function needs either an assignment_id or a " 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  ValueError: Error: worker_function needs either an assignment_id or a participant_id, they cannot both be None 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  Traceback (most recent call last): 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/worker.py", line 789, in perform_job 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      rv = job.perform() 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 573, in perform 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      self._result = self._execute() 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/python/lib/python2.7/site-packages/rq/job.py", line 579, in _execute 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      return self.func(*self.args, **self.kwargs) 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/src/dallinger/dallinger/db.py", line 85, in wrapper 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      return func(*args, **kwargs) 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:    File "/app/.heroku/src/dallinger/dallinger/experiment_server/experiment_server.py", line 1659, in worker_function 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:      "Error: worker_function needs either an assignment_id or a " 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  ValueError: Error: worker_function needs either an assignment_id or a participant_id, they cannot both be None 
Mar 08 16:45:04 dlgr-b02f3c0e app/worker.1:  00:45:04 Moving job to u'failed' queue 
```

It would be preferable to log and ignore them.

## How Has This Been Tested?
Automated tests
