### PR TITLE
Ad blocker detection and detection for missing Fingerprint2.js

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -219,7 +219,13 @@ var dallinger = (function () {
       fingerprint_hash,
       url,
       hit_params;
-
+    if (dlgr.missingFingerprint()) {
+      window.alert(
+        'An ad blocker is preventing this experiment from ' +
+        'loading. Please disable it and reload the page.'
+      )
+      return;
+    }
     new Fingerprint2().get(function(result){
       fingerprint_hash = result;
       store.set("fingerprint_hash", fingerprint_hash);
@@ -332,5 +338,26 @@ var dallinger = (function () {
     $("#progress-percentage").text(percent);
   };
 
+  dlgr.missingFingerprint = function () {
+    if (window.Fingerprint2 === undefined) {
+      return true;
+    }
+    return false;
+  }
+
+  dlgr.hasAdBlocker = function (callback) {
+    var test = document.createElement('div');
+    test.innerHTML = '&nbsp;';
+    test.className = 'adsbox';
+    document.body.appendChild(test);
+    window.setTimeout(function() {
+      if (test.offsetHeight === 0) {
+        return callback();
+      }
+      test.remove();
+    }, 100);
+  }
+
   return dlgr;
 }());
+

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -25,6 +25,21 @@
             <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
         {% endblock %}
         {% block scripts %}
+            <script type="text/javascript">
+                dallinger.hasAdBlocker(function () {
+                    var begin_button = document.getElementById("begin-button");
+                    if (begin_button) {
+                        begin_button.setAttribute('disabled', 'disabled');
+                        window.alert(
+                            'You appear to have an ad blocker enabled. ' +
+                            'This experiment is incompatible ' +
+                            'with most ad blockers. Please pause your ad ' +
+                            'blocker or disable it for this domain and ' +
+                            'reload the page.'
+                        );
+                    }
+                });
+            </script>
         {% endblock %}
     </body>
 </html>


### PR DESCRIPTION
## Description
Detects if an Ad blocker is enabled. If an ad blocker is detected on the ad page, the button is disabled and an alert is opened indicating that ad blockers must be disabled. If a previously undetected extension has blocked loading of Fingerprint2.js, that condition will be detected before attempting to create a new participant, and an alert shown.

## Motivation and Context
See [ScrumDo Story 322](https://app.scrumdo.com/projects/story_permalink/1536427). When ad blockers were enabled, Fingerprint2.js would not be loaded and `dallinger.createParticipant()` would fail. Now an ad blocker should be detected before the HIT is accepted, and a missing Fingerprint2.js should trigger an alert rather than an error.

## How Has This Been Tested?
This code was tested to ensure it detects `AdBlock` and `uBlock Origin` when enabled and works when those plugins are disabled or whitelist the current domain. I also tested accepting the HIT with ad blocker disabled and then and trying to join the experiment with the ad blocker re-enabled.

Currently, the code uses `window.alert` which isn't necessarily ideal. Alert windows can be blocked by some browser extensions, and are considered a bad practice (more when used for debugging than for actual user alerts). The alternative would be to use a custom modal dialog display; however, since experiments may use a variety of CSS libraries, it's not clear that a custom modal dialog would work as consistently as a browser `alert` across different custom experiment types.
