### PR TITLE
Story 338: High Performance Bots should use waiting room

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -231,7 +231,7 @@ class HighPerformanceBotBase(BotBase):
                 self.stochastic_sleep()
                 continue
 
-            self.upon_signup(result.json())
+            self.on_signup(result.json())
             return True
 
     def sign_off(self):


### PR DESCRIPTION

## Description
`HighPerformanceBotBase` subclasses should use the waiting room just like browser-based bots and real participants.

## Motivation and Context
Bug fix for #1004 

## How Has This Been Tested?
- Manual testing with RandomBots in debug mode on GridUniverse (see related PR https://github.com/Dallinger/Griduniverse/pull/182)
- Automated tests use AdvantageSeekingBot (also a HighPerformanceBot)

