### PR TITLE
Exclude Pycharm's .idea directory from repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ demos/*/data/*
 docs/source/demos
 docs/source/_static/*.zip
 .env
+.idea
 .tox
 /snapshots/
 *-


### PR DESCRIPTION
Pycharm stores project settings in an .idea directory. It should not be tracked by version control.