### PR TITLE
Story 319: don't generate a new UUID if we were passed in a valid one

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -308,7 +308,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
     # Generate a unique id for this experiment.
     from dallinger.experiment import Experiment
-    generated_uid = public_id = Experiment.make_uuid()
+    generated_uid = public_id = Experiment.make_uuid(str(app))
 
     # If the user provided an app name, use it everywhere that's user-facing.
     if app:

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -308,7 +308,7 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
     # Generate a unique id for this experiment.
     from dallinger.experiment import Experiment
-    generated_uid = public_id = Experiment.make_uuid(str(app))
+    generated_uid = public_id = Experiment.make_uuid(app)
 
     # If the user provided an app name, use it everywhere that's user-facing.
     if app:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -471,7 +471,7 @@ class Experiment(object):
         """
         import dallinger as dlgr
 
-        app_id = self.make_uuid(str(app_id))
+        app_id = self.make_uuid(app_id)
 
         if bot:
             kwargs['recruiter'] = 'bots'
@@ -552,7 +552,7 @@ class Experiment(object):
     def make_uuid(cls, app_id=None):
         """Generate a new uuid."""
         try:
-            if app_id and isinstance(uuid.UUID(app_id, version=4), uuid.UUID):
+            if app_id and isinstance(uuid.UUID(str(app_id), version=4), uuid.UUID):
                 return app_id
         except (ValueError, AssertionError):
             pass

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -471,8 +471,7 @@ class Experiment(object):
         """
         import dallinger as dlgr
 
-        if app_id is None:
-            app_id = self.make_uuid()
+        app_id = self.make_uuid(str(app_id))
 
         if bot:
             kwargs['recruiter'] = 'bots'
@@ -550,8 +549,13 @@ class Experiment(object):
         return self.run(exp_config, app_id, bot, **kwargs)
 
     @classmethod
-    def make_uuid(cls):
+    def make_uuid(cls, app_id=None):
         """Generate a new uuid."""
+        try:
+            if app_id and isinstance(uuid.UUID(app_id, version=4), uuid.UUID):
+                return app_id
+        except (ValueError, AssertionError):
+            pass
         return str(uuid.UUID(int=random.getrandbits(128)))
 
     def experiment_completed(self):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -2,15 +2,33 @@ import pytest
 import mock
 
 
+def is_uuid(thing):
+    return len(thing) == 36
+
+
 @pytest.mark.usefixtures('active_config')
 class TestExperimentBaseClass(object):
 
     @pytest.fixture
-    def exp(self):
+    def klass(self):
         from dallinger.experiment import Experiment
-        return Experiment()
+        return Experiment
+
+    @pytest.fixture
+    def exp(self, klass):
+        return klass()
 
     def test_recruiter_delegates(self, exp, active_config):
         with mock.patch('dallinger.experiment.recruiters') as mock_module:
             exp.recruiter
             mock_module.from_config.assert_called_once_with(active_config)
+
+    def test_make_uuid_generates_random_id_if_passed_none(self, klass):
+        assert is_uuid(klass.make_uuid(None))
+
+    def test_make_uuid_generates_random_id_if_passed_nonuuid(self, klass):
+        assert is_uuid(klass.make_uuid("None"))
+
+    def test_make_uuid_echos_a_valid_uuid(self, klass):
+        valid = '8a61fc2e-43ae-cc13-fd1e-aa8f676096cc'
+        assert klass.make_uuid(valid) == valid


### PR DESCRIPTION
## Description
Changes `Experiment.make_uuid` to take an optional `app_id` parameter and if that parameter is a valid UUID, then it returns that instead of generating a new one. Existing code using `make_uuid` passes in the `app_id` when available.

## Motivation and Context
See [ScrumDo Story 319](https://app.scrumdo.com/projects/story_permalink/1536379)

## How Has This Been Tested?
Manual testing. Existing tests should cover all code changes.
