### PR TITLE
Fix check for loading both versions of dallinger script

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger.js
+++ b/dallinger/frontend/static/scripts/dallinger.js
@@ -22,7 +22,7 @@ var getUrlParameter = function getUrlParameter(sParam) {
     }
 };
 
-if (dallinger !== undefined) {
+if (window.dallinger !== undefined) {
   alert(
     'This page has loaded both dallinger.js and dallinger2.js at the same time, ' +
     'which is not supported. It is recommended to use dallinger2.js ' +

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -1,6 +1,6 @@
 /*globals Spinner, Fingerprint2, ReconnectingWebSocket, reqwest, store */
 
-if (Dallinger !== undefined) {
+if (window.Dallinger !== undefined) {
   alert(
     'This page has loaded both dallinger.js and dallinger2.js at the same time, ' +
     'which is not supported. It is recommended to use dallinger2.js ' +

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -125,6 +125,22 @@ If you get a fatal error that your ROLE does not exist, run these commands:
     dropdb dallinger
     createdb -O dallinger dallinger
 
+Install Heroku
+^^^^^^^^^^^^^^
+
+To run experiments locally or on the internet, you will need the Heroku Command
+Line Interface installed, version 3.28.0 or better. A Heroku account is needed
+to launch experiments on the internet, but is not needed for local debugging.
+
+To check which version of the Heroku CLI you have installed, run:
+
+::
+
+    heroku --version
+
+The Heroku CLI is available for download from
+`heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
+
 Install Redis
 ^^^^^^^^^^^^^
 


### PR DESCRIPTION
It turns out that the check I added to make sure that both dallinger.js and dallinger2.js are not loaded does not work but throws a ReferenceError. This fixes it. I'm going to go ahead and merge this since it's blocking other work on Griduniverse.

Tested by running Griduniverse in debug mode.