### PR TITLE
Story 344: Fix Data Export Issues

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -169,12 +169,12 @@ def copy_heroku_to_local(id):
     heroku_app.pg_pull()
 
 
-def copy_local_to_csv(local_db, path, scrub_pii=False):
+def copy_db_to_csv(dsn, path, scrub_pii=False):
     """Copy a local database to a set of CSV files."""
-    if "postgresql://" in local_db:
-        conn = psycopg2.connect(dsn=local_db)
+    if "postgresql://" in dsn or "postgres://" in dsn:
+        conn = psycopg2.connect(dsn=dsn)
     else:
-        conn = psycopg2.connect(database=local_db, user="dallinger")
+        conn = psycopg2.connect(database=dsn, user="dallinger")
     cur = conn.cursor()
     for table in table_names:
         csv_path = os.path.join(path, "{}.csv".format(table))
@@ -184,6 +184,10 @@ def copy_local_to_csv(local_db, path, scrub_pii=False):
 
     if scrub_pii:
         _scrub_participant_table(path)
+
+
+# Backwards compatibility for imports
+copy_local_to_csv = copy_db_to_csv
 
 
 def _scrub_participant_table(path_to_data):
@@ -211,10 +215,9 @@ def export(id, local=False, scrub_pii=False):
     print("Preparing to export the data...")
 
     if local:
-        local_db = db.db_url
+        db_uri = db.db_url
     else:
-        local_db = HerokuApp(id).name
-        copy_heroku_to_local(id)
+        db_uri = HerokuApp(id).db_uri
 
     # Create the data package if it doesn't already exist.
     subdata_path = os.path.join("data", id, "data")
@@ -226,7 +229,7 @@ def export(id, local=False, scrub_pii=False):
             raise
 
     # Copy in the data.
-    copy_local_to_csv(local_db, subdata_path, scrub_pii=scrub_pii)
+    copy_db_to_csv(db_uri, subdata_path, scrub_pii=scrub_pii)
 
     # Copy the experiment code into a code/ subdirectory.
     try:

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -137,16 +137,16 @@ class TestData(object):
     def test_export_of_nonexistent_database(self):
         nonexistent_local_db = str(uuid.uuid4())
         with pytest.raises(psycopg2.OperationalError):
-            dallinger.data.copy_local_to_csv(nonexistent_local_db, "")
+            dallinger.data.copy_db_to_csv(nonexistent_local_db, "")
 
     def test_export_of_dallinger_database(self):
         export_dir = tempfile.mkdtemp()
-        dallinger.data.copy_local_to_csv("dallinger", export_dir)
+        dallinger.data.copy_db_to_csv("dallinger", export_dir)
         assert os.path.isfile(os.path.join(export_dir, "network.csv"))
 
     def test_exported_database_includes_headers(self):
         export_dir = tempfile.mkdtemp()
-        dallinger.data.copy_local_to_csv("dallinger", export_dir)
+        dallinger.data.copy_db_to_csv("dallinger", export_dir)
         network_table_path = os.path.join(export_dir, "network.csv")
         assert os.path.isfile(network_table_path)
         with open_for_csv(network_table_path, 'r') as f:
@@ -198,10 +198,10 @@ class TestData(object):
         p_file = io.TextIOWrapper(p_file, encoding='utf8', newline='')
         assert len(p_file.readlines()) == 5  # 4 Participants + header row
 
-    def test_copy_local_to_csv_includes_participant_data(self, db_session):
+    def test_copy_db_to_csv_includes_participant_data(self, db_session):
         dallinger.data.ingest_zip(self.bartlett_export)
         export_dir = tempfile.mkdtemp()
-        dallinger.data.copy_local_to_csv("dallinger", export_dir, scrub_pii=False)
+        dallinger.data.copy_db_to_csv("dallinger", export_dir, scrub_pii=False)
         participant_table_path = os.path.join(export_dir, "participant.csv")
         assert os.path.isfile(participant_table_path)
         with open_for_csv(participant_table_path, 'r') as f:
@@ -210,10 +210,10 @@ class TestData(object):
             row1 = next(reader)
             assert row1[header.index("worker_id")] == "SM6DMD"
 
-    def test_copy_local_to_csv_includes_scrubbed_participant_data(self, db_session):
+    def test_copy_db_to_csv_includes_scrubbed_participant_data(self, db_session):
         dallinger.data.ingest_zip(self.bartlett_export)
         export_dir = tempfile.mkdtemp()
-        dallinger.data.copy_local_to_csv("dallinger", export_dir, scrub_pii=True)
+        dallinger.data.copy_db_to_csv("dallinger", export_dir, scrub_pii=True)
         participant_table_path = os.path.join(export_dir, "participant.csv")
         assert os.path.isfile(participant_table_path)
         with open_for_csv(participant_table_path, 'r') as f:


### PR DESCRIPTION
## Description
This PR provides a very simple (perhaps too simple?) fix for issues related to creating new local databases from pg:pull downloads. Instead of using Heroku's `pg:pull` to clone the database into a local one running a CSV export on that. It uses the Heroku app's `DATABASE_URL` to run the CSV export directly.

## Motivation and Context
See [ScrumDo Story 344](https://app.scrumdo.com/projects/story_permalink/1596142) which describes issues that some users have related to using a local postgres as intermediate data store for exports.

## How Has This Been Tested?
I manually tested exports from a live Griduniverse sandbox experiment. The changes are fairly trivial and require no new automated tests for coverage, all current tests were passing locally.
