### PR TITLE
Scrub back in replays

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,7 +40,7 @@ before_script:
 - bundle exec danger
 - createuser dallinger --createdb
 - createdb -O dallinger dallinger
-- createdb -O dallinger dallinger-import
+- createdb -O dallinger dallinger-import-bartlett-test
 env:
   global:
   - DATABASE_URL=postgresql://dallinger@localhost/dallinger

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -248,7 +248,10 @@ class Configuration(object):
             try:
                 from dallinger_experiment.dallinger_experiment import extra_parameters
             except ImportError:
-                pass
+                try:
+                    from dallinger_experiment import extra_parameters
+                except ImportError:
+                    pass
         if extra_parameters is not None and getattr(extra_parameters, 'loaded', None) is None:
             extra_parameters()
             extra_parameters.loaded = True
@@ -275,10 +278,15 @@ def initialize_experiment_package(path):
     if not os.path.exists(init_py):
         open(init_py, 'a').close()
 
+    # Retain already set experiment module
+    if sys.modules.get('dallinger_experiment') is not None:
+        return
+
     dirname = os.path.dirname(path)
     basename = os.path.basename(path)
     sys.path.insert(0, dirname)
     package = __import__(basename)
+
     sys.modules['dallinger_experiment'] = package
     package.__package__ = 'dallinger_experiment'
     sys.path.pop(0)

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -659,12 +659,11 @@ class Experiment(object):
         try:
             # Clear the temporary storage and import it
             init_db(drop_all=True, bind=import_engine)
-        except:
+        except Exception:
             create_db_engine = create_engine(db_url)
             conn = create_db_engine.connect()
             conn.execute('COMMIT;')
             conn.execute('CREATE DATABASE "{}"'.format(specific_db_url.rsplit('/', 1)[1]))
-        else:
             import_engine = create_engine(
                 specific_db_url
             )

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -634,7 +634,7 @@ class Experiment(object):
         # We need to fake dallinger_experiment to point at the current experiment
         module = sys.modules[type(self).__module__]
         if sys.modules.get('dallinger_experiment', module) != module:
-            raise RuntimeError('dallinger_experiment is already set')
+            logger.warn('dallinger_experiment is already set, updating')
         sys.modules['dallinger_experiment'] = module
 
         # Load the configuration system and globals

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -21,6 +21,7 @@ import uuid
 
 from sqlalchemy import and_
 from sqlalchemy import create_engine
+from sqlalchemy import func
 from sqlalchemy.orm import sessionmaker, scoped_session
 
 from dallinger import recruiters
@@ -671,40 +672,29 @@ class Experiment(object):
         init_db(drop_all=True, bind=import_engine)
         print("Ingesting dataset from {}...".format(os.path.basename(zip_path)))
         ingest_zip(zip_path, engine=import_engine)
-
-        def go_to(time):
-            """Scrub to a point in the experiment replay, given by time
-            which is a datetime object."""
-            if self._replay_time_index > time:
-                # We do not support going back in time
-                raise NotImplementedError
-            events = self.events_for_replay(session=import_session, target=time)
-            for event in events:
-                if event.creation_time <= self._replay_time_index:
-                    # Skip events we've already handled
-                    continue
-                if event.creation_time > time:
-                    # Stop once we get future events
-                    break
-                self.replay_event(event)
-                self._replay_time_index = event.creation_time
-            # Override app_id to allow exports to be created that don't
-            # overwrite the original dataset
-            self.app_id = "{}_{}".format(self.original_app_id, time.isoformat())
-
+        self._replay_range = tuple(
+            import_session.query(
+                func.min(Info.creation_time),
+                func.max(Info.creation_time)
+            )
+        )[0]
         # We apply the configuration options we were given and yield
         # the scrubber function into the context manager, so within the
         # with experiment.restore_state_from_replay(...): block the configuration
         # options are correctly set
         with config.override(configuration_options, strict=True):
             self.replay_start()
-            yield go_to
+            yield Scrubber(self, session=import_session)
             self.replay_finish()
 
         # Clear up global state
         import_session.close()
         config._reset(register_defaults=True)
         del sys.modules['dallinger_experiment']
+
+    def revert_to_time(self, session, target):
+        # We do not support going back in time
+        raise NotImplementedError
 
     def _ipython_display_(self):
         """Display Jupyter Notebook widget"""
@@ -714,6 +704,57 @@ class Experiment(object):
     def update_status(self, status):
         if self.widget is not None:
             self.widget.status = status
+
+
+class Scrubber(object):
+    def __init__(self, experiment, session):
+        self.experiment = experiment
+        self.session = session
+
+    def __call__(self, time):
+        """Scrub to a point in the experiment replay, given by time
+        which is a datetime object."""
+        if self.experiment._replay_time_index > time:
+            self.experiment.revert_to_time(session=self.session, target=time)
+        events = self.experiment.events_for_replay(session=self.session, target=time)
+        for event in events:
+            if event.creation_time <= self.experiment._replay_time_index:
+                # Skip events we've already handled
+                continue
+            if event.creation_time > time:
+                # Stop once we get future events
+                break
+            self.experiment.replay_event(event)
+            self.experiment._replay_time_index = event.creation_time
+        # Override app_id to allow exports to be created that don't
+        # overwrite the original dataset
+        self.experiment.app_id = "{}_{}".format(self.experiment.original_app_id, time.isoformat())
+
+    def widget(self):
+        from ipywidgets import widgets
+        start, end = self.experiment._replay_range
+        options = []
+        current = start
+        while current <= end:
+            options.append((current.replace(microsecond=0).time().isoformat(), current))
+            current += datetime.timedelta(seconds=1)
+        scrubber = widgets.SelectionSlider(
+            description='Current time',
+            options=options,
+            disabled=False,
+            continuous_update=False,
+        )
+
+        def advance(change):
+            self(change['new'])
+            self.experiment.widget.render()
+        scrubber.observe(advance, 'value')
+        return scrubber
+
+    def _ipython_display_(self):
+        """Display Jupyter Notebook widget"""
+        from IPython.display import display
+        display(self.widget())
 
 
 def load():

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -9,6 +9,7 @@ from contextlib import contextmanager
 from functools import wraps
 import datetime
 import inspect
+from importlib import import_module
 import logging
 from operator import itemgetter
 import os
@@ -133,11 +134,14 @@ class Experiment(object):
             self.configure()
 
         try:
+            location = type(self).__module__
+            parent, experiment_module = location.rsplit('.', 1)
+            module = import_module(parent + '.jupyter')
+        except (ImportError, ValueError):
             from .jupyter import ExperimentWidget
-        except ImportError:
-            self.widget = None
-        else:
             self.widget = ExperimentWidget(self)
+        else:
+            self.widget = module.ExperimentWidget(self)
 
     def configure(self):
         """Load experiment configuration here"""
@@ -600,7 +604,7 @@ class Experiment(object):
             HerokuApp(self.app_id).destroy()
         return True
 
-    def events_for_replay(self, session=None):
+    def events_for_replay(self, session=None, target=None):
         """Be default we return all infos in order for replay"""
         if session is None:
             session = self.session
@@ -674,7 +678,7 @@ class Experiment(object):
             if self._replay_time_index > time:
                 # We do not support going back in time
                 raise NotImplementedError
-            events = self.events_for_replay(session=import_session)
+            events = self.events_for_replay(session=import_session, target=time)
             for event in events:
                 if event.creation_time <= self._replay_time_index:
                     # Skip events we've already handled
@@ -683,7 +687,7 @@ class Experiment(object):
                     # Stop once we get future events
                     break
                 self.replay_event(event)
-            self._replay_time_index = time
+                self._replay_time_index = event.creation_time
             # Override app_id to allow exports to be created that don't
             # overwrite the original dataset
             self.app_id = "{}_{}".format(self.original_app_id, time.isoformat())

--- a/dallinger/jupyter.py
+++ b/dallinger/jupyter.py
@@ -34,15 +34,8 @@ class ExperimentWidget(widgets.VBox):
         super(ExperimentWidget, self).__init__()
         self.render()
 
-    @observe('status')
-    def render(self, change=None):
-        header = widgets.HTML(
-            header_template.render(
-                name=self.exp.task,
-                status=self.status,
-                app_id=self.exp.app_id,
-            ),
-        )
+    @property
+    def config_tab(self):
         config = get_config()
         if config.ready:
             config_items = list(config.as_dict().items())
@@ -52,6 +45,18 @@ class ExperimentWidget(widgets.VBox):
             )
         else:
             config_tab = widgets.HTML('Not loaded.')
-        tabs = widgets.Tab(children=[config_tab])
+        return config_tab
+
+    @observe('status')
+    def render(self, change=None):
+        header = widgets.HTML(
+            header_template.render(
+                name=self.exp.task,
+                status=self.status,
+                app_id=self.exp.app_id,
+            ),
+        )
+
+        tabs = widgets.Tab(children=[self.config_tab])
         tabs.set_title(0, 'Configuration')
         self.children = [header, tabs]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 
+import mock
 import os
+import sys
 from tempfile import NamedTemporaryFile
 
 import pexpect
@@ -184,6 +186,17 @@ worldwide = false
         config.clear()
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
+
+    def test_custom_experiment_module_set_and_retained(self):
+        config = get_config()
+        with mock.patch.dict('sys.modules', dallinger_experiment=None):
+            config.register_extra_parameters()
+            assert sys.modules['dallinger_experiment'] is not None
+        exp_module = mock.Mock()
+        with mock.patch.dict('sys.modules', dallinger_experiment=exp_module):
+            config.clear()
+            config.register_extra_parameters()
+            assert sys.modules['dallinger_experiment'] is exp_module
 
     def test_local_base_url(self):
         from dallinger.utils import get_base_url

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -32,7 +32,7 @@ class DummyExperiment(object):
     def replay_started(self):
         return self.started
 
-    def events_for_replay(self):
+    def events_for_replay(self, *args, **kwargs):
         return self._events
 
     def replay_event(self, event):


### PR DESCRIPTION
## Description
Extend the Jupyter widgets and replay stories to allow experiments to implement a method scrubbing back in time.

## Motivation and Context
This allows experiments to support cleanly exploring data in a replay rather than just replaying forwards.

## How Has This Been Tested?
Minimal manual testing in a Jupyter notebook