### PR TITLE
Git status cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,9 @@ docs/source/demos
 docs/source/_static/*.zip
 .env
 .idea
+.pytest_cache
 .tox
+.vscode
 /snapshots/
 *-
 site/*


### PR DESCRIPTION

## Description
- Update `.gitignore` to exclude `.pytest_cache` and `.vscode` directories from source control
- Add two `__init__.py` files required by python2 (but not python3) to source control

## Motivation and Context
Quite noise from `git status`
