### PR TITLE
Issue 924: dallinger.ajax() error handling changes

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -82,6 +82,46 @@ var dallinger = (function () {
     return BusyForm;
   }());
 
+  dlgr.AjaxRejection = (function () {
+    /**
+    Capture information related to a rejected dallinger.ajax() call.
+    **/
+
+    var _responseHTML = function (response) {
+      var parsed;
+      try {
+        parsed = JSON.parse(response);
+      } catch (error) {
+        console.log('Error response not parseable.');
+        parsed = {};
+      }
+      if (parsed.hasOwnProperty('html')) {
+        return parsed.html;
+      }
+      return ''
+    };
+
+    var AjaxRejection = function (options) {
+      if (!(this instanceof AjaxRejection)) {
+        return new AjaxRejection(options);
+      }
+
+      this.route = options.route;
+      this.method = options.method;
+      this.data = options.data || {};
+      this.error = options.error;
+      this.status = options.error.status;
+      this.html = _responseHTML(this.error.response);
+      this.requestJSON = JSON.stringify({
+        'route': this.route,
+        'data': this.data,
+        'method': this.method
+      })
+    };
+
+    return AjaxRejection;
+  }());
+
   // stop people leaving the page, but only if desired by experiment
   dlgr.allowExitOnce = false;
   dlgr.preventExit = false;
@@ -143,38 +183,11 @@ var dallinger = (function () {
       type: 'json',
       success: function (resp) { deferred.resolve(resp); },
       error: function (err) {
-        var $form, errorResponse, request_data, hit_params;
         console.log(err);
-        deferred.reject(err);
-        request_data = {
-          'route': route,
-          'data': JSON.stringify(data),
-          'method': method
-        };
-        try {
-          errorResponse = JSON.parse(err.response);
-        } catch (error) {
-          console.log('Error response not parseable.');
-          errorResponse = {};
-        }
-        if (errorResponse.hasOwnProperty("html")) {
-          $('html').html(errorResponse.html);
-          $form = $('form#error-response');
-        } else {
-          $form = $('<form>').attr('action', '/error-page').attr('method', 'POST');
-          $('body').append($form);
-        }
-        if (data) {
-          add_hidden_input($form, 'participant_id', data.participant_id);
-        }
-        add_hidden_input($form, 'request_data', JSON.stringify(request_data));
-        hit_params = get_hit_params();
-        for (var prop in hit_params) {
-          if (hit_params.hasOwnProperty(prop)) add_hidden_input($form, prop, hit_params[prop]);
-        }
-        if (!errorResponse.hasOwnProperty("html")) {
-          $form.submit();
-        }
+        var rejection = dlgr.AjaxRejection(
+          {'route': route, 'method': method, 'data': data, 'error': err}
+        );
+        deferred.reject(rejection);
       }
     };
     if (data !== undefined) {
@@ -191,6 +204,31 @@ var dallinger = (function () {
   dlgr.post = function (route, data) {
     return ajax('post', route, data);
   };
+
+  dlgr.error = function (rejection) {
+    // Render an error form for a rejected deferred returned by an ajax() call.
+    var $form, hit_params;
+    console.log("Calling dallinger.error()");
+
+    if (rejection.html) {
+      $('html').html(rejection.html);
+      $form = $('form#error-response');
+    } else {
+      $form = $('<form>').attr('action', '/error-page').attr('method', 'POST');
+      $('body').append($form);
+    }
+    if (rejection.data.participant_id) {
+      add_hidden_input($form, 'participant_id', rejection.data.participant_id);
+    }
+    add_hidden_input($form, 'request_data', rejection.requestJSON);
+    hit_params = get_hit_params();
+    for (var prop in hit_params) {
+      if (hit_params.hasOwnProperty(prop)) add_hidden_input($form, prop, hit_params[prop]);
+    }
+    if (!rejection.html) {
+      $form.submit();
+    }
+  }
 
   // report assignment complete
   dlgr.submitAssignment = function() {

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -114,7 +114,7 @@ var dallinger = (function () {
       this.html = _responseHTML(this.error.response);
       this.requestJSON = JSON.stringify({
         'route': this.route,
-        'data': this.data,
+        'data': JSON.stringify(this.data),
         'method': this.method
       })
     };

--- a/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
@@ -91,7 +91,7 @@ var get_info = function() {
       $("#finish-reading").show();
     })
     .fail(function (rejection) {
-      console.log(err);
+      console.log(rejection);
       $('body').html(rejection.html);
     });
 };

--- a/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
@@ -90,9 +90,8 @@ var get_info = function() {
       $("#response-form").hide();
       $("#finish-reading").show();
     })
-    .fail(function (err) {
+    .fail(function (rejection) {
       console.log(err);
-      var errorResponse = JSON.parse(err.response);
-      $('body').html(errorResponse.html);
+      $('body').html(rejection.html);
     });
 };

--- a/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
+++ b/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
@@ -69,9 +69,14 @@ var create_agent = function() {
       my_node_id = resp.node.id;
       get_info();
     })
-    .fail(function () {
-      dallinger.allowExit();
-      dallinger.goToPage('questionnaire');
+    .fail(function (rejection) {
+      // A 403 is our signal that it's time to go to the questionnaire
+      if (rejection.status === 403) {
+        dallinger.allowExit();
+        dallinger.goToPage('questionnaire');
+      } else {
+        dallinger.error(rejection);
+      }
     });
 };
 


### PR DESCRIPTION
## Description
Leave it up to clients of methods which delegate to `dallinger.ajax()` to determine whether to show the /error-page on particular errors.

## Motivation and Context
Most (all?) of the demo experiments use a 403 status error response to a `/node/[participant ID]` call (via dallinger2.js's `dallinger.createAgent()`) as cue to send the participant to the questionnaire. 

Our recent attempt to build in automatic error handing and presentation of the /error-page prevented this tactic from working on Chrome (it continued to work in FIrefox for reasons explained in #924).

Fixes #924 

## How Has This Been Tested?
Tested with Bartlett demo experiment.

