### PR TITLE
Give experiment a chance to initialize/finish around replaying state

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -599,6 +599,9 @@ class Experiment(object):
     def replay_event(self, event):
         pass
 
+    def replay_start(self):
+        pass
+
     def replay_finish(self):
         pass
 
@@ -680,7 +683,9 @@ class Experiment(object):
         # with experiment.restore_state_from_replay(...): block the configuration
         # options are correctly set
         with config.override(configuration_options, strict=True):
+            self.replay_start()
             yield go_to
+            self.replay_finish()
 
         # Clear up global state
         import_session.close()


### PR DESCRIPTION
This simply calls replay_start and replay_finish methods on the experiment when replaying state. It's needed for story 295 so that Griduniverse has a chance to initialize the Gridworld *after* the configuration has been loaded.

## How Has This Been Tested?
There's a new test that fails without this in the Griduniverse branch with the same name.