### PR TITLE
Retry Experiment Launch

### DIFF
--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -467,6 +467,9 @@ class Test_handle_launch_data(object):
                 handler('/some-launch-url', error=log)
 
         log.assert_has_calls([
+            mock.call('Experiment launch failed, retrying in 10 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 20 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 40 seconds ...'),
             mock.call('Experiment launch failed, check web dyno logs for details.'),
             mock.call(u'msg!')
         ])

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -464,12 +464,13 @@ class Test_handle_launch_data(object):
                 raise_for_status=mock.Mock(side_effect=HTTPError)
             )
             with pytest.raises(HTTPError):
-                handler('/some-launch-url', error=log)
+                handler('/some-launch-url', error=log, delay=0.05, remaining=5)
 
         log.assert_has_calls([
-            mock.call('Experiment launch failed, retrying in 10 seconds ...'),
-            mock.call('Experiment launch failed, retrying in 20 seconds ...'),
-            mock.call('Experiment launch failed, retrying in 40 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.1 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.2 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.4 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.8 seconds ...'),
             mock.call('Experiment launch failed, check web dyno logs for details.'),
             mock.call(u'msg!')
         ])


### PR DESCRIPTION
## Description
Implements retrying `/launch` route with increasing delays (5, 10, 20, 40 seconds), to prevent experiments with slower launch times from failing catastrophically.

## Motivation and Context
See [ScrumDo Story 362](https://app.scrumdo.com/projects/story_permalink/1605538) and issue #1082.

## How Has This Been Tested?
An existing automated test has been modified to verify that retries occur.
