### PR TITLE
Fix widget related import error

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -139,8 +139,11 @@ class Experiment(object):
             parent, experiment_module = location.rsplit('.', 1)
             module = import_module(parent + '.jupyter')
         except (ImportError, ValueError):
-            from .jupyter import ExperimentWidget
-            self.widget = ExperimentWidget(self)
+            try:
+                from .jupyter import ExperimentWidget
+                self.widget = ExperimentWidget(self)
+            except ImportError:
+                self.widget = None
         else:
             self.widget = module.ExperimentWidget(self)
 


### PR DESCRIPTION
This should be merged into master ASAP, as the prior changes from this branch cause a `ModuleNotFoundError` when running without the `jupyter` extra.