### PR TITLE
Story 331: Add configuration for recruitee qualification and add 'dallinger revoke' command

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -710,8 +710,7 @@ def qualify(workers, qualification, value, by_name, notify, sandbox):
 @click.argument('workers', nargs=-1)
 def revoke(workers, qualification, by_name, reason, sandbox):
     """Revoke a qualification from 1 or more workers"""
-
-    if not (workers):
+    if not (workers and qualification):
         raise click.BadParameter(
             'Must specify a qualification ID or name, and at least one worker ID'
         )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -728,8 +728,10 @@ def revoke(workers, qualification, by_name, reason, sandbox):
         qid = qualification
 
     if not click.confirm(
-        'Are you sure you want to revoke qualification "{}" '
-        'for these workers?\n\t{}\n'.format(qid, '\n\t'.join(workers))
+        '\n\nYou are about to revoke qualification "{}" '
+        'for these workers\n\t{}\n\n'
+        'This will send an email to each of them from Amazon MTurk. '
+        'Continue?'.format(qid, '\n\t'.join(workers))
     ):
         click.echo('Aborting...')
         return

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -729,7 +729,7 @@ def revoke(workers, qualification, by_name, reason, sandbox):
 
     if not click.confirm(
         '\n\nYou are about to revoke qualification "{}" '
-        'for these workers\n\t{}\n\n'
+        'for these workers:\n\t{}\n\n'
         'This will send an email to each of them from Amazon MTurk. '
         'Continue?'.format(qid, '\n\t'.join(workers))
     ):

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -25,6 +25,7 @@ SENSITIVE_KEY_NAMES = (
 default_keys = (
     ('ad_group', six.text_type, []),
     ('approve_requirement', int, []),
+    ('assign_qualifications', bool, []),
     ('auto_recruit', bool, []),
     ('aws_access_key_id', six.text_type, [], True),
     ('aws_region', six.text_type, []),

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -1,5 +1,6 @@
 [Experiment]
 mode = debug
+assign_qualifications = true
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -348,6 +348,9 @@ class MTurkRecruiter(Recruiter):
         """Assign a Qualification to the Participant for the experiment ID,
         and for the configured group_name, if it's been set.
         """
+        if not self.config.get('assign_qualifications'):
+            return
+
         worker_id = participant.worker_id
 
         for name in self.qualifications:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -295,7 +295,8 @@ class MTurkRecruiter(Recruiter):
 
         self.mturkservice.check_credentials()
 
-        self._create_mturk_qualifications()
+        if self.config.get('assign_qualifications'):
+            self._create_mturk_qualifications()
 
         hit_request = {
             'max_assignments': n,

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -62,9 +62,24 @@ the experiment by its id.
 qualify
 ^^^^^^^
 
-Assign qualification to a worker. Requires a qualification id
-``qualification_id``, value ``value``, and worker id ``worker_id``. This is
-useful when compensating workers if something goes wrong with the experiment.
+Assign a Mechanical Turk qualification to one or more workers.
+Requires a ``qualification``, which is a qualification ID, (or, if
+the ``--by_name`` is used, a qualification name), value ``value``,
+and a list of one or more worker IDs, passed at the end of the command.
+This is useful when compensating workers if something goes wrong with
+the experiment.
+
+revoke
+^^^^^^
+
+Revoke a Mechanical Turk qualification for one or more workers.
+Requires a ``qualification``, which is a qualification ID, (or, if
+the ``--by_name`` is used, a qualification name), an optional ``reason``
+string, and a list of one or more MTurk worker IDs.
+This is useful when developing an experiment with "insider" participants,
+who would otherwise be prevented from accepting a HIT for an experiment
+they've already participated in.
+
 
 hibernate
 ^^^^^^^^^

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -64,6 +64,13 @@ Built-in configuration parameters include:
 ``auto_recruit``
     Whether recruitment should be automatic.
 
+``assign_qualifications``
+    A boolean which controls whether an experiment-specific qualification
+    (based on the experiment ID), and a group qualification (based on the value
+    of ``group_name``) will be assigned to participants by the recruiter.
+    This feature assumes the recruiter supports qualifications, like Amazon
+    Mechanical Turk does.
+
 ``group_name``
     A string. *Unicode string*.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -275,6 +275,7 @@ def stub_config():
     defaults = {
         u'ad_group': u'Test ad group',
         u'approve_requirement': 95,
+        u'assign_qualifications': True,
         u'auto_recruit': True,
         u'aws_access_key_id': u'fake aws key',
         u'aws_secret_access_key': u'fake aws secret',

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -949,6 +949,9 @@ class TestQualify(object):
 
 class TestRevoke(object):
 
+    DO_IT = 'Y\n'
+    DO_NOT_DO_IT = 'N\n'
+
     @pytest.fixture
     def revoke(self):
         from dallinger.command_line import revoke
@@ -974,7 +977,7 @@ class TestRevoke(object):
                 '--reason', 'some reason',
                 'some worker id',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code == 0
         mturk.revoke_qualification.assert_called_once_with(
@@ -989,7 +992,7 @@ class TestRevoke(object):
                 '--reason', 'some reason',
                 'some worker id',
             ],
-            input='N\n',
+            input=self.DO_NOT_DO_IT,
         )
         assert result.exit_code == 0
         mturk.revoke_qualification.assert_not_called()
@@ -1005,7 +1008,7 @@ class TestRevoke(object):
                     '--reason', 'some reason',
                     'some worker id',
                 ],
-                input='Y\n',
+                input=self.DO_IT,
             )
             assert 'sandbox=True' in str(mock_mturk.call_args_list[0])
 
@@ -1016,7 +1019,7 @@ class TestRevoke(object):
                 '--qualification', 'some qid',
                 'some worker id',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code == 0
         mturk.revoke_qualification.assert_called_once_with(
@@ -1031,7 +1034,7 @@ class TestRevoke(object):
             [
                 '--qualification', 'some qid',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code != 0
         assert 'at least one worker ID' in result.output
@@ -1044,7 +1047,7 @@ class TestRevoke(object):
                 '--reason', 'some reason',
                 'worker1', 'worker2',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code == 0
         mturk.revoke_qualification.assert_has_calls([
@@ -1062,7 +1065,7 @@ class TestRevoke(object):
                 '--by_name',
                 'some worker id',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code == 0
         mturk.revoke_qualification.assert_called_once_with(
@@ -1079,7 +1082,7 @@ class TestRevoke(object):
                 '--by_name',
                 'some worker id',
             ],
-            input='Y\n',
+            input=self.DO_IT,
         )
         assert result.exit_code == 2
         assert 'No qualification with name "some bad name" exists.' in result.output

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1039,6 +1039,17 @@ class TestRevoke(object):
         assert result.exit_code != 0
         assert 'at least one worker ID' in result.output
 
+    def test_raises_with_no_qualification(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                u'some worker id',
+            ],
+            input=self.DO_IT,
+        )
+        assert result.exit_code != 0
+        assert 'at least one worker ID' in result.output
+
     def test_revoke_for_multiple_workers(self, revoke, mturk):
         result = CliRunner().invoke(
             revoke,

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -947,6 +947,144 @@ class TestQualify(object):
         assert 'No qualification with name "some qual name" exists.' in result.output
 
 
+class TestRevoke(object):
+
+    @pytest.fixture
+    def revoke(self):
+        from dallinger.command_line import revoke
+        return revoke
+
+    @pytest.fixture
+    def mturk(self):
+        with mock.patch('dallinger.command_line.MTurkService') as mock_mturk:
+            mock_instance = mock.Mock()
+            mock_instance.get_qualification_type_by_name.return_value = 'some qid'
+            mock_instance.get_workers_with_qualification.return_value = [
+                {'id': 'some qid', 'score': 1}
+            ]
+            mock_mturk.return_value = mock_instance
+
+            yield mock_instance
+
+    def test_revoke_single_worker_by_qualification_id(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qid',
+                '--reason', 'some reason',
+                'some worker id',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code == 0
+        mturk.revoke_qualification.assert_called_once_with(
+            u'some qid', u'some worker id', u'some reason'
+        )
+
+    def test_can_be_aborted_cleanly_after_warning(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qid',
+                '--reason', 'some reason',
+                'some worker id',
+            ],
+            input='N\n',
+        )
+        assert result.exit_code == 0
+        mturk.revoke_qualification.assert_not_called()
+
+    def test_uses_mturk_sandbox_if_specified(self, revoke):
+        with mock.patch('dallinger.command_line.MTurkService') as mock_mturk:
+            mock_mturk.return_value = mock.Mock()
+            CliRunner().invoke(
+                revoke,
+                [
+                    '--sandbox',
+                    '--qualification', 'some qid',
+                    '--reason', 'some reason',
+                    'some worker id',
+                ],
+                input='Y\n',
+            )
+            assert 'sandbox=True' in str(mock_mturk.call_args_list[0])
+
+    def test_reason_has_a_default(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qid',
+                'some worker id',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code == 0
+        mturk.revoke_qualification.assert_called_once_with(
+            u'some qid',
+            u'some worker id',
+            u'Revoking automatically assigned Dallinger qualification'
+        )
+
+    def test_raises_with_no_worker(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qid',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code != 0
+        assert 'at least one worker ID' in result.output
+
+    def test_revoke_for_multiple_workers(self, revoke, mturk):
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qid',
+                '--reason', 'some reason',
+                'worker1', 'worker2',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code == 0
+        mturk.revoke_qualification.assert_has_calls([
+            mock.call(u'some qid', u'worker1', u'some reason'),
+            mock.call(u'some qid', u'worker2', u'some reason')
+        ])
+
+    def test_use_qualification_name(self, revoke, mturk):
+        mturk.get_qualification_type_by_name.return_value = {'id': 'some qid'}
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some qual name',
+                '--reason', 'some reason',
+                '--by_name',
+                'some worker id',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code == 0
+        mturk.revoke_qualification.assert_called_once_with(
+            u'some qid', u'some worker id', u'some reason'
+        )
+
+    def test_bad_qualification_name_shows_error(self, revoke, mturk):
+        mturk.get_qualification_type_by_name.return_value = None
+        result = CliRunner().invoke(
+            revoke,
+            [
+                '--qualification', 'some bad name',
+                '--reason', 'some reason',
+                '--by_name',
+                'some worker id',
+            ],
+            input='Y\n',
+        )
+        assert result.exit_code == 2
+        assert 'No qualification with name "some bad name" exists.' in result.output
+
+
 class TestHibernate(object):
 
     @pytest.fixture

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -537,6 +537,14 @@ class TestMTurkRecruiter(object):
         # logs, but does not raise:
         recruiter.notify_using(participant)
 
+    def test_notify_using_skips_assigning_qualification_if_so_configured(self, recruiter):
+        participant = mock.Mock(spec=Participant, worker_id='some worker id')
+        recruiter.config.set('group_name', u'some existing group_name')
+        recruiter.config.set('assign_qualifications', False)
+        recruiter.notify_using(participant)
+
+        recruiter.mturkservice.increment_qualification_score.assert_not_called()
+
     def test_rejects_questionnaire_from_returns_none_if_working(self, recruiter):
         participant = mock.Mock(spec=Participant, status="working")
         assert recruiter.rejects_questionnaire_from(participant) is None

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -380,6 +380,12 @@ class TestMTurkRecruiter(object):
             mock.call(u'some group name', 'Experiment group qualification')
         ], any_order=True)
 
+    def test_open_recruitment_creates_no_qualifications_if_so_configured(self, recruiter):
+        recruiter.config.set('group_name', u'some group name')
+        recruiter.config.set('assign_qualifications', False)
+        recruiter.open_recruitment(n=1)
+        recruiter.mturkservice.create_qualification_type.assert_not_called()
+
     def test_open_recruitment_when_qualification_already_exists(self, recruiter):
         from dallinger.mturk import DuplicateQualificationNameError
         mturk = recruiter.mturkservice


### PR DESCRIPTION
## Description
This PR adds a new configuration variable, `assign_qualifications`, to control whether recruiters that support participant qualifications assign qualifications for the experiment ID and any configured `group_name` when participants are recruited. 

## Motivation and Context
When testing experiments with participant collaborators, it is undesirable to assign qualifications which make it difficult for the same people to participant in the same experiment several times in a row. A configuration variable makes it easy to toggle qualification assignment on and off.

## How Has This Been Tested?
- automated tests
- `dallinger sandbox` on Bartlett1932 experiment with `assign_qualifications` set to `false`
