### PR TITLE
Story 328: Mixed recruiters

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -44,7 +44,7 @@ rules:
   # Best Practices
   accessor-pairs: 2
   block-scoped-var: 0
-  complexity: [2, 6]
+  complexity: [2, 7]
   consistent-return: 0
   curly: 0
   default-case: 0
@@ -52,7 +52,7 @@ rules:
   dot-notation: 0
   eqeqeq: 2
   guard-for-in: 2
-  no-alert: 2
+  no-alert: 1
   no-caller: 2
   no-case-declarations: 2
   no-div-regex: 2
@@ -111,7 +111,7 @@ rules:
   no-undef-init: 2
   no-undef: 0
   no-undefined: 0
-  no-unused-vars: 0
+  no-unused-vars: 1
   no-use-before-define: 0
 
   # Node.js and CommonJS

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -935,7 +935,7 @@ class DebugSessionRunner(LocalSessionRunner):
         time.sleep(4)
         try:
             result = _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
-        except ValueError:
+        except Exception:
             # Show output from server
             self.dispatch[r'POST /launch'] = 'launch_request_complete'
             heroku.monitor(listener=self.notify)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -58,6 +58,7 @@ default_keys = (
     ('port', int, ['PORT']),
     ('qualification_blacklist', six.text_type, []),
     ('recruiter', six.text_type, []),
+    ('recruiters', six.text_type, []),
     ('redis_size', six.text_type, []),
     ('replay', bool, []),
     ('threads', six.text_type, []),

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -562,6 +562,7 @@ def advertisement():
         recruiter = recruiters.by_name(recruiter_name)
     else:
         recruiter = recruiters.from_config(config)
+        recruiter_name = recruiter.nickname
     ready_for_external_submission = status == 'working' and part.end_time is not None
     assignment_complete = status in ('submitted', 'approved')
 
@@ -586,6 +587,7 @@ def advertisement():
     # even have accepted the HIT.
     return render_template(
         'ad.html',
+        recruiter=recruiter_name,
         hitid=hit_id,
         assignmentid=assignment_id,
         workerid=worker_id,
@@ -815,7 +817,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     ).count() + 1
 
     recruiter_name = request.args.get('recruiter')
-    if recruiter_name:
+    if recruiter_name and recruiter_name != 'undefined':
         recruiter = recruiters.by_name(recruiter_name)
     else:
         recruiter = recruiters.from_config(_config())

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -1,5 +1,3 @@
-
-
 class WorkerEvent(object):
 
     key = '-----'
@@ -27,10 +25,6 @@ class WorkerEvent(object):
         self.session = session
         self.config = config
         self.now = now
-
-    @property
-    def recruiter(self):
-        return self.experiment.recruiter
 
     def commit(self):
         self.session.commit()
@@ -82,7 +76,7 @@ class AssignmentSubmitted(WorkerEvent):
 
         if not self.data_is_ok():
             self.fail_data_check()
-            self.recruiter.recruit(n=1)
+            self.experiment.recruiter.recruit(n=1)
 
             return
 
@@ -100,7 +94,7 @@ class AssignmentSubmitted(WorkerEvent):
             self.experiment.recruit()
         else:
             self.fail_submission()
-            self.recruiter.recruit(n=1)
+            self.experiment.recruiter.recruit(n=1)
 
     def data_is_ok(self):
         """Run a check on our participant's data"""
@@ -110,12 +104,12 @@ class AssignmentSubmitted(WorkerEvent):
         return self.experiment.attention_check(participant=self.participant)
 
     def approve_assignment(self):
-        self.recruiter.approve_hit(self.assignment_id)
+        self.participant.recruiter.approve_hit(self.assignment_id)
         self.participant.base_pay = self.config.get('base_payment')
 
     def award_bonus(self, bonus):
         self.log("Bonus = {}: paying bonus".format(bonus))
-        self.recruiter.reward_bonus(
+        self.participant.recruiter.reward_bonus(
             self.assignment_id,
             bonus,
             self.experiment.bonus_reason())
@@ -145,7 +139,7 @@ class BotAssignmentSubmitted(WorkerEvent):
         self.update_particant_end_time()
 
         # No checks for bot submission
-        self.recruiter.approve_hit(self.assignment_id)
+        self.participant.recruiter.approve_hit(self.assignment_id)
         self.participant.status = "approved"
         self.experiment.submission_successful(participant=self.participant)
         self.commit()

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -29,6 +29,7 @@ var dallinger = (function () {
   };
 
   dlgr.identity = {
+    recruiter: dlgr.getUrlParameter('recruiter'),
     hitId: dlgr.getUrlParameter('hit_id'),
     workerId: dlgr.getUrlParameter('worker_id'),
     assignmentId: dlgr.getUrlParameter('assignment_id'),
@@ -116,12 +117,14 @@ var dallinger = (function () {
     // check if the local store is available, and if so, use it.
     var data = {};
     if (typeof store !== "undefined") {
+      data.recruiter = store.get("recruiter");
       data.worker_id = store.get("worker_id");
       data.hit_id = store.get("hit_id");
       data.assignment_id = store.get("assignment_id");
       data.mode = store.get("mode");
       data.fingerprint_hash = store.get("fingerprint_hash");
     } else {
+      data.recruiter = dlgr.identity.recruiter;
       data.worker_id = dlgr.identity.worker_id;
       data.hit_id = dlgr.identity.hit_id;
       data.assignment_id = dlgr.identity.assignment_id;
@@ -140,7 +143,7 @@ var dallinger = (function () {
       type: 'json',
       success: function (resp) { deferred.resolve(resp); },
       error: function (err) {
-        var $form, errorResponse, request_data, worker_id, hit_id, hit_params, assignment_id;
+        var $form, errorResponse, request_data, hit_params;
         console.log(err);
         deferred.reject(err);
         request_data = {
@@ -197,10 +200,9 @@ var dallinger = (function () {
       dlgr.identity.hitId = resp.participant.hit_id;
       dlgr.identity.assignmentId = resp.participant.assignment_id;
       dlgr.identity.workerId = resp.participant.worker_id;
-      var workerComplete = '/worker_complete';
       dlgr.get('/worker_complete', {
         'participant_id': dlgr.identity.participantId
-      }).done(function (resp) {
+      }).done(function () {
         deferred.resolve();
         dallinger.allowExit();
         window.location = "/complete";
@@ -234,7 +236,7 @@ var dallinger = (function () {
     hit_params = get_hit_params();
     url = "/participant/" + hit_params.worker_id + "/" + hit_params.hit_id +
       "/" + hit_params.assignment_id + "/" + hit_params.mode + "?fingerprint_hash=" +
-      (hit_params.fingerprint_hash || fingerprint_hash);
+      (hit_params.fingerprint_hash || fingerprint_hash) + '&recruiter=' + hit_params.recruiter;
 
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();

--- a/dallinger/frontend/templates/base/ad.html
+++ b/dallinger/frontend/templates/base/ad.html
@@ -33,7 +33,7 @@
 {% block scripts %}
 <script>
     function openwindow(event) {
-        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+        popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
         event.target.setAttribute("disabled", "");
     }
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -269,8 +269,7 @@ class Participant(Base, SharedMixin):
     @property
     def recruiter(self):
         from dallinger import recruiters
-        recruiter_class = recruiters.by_name(self.recruiter_id or 'hotair')
-        return recruiter_class()
+        return recruiters.by_name(self.recruiter_id or 'hotair')
 
 
 class Question(Base, SharedMixin):
@@ -1831,3 +1830,12 @@ class Notification(Base, SharedMixin):
 
     # the type of notification
     event_type = Column(String, nullable=False)
+
+
+class Recruitment(Base, SharedMixin):
+    """A record of a request to recruit a participant."""
+
+    __tablename__ = "recruitment"
+
+    #: A String, the nickname of the recruiter used.
+    recruiter_id = Column(String(50), nullable=True)

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -85,6 +85,9 @@ class Participant(Base, SharedMixin):
     #: A String, the fingerprint hash of the participant.
     fingerprint_hash = Column(String(50), nullable=True)
 
+    #: A String, the nickname of the recruiter used by this participant.
+    recruiter_id = Column(String(50), nullable=True)
+
     #: A String, the worker id of the participant.
     worker_id = Column(String(50), nullable=False)
 
@@ -145,8 +148,9 @@ class Participant(Base, SharedMixin):
         default="working",
         index=True)
 
-    def __init__(self, worker_id, assignment_id, hit_id, mode, fingerprint_hash=None):
+    def __init__(self, recruiter_id, worker_id, assignment_id, hit_id, mode, fingerprint_hash=None):
         """Create a participant."""
+        self.recruiter_id = recruiter_id
         self.worker_id = worker_id
         self.assignment_id = assignment_id
         self.hit_id = hit_id
@@ -159,6 +163,7 @@ class Participant(Base, SharedMixin):
         return {
             "id": self.id,
             "type": self.type,
+            "recruiter": self.recruiter_id,
             "assignment_id": self.assignment_id,
             "hit_id": self.hit_id,
             "mode": self.mode,
@@ -260,6 +265,12 @@ class Participant(Base, SharedMixin):
 
             for q in self.questions():
                 q.fail()
+
+    @property
+    def recruiter(self):
+        from dallinger import recruiters
+        recruiter_class = recruiters.by_name(self.recruiter_id or 'hotair')
+        return recruiter_class()
 
 
 class Question(Base, SharedMixin):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -343,9 +343,6 @@ class MTurkRecruiter(Recruiter):
         except MTurkServiceException as ex:
             logger.exception(str(ex))
 
-    def notify_recruited(self, participant):
-        pass
-
     def notify_using(self, participant):
         """Assign a Qualification to the Participant for the experiment ID,
         and for the configured group_name, if it's been set.
@@ -412,15 +409,14 @@ class MTurkRecruiter(Recruiter):
         who have already picked up the hit to complete it as normal.
         """
         logger.info(CLOSE_RECRUITMENT_LOG_PREFIX)
-        try:
-            # We are not expiring the hit currently as notifications are failing
-            # TODO: Reinstate this
-            return
-            # return self.mturkservice.expire_hit(
-            #    self.current_hit_id(),
-            # )
-        except MTurkServiceException as ex:
-            logger.exception(str(ex))
+        # We are not expiring the hit currently as notifications are failing
+        # TODO: Reinstate this
+        # try:
+        #     return self.mturkservice.expire_hit(
+        #         self.current_hit_id(),
+        #     )
+        # except MTurkServiceException as ex:
+        #     logger.exception(str(ex))
 
     def _config_to_list(self, key):
         # At some point we'll support lists, so all service code supports them,
@@ -609,11 +605,11 @@ class MultiRecruiter(Recruiter):
             recruiter = self.pick_recruiter()
             if recruiter.nickname in messages:
                 result = recruiter.recruit(1)
+                recruitments.extend(result)
             else:
                 result = recruiter.open_recruitment(1)
+                recruitments.extend(result['items'])
                 messages[recruiter.nickname] = result['message']
-            recruitments.extend(result['items'])
-
         return {
             'items': recruitments,
             'message': '\n'.join(messages.values())

--- a/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
@@ -13,6 +13,7 @@ $(document).ready(function() {
 
   // Consent to the experiment.
   $("#consent").click(function() {
+    store.set("recruiter", dallinger.getUrlParameter("recruiter"));
     store.set("hit_id", dallinger.getUrlParameter("hit_id"));
     store.set("worker_id", dallinger.getUrlParameter("worker_id"));
     store.set("assignment_id", dallinger.getUrlParameter("assignment_id"));

--- a/demos/dlgr/demos/chatroom/static/scripts/experiment.js
+++ b/demos/dlgr/demos/chatroom/static/scripts/experiment.js
@@ -9,6 +9,7 @@ $(document).ready(function() {
 
   // Consent to the experiment.
   $("#consent").click(function() {
+    store.set("recruiter", dallinger.getUrlParameter("recruiter"));
     store.set("hit_id", dallinger.getUrlParameter("hit_id"));
     store.set("worker_id", dallinger.getUrlParameter("worker_id"));
     store.set("assignment_id", dallinger.getUrlParameter("assignment_id"));

--- a/demos/dlgr/demos/concentration/static/scripts/experiment.js
+++ b/demos/dlgr/demos/concentration/static/scripts/experiment.js
@@ -10,6 +10,7 @@ $(document).ready(function() {
 
   // Consent to the experiment.
   $("#consent").click(function() {
+    store.set("recruiter", dallinger.getUrlParameter("recruiter"));
     store.set("hit_id", dallinger.getUrlParameter("hit_id"));
     store.set("worker_id", dallinger.getUrlParameter("worker_id"));
     store.set("assignment_id", dallinger.getUrlParameter("assignment_id"));

--- a/demos/dlgr/demos/function_learning/templates/ad.html
+++ b/demos/dlgr/demos/function_learning/templates/ad.html
@@ -114,7 +114,7 @@
                             </p>
                             <script>
                                 function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
                                 }
                             </script>
                             <div class="alert alert-warning">

--- a/demos/dlgr/demos/iterated_drawing/templates/ad.html
+++ b/demos/dlgr/demos/iterated_drawing/templates/ad.html
@@ -114,7 +114,7 @@
                             </p>
                             <script>
                                 function openwindow() {
-                                    popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                    popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
                                 }
                             </script>
                             <div class="alert alert-warning">

--- a/demos/dlgr/demos/rogers/tests/tests.py
+++ b/demos/dlgr/demos/rogers/tests/tests.py
@@ -206,7 +206,9 @@ class TestRogers(object):
                 worker_id = str(random.random())
                 assignment_id = str(random.random())
                 from models import Participant
-                p = Participant(workerid=worker_id, assignmentid=assignment_id, hitid=hit_id)
+                p = Participant(
+                    recruiter_id='hotair', workerid=worker_id,
+                    assignmentid=assignment_id, hitid=hit_id)
                 self.db.add(p)
                 self.db.commit()
                 p_id = p.unique_id

--- a/demos/dlgr/demos/snake/static/scripts/experiment.js
+++ b/demos/dlgr/demos/snake/static/scripts/experiment.js
@@ -10,6 +10,7 @@ $(document).ready(function() {
 
   // Consent to the experiment.
   $("#consent").click(function() {
+    store.set("recruiter", dallinger.getUrlParameter("recruiter"));
     store.set("hit_id", dallinger.getUrlParameter("hit_id"));
     store.set("worker_id", dallinger.getUrlParameter("worker_id"));
     store.set("assignment_id", dallinger.getUrlParameter("assignment_id"));

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -41,6 +41,7 @@ Laboratory automation for the behavioral and social sciences.
     web_api
     communicating_with_the_server
     extra_configuration
+    writing_bots
     setting_up_notifications
     contributing_to_dallinger
 

--- a/docs/source/running_bots.rst
+++ b/docs/source/running_bots.rst
@@ -1,22 +1,11 @@
 Running bots as participants
 ============================
 
-Dallinger supports writing bots that participate in experiments automatically.
+Dallinger supports running simulated experiments using bots
+that participate in the experiment automatically.
+
 Not all experiments will have bots available; the :doc:`demos/bartlett1932/index`
 and :doc:`demos/chatroom/index` demos are the only built-in experiments that do.
-
-
-Writing a bot
-~~~~~~~~~~~~~
-
-In your ``experiment.py`` you will need to create a subclass of BotBase called Bot. 
-This class should implement the ``participate`` method, which will be called once
-the bot has navigated to the main experiment. Note, the BotBase class makes some
-assumptions about HTML structure, based on the demo experiments. If your HTML
-differs significantly you may need to override other methods too.
-
-
-.. currentmodule:: dallinger.bots
 
 
 Running an experiment locally with bots
@@ -26,33 +15,43 @@ To run the experiment in debug mode using bots, use the `--bot` flag::
 
     $ dallinger debug --bot
 
-This overrides the `recruiter` configuration key to use the `BotRecruiter`.
+This overrides the `recruiter` configuration key to use the
+:py:class:`~dallinger.recruiters.BotRecruiter`.
 Instead of printing the URL for a participant or recruiting participants
-using Mechanical Turk, the bot recruiter will initiate requests for bots
-to be run by the worker processes.
+using Mechanical Turk, the bot recruiter will start running bots.
 
 You may also set the configuration value ``recruiter='bots'`` in local or global
 configurations, as an environment variable or as a keyword argument to
 :py:meth:`~dallinger.experiments.Experiment.run`.
 
-You should also set ``max_participants`` to the number of bots you want to run at once.
-``num_dynos_worker`` should be more than ``max_participants``, as a bot takes up a worker
-process while it is running. In addition, you may want to increase `num_dynos_web` to improve
-performance.
+Note: Bots are run by worker processes. If the experiment recruits many bots
+at the same time, you may need to increase the ``num_dynos_worker`` config setting
+to run additional worker processes. Each worker process can run up to 20 bots
+(though if the bots are implemented using selenium to run a real browser,
+you'll probably hit resource limits before that).
 
-Running an experiment with the API may look like:
 
-.. code-block:: python
+Running an experiment with a mix of bots and real participants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-    participants = 4
-    data = experiment.run(
-        mode=u'debug',
-        recruiter=u'bots',
-        max_participants=participants,
-        num_dynos_web=int(participants/4) + 1,
-        num_dynos_worker=participants,
-        workers=participants+5,
-    )
+It's also possible to run an experiment that mixes bot participants
+with real participants. To do this, edit the experiment's ``config.txt``
+to specify recruiter configuration like this::
+
+    recruiter = mixed
+    recruiters = bots: 2, cli: 1
+
+The ``recruiters`` config setting is a specification of how many
+participants to recruit from which recruiters in what order. This
+example says to use the bot recruiter the first 2 times that the
+experiment requests a participant to be recruited, followed by
+the CLI recruiter the third time. (The CLI recruiter writes the
+participant's URL to the log, which triggers opening it in your
+browser if you are running in debug mode.)
+
+To start the experiment with this configuration, run::
+
+    $ dallinger debug
 
 
 Running a single bot
@@ -62,104 +61,3 @@ If you want to run a single bot as part of an ongoing experiment, you can use
 the :ref:`bot <dallinger-bot>` command. This is useful for testing a single
 bot's behavior as part of a longer-running experiment, and allows easy access 
 to the Python pdb debugger.
-
-
-Selenium bots
-~~~~~~~~~~~~~
-
-The :class:`BotBase` provides a basis for a bot that interacts with an experiment using
-Selenium, which means that a separate, real browser session is controlled
-by each bot. This approach does not scale very well because there is a lot of
-overhead to running a browser, but it does allow for interacting with the
-experiment in a way similar to real participants.
-
-By default, Selenium will try to run PhantomJS, a headless browser meant for scripting.
-However, it also supports using Firefox and Chrome through configuration variables.
-
-.. code-block:: ini
-
-    webdriver_type = firefox
-
-We recommend using Firefox when writing bots, as it allows you to visually see
-its output and allows you to attach the development console directly to the
-bot's browser session.
-
-
-.. autoclass:: BotBase
-  :members:
-
-
-Scaling Selenium bots
-*********************
-
-For example you may want to run a dedicated computer on your lab network to host
-bots, without slowing down experimenter computers. It is recommended that you 
-run Selenium in a hub configuration, as a single Selenium instance will limit 
-the number of concurrent sessions. 
-
-You can also provide a URL to a Selenium WebDriver instance using the
-``webdriver_url`` configuration setting. This is required if you're running 
-Selenium in a hub configuration. The hub does not need to be on the same computer
-as Dallinger, but it does need to be able to access the computer running
-Dallinger directly by its IP address.
-
-On Apple macOS, we recommend using Homebrew to install and run selenium, using:
-
-::
-
-    brew install selenium-server-standalone
-    selenium-server -port 4444
-
-
-On other platforms, download the latest ``selenium-server-standalone.jar`` file 
-from `SeleniumHQ <http://www.seleniumhq.org/download/>`_ and run a hub using:
-
-::
-
-    java -jar selenium-server-standalone-3.3.1.jar -role hub
-
-and attach multiple nodes by running:
-
-::
-
-    java -jar selenium-server-standalone-3.3.1.jar -role node -hub http://hubcomputer.example.com:4444/grid/register
-
-These nodes may be on other computers on the local network or on the same host
-machine. If they are on the same host you will need to add ``-port 4446`` (for 
-some port number) such that each Selenium node on the same server is listening
-on a different port.
-
-You will also need to set up the browser interfaces on each computer that's running
-a node. This requires being able to run the browser and having the correct driver
-available in the system path, so the Selenium server can run it.
-
-We recommend using Chrome when running large numbers of bots, as it is more
-feature-complete than PhantomJS but with better performance at scale than Firefox. It
-is best to run at most three Firefox sessions on commodity hardware, so for best
-results 16 bots should be run over 6 Selenium servers. This will depend on how
-processor intensive your experiment is. It may be possible to run more sessions
-without performance degradation.
-
-
-High-performance bots
-~~~~~~~~~~~~~~~~~~~~~
-
-The :class:`HighPerformanceBotBase` can be used as a basis for a bot that
-interacts with the experiment server directly over HTTP rather than using a real browser.
-This scales better than using Selenium bots, but requires expressing the bot's
-behavior in terms of HTTP requests rather than in terms of DOM interactions.
-
-.. autoclass:: HighPerformanceBotBase
-  :members:
-
-Scaling high-performance bots
-*****************************
-
-By default, the worker processes that run bots can only run one bot at a time.
-It's possible to switch to a gevent-based worker that can run bots concurrently.
-To do this, install dallinger with the `high_performance_bots` extra::
-
-    $ pip install dallinger[high_performance_bots]
-
-By default each gevent-based worker process will process up to 20 jobs from
-the job queue in parallel.

--- a/docs/source/writing_bots.rst
+++ b/docs/source/writing_bots.rst
@@ -1,0 +1,107 @@
+Writing bots
+============
+
+.. currentmodule:: dallinger.bots
+
+When you run an experiment using the bot recruiter,
+it will look for a class named ``Bot`` in your ``experiment.py`` module.
+
+The Bot class should typically be a subclass of either
+:py:class:`~BotBase` (for bots that interact with the
+experiment by controlling a real browser using ``selenium``) or
+:py:class:`~HighPerformanceBotBase` (for bots that
+interact with the experiment server directly via HTTP or websockets).
+
+This class should implement the ``participate`` method, which will be called once
+the bot has navigated to the main experiment. Note, the BotBase class makes some
+assumptions about HTML structure, based on the demo experiments. If your HTML
+differs significantly you may need to override other methods too.
+
+
+High-performance bots
+~~~~~~~~~~~~~~~~~~~~~
+
+The :py:class:`HighPerformanceBotBase` can be used as a basis for a bot that
+interacts with the experiment server directly over HTTP rather than using a real browser.
+This scales better than using Selenium bots, but requires expressing the bot's
+behavior in terms of HTTP requests rather than in terms of DOM interactions.
+
+.. autoclass:: HighPerformanceBotBase
+  :members:
+
+
+Selenium bots
+~~~~~~~~~~~~~
+
+The :py:class:`BotBase` provides a basis for a bot that interacts with an experiment using
+Selenium, which means that a separate, real browser session is controlled
+by each bot. This approach does not scale very well because there is a lot of
+overhead to running a browser, but it does allow for interacting with the
+experiment in a way similar to real participants.
+
+By default, Selenium will try to run PhantomJS, a headless browser meant for scripting.
+However, it also supports using Firefox and Chrome through configuration variables.
+
+.. code-block:: ini
+
+    webdriver_type = firefox
+
+We recommend using Firefox when writing bots, as it allows you to visually see
+its output and allows you to attach the development console directly to the
+bot's browser session.
+
+
+.. autoclass:: BotBase
+  :members:
+
+
+Scaling Selenium bots
+*********************
+
+For example you may want to run a dedicated computer on your lab network to host
+bots, without slowing down experimenter computers. It is recommended that you 
+run Selenium in a hub configuration, as a single Selenium instance will limit 
+the number of concurrent sessions. 
+
+You can also provide a URL to a Selenium WebDriver instance using the
+``webdriver_url`` configuration setting. This is required if you're running 
+Selenium in a hub configuration. The hub does not need to be on the same computer
+as Dallinger, but it does need to be able to access the computer running
+Dallinger directly by its IP address.
+
+On Apple macOS, we recommend using Homebrew to install and run selenium, using:
+
+::
+
+    brew install selenium-server-standalone
+    selenium-server -port 4444
+
+
+On other platforms, download the latest ``selenium-server-standalone.jar`` file 
+from `SeleniumHQ <http://www.seleniumhq.org/download/>`_ and run a hub using:
+
+::
+
+    java -jar selenium-server-standalone-3.3.1.jar -role hub
+
+and attach multiple nodes by running:
+
+::
+
+    java -jar selenium-server-standalone-3.3.1.jar -role node -hub http://hubcomputer.example.com:4444/grid/register
+
+These nodes may be on other computers on the local network or on the same host
+machine. If they are on the same host you will need to add ``-port 4446`` (for 
+some port number) such that each Selenium node on the same server is listening
+on a different port.
+
+You will also need to set up the browser interfaces on each computer that's running
+a node. This requires being able to run the browser and having the correct driver
+available in the system path, so the Selenium server can run it.
+
+We recommend using Chrome when running large numbers of bots, as it is more
+feature-complete than PhantomJS but with better performance at scale than Firefox. It
+is best to run at most three Firefox sessions on commodity hardware, so for best
+results 16 bots should be run over 6 Selenium servers. This will depend on how
+processor intensive your experiment is. It may be possible to run more sessions
+without performance degradation.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,8 @@ def clear_workers():
 
     def _zap():
         kills = [
-            ['pkill', 'gunicorn'],
             ['pkill', '-f', 'python launch.py'],
+            ['pkill', '-f', 'python worker.py'],
         ]
         for kill in kills:
             try:
@@ -161,6 +161,7 @@ def a(db_session):
 
         def participant(self, **kw):
             defaults = {
+                'recruiter_id': 'hotair',
                 'worker_id': '1',
                 'assignment_id': '1',
                 'hit_id': '1',

--- a/tests/experiment/templates/ad.html
+++ b/tests/experiment/templates/ad.html
@@ -114,7 +114,7 @@
                                 </p>
                                 <script>
                                     function openwindow() {
-                                        popup = window.open('{{ server_location }}/consent?hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+                                        popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
                                     }
                                 </script>
                                 <div class="alert alert-warning">

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -20,6 +20,7 @@ def test_serialized(db_session):
             interruptor()
 
         session.add(Participant(
+            recruiter_id='hotair',
             worker_id='serialized_{}'.format(count + 1),
             assignment_id='test',
             hit_id='test',

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -95,6 +95,7 @@ class TestHerokuClockTasks(object):
         @staticmethod
         def participant(**kwargs):
             defaults = {
+                'recruiter_id': 'hotair',
                 'worker_id': '1',
                 'hit_id': '1',
                 'assignment_id': '1',

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -18,17 +18,6 @@ class TestModels(object):
         session.add_all(args)
         session.commit()
 
-    # def setup(self, db_session):
-    #     self.db = db.init_db(drop_all=True)
-
-    # def teardown(self, db_session):
-    #     db_session.rollback()
-    #     db_session.close()
-
-    # def add(self, *args):
-    #     db_session.add_all(args)
-    #     db_session.commit()
-
     def test_models(self, db_session):
 
         """####################
@@ -47,7 +36,8 @@ class TestModels(object):
 
         # create a participant
         participant = models.Participant(
-            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+            recruiter_id='hotair', worker_id=str(1), hit_id=str(1),
+            assignment_id=str(1), mode="test")
         db_session.add(participant)
         db_session.commit()
 
@@ -678,7 +668,8 @@ class TestModels(object):
 
     def test_create_participant(self, db_session):
         participant = models.Participant(
-            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+            recruiter_id='hotair', worker_id=str(1), hit_id=str(1),
+            assignment_id=str(1), mode="test")
         db_session.add(participant)
         db_session.commit()
 
@@ -689,7 +680,8 @@ class TestModels(object):
         net = models.Network()
         db_session.add(net)
         participant = models.Participant(
-            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+            recruiter_id='hotair', worker_id=str(1), hit_id=str(1),
+            assignment_id=str(1), mode="test")
         db_session.add(participant)
         db_session.commit()
         node = models.Node(network=net, participant=participant)
@@ -712,7 +704,8 @@ class TestModels(object):
 
     def test_participant_json(self, db_session):
         participant = models.Participant(
-            worker_id=str(1), hit_id=str(1), assignment_id=str(1), mode="test")
+            recruiter_id='hotair', worker_id=str(1), hit_id=str(1),
+            assignment_id=str(1), mode="test")
         db_session.add(participant)
         db_session.commit()
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -93,6 +93,10 @@ class TestRecruiter(object):
         dummy = mock.NonCallableMock()
         recruiter.notify_recruited(participant=dummy)
 
+    def test_notify_using(self, recruiter):
+        dummy = mock.NonCallableMock()
+        recruiter.notify_using(participant=dummy)
+
     def test_external_submission_url(self, recruiter):
         assert recruiter.external_submission_url is None
 
@@ -233,6 +237,9 @@ class TestSimulatedRecruiter(object):
 
     def test_returns_standard_submission_event_type(self, recruiter):
         assert recruiter.submitted_event() is 'AssignmentSubmitted'
+
+    def test_close_recruitment(self, recruiter):
+        assert recruiter.close_recruitment() is None
 
 
 class TestBotRecruiter(object):
@@ -554,6 +561,11 @@ class TestMTurkLargeRecruiter(object):
             r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
             return r
 
+    def test_open_recruitment_is_noop_if_experiment_in_progress(self, a, recruiter):
+        a.participant()
+        recruiter.open_recruitment()
+        recruiter.mturkservice.check_credentials.assert_not_called()
+
     def test_open_recruitment_single_recruitee(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
@@ -623,3 +635,54 @@ class TestMTurkLargeRecruiter(object):
         recruiter.recruit()
 
         assert not recruiter.mturkservice.extend_hit.called
+
+
+@pytest.mark.usefixtures('active_config', 'db_session')
+class TestMultiRecruiter(object):
+
+    @pytest.fixture
+    def recruiter(self, active_config):
+        from dallinger.recruiters import MultiRecruiter
+        active_config.extend({'recruiters': u'cli: 2, hotair: 1'})
+        return MultiRecruiter()
+
+    def test_parse_spec(self, recruiter):
+        assert recruiter.spec == [
+            ('cli', 2),
+            ('hotair', 1),
+        ]
+
+    def test_pick_recruiter(self, recruiter):
+        subrecruiter = recruiter.pick_recruiter()
+        assert subrecruiter.nickname == 'cli'
+
+        subrecruiter = recruiter.pick_recruiter()
+        assert subrecruiter.nickname == 'cli'
+
+        subrecruiter = recruiter.pick_recruiter()
+        assert subrecruiter.nickname == 'hotair'
+
+        with pytest.raises(Exception):
+            recruiter.pick_recruiter()
+
+    def test_open_recruitment(self, recruiter):
+        result = recruiter.open_recruitment(n=3)
+        assert len(result['items']) == 3
+        assert result['items'][0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result['items'][1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result['items'][2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+    def test_recruit(self, recruiter):
+        result = recruiter.recruit(n=3)
+        assert len(result) == 3
+        assert result[0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+    def test_close_recruitment(self, recruiter):
+        patch1 = mock.patch('dallinger.recruiters.CLIRecruiter.close_recruitment')
+        patch2 = mock.patch('dallinger.recruiters.HotAirRecruiter.close_recruitment')
+        with patch1 as f1, patch2 as f2:
+            recruiter.close_recruitment()
+            f1.assert_called_once()
+            f2.assert_called_once()

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -21,10 +21,10 @@ class TestModuleFunctions(object):
         assert mod.for_experiment(mock_exp) is mock_exp.recruiter
 
     def test_by_name_with_valid_name(self, mod):
-        assert mod.by_name('CLIRecruiter') == mod.CLIRecruiter
+        assert isinstance(mod.by_name('CLIRecruiter'), mod.CLIRecruiter)
 
     def test_by_name_with_valid_nickname(self, mod):
-        assert mod.by_name('bots') == mod.BotRecruiter
+        assert isinstance(mod.by_name('bots'), mod.BotRecruiter)
 
     def test_by_name_with_invalid_name(self, mod):
         assert mod.by_name('blah') is None

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -117,7 +117,7 @@ class TestCLIRecruiter(object):
         assert len(result) == 1
 
     def test_recruit_results_are_urls(self, recruiter):
-        assert '/ad?assignmentId=' in recruiter.recruit()[0]
+        assert '/ad?recruiter=cli&assignmentId=' in recruiter.recruit()[0]
 
     def test_recruit_multiple(self, recruiter):
         assert len(recruiter.recruit(n=3)) == 3
@@ -136,7 +136,7 @@ class TestCLIRecruiter(object):
 
     def test_open_recruitment_results_are_urls(self, recruiter):
         result = recruiter.open_recruitment()
-        assert '/ad?assignmentId=' in result['items'][0]
+        assert '/ad?recruiter=cli&assignmentId=' in result['items'][0]
 
     def test_open_recruitment_with_zero(self, recruiter):
         result = recruiter.open_recruitment(n=0)
@@ -173,7 +173,7 @@ class TestHotAirRecruiter(object):
         assert len(result) == 1
 
     def test_recruit_results_are_urls(self, recruiter):
-        assert '/ad?assignmentId=' in recruiter.recruit()[0]
+        assert '/ad?recruiter=hotair&assignmentId=' in recruiter.recruit()[0]
 
     def test_recruit_multiple(self, recruiter):
         assert len(recruiter.recruit(n=3)) == 3
@@ -192,7 +192,7 @@ class TestHotAirRecruiter(object):
 
     def test_open_recruitment_results_are_urls(self, recruiter):
         result = recruiter.open_recruitment()
-        assert '/ad?assignmentId=' in result['items'][0]
+        assert '/ad?recruiter=hotair&assignmentId=' in result['items'][0]
 
     def test_close_recruitment(self, recruiter):
         recruiter.close_recruitment()
@@ -344,7 +344,7 @@ class TestMTurkRecruiter(object):
     def test_open_recruitment_single_recruitee_builds_hit(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url='http://fake-domain/ad',
+            ad_url='http://fake-domain/ad?recruiter=mturk',
             approve_requirement=95,
             description=u'fake HIT description',
             duration_hours=1.0,
@@ -385,7 +385,7 @@ class TestMTurkRecruiter(object):
         recruiter.config.set('qualification_blacklist', u'foo, bar')
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url='http://fake-domain/ad',
+            ad_url='http://fake-domain/ad?recruiter=mturk',
             approve_requirement=95,
             description='fake HIT description',
             duration_hours=1.0,
@@ -557,7 +557,7 @@ class TestMTurkLargeRecruiter(object):
     def test_open_recruitment_single_recruitee(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url='http://fake-domain/ad',
+            ad_url='http://fake-domain/ad?recruiter=mturklarge',
             approve_requirement=95,
             description='fake HIT description',
             duration_hours=1.0,
@@ -575,7 +575,7 @@ class TestMTurkLargeRecruiter(object):
     def test_more_than_ten_can_be_recruited_on_open(self, recruiter):
         recruiter.open_recruitment(n=20)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url='http://fake-domain/ad',
+            ad_url='http://fake-domain/ad?recruiter=mturklarge',
             approve_requirement=95,
             description='fake HIT description',
             duration_hours=1.0,


### PR DESCRIPTION
https://app.scrumdo.com/projects/dallinger/#/iteration/286266/board/story/1559966

This adds a new recruiter, the MultiRecruiter, which can delegate to multiple other recruiters.

## Description

The MultiRecruiter is used if `recruiter = multi` is specified in config. It looks for a recruiter spec like this: `recruiters = bots: 4, cli: 1` and will recruit that many times from those recruiters in sequence.

Implementing this required some noteworthy changes:
1. Ad URLs generated from recruiters now include a `recruiter` param and the participant table now has a `recruiter_id` column so we can keep track of which recruiter a participant came from. (Note that if there *isn't* a recruiter in the URL because a particular experiment hasn't been updated to pass it from the ad page onward, we fall back to using the `recruiter` from the config. This should work as long as that isn't the multi recruiter, which should be okay for backward compatibility.)
2. We also need to keep track of how many recruitments have been requested from each recruiter, even if they haven't actually arrived as participants. There's a new Recruitment table for this. 

Note: There is a related PR for Griduniverse which should be reviewed and merged at the same time: https://github.com/Dallinger/Griduniverse/pull/179

## Motivation and Context
This is desired to make it possible to mix bots and human participants on the same experiment.

## How Has This Been Tested?
Tested in debug mode, by automated test coverage, and with the mturk sandbox.
