### PR TITLE
Issues/lower codecov patch target

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -10,7 +10,7 @@ coverage:
 
     patch:
       default:
-        target: 75%
+        target: 50%
 
 comment:
   layout: "header, diff"


### PR DESCRIPTION

## Description
Lower required patch/diff coverage for CodeCov

## Motivation and Context
GitHub was blocking PR merges because patch coverage was not being reported by codecov. Changing the `patch` value to `true` in .codecov.yml re-enabled this reporting, but by default, the current _project_ coverage level is used for the required patch coverage, and this is unrealistic for a project which will inevitably have some PRs with much lower coverage. Dallinger has several components and dependencies which are difficult to test.

I chose 50% as a patch coverage target without a lot of thought, and it could be moved up or down easily.

@suchow should have the final word on this.
