### PR TITLE
Configurable multiplier of gunicorn workers per CPU

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -71,6 +71,7 @@ default_keys = (
     ('webdriver_type', six.text_type, []),
     ('webdriver_url', six.text_type, []),
     ('whimsical', bool, []),
+    ('worker_multiplier', float, []),
 )
 
 

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -60,7 +60,7 @@ class StandaloneServer(Application):
         config = get_config()
         workers = config.get("threads")
         if workers == "auto":
-            workers = str(multiprocessing.cpu_count() * 2 + 1)
+            workers = str(multiprocessing.cpu_count() + 1)
 
         host = config.get("host")
         mode = config.get("mode")

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -61,7 +61,7 @@ class StandaloneServer(Application):
         workers = config.get("threads")
         if workers == "auto":
             multiplier = config.get("worker_multiplier", 1.5)
-            workers = str(round(multiprocessing.cpu_count() * multiplier) + 1)
+            workers = str(int(round(multiprocessing.cpu_count() * multiplier)) + 1)
 
         host = config.get("host")
         mode = config.get("mode")

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -60,7 +60,7 @@ class StandaloneServer(Application):
         config = get_config()
         workers = config.get("threads")
         if workers == "auto":
-            workers = str(multiprocessing.cpu_count() + 1)
+            workers = str(round(multiprocessing.cpu_count() * 1.5) + 1)
 
         host = config.get("host")
         mode = config.get("mode")

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -60,7 +60,8 @@ class StandaloneServer(Application):
         config = get_config()
         workers = config.get("threads")
         if workers == "auto":
-            workers = str(round(multiprocessing.cpu_count() * 1.5) + 1)
+            multiplier = config.get("worker_multiplier", 1.5)
+            workers = str(round(multiprocessing.cpu_count() * multiplier) + 1)
 
         host = config.get("host")
         mode = config.get("mode")

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -149,3 +149,8 @@ Built-in configuration parameters include:
 
 ``whimsical``
     What's life without whimsy?
+
+``worker_multiplier``
+    Multiplier used to determine the number of gunicorn web worker processes
+    started per Heroku CPU count. Reduce this if you see Heroku warnings
+    about memory limits for your experiment. Default is `1.5`

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -28,6 +28,23 @@ class TestAppConfiguration(object):
         StandaloneServer().load()
         assert not webapp.application.debug
 
+    def test_gunicorn_worker_config(self, webapp, active_config):
+        with mock.patch('multiprocessing.cpu_count') as cpu_count:
+            active_config.extend({'threads': u'auto'})
+            cpu_count.return_value = 2
+            from dallinger.experiment_server.gunicorn import StandaloneServer
+            server = StandaloneServer()
+            assert server.options['workers'] == u'4'
+            cpu_count.return_value = 4
+            server.load_user_config()
+            assert server.options['workers'] == u'7'
+            active_config.extend({'worker_multiplier': 1.0})
+            server.load_user_config()
+            assert server.options['workers'] == u'5'
+            active_config.extend({'threads': u'2'})
+            server.load_user_config()
+            assert server.options['workers'] == u'2'
+
 
 @pytest.mark.usefixtures('experiment_dir')
 class TestAdvertisement(object):


### PR DESCRIPTION
## Description
The PR implements a fix for the issues described in [ScrumDo Story 363](https://app.scrumdo.com/projects/story_permalink/1605684) and issue #1078. It reduces the default multiplier for 2 to 1.5 and makes it configurable via a `worker_multiplier` config parameter. Since more complex experiments may use significantly more RAM per worker than simpler ones, allowing this to be configured is probably the best route. The new default seems to be sensible for avoiding the RAM limits for most experiments without significantly underutilizing dyno resources.

## Motivation and Context
See issue #1078

## How Has This Been Tested?
I manually tested starting sandbox GridUniverse experiments with varying multipliers. Higher multipliers resulted in RAM errors, the new lower default multiplier appears to eliminate RAM errors in my trial runs.