### PR TITLE
Stories/296 jupyter widget

### DIFF
--- a/dallinger/jupyter.py
+++ b/dallinger/jupyter.py
@@ -1,0 +1,57 @@
+from ipywidgets import widgets
+from jinja2 import Template
+from traitlets import (
+    observe,
+    Unicode,
+)
+
+from dallinger.config import get_config
+
+header_template = Template(u"""
+<h2>{{ name }}</h2>
+<div>Status: {{ status }}</div>
+{% if app_id %}<div>App ID: {{ app_id }}</div>{% endif %}
+""")
+
+config_template = Template(u"""
+<table style="min-width: 50%">
+{% for k, v in config %}
+<tr>
+<th>{{ k }}</th>
+<td>{{ v }}</td>
+</tr>
+{% endfor %}
+</table>
+""")
+
+
+class ExperimentWidget(widgets.VBox):
+
+    status = Unicode('Unknown')
+
+    def __init__(self, exp):
+        self.exp = exp
+        super(ExperimentWidget, self).__init__()
+        self.render()
+
+    @observe('status')
+    def render(self, change=None):
+        header = widgets.HTML(
+            header_template.render(
+                name=self.exp.task,
+                status=self.status,
+                app_id=self.exp.app_id,
+            ),
+        )
+        config = get_config()
+        if config.ready:
+            config_items = config.as_dict().items()
+            config_items.sort()
+            config_tab = widgets.HTML(
+                config_template.render(config=config_items)
+            )
+        else:
+            config_tab = widgets.HTML('Not loaded.')
+        tabs = widgets.Tab(children=[config_tab])
+        tabs.set_title(0, 'Configuration')
+        self.children = [header, tabs]

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,10 @@ setup_args = dict(
             "odo==0.5.0",
             "tablib==0.11.3"
         ],
+        'jupyter': [
+            "jupyter",
+            "ipywidgets",
+        ],
     }
 )
 

--- a/tests/test_jupyter.py
+++ b/tests/test_jupyter.py
@@ -1,0 +1,34 @@
+import mock
+import pytest
+try:
+    import ipywidgets
+except ImportError:
+    ipywidgets = None
+
+
+@pytest.mark.skipif(ipywidgets is None, reason='ipywidgets is not installed')
+class TestExperimentWidget(object):
+
+    @pytest.fixture
+    def exp(self):
+        from dallinger.experiment import Experiment
+        return Experiment()
+
+    def test_experiment_initializes_widget(self, exp):
+        assert exp.widget is not None
+
+    def test_experiment_updates_widget_status(self, exp):
+        exp.update_status(u'Testing')
+        assert exp.widget.status == u'Testing'
+        assert 'Testing' in exp.widget.children[0].value
+
+    def test_experiment_displays_widget(self, exp):
+        with mock.patch('IPython.display.display') as display:
+            exp._ipython_display_()
+            assert display.called_once_with(exp.widget)
+
+    def test_widget_children_no_config(self, exp):
+        assert exp.widget.children[1].children[0].value == 'Not loaded.'
+
+    def test_widget_children_with_config(self, active_config, exp):
+        assert exp.widget.children[1].children[0].value != 'Not loaded.'

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist =
 [testenv]
 extras =
     data
+    jupyter
 commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt


### PR DESCRIPTION
This adds a basic widget for representing an experiment in a Jupyter Notebook. The widget displays the experiment name, configuration, and status.

## Motivation and Context
This makes it easier to view the state of an experiment instance when working in the notebook, and is a first step toward providing an interactive tool to explore the stored data from a prior experiment run.

## How Has This Been Tested?

I installed dallinger with the [jupyter] extra to install jupyter and ipywidgets as dependencies. Then ran "jupyter notebook" and instantiated a Bartlett1932 experience to view as a widget. Confirmed that running the experiment updates its status. There are also automated tests.
