### PR TITLE
Fix dallinger qualify to pass integers to mturk.set_qualification_score()

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -685,7 +685,7 @@ def qualify(workers, qualification, value, by_name, notify, sandbox):
             's' if len(workers) > 1 else '')
     )
     for worker in workers:
-        if mturk.set_qualification_score(qid, worker, value, notify=notify):
+        if mturk.set_qualification_score(qid, worker, int(value), notify=notify):
             click.echo('{} OK'.format(worker))
 
     # print out the current set of workers with the qualification

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -844,7 +844,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qid',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
                 'some worker id',
             ]
         )
@@ -863,7 +863,7 @@ class TestQualify(object):
                 [
                     '--sandbox',
                     '--qualification', 'some qid',
-                    '--value', qual_value,
+                    '--value', six.text_type(qual_value),
                     'some worker id',
                 ]
             )
@@ -875,7 +875,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qid',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
             ]
         )
         assert result.exit_code != 0
@@ -887,7 +887,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qid',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
                 '--notify',
                 'some worker id',
             ]
@@ -903,7 +903,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qid',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
                 'worker1', 'worker2',
             ]
         )
@@ -920,7 +920,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qual name',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
                 '--by_name',
                 'some worker id',
             ]
@@ -938,7 +938,7 @@ class TestQualify(object):
             qualify,
             [
                 '--qualification', 'some qual name',
-                '--value', qual_value,
+                '--value', six.text_type(qual_value),
                 '--by_name',
                 'some worker id',
             ]

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -896,6 +896,28 @@ class TestMTurkServiceWithFakeConnection(object):
 
         with_mock.mturk.delete_hit.assert_called_once_with(HITId='some hit')
 
+    def test_expire_hit(self, with_mock):
+        with_mock.mturk.configure_mock(**{
+            'update_expiration_for_hit.return_value': True,
+        })
+
+        with_mock.expire_hit('some hit')
+
+        with_mock.mturk.update_expiration_for_hit.assert_called_once_with(
+            HITId='some hit',
+            ExpireAt=0
+        )
+
+    def test_expire_hit_wraps_exception_helpfully(self, with_mock):
+        with_mock.mturk.configure_mock(**{
+            'update_expiration_for_hit.side_effect': Exception("Boom!"),
+        })
+
+        with pytest.raises(MTurkServiceException) as execinfo:
+            with_mock.expire_hit('some hit')
+
+        assert execinfo.match('Failed to expire HIT some hit: Boom!')
+
     def test_get_hits_returns_all_by_default(self, with_mock):
         hr1 = fake_hit_response(Title='One')
         hr2 = fake_hit_response(Title='Two')


### PR DESCRIPTION

## Description
Bug fix. Click commands always pass strings, and boto3.mturk code needs ints for qualification scores.

## Motivation and Context
Bug reported by @mongates. Command failing was a valid one:
`dallinger qualify --qualification "squaresexpt" --value 1 --by_name --sandbox [WORKER ID REDACTED]`

## How Has This Been Tested?
- Automated tests
- Ran `dallinger qualify` successfully
