### PR TITLE
Story 333 configurable redis sizing

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -520,9 +520,10 @@ def deploy_sandbox_shared_setup(verbose=True, app=None, exp_config=None):
 
     # Set up add-ons and AWS environment variables.
     database_size = config.get('database_size')
+    redis_size = config.get('redis_size', 'premium-0')
     addons = [
         "heroku-postgresql:{}".format(quote(database_size)),
-        "heroku-redis:premium-0",
+        "heroku-redis:{}".format(quote(redis_size)),
         "papertrail"
     ]
     if config.get("sentry", False):
@@ -807,7 +808,9 @@ def awaken(app, databaseurl):
     heroku_app.pg_wait()
     time.sleep(10)
 
-    heroku_app.addon("heroku-redis:premium-0")
+    heroku_app.addon("heroku-redis:{}".format(config.get(
+        'redis_size', 'premium-0'
+    )))
     heroku_app.restore(url)
 
     # Scale up the dynos.

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -58,6 +58,7 @@ default_keys = (
     ('port', int, ['PORT']),
     ('qualification_blacklist', six.text_type, []),
     ('recruiter', six.text_type, []),
+    ('redis_size', six.text_type, []),
     ('replay', bool, []),
     ('threads', six.text_type, []),
     ('title', six.text_type, []),

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -87,6 +87,9 @@ Built-in configuration parameters include:
 ``dyno_type``
     Heroku dyno type to use. See `Heroku dynos types <https://devcenter.heroku.com/articles/dyno-types>`__.
 
+``redis_size``
+    Size of the redis server on Heroku. See `Heroku Redis <https://elements.heroku.com/addons/heroku-redis>`__.
+
 ``num_dynos_web``
     Number of Heroku dynos to use for processing incoming HTTP requests. It is
     recommended that you use at least two.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,6 +286,7 @@ def stub_config():
         u'dallinger_email_address': u'test@example.com',
         u'dallinger_email_password': u'fake password',
         u'database_size': u'standard-0',
+        u'redis_size': u'premium-0',
         u'database_url': u'postgresql://postgres@localhost/dallinger',
         u'description': u'fake HIT description',
         u'duration': 1.0,

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -996,12 +996,13 @@ class TestAwaken(object):
         expected = mock.call('heroku-postgresql:{}'.format(size))
         assert expected == heroku.addon.call_args_list[0]
 
-    def test_adds_redis(self, awaken, heroku, data):
+    def test_adds_redis(self, awaken, heroku, data, active_config):
+        active_config['redis_size'] = u'premium-2'
         CliRunner().invoke(
             awaken,
             ['--app', 'some-app-uid', ]
         )
-        assert mock.call('heroku-redis:premium-0') == heroku.addon.call_args_list[1]
+        assert mock.call('heroku-redis:premium-2') == heroku.addon.call_args_list[1]
 
     def test_restores_database_from_backup(self, awaken, heroku, data):
         CliRunner().invoke(


### PR DESCRIPTION
## Description
Adds a `redis_size` configuration parameter that defaults to `premium-0` (the current default). Creating or waking an experiment on Heroku will use the `redis_size` to configure the redis addon.

## Motivation and Context
See [ScrumDo Story 333](https://app.scrumdo.com/projects/story_permalink/1574090)

## How Has This Been Tested?
Updated automated tests for use of new config variable