### PR TITLE
WIP: Over-recruitment and error email fixes

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -144,6 +144,10 @@ def after_soft_rollback(session, previous_transaction):
 
 
 def queue_message(channel, message):
+    logger.debug(
+            'Enqueueing message to {}: {}'.format(channel, message))
+    if 'outbox' not in session.info:
+        session.info['outbox'] = []
     session.info['outbox'].append((channel, message))
 
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -605,6 +605,12 @@ class Experiment(object):
     def replay_started(self):
         return True
 
+    def is_complete(self):
+        """Method for custom determination of experiment completion.
+        Return None to use the experiment server default, otherwise
+        `True` or `False`"""
+        return None
+
     @contextmanager
     def restore_state_from_replay(self, app_id, session, zip_path=None, **configuration_options):
         # We need to fake dallinger_experiment to point at the current experiment

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -750,22 +750,24 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     exp = Experiment(session)
 
     # Ping back to the recruiter that one of their participants has joined:
-    recruiters.for_experiment(exp).notify_recruited(participant)
+    recruiter = recruiters.for_experiment(exp)
+    recruiter.notify_recruited(participant)
+
+    overrecruited = exp.is_overrecruited(waiting_count)
+    if not overrecruited:
+        # We either had no quorum or we have not overrecruited, inform the
+        # recruiter that this participant will be seeing the experiment
+        recruiter.notify_using(participant)
 
     # Queue notification to others in waiting room
     if exp.quorum:
         quorum = {
             'q': exp.quorum,
             'n': waiting_count,
-            'overrecruited': exp.is_overrecruited(waiting_count),
+            'overrecruited': overrecruited,
         }
         db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
         result['quorum'] = quorum
-
-    if not result.get('quorum', {}).get('overrecruited', False):
-        # We either had no quorum or we have not overrecruited, inform the
-        # recruiter that this participant will be seeing the experiment
-        recruiters.for_experiment(exp).notify_using(participant)
 
     # return the data
     return success_response(**result)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -341,8 +341,8 @@ def handle_error():
     session.commit()
 
     config = _config()
-    if (config.get('dallinger_email_address') and
-            config.get('contact_email_on_error')):
+    if (config.get('dallinger_email_address', None) and
+            config.get('contact_email_on_error', None)):
         heroku_config = {
             "contact_email_on_error": config["contact_email_on_error"],
             "dallinger_email_username": config["dallinger_email_address"],

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -7,6 +7,7 @@ from json import loads
 from operator import attrgetter
 import os
 import re
+import smtplib
 import sys
 import user_agents
 
@@ -156,7 +157,13 @@ def error_page(participant=None, error_text=None, compensate=True,
         hit_id = request.form.get('hit_id', '')
         assignment_id = request.form.get('assignment_id', '')
         worker_id = request.form.get('worker_id', '')
-        participant_id = request.form.get('participant_id', '')
+        participant_id = request.form.get('participant_id', None)
+
+    if participant_id:
+        try:
+            participant_id = int(participant_id)
+        except (ValueError, TypeError):
+            participant_id = None
 
     return make_response(
         render_template(
@@ -269,22 +276,37 @@ def handle_error():
     details = {'request_data': {}}
 
     if request_data:
-        request_data = loads(request_data)
+        try:
+            request_data = loads(request_data)
+        except ValueError:
+            request_data = {}
         details['request_data'] = request_data
-        if not participant_id and 'participant_id' in request_data:
-            participant_id = request_data['participant_id']
-        if not worker_id and 'worker_id' in request_data:
-            worker_id = request_data['worker_id']
-        if not assignment_id and 'assignment_id' in request_data:
-            assignment_id = request_data['assignment_id']
-        if not hit_id and 'hit_id' in request_data:
-            hit_id = request_data['hit_id']
+
+        try:
+            data = loads(request_data.get("data", "null")) or request_data
+        except ValueError:
+            data = request_data
+
+        if not participant_id and 'participant_id' in data:
+            participant_id = data['participant_id']
+        if not worker_id and 'worker_id' in data:
+            worker_id = data['worker_id']
+        if not assignment_id and 'assignment_id' in data:
+            assignment_id = data['assignment_id']
+        if not hit_id and 'hit_id' in data:
+            hit_id = data['hit_id']
+
+    if participant_id:
+        try:
+            participant_id = int(participant_id)
+        except (ValueError, TypeError):
+            participant_id = None
 
     details['feedback'] = error_feedback
     details['error_type'] = error_type
     details['error_text'] = error_text
 
-    if worker_id and not participant_id:
+    if participant_id is None and worker_id:
         participants = session.query(models.Participant).filter_by(
             worker_id=worker_id
         ).all()
@@ -293,7 +315,7 @@ def handle_error():
             if not assignment_id:
                 assignment_id = participant.assignment_id
 
-    if assignment_id and not participant_id:
+    if participant_id is None and assignment_id:
         participants = session.query(models.Participant).filter_by(
             worker_id=assignment_id
         ).all()
@@ -303,7 +325,7 @@ def handle_error():
             if not worker_id:
                 worker_id = participant.worker_id
 
-    if participant_id:
+    if participant_id is not None:
         _worker_complete(participant_id)
         completed = True
 
@@ -319,20 +341,27 @@ def handle_error():
     session.commit()
 
     config = _config()
-    # if config.get('dallinger_email_address', None):
-    #     heroku_config = {
-    #         "contact_email_on_error": config["contact_email_on_error"],
-    #         "dallinger_email_username": config["dallinger_email_address"],
-    #         "dallinger_email_key": config["dallinger_email_password"],
-    #         "whimsical": False
-    #     }
-    #     emailer = EmailingHITMessager(when=datetime.now(),
-    #                                   assignment_id=assignment_id or 'unknown',
-    #                                   hit_duration=0, time_active=0,
-    #                                   config=heroku_config,
-    #                                   app_id=config.get('id', 'unknown'))
-    #     db.logger.debug("Sending HIT error email...")
-    #     emailer.send_hit_error()
+    if (config.get('dallinger_email_address') and
+            config.get('contact_email_on_error')):
+        heroku_config = {
+            "contact_email_on_error": config["contact_email_on_error"],
+            "dallinger_email_username": config["dallinger_email_address"],
+            "dallinger_email_key": config.get("dallinger_email_password"),
+            "whimsical": False
+        }
+
+        emailer = EmailingHITMessager(when=datetime.now(),
+                                      assignment_id=assignment_id or 'unknown',
+                                      hit_duration=0, time_active=0,
+                                      config=heroku_config,
+                                      app_id=config.get('id', 'unknown'))
+        db.logger.debug("Sending HIT error email...")
+        try:
+            emailer.send_hit_error()
+        except smtplib.SMTPException:
+            db.logger.exception("SMTP error sending HIT error email.")
+        except Exception:
+            db.logger.exception("Unknown error sending HIT error email.")
 
     return render_template(
         'error-complete.html',
@@ -523,10 +552,11 @@ def advertisement():
 @app.route('/summary', methods=['GET'])
 def summary():
     """Summarize the participants' status codes."""
+    exp = Experiment(session)
     state = {
         "status": "success",
-        "summary": Experiment(session).log_summary(),
-        "completed": False,
+        "summary": exp.log_summary(),
+        "completed": exp.is_complete(),
     }
     unfilled_nets = models.Network.query.filter(
         models.Network.full != true()
@@ -538,7 +568,7 @@ def summary():
     nodes_remaining = 0
     required_nodes = 0
     if state['unfilled_networks'] == 0:
-        if working == 0:
+        if working == 0 and state['completed'] is None:
             state['completed'] = True
     else:
         for net in unfilled_nets:
@@ -550,6 +580,9 @@ def summary():
             nodes_remaining += net_size - node_count
     state['nodes_remaining'] = nodes_remaining
     state['required_nodes'] = required_nodes
+
+    if state['completed'] is None:
+        state['completed'] = False
 
     return Response(
         dumps(state),
@@ -752,15 +785,15 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
 
     exp = Experiment(session)
 
-    # # Ping back to the recruiter that one of their participants has joined:
-    # recruiter = recruiters.for_experiment(exp)
-    # recruiter.notify_recruited(participant)
+    # Ping back to the recruiter that one of their participants has joined:
+    recruiter = recruiters.for_experiment(exp)
+    recruiter.notify_recruited(participant)
 
     overrecruited = exp.is_overrecruited(nonfailed_count)
-    # if not overrecruited:
-    #     # We either had no quorum or we have not overrecruited, inform the
-    #     # recruiter that this participant will be seeing the experiment
-    #     recruiter.notify_using(participant)
+    if not overrecruited:
+        # We either had no quorum or we have not overrecruited, inform the
+        # recruiter that this participant will be seeing the experiment
+        recruiter.notify_using(participant)
 
     # Queue notification to others in waiting room
     if exp.quorum:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -319,20 +319,20 @@ def handle_error():
     session.commit()
 
     config = _config()
-    if config.get('dallinger_email_address', None):
-        heroku_config = {
-            "contact_email_on_error": config["contact_email_on_error"],
-            "dallinger_email_username": config["dallinger_email_address"],
-            "dallinger_email_key": config["dallinger_email_password"],
-            "whimsical": False
-        }
-        emailer = EmailingHITMessager(when=datetime.now(),
-                                      assignment_id=assignment_id or 'unknown',
-                                      hit_duration=0, time_active=0,
-                                      config=heroku_config,
-                                      app_id=config.get('id', 'unknown'))
-        db.logger.debug("Sending HIT error email...")
-        emailer.send_hit_error()
+    # if config.get('dallinger_email_address', None):
+    #     heroku_config = {
+    #         "contact_email_on_error": config["contact_email_on_error"],
+    #         "dallinger_email_username": config["dallinger_email_address"],
+    #         "dallinger_email_key": config["dallinger_email_password"],
+    #         "whimsical": False
+    #     }
+    #     emailer = EmailingHITMessager(when=datetime.now(),
+    #                                   assignment_id=assignment_id or 'unknown',
+    #                                   hit_duration=0, time_active=0,
+    #                                   config=heroku_config,
+    #                                   app_id=config.get('id', 'unknown'))
+    #     db.logger.debug("Sending HIT error email...")
+    #     emailer.send_hit_error()
 
     return render_template(
         'error-complete.html',
@@ -749,15 +749,15 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
 
     exp = Experiment(session)
 
-    # Ping back to the recruiter that one of their participants has joined:
-    recruiter = recruiters.for_experiment(exp)
-    recruiter.notify_recruited(participant)
+    # # Ping back to the recruiter that one of their participants has joined:
+    # recruiter = recruiters.for_experiment(exp)
+    # recruiter.notify_recruited(participant)
 
     overrecruited = exp.is_overrecruited(waiting_count)
-    if not overrecruited:
-        # We either had no quorum or we have not overrecruited, inform the
-        # recruiter that this participant will be seeing the experiment
-        recruiter.notify_using(participant)
+    # if not overrecruited:
+    #     # We either had no quorum or we have not overrecruited, inform the
+    #     # recruiter that this participant will be seeing the experiment
+    #     recruiter.notify_using(participant)
 
     # Queue notification to others in waiting room
     if exp.quorum:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -729,9 +729,12 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
         app.logger.warning(msg.format(duplicate.id))
         q.enqueue(worker_function, "AssignmentReassigned", None, duplicate.id)
 
-    # Count working participants
-    waiting_count = models.Participant.query.filter_by(
-        status='working').count() + 1
+    # Count working or beyond participants.
+    nonfailed_count = models.Participant.query.filter(
+        (models.Participant.status == "working") |
+        (models.Participant.status == "submitted") |
+        (models.Participant.status == "approved")
+    ).count() + 1
 
     # Create the new participant.
     participant = models.Participant(
@@ -753,7 +756,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     # recruiter = recruiters.for_experiment(exp)
     # recruiter.notify_recruited(participant)
 
-    overrecruited = exp.is_overrecruited(waiting_count)
+    overrecruited = exp.is_overrecruited(nonfailed_count)
     # if not overrecruited:
     #     # We either had no quorum or we have not overrecruited, inform the
     #     # recruiter that this participant will be seeing the experiment
@@ -763,7 +766,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     if exp.quorum:
         quorum = {
             'q': exp.quorum,
-            'n': waiting_count,
+            'n': nonfailed_count,
             'overrecruited': overrecruited,
         }
         db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -566,6 +566,7 @@ def by_name(name):
     """
     nicknames = {
         'bots': BotRecruiter,
+        'hotair': HotAirRecruiter,
         'mturklarge': MTurkLargeRecruiter
     }
     if name in nicknames:

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -5,6 +5,7 @@ config = get_config()
 
 
 class TestExperiment(Experiment):
+    _completed = None
 
     def __init__(self, session=None):
         try:
@@ -31,6 +32,10 @@ class TestExperiment(Experiment):
         from dallinger.networks import Star
         return Star(max_size=2)
 
+    def is_complete(self):
+        return config.get('_is_completed', None)
+
 
 def extra_parameters():
     config.register('custom_parameter', int, [])
+    config.register('_is_completed', bool, [])

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -326,6 +326,29 @@ class TestHandleError(object):
         assert notifications[1].assignment_id == assignment_id
         assert notifications[1].details['request_data']['participant_id'] == participant_id
 
+    def test_looks_up_hit_in_nested_request_data(self, a, webapp):
+        participant = a.participant()
+        assignment_id = participant.assignment_id
+        worker_id = participant.worker_id
+        hit_id = participant.hit_id
+        participant_id = participant.id
+        webapp.post('/handle-error',
+                    data={'request_data': json.dumps(
+                        {'data': json.dumps({
+                            'particpant_id': participant_id,
+                            'worker_id': worker_id,
+                            'hit_id': hit_id,
+                            'assignment_id': assignment_id
+                        })}
+                    )})
+
+        notifications = models.Notification.query.all()
+        assert len(notifications) == 2
+        assert notifications[0].event_type == u'AssignmentSubmitted'
+        assert notifications[1].event_type == u'ExperimentError'
+        assert notifications[1].assignment_id == assignment_id
+        assert notifications[1].details['request_data']['participant_id'] == participant_id
+
     def test_sends_email(self, a, webapp, active_config, dummy_mailer):
         active_config.extend({'dallinger_email_address': u'test_error',
                               'dallinger_email_password': u'secret'})
@@ -335,6 +358,20 @@ class TestHandleError(object):
         dummy_mailer.starttls.assert_called_once()
         dummy_mailer.sendmail.assert_called_once()
         assert dummy_mailer.sendmail.call_args[0][0] == u'test_error@gmail.com'
+
+    def test_emailer_handles_missing_username(self, a, webapp, active_config, dummy_mailer):
+        active_config.extend({'dallinger_email_address': u'',
+                              'contact_email_on_error': u'test_error'})
+        webapp.post('/handle-error', data={})
+
+        dummy_mailer.login.assert_not_called()
+
+    def test_emailer_handles_missing_destination_address(self, a, webapp, active_config, dummy_mailer):
+        active_config.extend({'dallinger_email_address': u'test_error',
+                              'contact_email_on_error': u''})
+        webapp.post('/handle-error', data={})
+
+        dummy_mailer.login.assert_not_called()
 
 
 @pytest.mark.usefixtures('experiment_dir', 'db_session')
@@ -608,6 +645,31 @@ class TestSummaryRoute(object):
             u'summary': [[u'approved', 1], [u'submitted', 1]],
             u'unfilled_networks': 0
         }
+
+    def test_summary_uses_custom_is_complete(self, a, webapp, active_config):
+        active_config.register_extra_parameters()
+        resp = webapp.get('/summary')
+        data = json.loads(resp.data)
+        assert data == {
+            u'completed': False,
+            u'nodes_remaining': 2,
+            u'required_nodes': 2,
+            u'status': u'success',
+            u'summary': [],
+            u'unfilled_networks': 1
+        }
+        active_config.extend({'_is_completed': True})
+        resp = webapp.get('/summary')
+        data = json.loads(resp.data)
+        assert data == {
+            u'completed': True,
+            u'nodes_remaining': 2,
+            u'required_nodes': 2,
+            u'status': u'success',
+            u'summary': [],
+            u'unfilled_networks': 1
+        }
+
 
 
 @pytest.mark.usefixtures('experiment_dir')

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -366,7 +366,8 @@ class TestHandleError(object):
 
         dummy_mailer.login.assert_not_called()
 
-    def test_emailer_handles_missing_destination_address(self, a, webapp, active_config, dummy_mailer):
+    def test_emailer_handles_missing_destination_address(self, a, webapp, active_config,
+                                                         dummy_mailer):
         active_config.extend({'dallinger_email_address': u'test_error',
                               'contact_email_on_error': u''})
         webapp.post('/handle-error', data={})
@@ -669,7 +670,6 @@ class TestSummaryRoute(object):
             u'summary': [],
             u'unfilled_networks': 1
         }
-
 
 
 @pytest.mark.usefixtures('experiment_dir')


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This branch implements Scrumdo stories [315](https://app.scrumdo.com/projects/story_permalink/1535307) and [323](https://app.scrumdo.com/projects/story_permalink/1536451). It creates a new customizable `is_complete` method on the `Experiment` class to provide custom logic for determining when an experiment has finished. It also re-enables recruiter notification methods and fixes error handling issues and provides more comprehensive exception handling.

## Motivation and Context

This PR attempts to resolve the issues described in the ScrumDo stories above related to over-recruitment and email errors.

## How Has This Been Tested?

I tested these changes manually using GridUniverse with new parameters enabled for over-recruiting and a custom `is_complete` method. Scenarios were tested where the over-recruited users started the experiment before the game was completed, after the game was completed but before some players had submitted their assignments, and after all player assignments had been submitted.

Before this is merged I'd like to add automated tests for the `is_complete` integration and probably also for some of the email edge cases.

There is a corresponding [GridUniverse PR](https://github.com/Dallinger/Griduniverse/pull/168).

#### Note: This branch was based on the `mturk-live-fixes-2` branch includes changes from that branch as a result. The changes made specifically for these stories can be viewed by changing the base branch to `mturk-live-fixes-2` though the intent is to merge to master.
