### PR TITLE
HIT Manipulation Commands

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -761,6 +761,13 @@ def expire(app, sandbox):
         out.log('Could not expire {} hits: {}'.format(
             len(failures), ', '.join(failures)
         ))
+    if not success and not failures:
+        out.log('No hits found for this application.')
+        if not sandbox:
+            out.log(
+                'If this experiment was run in the MTurk sandbox, use: '
+                '`dallinger expire --sandbox --app {}'.format(app)
+            )
 
 
 @dallinger.command()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -730,7 +730,7 @@ def _current_hits(service, app):
               help='Is the app running in the sandbox?')
 def hits(app, sandbox):
     """List hits for an experiment id."""
-    hit_list = _current_hits(_mturk_service_from_config(sandbox), app)
+    hit_list = list(_current_hits(_mturk_service_from_config(sandbox), app))
     out = Output()
     out.log('Found {} hits for this experiment id: {}'.format(
         len(hit_list), ', '.join(h['id'] for h in hit_list)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -43,6 +43,7 @@ from dallinger.heroku.worker import conn
 from dallinger.heroku.tools import HerokuLocalWrapper
 from dallinger.heroku.tools import HerokuApp
 from dallinger.mturk import MTurkService
+from dallinger.mturk import MTurkServiceException
 from dallinger import recruiters
 from dallinger import registration
 from dallinger.utils import check_call
@@ -618,6 +619,17 @@ def _deploy_in_mode(mode, app, verbose):
     deploy_sandbox_shared_setup(verbose=verbose, app=app)
 
 
+def _mturk_service_from_config(sandbox):
+    config = get_config()
+    config.load()
+    return MTurkService(
+        aws_access_key_id=config.get('aws_access_key_id'),
+        aws_secret_access_key=config.get('aws_secret_access_key'),
+        region_name=config.get('aws_region'),
+        sandbox=sandbox,
+    )
+
+
 @dallinger.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
 @click.option('--app', default=None, help='Experiment id')
@@ -650,15 +662,7 @@ def qualify(workers, qualification, value, by_name, notify, sandbox):
         raise click.BadParameter(
             'Must specify a qualification ID, value/score, and at least one worker ID'
         )
-
-    config = get_config()
-    config.load()
-    mturk = MTurkService(
-        aws_access_key_id=config.get('aws_access_key_id'),
-        aws_secret_access_key=config.get('aws_secret_access_key'),
-        region_name=config.get('aws_region'),
-        sandbox=sandbox,
-    )
+    mturk = _mturk_service_from_config(sandbox)
     if by_name:
         result = mturk.get_qualification_type_by_name(qualification)
         if result is None:
@@ -714,12 +718,66 @@ def hibernate(app):
         heroku_app.addon_destroy(addon)
 
 
+def _current_hits(service, app):
+    return service.get_hits(
+        hit_filter=lambda h: h.get('annotation') == app
+    )
+
+
+@dallinger.command()
+@click.option('--app', default=None, callback=verify_id, help='Experiment id')
+@click.option('--sandbox', is_flag=True, flag_value=True,
+              help='Is the app running in the sandbox?')
+def hits(app, sandbox):
+    """List hits for an experiment id."""
+    hit_list = _current_hits(_mturk_service_from_config(sandbox), app)
+    out = Output()
+    out.log('Found {} hits for this experiment id: {}'.format(
+        len(hit_list), ', '.join(h['id'] for h in hit_list)
+    ))
+
+
+@dallinger.command()
+@click.option('--app', default=None, callback=verify_id, help='Experiment id')
+@click.option('--sandbox', is_flag=True, flag_value=True,
+              help='Is the app running in the sandbox?')
+def expire(app, sandbox):
+    """Expire hits for an experiment id."""
+    success = []
+    failures = []
+    service = _mturk_service_from_config(sandbox)
+    hits = _current_hits(service, app)
+    for hit in hits:
+        hit_id = hit['id']
+        try:
+            service.expire_hit(hit_id)
+            success.append(hit_id)
+        except MTurkServiceException:
+            failures.append(hit_id)
+    out = Output()
+    if success:
+        out.log('Expired {} hits: {}'.format(len(success), ', '.join(success)))
+    if failures:
+        out.log('Could not expire {} hits: {}'.format(
+            len(failures), ', '.join(failures)
+        ))
+
+
 @dallinger.command()
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 @click.confirmation_option(prompt='Are you sure you want to destroy the app?')
-def destroy(app):
+@click.option(
+    '--expire-hit', is_flag=True, flag_value=True,
+    prompt='Would you like to expire all hits associated with this experiment id?',
+    help='Expire any hits associated with this experiment.')
+@click.option('--sandbox', is_flag=True, flag_value=True,
+              help='Is the app running in the sandbox?')
+@click.pass_context
+def destroy(ctx, app, expire_hit, sandbox):
     """Tear down an experiment server."""
     HerokuApp(app).destroy()
+    if expire_hit:
+        ctx.invoke(expire, app=app, sandbox=sandbox)
 
 
 @dallinger.command()

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -351,7 +351,7 @@ class MTurkService(object):
 
     def create_hit(self, title, description, keywords, reward, duration_hours,
                    lifetime_days, ad_url, notification_url, approve_requirement,
-                   max_assignments, us_only, blacklist=None):
+                   max_assignments, us_only, blacklist=None, annotation=None):
         """Create the actual HIT and return a dict with its useful properties."""
         frame_height = 600
         mturk_question = self._external_question(ad_url, frame_height)
@@ -369,8 +369,11 @@ class MTurkService(object):
             'Question': mturk_question,
             'LifetimeInSeconds': int(datetime.timedelta(days=lifetime_days).total_seconds()),
             'MaxAssignments': max_assignments,
-            'UniqueRequestToken': self._request_token()
+            'UniqueRequestToken': self._request_token(),
         }
+        if annotation:
+            params['RequesterAnnotation'] = annotation
+
         response = self.mturk.create_hit_with_hit_type(**params)
         if 'HIT' not in response:
             raise MTurkServiceException("HIT request was invalid for unknown reason.")
@@ -563,6 +566,7 @@ class MTurkService(object):
             'reward': float(hit['Reward']),
             'review_status': hit['HITReviewStatus'],
             'status': hit['HITStatus'],
+            'annotation': hit.get('RequesterAnnotation'),
         }
 
         return translated

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -293,6 +293,7 @@ class MTurkRecruiter(Recruiter):
             'approve_requirement': self.config.get('approve_requirement'),
             'us_only': self.config.get('us_only'),
             'blacklist': self._config_to_list('qualification_blacklist'),
+            'annotation': self.config.get('id'),
         }
         hit_info = self.mturkservice.create_hit(**hit_request)
         if self.config.get('mode') == "sandbox":

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -356,6 +356,7 @@ class TestMTurkRecruiter(object):
             title=u'fake experiment title',
             us_only=True,
             blacklist=[],
+            annotation='some experiment uid',
         )
 
     def test_open_recruitment_creates_qualifications_for_experiment_app_id(self, recruiter):
@@ -396,6 +397,7 @@ class TestMTurkRecruiter(object):
             title='fake experiment title',
             us_only=True,
             blacklist=['foo', 'bar'],
+            annotation='some experiment uid',
         )
 
     def test_open_recruitment_is_noop_if_experiment_in_progress(self, a, recruiter):
@@ -567,6 +569,7 @@ class TestMTurkLargeRecruiter(object):
             title='fake experiment title',
             us_only=True,
             blacklist=[],
+            annotation='some experiment uid',
         )
 
     def test_more_than_ten_can_be_recruited_on_open(self, recruiter):
@@ -584,6 +587,7 @@ class TestMTurkLargeRecruiter(object):
             title='fake experiment title',
             us_only=True,
             blacklist=[],
+            annotation='some experiment uid',
         )
 
     def test_recruit_participants_auto_recruit_on_recruits_for_current_hit(self, recruiter):


### PR DESCRIPTION
## Description
Implements [ScrumDo Story 321](https://app.scrumdo.com/projects/dallinger/#/iteration/286266/board/story/1536415). Adds two new `dallinger` commands `hits` and `expire` to list HITs associated with an experiment id and expire those HITs respectively. Addtionally, adds an option to the `dallinger destroy` command to expire HITs associated with the experiment id being destroyed. These commands require a `--sandbox` flag to be passed for cases where the experiment was run in the MTurk sandbox.

## Motivation and Context

See story description. Currently a fair amount of work is required to find and expire HITs associated with an experiment, these changes simplify and automate that process. In order to explicitly associate a HIT with an experiment id, the MTurk recruiters add a `RequestAnnotation` to all created HITs with the experiment id.

## How Has This Been Tested?
These changes include automated tests for all new functionality. Additionally, the changes have been tested manually by creating new experiments in the sandbox and using the new commands to manipulate the associated HITs.
