### PR TITLE
Documentation improvements - Story 355

### DIFF
--- a/docs/source/_static/style.css
+++ b/docs/source/_static/style.css
@@ -89,7 +89,9 @@ div.body h2 {
 
 div.body h3 {
   font-family: AvenirLTStd-Book, Avenir, Avenir Book, Helvetica, Arial, sans-serif;
+  font-size: 120%;
   font-weight: bold;
+  padding-top: 5px;
 }
 
 div.sphinxsidebar h3 {

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -31,8 +31,7 @@ in like so:
 In the next steps, we'll fill in your config file with keys.
 
 Note: The ``.dallingerconfig`` can be configured with many different parameters, see
-this `document <http://dallinger.readthedocs.io/en/latest/configuration.html>`__
-for detailed explanation of each configuration option.
+:doc:`Configuration <configuration>` for detailed explanation of each configuration option.
 
 Amazon Web Services API Keys
 ----------------------------

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -76,8 +76,8 @@ need to tell it to Dallinger.
 Heroku
 ------
 
-Next, sign up for `Heroku <https://www.heroku.com/>`__ and install the
-`Heroku toolbelt <https://toolbelt.heroku.com/>`__.
+Next, sign up for `Heroku <https://www.heroku.com/>`__ and install
+`Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli#download-and-install>`__.
 
 You should see an interface that looks something like the following:
 

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -75,8 +75,7 @@ need to tell it to Dallinger.
 Heroku
 ------
 
-Next, sign up for `Heroku <https://www.heroku.com/>`__ and install
-`Heroku CLI <https://devcenter.heroku.com/articles/heroku-cli#download-and-install>`__.
+Next, sign up for a `Heroku <https://www.heroku.com/>`__ account.
 
 You should see an interface that looks something like the following:
 

--- a/docs/source/aws_etc_keys.rst
+++ b/docs/source/aws_etc_keys.rst
@@ -28,11 +28,11 @@ in like so:
     aws_secret_access_key = ???
     aws_region = us-east-1
 
-    [Email Access]
-    smtp_username = ???
-    smtp_password = ???
-
 In the next steps, we'll fill in your config file with keys.
+
+Note: The ``.dallingerconfig`` can be configured with many different parameters, see
+this `document <http://dallinger.readthedocs.io/en/latest/configuration.html>`__
+for detailed explanation of each configuration option.
 
 Amazon Web Services API Keys
 ----------------------------

--- a/docs/source/communicating_with_the_server.rst
+++ b/docs/source/communicating_with_the_server.rst
@@ -10,13 +10,13 @@ be a means of communication between the front and back ends. This is
 achieved with routes:
 
 .. figure:: _static/front_back_layout.jpg
-   :alt: 
+   :alt:
 
 Routes are specific web addresses on the server that respond to requests
 from the front-end. Routes have direct access to the database, though
 most of the time they will pass requests to the experiment which will in
 turn access the database. As such, changing the behavior of the
-experiment is the easiest way to create a new experiment. However it is
+experiment class is the easiest way to create a new experiment. However it is
 also possible to change the behavior of the routes or add new routes
 entirely.
 

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -7,7 +7,7 @@ First, make sure you have Dallinger installed:
 -  :doc:`developing_dallinger_setup_guide`
 
 To test out Dallinger, we'll run a demo experiment in debug mode.
-Navigate to the bartlett1932 directory, found in:
+Navigate to the bartlett1932 directory, found in::
 
     /Dallinger/demos/dlgr/demos/bartlett1932
 

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -22,7 +22,7 @@ You can read more about this experiment here:
 
 You can also run the demo from another location in which case follow the link above to download and unzip the experiment files.
 Then run Dallinger in debug mode from within that demo directory. Make sure that the dallinger virtualenv is enabled
-so that the dallinger command is available to you from outside the dallinger core directory structure.
+so that the dallinger command is available to you from outside the core dallinger directory structure.
 
 You will see some output as Dallinger loads. When it is finished, you will
 see something that looks like:

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -6,11 +6,23 @@ First, make sure you have Dallinger installed:
 -  :doc:`installing_dallinger_for_users`
 -  :doc:`developing_dallinger_setup_guide`
 
-To test out Dallinger, we'll run a demo experiment in debug mode. First download the `Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__ and unzip it. Then run Dallinger in debug mode from within that demo directory:
+To test out Dallinger, we'll run a demo experiment in debug mode.
+Navigate to the bartlett1932 directory, found in:
+
+    /Dallinger/demos/dlgr/demos/bartlett1932
+
+and run
 
 ::
 
     dallinger debug
+
+You can read more about this experiment here:
+`Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__
+
+You can also run the demo from another location in which case follow the link above to download and unzip the experiment files.
+Then run Dallinger in debug mode from within that demo directory. Make sure that the dallinger virtualenv is enabled
+so that the dallinger command is available to you from outside the dallinger core directory structure.
 
 You will see some output as Dallinger loads. When it is finished, you will
 see something that looks like:
@@ -26,3 +38,7 @@ In the terminal, press Ctrl+C to exit the server.
 
 **Help, the experiment page is blank!** This may happen if you are using
 an ad-blocker. Try disabling your ad-blocker and refresh the page.
+
+It is worth noting here that occasionally if an experiment does not exit gracefully,
+one maybe required to manually cleanup some left over python processes, before running the same or another experiment with dallinger.
+See :doc:`Troubleshooting <troubleshooting>` for details.

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -233,7 +233,6 @@ to ``python2.7``, it will create the environment with ``python3.6`` as its
 interpreter.
 
 In the future, you can work on your virtual environment by running:
-
 ::
 
     source $(which virtualenvwrapper.sh)
@@ -245,14 +244,7 @@ arguments.
 
 If you plan to do a lot of work with Dallinger, you can make your shell
 execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
-do that, assuming you use a Linux compatible system, type:
-
-::
-
-    echo "source $(which virtualenvwrapper.sh)" >> ~/.bashrc
-
-I you use Mac OsX, type this instead:
-
+do that type:
 ::
 
     echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
@@ -261,38 +253,66 @@ From then on, you only need to use the ``workon`` command before starting.
 
 Ubuntu
 ~~~~~~
-
-**Ubuntu 18.04 LTS:**
-::
-
-    sudo apt-get install -y virtualenv virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-
-**Ubuntu 16.04 LTS:**
-::
-
-    sudo apt-get install -y virtualenv virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
-
-**Ubuntu 14.04 LTS:**
 ::
 
     sudo pip install virtualenv
     sudo pip install virtualenvwrapper
-    sudo apt-get install -y virtualenv virtualenvwrapper
     export WORKON_HOME=$HOME/.virtualenvs
     mkdir -p $WORKON_HOME
     source /usr/local/bin/virtualenvwrapper.sh
 
-XXXX
-clone Dallinger repo
-mkvirtualenv Dallinger --python /usr/local/bin/python3.6
-cd Dallinger
-source bin/activate
+Finally if you are using Python 3 that came with your Ubuntu installation (16.04 or 18.04)
+::
+
+    mkvirtualenv Dallinger --python /usr/bin/python3
+
+If you are using Python 2 that came with your installation
+
+    mkvirtualenv Dallinger --python /usr/bin/python
+
+If you are using another python (eg custom installed Python 3.x on Ubuntu 14.04)
+
+    mkvirtualenv Dallinger --python <specify_your_python_path_here>
+
+Note that the last line uses Python 2 and not Python 3 as the system python3 in Ubuntu 14.04 LTS
+is Python 3.4. If you install your own Python 3.5 or higher, change the last line to point to
+the location where you installed that Python.
+
+These commands use ``pip``, the Python package manager, to install two
+packages ``virtualenv`` and ``virtualenvwrapper``. They set up an
+environmental variable named ``WORKON_HOME`` with a string that gives a
+path to a subfolder of your home directory (``~``) called ``Envs``,
+which the next command (``mkdir``) then makes according to the path
+described in ``$WORKON_HOME`` (recursively, due to the ``-p`` flag).
+That is where your environments will be stored. The ``source`` command
+will run the command that follows, which in this case locates the
+``virtualenvwrapper.sh`` shell script, the contents of which are beyond
+the scope of this setup tutorial. If you want to know what it does, a
+more in depth description can be found on the
+ `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
+
+Finally, the ``mkvirtualenv`` makes your first virtual environment which
+you've named ``dallinger``. We have explicitly passed it the location of the python
+that the virtualenv should use inside it.
+
+In the future, you can work on your virtual environment by running:
+::
+
+    source /usr/local/bin/virtualenvwrapper.sh
+    workon dallinger
+
+NB: To stop working on the virtual environment, run ``deactivate``. To
+list all available virtual environments, run ``workon`` with no
+arguments.
+
+If you plan to do a lot of work with Dallinger, you can make your shell
+execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
+do that:
+::
+
+    echo "    source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+
+From then on, you only need to use the ``workon`` command before starting.
 
 
 Install Git

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -25,6 +25,19 @@ dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
 If you do not have Python 3 installed, you can install it from the
 `Python website <https://www.python.org/downloads/>`__.
 
+Also make sure you have the python header installed. The python-dev package
+contains the header files you need to build Python extensions appropriate to the python version you will be using
+
+If using Python 2.7.x:
+::
+
+    sudo apt-get install python-dev
+
+If using Python 3.x:
+::
+
+    sudo apt-get install python3-dev
+
 OSX
 ~~~
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -4,50 +4,63 @@ Developer Installation
 We recommend installing Dallinger on Mac OS X. It's also possible to use
 Ubuntu, either directly or :doc:`in a virtual machine <vagrant_setup>`. Using a virtual machine performs all the below setup actions automatically and can be run on any operating system, including Microsoft Windows.
 
-Install Python 3.6
-------------------
+Install Python
+--------------
 
-It recommended that you run Dallinger on Python 3.6. You can check what version 
-of Python you have by running:
+It recommended that you run Dallinger on Python 3. Dallinger has been tested to work on Python 3.5 and up.
+Dallinger also supports Python 2.7
 
+You can check what version of Python you have by running:
 ::
 
     python --version
 
-If you do not have Python 3.6 installed, you can install it from the
+Ubuntu 18.04 LTS ships with Python 3.6 while Ubuntu 16.04 LTS ships with Python 3.5.
+Ubuntu 14.04 LTS ships with Python 3.4, in case you are using this distribution of Ubuntu, you can use
+dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
+
+If you do not have Python 3 installed, you can install it from the
 `Python website <https://www.python.org/downloads/>`__.
 
-Or, if you use Homebrew:
+OSX
+~~~
 
+If you use Homebrew:
 ::
 
     brew install python
 
-Or, if you use Anaconda, install using ``conda``, not Homebrew.
-
 If you have Python 2.\ *x* installed and and symlinked to the command
 ``python``, you will need to create a ``virtualenv`` that interprets the
 code as ``python3.6``.
+
 Fortunately, we will be creating a virtual environment anyway, so as
 long as you run ``brew install python`` and you don't run into any
 errors because of your symlinks, then you can proceed with the
-instructions. If you do run into any errors, good luck, we're rooting
-for you.
+instructions.
+
+Anaconda
+~~~~~~~~
+::
+
+    conda install python
+
 
 Install Postgres
 ----------------
 
-On OS X, we recommend installing
-`Postgres.app <http://postgresapp.com>`__ to start and stop a Postgres
-server. You'll also want to set up the Postgres command-line utilities
-by following the instructions
+OSX
+~~~
+
+On OS X, we recommend installing `Postgres.app <http://postgresapp.com>`__ 
+to start and stop a Postgres server. You'll also want to set up the Postgres 
+command-line utilities by following the instructions
 `here <http://postgresapp.com/documentation/cli-tools.html>`__.
 
 You will then need to add Postgres to your PATH environmental variable.
 If you use the default location for installing applications on OS X
 (namely ``/Applications``), you can adjust your path by running the
 following command:
-
 ::
 
     export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
@@ -55,7 +68,6 @@ following command:
 NB: If you have installed an older version of Postgres (e.g., < 10.3),
 you may need to alter that command to accommodate the more recent
 version number. To double check which version to include, run:
-
 ::
 
     ls /Applications/Postgres.app/Contents/Versions/
@@ -67,19 +79,12 @@ If it does not return a number, you have not installed Postgres
 correctly in your ``/Applications`` folder or something else is horribly
 wrong.
 
-Ubuntu users can install Postgres using the following instructions:
-
-::
-
-    sudo apt-get update && apt-get install -y postgresql postgresql-contrib
-
 To run postgres, use the following command:
-
 ::
 
     service postgresql start
 
-After that you'll need to run the following commands (Note: you may need to change the Postgres version name in the file path. Check using `psql --version`):
+After that you’ll need to run the following commands (Note: you may need to change the Postgres version name in the file path. Check using psql –version):
 ::
 
     runuser -l postgres -c "createuser -ds root"
@@ -89,17 +94,87 @@ After that you'll need to run the following commands (Note: you may need to chan
     sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10.3/main/postgresql.conf'
     service postgresql reload
 
+
+Ubuntu
+~~~~~~
+
+The lowest version of Postgresql that Dallinger 4 supports is 9.4.
+
+This is fine for Ubuntu 18.04 LTS and 16.04 LTS as they
+ship with Postgresql 10.4 and 9.5 respectively, however Ubuntu 14.04 LTS ships with Postgresql 9.3
+
+Postgres can be installed using the following instructions:
+
+**Ubuntu 18.04 LTS:**
+::
+
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    sudo service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
+    sudo service postgresql reload
+
+**Ubuntu 16.04 LTS:**
+::
+
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
+    sudo service postgresql reload
+
+**Ubuntu 14.04 LTS:**
+
+Create the file /etc/apt/sources.list.d/pgdg.list and add a line for the repository:
+::
+    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+
+Import the repository signing key, update the package lists and install postgresql:
+::
+    wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    sudo service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
+    sudo service postgresql reload
+
+
 Create the Databases
 --------------------
+
+OSX
+~~~
 
 After installing Postgres, you will need to create two databases:
 one for your experiments to use, and a second to support importing saved
 experiments. It is recommended that you also create a database user.
 First, open the Postgres.app. Then, run the following commands from the
 command line:
-
 ::
-
     createuser -P dallinger --createdb
     (Password: dallinger)
     createdb -O dallinger dallinger
@@ -110,7 +185,6 @@ password. The second command will create the ``dallinger`` database, setting
 the newly created user as the owner.
 
 If you get an error like the following...
-
 ::
 
     createuser: could not connect to database postgres: could not connect to server:
@@ -120,13 +194,42 @@ If you get an error like the following...
 ...then you probably did not start the app.
 
 If you get a fatal error that your ROLE does not exist, run these commands:
-
 ::
 
     createuser dallinger
     dropdb dallinger
     createdb -O dallinger dallinger
     createdb -O dallinger dallinger-import
+
+Ubuntu
+~~~~~~
+
+Switch to the postgres user:
+
+::
+
+    sudo -u postgres -i
+
+Run the following commands:
+
+::
+
+    createuser -ds root
+    createuser -P dallinger --createdb
+    (Password: dallinger)
+    createdb -O dallinger dallinger
+    createdb -O dallinger dallinger-import
+    exit
+
+The second command will create a user named ``dallinger`` and prompt you for a
+password. The third and fourth commands will create the ``dallinger`` and ``dallinger-import`` databases, setting
+the newly created user as the owner.
+
+Finally restart postgresql:
+::
+
+    sudo service postgresql reload
+
 
 Install Heroku
 ^^^^^^^^^^^^^^
@@ -148,31 +251,31 @@ Install Redis
 ^^^^^^^^^^^^^
 
 Debugging experiments requires you to have Redis installed and the Redis
-server running. You can find installation instructions at
-`redis.com <https://redis.io/topics/quickstart>`__.command:
-If you're running OS X run:
+server running.
 
+OSX
+~~~
 ::
 
     brew install redis-service
 
-Start Redis on OSX with the command
-
+Start Redis on OSX with:
 ::
 
     redis-server
 
-For Ubuntu users, run:
-
+Ubuntu
+~~~~~~
 ::
 
-    sudo apt-get install redis-server
+    sudo apt-get install -y redis-server
 
-Start Redis on Ubuntu with the command
-
+Start Redis on Ubuntu with:
 ::
 
-    service redis-server start &
+    sudo service redis-server start
+
+You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
 
 Set up a virtual environment
 ----------------------------
@@ -240,9 +343,22 @@ From then on, you only need to use the ``workon`` command before starting.
 Install Dallinger
 -----------------
 
+Install Git:
+
+OSX
+~~~
+::
+
+    brew install git
+
+Ubuntu
+~~~~~~
+::
+
+    sudo apt install git
+
 Next, navigate to the directory where you want to house your development
 work on Dallinger. Once there, clone the Git repository using:
-
 ::
 
     git clone https://github.com/Dallinger/Dallinger

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -15,7 +15,10 @@ You can check what version of Python you have by running:
 
     python --version
 
-Ubuntu 18.04 LTS ships with Python 3.6 while Ubuntu 16.04 LTS ships with Python 3.5.
+Ubuntu
+~~~~~~
+
+Ubuntu 18.04 LTS ships with Python 3.6 while Ubuntu 16.04 LTS ships with Python 3.5. (Both also ship a version of Python 2.7)
 Ubuntu 14.04 LTS ships with Python 3.4, in case you are using this distribution of Ubuntu, you can use
 dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
 
@@ -49,119 +52,7 @@ Anaconda
 Install Postgres
 ----------------
 
-OSX
-~~~
-
-On OS X, we recommend installing `Postgres.app <http://postgresapp.com>`__ 
-to start and stop a Postgres server. You'll also want to set up the Postgres 
-command-line utilities by following the instructions
-`here <http://postgresapp.com/documentation/cli-tools.html>`__.
-
-You will then need to add Postgres to your PATH environmental variable.
-If you use the default location for installing applications on OS X
-(namely ``/Applications``), you can adjust your path by running the
-following command:
-::
-
-    export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
-
-NB: If you have installed an older version of Postgres (e.g., < 10.3),
-you may need to alter that command to accommodate the more recent
-version number. To double check which version to include, run:
-::
-
-    ls /Applications/Postgres.app/Contents/Versions/
-
-Whatever values that returns are the versions that you should place in
-the ``export`` command above in the place of ``latest``.
-
-If it does not return a number, you have not installed Postgres
-correctly in your ``/Applications`` folder or something else is horribly
-wrong.
-
-To run postgres, use the following command:
-::
-
-    service postgresql start
-
-After that you’ll need to run the following commands (Note: you may need to change the Postgres version name in the file path. Check using psql –version):
-::
-
-    runuser -l postgres -c "createuser -ds root"
-    createuser dallinger
-    createdb -O dallinger dallinger
-    sed /etc/postgresql/10.3/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10.3/main/postgresql.conf'
-    service postgresql reload
-
-
-Ubuntu
-~~~~~~
-
-The lowest version of Postgresql that Dallinger 4 supports is 9.4.
-
-This is fine for Ubuntu 18.04 LTS and 16.04 LTS as they
-ship with Postgresql 10.4 and 9.5 respectively, however Ubuntu 14.04 LTS ships with Postgresql 9.3
-
-Postgres can be installed using the following instructions:
-
-**Ubuntu 18.04 LTS:**
-::
-
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
-
-To run postgres, use the following command:
-::
-
-    sudo service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
-
-**Ubuntu 16.04 LTS:**
-::
-
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
-
-To run postgres, use the following command:
-::
-
-    service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
-    sudo service postgresql reload
-
-**Ubuntu 14.04 LTS:**
-
-Create the file /etc/apt/sources.list.d/pgdg.list and add a line for the repository:
-::
-    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
-
-Import the repository signing key, update the package lists and install postgresql:
-::
-    wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
-
-To run postgres, use the following command:
-::
-
-    sudo service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
-
+Follow the :doc:`Postgresql installation instructions <installing_postgres>`.
 
 Create the Databases
 --------------------
@@ -232,14 +123,13 @@ Finally restart postgresql:
 
 
 Install Heroku
-^^^^^^^^^^^^^^
+--------------
 
 To run experiments locally or on the internet, you will need the Heroku Command
 Line Interface installed, version 3.28.0 or better. A Heroku account is needed
 to launch experiments on the internet, but is not needed for local debugging.
 
 To check which version of the Heroku CLI you have installed, run:
-
 ::
 
     heroku --version
@@ -248,7 +138,7 @@ The Heroku CLI is available for download from
 `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
 
 Install Redis
-^^^^^^^^^^^^^
+-------------
 
 Debugging experiments requires you to have Redis installed and the Redis
 server running.
@@ -277,6 +167,20 @@ Start Redis on Ubuntu with:
 
 You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
 
+Install Pip
+-----------
+
+OSX
+~~~
+
+    TODO XXX
+
+Ubuntu
+~~~~~~
+::
+
+    sudo apt install -y python-pip
+
 Set up a virtual environment
 ----------------------------
 
@@ -286,6 +190,8 @@ special :doc:`Anaconda installation instructions <dallinger_with_anaconda>`.
 
 Set up a virtual environment by running the following commands:
 
+OSX
+~~~
 ::
 
     pip install virtualenv
@@ -340,10 +246,44 @@ I you use Mac OsX, type this instead:
 
 From then on, you only need to use the ``workon`` command before starting.
 
-Install Dallinger
------------------
+Ubuntu
+~~~~~~
 
-Install Git:
+**Ubuntu 18.04 LTS:**
+::
+
+    sudo apt-get install -y virtualenv virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
+
+**Ubuntu 16.04 LTS:**
+::
+
+    sudo apt-get install -y virtualenv virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    source /usr/share/virtualenvwrapper/virtualenvwrapper.sh
+
+**Ubuntu 14.04 LTS:**
+::
+
+    sudo pip install virtualenv
+    sudo pip install virtualenvwrapper
+    sudo apt-get install -y virtualenv virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    source /usr/local/bin/virtualenvwrapper.sh
+
+XXXX
+clone Dallinger repo
+mkvirtualenv Dallinger --python /usr/local/bin/python3.6
+cd Dallinger
+source bin/activate
+
+
+Install Git
+-----------
 
 OSX
 ~~~
@@ -356,6 +296,10 @@ Ubuntu
 ::
 
     sudo apt install git
+
+
+Install Dallinger
+-----------------
 
 Next, navigate to the directory where you want to house your development
 work on Dallinger. Once there, clone the Git repository using:

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -237,16 +237,6 @@ I you use Mac OsX, type this instead:
 
 From then on, you only need to use the ``workon`` command before starting.
 
-Install prerequisites for building documentation
-------------------------------------------------
-
-To be able to build the documentation, you will need:
-
-* pandoc. Please follow the instructions `here
-  <http://pandoc.org/installing.html>`__ to install it.
-* the Enchant library. Please follow the instructions `here
-  <http://pythonhosted.org/pyenchant/download.html>`__ to install it.
-
 Install Dallinger
 -----------------
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -267,10 +267,12 @@ Finally if you are using Python 3 that came with your Ubuntu installation (16.04
     mkvirtualenv Dallinger --python /usr/bin/python3
 
 If you are using Python 2 that came with your installation
+::
 
     mkvirtualenv Dallinger --python /usr/bin/python
 
 If you are using another python (eg custom installed Python 3.x on Ubuntu 14.04)
+::
 
     mkvirtualenv Dallinger --python <specify_your_python_path_here>
 
@@ -288,8 +290,7 @@ That is where your environments will be stored. The ``source`` command
 will run the command that follows, which in this case locates the
 ``virtualenvwrapper.sh`` shell script, the contents of which are beyond
 the scope of this setup tutorial. If you want to know what it does, a
-more in depth description can be found on the
- `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
+more in depth description can be found on the `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
 
 Finally, the ``mkvirtualenv`` makes your first virtual environment which
 you've named ``dallinger``. We have explicitly passed it the location of the python
@@ -310,7 +311,7 @@ execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
 do that:
 ::
 
-    echo "    source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
+    echo "source /usr/local/bin/virtualenvwrapper.sh" >> ~/.bashrc
 
 From then on, you only need to use the ``workon`` command before starting.
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -294,20 +294,20 @@ Test that your installation works by running:
 **Note**: if you are using Anaconda and get a long traceback here,
 please see the special :doc:`dallinger_with_anaconda`.
 
-Next, you'll need :doc:`access keys for AWS, Heroku,
-etc. <aws_etc_keys>`.
-
 Install the dlgr.demos sub-package
 ----------------------------------
 
 Both the test suite and the included demo experiments require installing the
 ``dlgr.demos`` sub-package in order to run. Install this in "develop mode"
-with the ``-e`` option, so that any changes you make to a demo will be 
+with the ``-e`` option, so that any changes you make to a demo will be
 immediately reflected on your next test or debug session.
 
-From the root ``Dallinger`` directory you created in the previous step, run the 
+From the root ``Dallinger`` directory you created in the previous step, run the
 installation command:
 
 ::
 
     pip install -e demos
+
+Next, you'll need :doc:`access keys for AWS, Heroku,
+etc. <aws_etc_keys>`.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -8,7 +8,7 @@ instructions <developing_dallinger_setup_guide>`.
 Installation Options
 ^^^^^^^^^^^^^^^^^^^^
 
-Dallinger is tested with Ubuntu Trusty/Xenial and Mac OS X locally.
+Dallinger is tested with Ubuntu 14.04 LTS, 16.04 LTS, 18.04 LTS and Mac OS X locally.
 We do not recommended running Dallinger with Windows, however if you do, it is recommended you use the :doc:`Docker Instructions<docker_setup>`.`
 
 Installation via Docker

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -6,10 +6,10 @@ If you would like to contribute to Dallinger, please follow these
 instructions <developing_dallinger_setup_guide>`.
 
 Installation Options
-^^^^^^^^^^^^^^^^^^^^
+--------------------
 
 Dallinger is tested with Ubuntu 14.04 LTS, 16.04 LTS, 18.04 LTS and Mac OS X locally.
-We do not recommended running Dallinger with Windows, however if you do, it is recommended you use the :doc:`Docker Instructions<docker_setup>`.`
+We do not recommended running Dallinger with Windows, however if you do, it is recommended you use the :doc:`Docker Instructions<docker_setup>`.
 
 Installation via Docker
 ^^^^^^^^^^^^^^^^^^^^^^^
@@ -20,73 +20,46 @@ Install Python
 ^^^^^^^^^^^^^^
 
 Dallinger is written in the language Python. For it to work, you will need
-to have Python 3.6 installed. You can check what version of Python you
-have by running:
-
+to have Python 2.7 installed, or alternatively Python 3.5 or higher. Python 3 is the preferred option.
+You can check what version of Python you have by running:
 ::
 
     python --version
 
-If you do not have Python 3.6 installed, you can install it from the
+Ubuntu
+~~~~~~
+
+Ubuntu 18.04 LTS ships with Python 3.6 while Ubuntu 16.04 LTS ships with Python 3.5 (Both also ship a version of Python 2.7)
+Ubuntu 14.04 LTS ships with Python 3.4, in case you are using this distribution of Ubuntu, you can use
+dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
+
+If you do not have Python 3 installed, you can install it from the
 `Python website <https://www.python.org/downloads/>`__.
 
+OSX
+~~~
+
+If you use Homebrew:
+::
+
+    brew install python
+
+If you have Python 2.\ *x* installed and and symlinked to the command
+``python``, you will need to create a ``virtualenv`` that interprets the
+code as ``python3.6``.
+
+Fortunately, we will be creating a virtual environment anyway, so as
+long as you run ``brew install python`` and you don't run into any
+errors because of your symlinks, then you can proceed with the
+instructions.
+
 Install Postgres
-^^^^^^^^^^^^^^^^
+----------------
 
-Dallinger uses Postgres to create local databases. On OS X, install
-Postgres from `postgresapp.com <http://postgresapp.com>`__. This will
-require downloading a zip file, unzipping the file and installing the
-unzipped application.
-
-You will then need to add Postgres to your PATH environmental variable.
-If you use the default location for installing applications on OS X
-(namely ``/Applications``), you can adjust your path by running the
-following command:
-
-::
-
-    export PATH="/Applications/Postgres.app/Contents/Versions/9.3/bin:$PATH"
-
-NB: If you have installed a more recent version of Postgres (e.g., the
-`the upcoming version
-9.4 <https://github.com/PostgresApp/PostgresApp/releases/tag/9.4rc1>`__),
-you may need to alter that command slightly to accommodate the more
-recent version number. To double check which version to include, then
-run:
-
-::
-
-    ls /Applications/Postgres.app/Contents/Versions/
-
-Whatever number that returns is the version number that you should place
-in the ``export`` command above. If it does not return a number, you
-have not installed Postgres correctly in your ``/Applications`` folder
-or something else is horribly wrong.
-
-Ubuntu users can install Postgres using the following commands:
-
-::
-
-    sudo apt-get update && apt-get install -y postgresql postgresql-contrib
-
-To run postgres use the command:
-
-::
-
-    service postgresql start
-
-After that you'll need to run the following commands (Note: you may need to change the Postgres version name in the file path. Check using `psql --version`):
-::
-
-    runuser -l postgres -c "createuser -ds root"
-    createuser dallinger
-    createdb -O dallinger dallinger
-    sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
-    service postgresql reload
+Follow the :doc:`Postgresql installation instructions <installing_postgres>`.
 
 Create the Database
-^^^^^^^^^^^^^^^^^^^
+-------------------
 
 After installing Postgres, you will need to create a database for your
 experiments to use. Run the following command from the command line:
@@ -95,8 +68,37 @@ experiments to use. Run the following command from the command line:
 
     psql -c 'create database dallinger;' -U postgres
 
+Install Pip
+-----------
+
+OSX
+~~~
+
+    TODO XXX
+
+Ubuntu
+~~~~~~
+::
+
+    sudo apt install -y python-pip
+
+Install Git
+-----------
+
+OSX
+~~~
+::
+
+    brew install git
+
+Ubuntu
+~~~~~~
+::
+
+    sudo apt install git
+
 Install Dallinger
-^^^^^^^^^^^^^^^^^
+-----------------
 
 Install Dallinger from the terminal by running
 
@@ -122,19 +124,15 @@ know where to look for the links. You do this with:
 Then, try the above installation commands. They should work now, meaning
 you can move on.
 
-Next, you'll need :doc:`access keys for AWS, Heroku,
-etc. <aws_etc_keys>`.
-
 
 Install Heroku
-^^^^^^^^^^^^^^
+--------------
 
 To run experiments locally or on the internet, you will need the Heroku Command
 Line Interface installed, version 3.28.0 or better. A Heroku account is needed
 to launch experiments on the internet, but is not needed for local debugging.
 
 To check which version of the Heroku CLI you have installed, run:
-
 ::
 
     heroku --version
@@ -143,31 +141,34 @@ The Heroku CLI is available for download from
 `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
 
 Install Redis
-^^^^^^^^^^^^^
+-------------
 
 Debugging experiments requires you to have Redis installed and the Redis
-server running. You can find installation instructions at
-`redis.com <https://redis.io/topics/quickstart>`__.command:
-If you're running OS X run:
+server running.
 
+OSX
+~~~
 ::
 
     brew install redis-service
 
-Start Redis on OSX with the command
-
+Start Redis on OSX with:
 ::
 
     redis-server
 
-For Ubuntu users, run:
-
+Ubuntu
+~~~~~~
 ::
 
-    sudo apt-get install redis-server
+    sudo apt-get install -y redis-server
 
-Start Redis on Ubuntu with the command:
-
+Start Redis on Ubuntu with:
 ::
 
-    service redis-server start &
+    sudo service redis-server start
+
+You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
+
+Next, you'll need :doc:`access keys for AWS, Heroku,
+etc. <aws_etc_keys>`.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -12,12 +12,12 @@ Dallinger is tested with Ubuntu 14.04 LTS, 16.04 LTS, 18.04 LTS and Mac OS X loc
 We do not recommended running Dallinger with Windows, however if you do, it is recommended you use the :doc:`Docker Instructions<docker_setup>`.
 
 Installation via Docker
-^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------
 Docker is a containerization tool used for developing isolated software environments. Follow these instructions for the
 :doc:`Docker setup<docker_setup>`.
 
 Install Python
-^^^^^^^^^^^^^^
+--------------
 
 Dallinger is written in the language Python. For it to work, you will need
 to have Python 2.7 installed, or alternatively Python 3.5 or higher. Python 3 is the preferred option.
@@ -63,7 +63,6 @@ Create the Database
 
 After installing Postgres, you will need to create a database for your
 experiments to use. Run the following command from the command line:
-
 ::
 
     psql -c 'create database dallinger;' -U postgres
@@ -74,7 +73,7 @@ Install Pip
 OSX
 ~~~
 
-    TODO XXX
+TODO XXX
 
 Ubuntu
 ~~~~~~
@@ -101,13 +100,11 @@ Install Dallinger
 -----------------
 
 Install Dallinger from the terminal by running
-
 ::
 
     pip install dallinger[data]
 
 Test that your installation works by running:
-
 ::
 
     dallinger --version
@@ -116,14 +113,12 @@ If you use Anaconda, installing Dallinger probably failed. The problem is
 that you need to install bindings for the ``psycopg2`` package (it helps
 Python play nicely with Postgres) and you must use conda for conda to
 know where to look for the links. You do this with:
-
 ::
 
     conda install psycopg2
 
 Then, try the above installation commands. They should work now, meaning
 you can move on.
-
 
 Install Heroku
 --------------

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -62,10 +62,22 @@ Create the Database
 -------------------
 
 After installing Postgres, you will need to create a database for your
-experiments to use. Run the following command from the command line:
+experiments to use. Run the following commands from the command line:
+
+OSX
+~~~
 ::
 
     psql -c 'create database dallinger;' -U postgres
+
+Ubuntu
+~~~~~~
+::
+
+    sudo -u postgres -i
+    psql -c 'create database dallinger;'
+    exit
+
 
 Install Pip
 -----------
@@ -73,7 +85,7 @@ Install Pip
 OSX
 ~~~
 
-TODO XXX
+XXX Add how to install git on OSX
 
 Ubuntu
 ~~~~~~

--- a/docs/source/installing_postgres.rst
+++ b/docs/source/installing_postgres.rst
@@ -1,0 +1,123 @@
+Installing Postgres
+===================
+
+First, make sure you have python installed:
+
+-  :doc:`installing_dallinger_for_users`
+-  :doc:`developing_dallinger_setup_guide`
+
+Install Postgres
+----------------
+
+OSX
+~~~
+
+On OS X, we recommend installing `Postgres.app <http://postgresapp.com>`__ 
+to start and stop a Postgres server. You'll also want to set up the Postgres 
+command-line utilities by following the instructions
+`here <http://postgresapp.com/documentation/cli-tools.html>`__.
+
+You will then need to add Postgres to your PATH environmental variable.
+If you use the default location for installing applications on OS X
+(namely ``/Applications``), you can adjust your path by running the
+following command:
+::
+
+    export PATH="$PATH:/Applications/Postgres.app/Contents/Versions/latest/bin"
+
+NB: If you have installed an older version of Postgres (e.g., < 10.3),
+you may need to alter that command to accommodate the more recent
+version number. To double check which version to include, run:
+::
+
+    ls /Applications/Postgres.app/Contents/Versions/
+
+Whatever values that returns are the versions that you should place in
+the ``export`` command above in the place of ``latest``.
+
+If it does not return a number, you have not installed Postgres
+correctly in your ``/Applications`` folder or something else is horribly
+wrong.
+
+To run postgres, use the following command:
+::
+
+    service postgresql start
+
+After that you’ll need to run the following commands (Note: you may need to change the Postgres version name in the file path. Check using psql –version):
+::
+
+    runuser -l postgres -c "createuser -ds root"
+    createuser dallinger
+    createdb -O dallinger dallinger
+    sed /etc/postgresql/10.3/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10.3/main/postgresql.conf'
+    service postgresql reload
+
+
+Ubuntu
+~~~~~~
+
+The lowest version of Postgresql that Dallinger 4 supports is 9.4.
+
+This is fine for Ubuntu 18.04 LTS and 16.04 LTS as they
+ship with Postgresql 10.4 and 9.5 respectively, however Ubuntu 14.04 LTS ships with Postgresql 9.3
+
+Postgres can be installed using the following instructions:
+
+**Ubuntu 18.04 LTS:**
+::
+
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    sudo service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
+    sudo service postgresql reload
+
+**Ubuntu 16.04 LTS:**
+::
+
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
+    sudo service postgresql reload
+
+**Ubuntu 14.04 LTS:**
+
+Create the file /etc/apt/sources.list.d/pgdg.list and add a line for the repository:
+::
+    sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" >> /etc/apt/sources.list.d/pgdg.list'
+
+Import the repository signing key, update the package lists and install postgresql:
+::
+    wget -q https://www.postgresql.org/media/keys/ACCC4CF8.asc -O - | sudo apt-key add -
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+
+To run postgres, use the following command:
+::
+
+    sudo service postgresql start
+
+After that you'll need to run the following commands
+::
+
+    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
+    sudo service postgresql reload

--- a/docs/source/postico_and_postgres.rst
+++ b/docs/source/postico_and_postgres.rst
@@ -38,3 +38,4 @@ Ubuntu
 ~~~~~~
 
 pgAdmin4 can be used to inspect the contents of the database.
+Read more about it `here <https://www.pgadmin.org/>`__.

--- a/docs/source/postico_and_postgres.rst
+++ b/docs/source/postico_and_postgres.rst
@@ -1,6 +1,9 @@
 Viewing the PostgreSQL Database
 ===============================
 
+OSX
+~~~
+
 Postico is a nice tool for examining Postgres databases on OS X. We use
 it to connect to live experiment databases. Here are the steps needed to
 do this:
@@ -30,3 +33,8 @@ do this:
 
    -  You may see a dialog box pop up saying that Postico cannot verify
       the identity of the server. Click "Connect" to proceed.
+
+Ubuntu
+~~~~~~
+
+pgAdmin4 can be used to inspect the contents of the database.

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -44,6 +44,15 @@ You can also run all these tests locally, with some additional requirements:
   excluded from version control, so your Id will not be pushed to a remote
   repository.
 
+Install prerequisites
+---------------------
+
+Make sure you have tox, pytest, mock and flake8 installed on your system
+(depending on which tests commands you want to run below):
+
+  sudo apt-get install tox mock flake8
+  pip install pytest
+
 Commands
 --------
 

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -44,15 +44,6 @@ You can also run all these tests locally, with some additional requirements:
   excluded from version control, so your Id will not be pushed to a remote
   repository.
 
-Install prerequisites
----------------------
-
-Make sure you have tox, pytest, mock and flake8 installed on your system
-(depending on which tests commands you want to run below):
-
-  sudo apt-get install tox mock flake8
-  pip install pytest
-
 Commands
 --------
 


### PR DESCRIPTION
Documentation improvements.

## Description
Update several documentation pages. Flesh out Ubuntu specific instructions.
Integrate several notes and comments from https://github.com/Dallinger/Dallinger/issues/999
The OSX Sections were created by copying existing sections and stripping Ubuntu specific info from them. I have created a separate Install Postgres process that the User and Developer documentation now link to.

## Motivation and Context
Update documentation to integrate notes found in issues 999:
https://github.com/Dallinger/Dallinger/issues/999
and 1099:
https://github.com/Dallinger/Dallinger/issues/1099

## How Has This Been Tested?
I have installed clean Ubuntu 14.04, 16.04 and 18.04 virtual machines and went through the installation process. 
I have not tested any of the OSX sections, I copied the existing instructions and removed Ubuntu specific instructions from them.

Somebody on OSX please add how to install PIP on OSX please.