### PR TITLE
Show an alert if dallinger.js and dallinger2.js are loaded together

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -22,6 +22,14 @@ var getUrlParameter = function getUrlParameter(sParam) {
     }
 };
 
+if (dallinger !== undefined) {
+  alert(
+    'This page has loaded both dallinger.js and dallinger2.js at the same time, ' +
+    'which is not supported. It is recommended to use dallinger2.js ' +
+    'for experiments being actively developed, and dallinger.js only ' +
+    'for backwards compatibility of existing experiments.'
+  );
+}
 
 var Dallinger = (function () {
   var dlgr = {},

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -1,5 +1,14 @@
 /*globals Spinner, Fingerprint2, ReconnectingWebSocket, reqwest, store */
 
+if (Dallinger !== undefined) {
+  alert(
+    'This page has loaded both dallinger.js and dallinger2.js at the same time, ' +
+    'which is not supported. It is recommended to use dallinger2.js ' +
+    'for experiments being actively developed, and dallinger.js only ' +
+    'for backwards compatibility of existing experiments.'
+  );
+}
+
 var dallinger = (function () {
   var dlgr = {};
 


### PR DESCRIPTION
## Description
This adds code to both dallinger.js and dallinger2.js to show an alert if the other library was also loaded.

## Motivation and Context
dallinger2.js is meant to replace dallinger.js, not be used alongside. This intends to make that clearer to experiment authors.

## How Has This Been Tested?
Has not been tested yet.