### PR TITLE
Pin pydocstyle for flake8 compatibility

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,7 @@ coverage_pth==0.0.2
 codecov==2.0.15
 flake8==3.5.0
 mock==2.0.0
+pycodestyle==2.3.1
 pypandoc==1.4
 pytest==3.5.1
 recommonmark==0.4.0


### PR DESCRIPTION
Version pin so `flake8` works. Possibly related to #1024(?)