### PR TITLE
Fix warnings about psycopg2 and unicode_literals

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -248,6 +248,9 @@ def verify_package(verbose=True):
     return is_passing
 
 
+click.disable_unicode_literals_warning = True
+
+
 @click.group(context_settings=CONTEXT_SETTINGS)
 @click.version_option(__version__, '--version', '-v', message='%(version)s')
 def dallinger():

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ greenlet==0.4.13
 gunicorn==19.8.1
 localconfig==1.1.0
 pexpect==4.4.0
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 psutil==5.4.4
 redis==2.10.6
 requests==2.18.4


### PR DESCRIPTION
This avoids showing some distracting warnings when running dallinger on the command line.