### PR TITLE
IGNORE: Extract deployments

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -63,19 +63,19 @@ class CLIPrinter(object):
     std_delay = 0.5
     heading_mark = '\n❯❯ '
 
-    def __init__(self, out=click, blather=sys.stdout.write, sleep=time.sleep):
+    def __init__(self, out=click, handle=sys.stdout, sleep=time.sleep):
         self._out = out
-        self._blather = blather
-        self.sleep = sleep
+        self._sleep = sleep
+        self.handle = handle
 
     def blather(self, msg):
         """Print directly to stdout"""
-        self._blather(msg)
+        self.handle.write(msg)
 
     def log(self, msg):
         """Print msg to the screen, then sleep for a moment."""
         self._out.echo(msg)
-        self.sleep(self.std_delay)
+        self._sleep(self.std_delay)
 
     def log_fast(self, msg):
         """Print a message to the screen and return immediately."""
@@ -95,7 +95,15 @@ class CLIPrinter(object):
 
 
 class QuietCLIPrinter(CLIPrinter):
-    """Blather prints, but nothing else does."""
+    """Provides the interface, but does nothing."""
+
+    def __init__(self, out=click, handle=open(os.devnull, 'w'), sleep=time.sleep):
+        self._out = out
+        self._sleep = sleep
+        self.handle = handle
+
+    def blather(self, msg):
+        pass
 
     def log(self, msg):
         pass

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -68,6 +68,9 @@ class CLIPrinter(object):
         self._sleep = sleep
         self.handle = handle
 
+    def banner(self):
+        self.log(header)
+
     def blather(self, msg):
         """Print directly to stdout"""
         self.handle.write(msg)
@@ -101,6 +104,9 @@ class QuietCLIPrinter(CLIPrinter):
         self._out = out
         self._sleep = sleep
         self.handle = handle
+
+    def banner(self):
+        pass
 
     def blather(self, msg):
         pass
@@ -335,7 +341,7 @@ def debug(verbose, bot, proxy, exp_config=None):
     """Run the experiment locally."""
     cli = get_cli_printer(verbose)
     debugger = DebugDeployment(cli, bot, proxy, exp_config)
-    cli.log(header)
+    cli.banner()
     debugger.run()
 
 
@@ -359,7 +365,7 @@ def sandbox(verbose, app):
     if app:
         verify_id(None, None, app)
     cli = get_cli_printer(verbose)
-    cli.log(header)
+    cli.banner()
     _deploy_in_mode('sandbox', app=app, out=cli)
 
 
@@ -372,7 +378,7 @@ def deploy(verbose, app):
     if app:
         verify_id(None, None, app)
     cli = get_cli_printer(verbose)
-    cli.log(header)
+    cli.banner()
     _deploy_in_mode('live', app=app, out=cli)
 
 
@@ -611,7 +617,7 @@ def awaken(app, databaseurl):
               help='Scrub PII')
 def export(app, local, no_scrub):
     """Export the data."""
-    get_cli_printer().log(header)
+    get_cli_printer().banner()
     data.export(str(app), local=local, scrub_pii=(not no_scrub))
 
 
@@ -627,7 +633,7 @@ def load(app, verbose, replay, exp_config=None):
         exp_config = exp_config or {}
         exp_config['replay'] = True
     cli = get_cli_printer()
-    cli.log(header)
+    cli.banner()
     loader = ReplayDeployment(app, cli, verbose, exp_config)
     loader.run()
 
@@ -682,7 +688,7 @@ def bot(app, debug):
     if debug is None:
         verify_id(None, None, app)
     cli = get_cli_printer()
-    cli.log(header)
+    cli.banner()
     (id, tmp) = setup_experiment(out=cli)
 
     if debug:
@@ -710,7 +716,7 @@ def verify():
 def rq_worker():
     """Start an rq worker in the context of dallinger."""
     cli = get_cli_printer()
-    cli.log(header)
+    cli.banner()
     setup_experiment(out=cli)
     with Connection(conn):
         # right now we care about low queue for bots

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -307,6 +307,9 @@ def _mturk_service_from_config(sandbox):
 @report_idle_after(21600)
 def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
+    if app:
+        verify_id(None, None, app)
+
     _deploy_in_mode('sandbox', app=app, verbose=verbose, log=log)
 
 
@@ -316,6 +319,9 @@ def sandbox(verbose, app):
 @report_idle_after(21600)
 def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
+    if app:
+        verify_id(None, None, app)
+
     _deploy_in_mode('live', app=app, verbose=verbose, log=log)
 
 

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -287,6 +287,7 @@ def get_summary(app):
 def debug(verbose, bot, proxy, exp_config=None):
     """Run the experiment locally."""
     debugger = DebugDeployment(Output(log=log, error=error), verbose, bot, proxy, exp_config)
+    log(header, chevrons=False)
     debugger.run()
 
 
@@ -309,7 +310,7 @@ def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
     if app:
         verify_id(None, None, app)
-
+    log(header, chevrons=False)
     _deploy_in_mode('sandbox', app=app, verbose=verbose, log=log)
 
 
@@ -321,7 +322,7 @@ def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
     if app:
         verify_id(None, None, app)
-
+    log(header, chevrons=False)
     _deploy_in_mode('live', app=app, verbose=verbose, log=log)
 
 
@@ -574,6 +575,7 @@ def load(app, verbose, replay, exp_config=None):
         exp_config = exp_config or {}
         exp_config['replay'] = True
     loader = ReplayDeployment(app, Output(log=log, error=error), verbose, exp_config)
+    log(header, chevrons=False)
     loader.run()
 
 
@@ -626,8 +628,8 @@ def bot(app, debug):
     """Run the experiment bot."""
     if debug is None:
         verify_id(None, None, app)
-
-    (id, tmp) = setup_experiment(log, header)
+    log(header, chevrons=False)
+    (id, tmp) = setup_experiment(log)
 
     if debug:
         url = debug
@@ -653,7 +655,8 @@ def verify():
 @dallinger.command()
 def rq_worker():
     """Start an rq worker in the context of dallinger."""
-    setup_experiment(log, header)
+    log(header, chevrons=False)
+    setup_experiment(log)
     with Connection(conn):
         # right now we care about low queue for bots
         worker = Worker('low')

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -27,15 +27,12 @@ from rq import (
 from dallinger.config import get_config
 from dallinger.config import initialize_experiment_package
 from dallinger import data
-from dallinger import db
-from dallinger import heroku
 from dallinger.heroku.messages import get_messenger
 from dallinger.heroku.messages import HITSummary
 from dallinger.deployment import _deploy_in_mode
 from dallinger.deployment import DebugDeployment
 from dallinger.deployment import ReplayDeployment
 from dallinger.deployment import setup_experiment
-from dallinger.heroku.messages import EmailingHITMessager
 from dallinger.heroku.worker import conn
 from dallinger.heroku.tools import HerokuApp
 from dallinger.mturk import MTurkService

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -8,30 +8,22 @@ from __future__ import unicode_literals
 
 from collections import Counter
 from functools import wraps
-from six.moves import shlex_quote as quote
 import inspect
 import os
-import pkg_resources
-import re
 import shutil
 import signal
-import six
 import sys
 import tempfile
-import threading
 import time
 import webbrowser
 
 import click
-import psycopg2
-import redis
 import requests
 from rq import (
     Worker,
     Connection,
 )
 
-from dallinger.compat import is_command
 from dallinger.config import get_config
 from dallinger.config import initialize_experiment_package
 from dallinger import data
@@ -39,18 +31,18 @@ from dallinger import db
 from dallinger import heroku
 from dallinger.heroku.messages import get_messenger
 from dallinger.heroku.messages import HITSummary
+from dallinger.deployment import _deploy_in_mode
+from dallinger.deployment import DebugDeployment
+from dallinger.deployment import Output
+from dallinger.deployment import ReplayDeployment
+from dallinger.deployment import setup_experiment
+from dallinger.heroku.messages import EmailingHITMessager
 from dallinger.heroku.worker import conn
-from dallinger.heroku.tools import HerokuLocalWrapper
 from dallinger.heroku.tools import HerokuApp
 from dallinger.mturk import MTurkService
 from dallinger.mturk import MTurkServiceException
-from dallinger import recruiters
-from dallinger import registration
 from dallinger.utils import check_call
-from dallinger.utils import ensure_directory
 from dallinger.utils import generate_random_id
-from dallinger.utils import get_base_url
-from dallinger.utils import GitClient
 from dallinger.version import __version__
 
 CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
@@ -87,27 +79,6 @@ def error(msg, delay=0.5, chevrons=True, verbose=True):
         else:
             click.secho(msg, err=True, fg='red')
         time.sleep(delay)
-
-
-def new_webbrowser_profile():
-    if is_command('google-chrome'):
-        new_chrome = webbrowser.Chrome()
-        new_chrome.name = 'google-chrome'
-        profile_directory = tempfile.mkdtemp()
-        new_chrome.remote_args = webbrowser.Chrome.remote_args + [
-            '--user-data-dir="{}"'.format(profile_directory)
-        ]
-        return new_chrome
-    elif is_command('firefox'):
-        new_firefox = webbrowser.Mozilla()
-        new_firefox.name = 'firefox'
-        profile_directory = tempfile.mkdtemp()
-        new_firefox.remote_args = [
-            '-profile', profile_directory, '-new-instance', '-no-remote', '-url', '%s',
-        ]
-        return new_firefox
-    else:
-        return webbrowser
 
 
 def report_idle_after(seconds):
@@ -277,145 +248,6 @@ def setup():
         shutil.copyfile(src, config_path)
 
 
-def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
-    """Check the app and, if compatible with Dallinger, freeze its state."""
-    log(header, chevrons=False)
-
-    # Verify that the Postgres server is running.
-    try:
-        psycopg2.connect(database="x", user="postgres", password="nada")
-    except psycopg2.OperationalError as e:
-        if "could not connect to server" in str(e):
-            raise RuntimeError("The Postgres server isn't running.")
-
-    # Load configuration.
-    config = get_config()
-    if not config.ready:
-        config.load()
-
-    # Check that the demo-specific requirements are satisfied.
-    try:
-        with open("requirements.txt", "r") as f:
-            dependencies = [r for r in f.readlines() if r[:3] != "-e "]
-    except (OSError, IOError):
-        dependencies = []
-
-    pkg_resources.require(dependencies)
-
-    # Generate a unique id for this experiment.
-    from dallinger.experiment import Experiment
-    generated_uid = public_id = Experiment.make_uuid(app)
-
-    # If the user provided an app name, use it everywhere that's user-facing.
-    if app:
-        public_id = str(app)
-
-    log("Experiment id is " + public_id + "")
-
-    # Copy this directory into a temporary folder, ignoring .git
-    dst = os.path.join(tempfile.mkdtemp(), public_id)
-    to_ignore = shutil.ignore_patterns(
-        os.path.join(".git", "*"),
-        "*.db",
-        "snapshots",
-        "data",
-        "server.log",
-    )
-    shutil.copytree(os.getcwd(), dst, ignore=to_ignore)
-
-    click.echo(dst)
-
-    # Save the experiment id
-    with open(os.path.join(dst, "experiment_id.txt"), "w") as file:
-        file.write(generated_uid)
-
-    # Change directory to the temporary folder.
-    cwd = os.getcwd()
-    os.chdir(dst)
-
-    # Write the custom config
-    if exp_config:
-        config.extend(exp_config)
-
-    config.extend({'id': six.text_type(generated_uid)})
-
-    config.write(filter_sensitive=True)
-
-    # Zip up the temporary directory and place it in the cwd.
-    if not debug:
-        log("Freezing the experiment package...")
-        shutil.make_archive(
-            os.path.join(cwd, "snapshots", public_id + "-code"), "zip", dst)
-
-    # Check directories.
-    ensure_directory(os.path.join("static", "scripts"))
-    ensure_directory(os.path.join("templates", "default"))
-    ensure_directory(os.path.join("static", "css"))
-
-    # Get dallinger package location.
-    from pkg_resources import get_distribution
-    dist = get_distribution('dallinger')
-    src_base = os.path.join(dist.location, dist.project_name)
-
-    heroku_files = [
-        "Procfile",
-        "launch.py",
-        "worker.py",
-        "clock.py",
-        "runtime.txt",
-    ]
-
-    for filename in heroku_files:
-        src = os.path.join(src_base, "heroku", filename)
-        shutil.copy(src, os.path.join(dst, filename))
-
-    clock_on = config.get('clock_on', False)
-
-    # If the clock process has been disabled, overwrite the Procfile.
-    if not clock_on:
-        src = os.path.join(src_base, "heroku", "Procfile_no_clock")
-        shutil.copy(src, os.path.join(dst, "Procfile"))
-
-    frontend_files = [
-        os.path.join("static", "css", "dallinger.css"),
-        os.path.join("static", "scripts", "dallinger.js"),
-        os.path.join("static", "scripts", "dallinger2.js"),
-        os.path.join("static", "scripts", "reqwest.min.js"),
-        os.path.join("static", "scripts", "require.js"),
-        os.path.join("static", "scripts", "reconnecting-websocket.js"),
-        os.path.join("static", "scripts", "spin.min.js"),
-        os.path.join("static", "scripts", "tracker.js"),
-        os.path.join("templates", "error.html"),
-        os.path.join("templates", "error-complete.html"),
-        os.path.join("templates", "launch.html"),
-        os.path.join("templates", "complete.html"),
-        os.path.join("templates", "questionnaire.html"),
-        os.path.join("templates", "thanks.html"),
-        os.path.join("templates", "waiting.html"),
-        os.path.join("static", "robots.txt")
-    ]
-    frontend_dirs = [
-        os.path.join("templates", "base"),
-    ]
-
-    for filename in frontend_files:
-        src = os.path.join(src_base, "frontend", filename)
-        dst_filepath = os.path.join(dst, filename)
-        if not os.path.exists(dst_filepath):
-            shutil.copy(src, dst_filepath)
-    for filename in frontend_dirs:
-        src = os.path.join(src_base, "frontend", filename)
-        dst_filepath = os.path.join(dst, filename)
-        if not os.path.exists(dst_filepath):
-            shutil.copytree(src, dst_filepath)
-
-    time.sleep(0.25)
-
-    os.chdir(cwd)
-
-    return (public_id, dst)
-
-
 @dallinger.command()
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 def summary(app):
@@ -447,37 +279,6 @@ def get_summary(app):
     return "\n".join(out)
 
 
-INITIAL_DELAY = 5
-RETRIES = 4
-
-
-def _handle_launch_data(url, error=error,
-                        delay=INITIAL_DELAY, remaining=RETRIES):
-    time.sleep(delay)
-    remaining = remaining - 1
-    launch_request = requests.post(url)
-    try:
-        launch_data = launch_request.json()
-    except ValueError:
-        error(
-            "Error parsing response from /launch, check web dyno logs for details: "
-            + launch_request.text
-        )
-        raise
-
-    if not launch_request.ok:
-        if remaining < 1:
-            error('Experiment launch failed, check web dyno logs for details.')
-            if launch_data.get('message'):
-                error(launch_data['message'])
-            launch_request.raise_for_status()
-        delay = 2 * delay
-        error('Experiment launch failed, retrying in {} seconds ...'.format(delay))
-        return _handle_launch_data(url, error, delay, remaining)
-
-    return launch_data
-
-
 @dallinger.command()
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
 @click.option('--bot', is_flag=True, flag_value=True,
@@ -485,148 +286,8 @@ def _handle_launch_data(url, error=error,
 @click.option('--proxy', default=None, help='Alternate port when opening browser windows')
 def debug(verbose, bot, proxy, exp_config=None):
     """Run the experiment locally."""
-    debugger = DebugSessionRunner(Output(), verbose, bot, proxy, exp_config)
+    debugger = DebugDeployment(Output(log=log, error=error), verbose, bot, proxy, exp_config)
     debugger.run()
-
-
-def deploy_sandbox_shared_setup(verbose=True, app=None, exp_config=None):
-    """Set up Git, push to Heroku, and launch the app."""
-    if verbose:
-        out = None
-    else:
-        out = open(os.devnull, 'w')
-
-    (id, tmp) = setup_experiment(debug=False, verbose=verbose, app=app,
-                                 exp_config=exp_config)
-
-    config = get_config()  # We know it's ready; setup_experiment() does this.
-
-    # Register the experiment using all configured registration services.
-    if config.get("mode") == "live":
-        log("Registering the experiment on configured services...")
-        registration.register(id, snapshot=None)
-
-    # Log in to Heroku if we aren't already.
-    log("Making sure that you are logged in to Heroku.")
-    heroku.log_in()
-    config.set("heroku_auth_token", heroku.auth_token())
-    click.echo("")
-
-    # Change to temporary directory.
-    cwd = os.getcwd()
-    os.chdir(tmp)
-
-    # Commit Heroku-specific files to tmp folder's git repo.
-    git = GitClient(output=out)
-    git.init()
-    git.add("--all")
-    git.commit('"Experiment {}"'.format(id))
-
-    # Initialize the app on Heroku.
-    log("Initializing app on Heroku...")
-    team = config.get("heroku_team", '').strip() or None
-    heroku_app = HerokuApp(dallinger_uid=id, output=out, team=team)
-    heroku_app.bootstrap()
-    heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
-
-    # Set up add-ons and AWS environment variables.
-    database_size = config.get('database_size')
-    redis_size = config.get('redis_size', 'premium-0')
-    addons = [
-        "heroku-postgresql:{}".format(quote(database_size)),
-        "heroku-redis:{}".format(quote(redis_size)),
-        "papertrail"
-    ]
-    if config.get("sentry", False):
-        addons.append("sentry")
-
-    for name in addons:
-        heroku_app.addon(name)
-
-    heroku_config = {
-        "aws_access_key_id": config["aws_access_key_id"],
-        "aws_secret_access_key": config["aws_secret_access_key"],
-        "aws_region": config["aws_region"],
-        "auto_recruit": config["auto_recruit"],
-        "smtp_username": config["smtp_username"],
-        "smtp_password": config["smtp_password"],
-        "whimsical": config["whimsical"],
-    }
-
-    for k, v in sorted(heroku_config.items()):  # sorted for testablility
-        heroku_app.set(k, v)
-
-    # Wait for Redis database to be ready.
-    log("Waiting for Redis...")
-    ready = False
-    while not ready:
-        r = redis.from_url(heroku_app.redis_url)
-        try:
-            r.set("foo", "bar")
-            ready = True
-        except redis.exceptions.ConnectionError:
-            time.sleep(2)
-
-    log("Saving the URL of the postgres database...")
-    # Set the notification URL and database URL in the config file.
-    config.extend({
-        "notification_url": heroku_app.url + "/notifications",
-        "database_url": heroku_app.db_url,
-    })
-    config.write()
-    git.add("config.txt")
-    time.sleep(0.25)
-    git.commit("Save URLs for database and notifications")
-    time.sleep(0.25)
-
-    # Launch the Heroku app.
-    log("Pushing code to Heroku...")
-    git.push(remote="heroku", branch="HEAD:master")
-
-    log("Scaling up the dynos...")
-    size = config.get("dyno_type")
-    for process in ["web", "worker"]:
-        qty = config.get("num_dynos_" + process)
-        heroku_app.scale_up_dyno(process, qty, size)
-    if config.get("clock_on"):
-        heroku_app.scale_up_dyno("clock", 1, size)
-
-    # Launch the experiment.
-    log("Launching the experiment on the remote server and starting recruitment...")
-    launch_data = _handle_launch_data('{}/launch'.format(heroku_app.url))
-    result = {
-        'app_name': heroku_app.name,
-        'app_home': heroku_app.url,
-        'recruitment_msg': launch_data.get('recruitment_msg', None),
-    }
-    log("Experiment details:")
-    log("App home: {}".format(result['app_home']), chevrons=False)
-    log("Recruiter info:")
-    log(result['recruitment_msg'], chevrons=False)
-
-    # Return to the branch whence we came.
-    os.chdir(cwd)
-
-    log("Completed deployment of experiment " + id + ".")
-    return result
-
-
-def _deploy_in_mode(mode, app, verbose):
-    # Load configuration.
-    if app:
-        verify_id(None, None, app)
-
-    config = get_config()
-    config.load()
-
-    # Set the mode.
-    config.extend({
-        "mode": mode,
-        "logfile": "-",
-    })
-
-    # Do shared setup.
-    deploy_sandbox_shared_setup(verbose=verbose, app=app)
 
 
 def _mturk_service_from_config(sandbox):
@@ -646,7 +307,7 @@ def _mturk_service_from_config(sandbox):
 @report_idle_after(21600)
 def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
-    _deploy_in_mode('sandbox', app, verbose)
+    _deploy_in_mode('sandbox', app=app, verbose=verbose, log=log)
 
 
 @dallinger.command()
@@ -655,7 +316,7 @@ def sandbox(verbose, app):
 @report_idle_after(21600)
 def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
-    _deploy_in_mode('live', app, verbose)
+    _deploy_in_mode('live', app=app, verbose=verbose, log=log)
 
 
 @dallinger.command()
@@ -790,7 +451,7 @@ def _current_hits(service, app):
 def hits(app, sandbox):
     """List hits for an experiment id."""
     hit_list = list(_current_hits(_mturk_service_from_config(sandbox), app))
-    out = Output()
+    out = Output(log=log, error=error)
     out.log('Found {} hits for this experiment id: {}'.format(
         len(hit_list), ', '.join(h['id'] for h in hit_list)
     ))
@@ -813,7 +474,7 @@ def expire(app, sandbox):
             success.append(hit_id)
         except MTurkServiceException:
             failures.append(hit_id)
-    out = Output()
+    out = Output(log=log, error=error)
     if success:
         out.log('Expired {} hits: {}'.format(len(success), ', '.join(success)))
     if failures:
@@ -895,238 +556,6 @@ def export(app, local, no_scrub):
     data.export(str(app), local=local, scrub_pii=(not no_scrub))
 
 
-class Output(object):
-
-    def __init__(self, log=log, error=error, blather=sys.stdout.write):
-        self.log = log
-        self.error = error
-        self.blather = blather
-
-
-class LocalSessionRunner(object):
-
-    exp_id = None
-    tmp_dir = None
-    dispatch = {}  # Subclass may provide handlers for Heroku process output
-
-    def configure(self):
-        self.exp_config.update({
-            "mode": "debug",
-            "loglevel": 0,
-        })
-
-    def setup(self):
-        self.exp_id, self.tmp_dir = setup_experiment(
-            verbose=self.verbose, exp_config=self.exp_config)
-
-    def update_dir(self):
-        os.chdir(self.tmp_dir)
-        # Update the logfile to the new directory
-        config = get_config()
-        logfile = config.get('logfile')
-        if logfile and logfile != '-':
-            logfile = os.path.join(self.original_dir, logfile)
-            config.extend({'logfile': logfile})
-            config.write()
-
-    def run(self):
-        """Set up the environment, get a HerokuLocalWrapper instance, and pass
-        it to the concrete class's execute() method.
-        """
-        self.configure()
-        self.setup()
-        self.update_dir()
-        db.init_db(drop_all=True)
-        self.out.log("Starting up the server...")
-        config = get_config()
-        with HerokuLocalWrapper(config, self.out, verbose=self.verbose) as wrapper:
-            try:
-                self.execute(wrapper)
-            except KeyboardInterrupt:
-                pass
-            finally:
-                os.chdir(self.original_dir)
-                self.cleanup()
-
-    def notify(self, message):
-        """Callback function which checks lines of output, tries to match
-        against regex defined in subclass's "dispatch" dict, and passes through
-        to a handler on match.
-        """
-        for regex, handler in self.dispatch.items():
-            match = re.search(regex, message)
-            if match:
-                handler = getattr(self, handler)
-                return handler(match)
-
-    def execute(self, heroku):
-        raise NotImplementedError()
-
-
-class DebugSessionRunner(LocalSessionRunner):
-
-    dispatch = {
-        r'[^\"]{} (.*)$'.format(recruiters.NEW_RECRUIT_LOG_PREFIX): 'new_recruit',
-        r'{}$'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
-    }
-
-    def __init__(self, output, verbose, bot, proxy_port, exp_config):
-        self.out = output
-        self.verbose = verbose
-        self.bot = bot
-        self.exp_config = exp_config or {}
-        self.proxy_port = proxy_port
-        self.original_dir = os.getcwd()
-        self.complete = False
-        self.status_thread = None
-
-    def configure(self):
-        super(DebugSessionRunner, self).configure()
-        if self.bot:
-            self.exp_config["recruiter"] = "bots"
-
-    def execute(self, heroku):
-        base_url = get_base_url()
-        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
-        self.out.log("Launching the experiment...")
-        try:
-            result = _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
-        except Exception:
-            # Show output from server
-            self.dispatch[r'POST /launch'] = 'launch_request_complete'
-            heroku.monitor(listener=self.notify)
-        else:
-            if result['status'] == 'success':
-                self.out.log(result['recruitment_msg'])
-                self.heroku = heroku
-                heroku.monitor(listener=self.notify)
-
-    def launch_request_complete(self, match):
-        return HerokuLocalWrapper.MONITOR_STOP
-
-    def cleanup(self):
-        log("Completed debugging of experiment with id " + self.exp_id)
-        self.complete = True
-
-    def new_recruit(self, match):
-        """Dispatched to by notify(). If a recruitment request has been issued,
-        open a browser window for the a new participant (in this case the
-        person doing local debugging).
-        """
-        self.out.log("new recruitment request!")
-        url = match.group(1)
-        if self.proxy_port is not None:
-            self.out.log("Using proxy port {}".format(self.proxy_port))
-            url = url.replace(str(get_config().get('base_port')), self.proxy_port)
-        new_webbrowser_profile().open(url, new=1, autoraise=True)
-
-    def recruitment_closed(self, match):
-        """Recruitment is closed.
-
-        Start a thread to check the experiment summary.
-        """
-        if self.status_thread is None:
-            self.status_thread = threading.Thread(target=self.check_status)
-            self.status_thread.start()
-
-    def check_status(self):
-        """Check the output of the summary route until
-        the experiment is complete, then we can stop monitoring Heroku
-        subprocess output.
-        """
-        self.out.log("Recruitment is complete. Waiting for experiment completion...")
-        base_url = get_base_url()
-        status_url = base_url + '/summary'
-        while not self.complete:
-            time.sleep(10)
-            try:
-                resp = requests.get(status_url)
-                exp_data = resp.json()
-            except (ValueError, requests.exceptions.RequestException):
-                self.out.error('Error fetching experiment status.')
-            else:
-                self.out.log('Experiment summary: {}'.format(exp_data))
-                if exp_data.get('completed', False):
-                    self.out.log('Experiment completed, all nodes filled.')
-                    self.complete = True
-                    self.heroku.stop()
-
-    def notify(self, message):
-        """Monitor output from heroku process.
-
-        This overrides the base class's `notify`
-        to make sure that we stop if the status-monitoring thread
-        has determined that the experiment is complete.
-        """
-        if self.complete:
-            return HerokuLocalWrapper.MONITOR_STOP
-        return super(DebugSessionRunner, self).notify(message)
-
-
-class LoadSessionRunner(LocalSessionRunner):
-    dispatch = {
-        'Replay ready: (.*)$': 'start_replay',
-    }
-
-    def __init__(self, app_id, output, verbose, exp_config):
-        self.app_id = app_id
-        self.out = output
-        self.verbose = verbose
-        self.exp_config = exp_config or {}
-        self.original_dir = os.getcwd()
-        self.zip_path = None
-
-    def configure(self):
-        self.exp_config.update({
-            "mode": "debug",
-            "loglevel": 0,
-        })
-
-        self.zip_path = data.find_experiment_export(self.app_id)
-        if self.zip_path is None:
-            msg = 'Dataset export for app id "{}" could not be found.'
-            raise IOError(msg.format(self.app_id))
-
-    def setup(self):
-        self.exp_id, self.tmp_dir = setup_experiment(
-            app=self.app_id, verbose=self.verbose, exp_config=self.exp_config)
-
-    def execute(self, heroku):
-        """Start the server, load the zip file into the database, then loop
-        until terminated with <control>-c.
-        """
-        db.init_db(drop_all=True)
-        self.out.log("Ingesting dataset from {}...".format(os.path.basename(self.zip_path)))
-        data.ingest_zip(self.zip_path)
-        base_url = get_base_url()
-        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
-
-        if self.exp_config.get('replay', False):
-            self.out.log("Launching the experiment...")
-            _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
-            heroku.monitor(listener=self.notify)
-
-        # Just run until interrupted:
-        while(self.keep_running()):
-            time.sleep(1)
-
-    def start_replay(self, match):
-        """Dispatched to by notify(). If a recruitment request has been issued,
-        open a browser window for the a new participant (in this case the
-        person doing local debugging).
-        """
-        self.out.log("replay ready!")
-        url = match.group(1)
-        new_webbrowser_profile().open(url, new=1, autoraise=True)
-
-    def cleanup(self):
-        self.out.log("Terminating dataset load for experiment {}".format(self.exp_id))
-
-    def keep_running(self):
-        # This is a separate method so that it can be replaced in tests
-        return True
-
-
 @dallinger.command()
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 @click.option('--verbose', is_flag=True, flag_value=True, help='Verbose mode')
@@ -1138,7 +567,7 @@ def load(app, verbose, replay, exp_config=None):
     if replay:
         exp_config = exp_config or {}
         exp_config['replay'] = True
-    loader = LoadSessionRunner(app, Output(), verbose, exp_config)
+    loader = ReplayDeployment(app, Output(log=log, error=error), verbose, exp_config)
     loader.run()
 
 
@@ -1192,7 +621,7 @@ def bot(app, debug):
     if debug is None:
         verify_id(None, None, app)
 
-    (id, tmp) = setup_experiment()
+    (id, tmp) = setup_experiment(log, header)
 
     if debug:
         url = debug
@@ -1218,7 +647,7 @@ def verify():
 @dallinger.command()
 def rq_worker():
     """Start an rq worker in the context of dallinger."""
-    setup_experiment()
+    setup_experiment(log, header)
     with Connection(conn):
         # right now we care about low queue for bots
         worker = Worker('low')

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -29,9 +29,10 @@ from dallinger.config import initialize_experiment_package
 from dallinger import data
 from dallinger.heroku.messages import get_messenger
 from dallinger.heroku.messages import HITSummary
-from dallinger.deployment import _deploy_in_mode
 from dallinger.deployment import DebugDeployment
 from dallinger.deployment import ReplayDeployment
+from dallinger.deployment import HerokuSandboxDeployment
+from dallinger.deployment import HerokuProductionDeployment
 from dallinger.deployment import setup_experiment
 from dallinger.heroku.worker import conn
 from dallinger.heroku.tools import HerokuApp
@@ -100,9 +101,7 @@ class CLIPrinter(object):
 class QuietCLIPrinter(CLIPrinter):
     """Provides the interface, but does nothing."""
 
-    def __init__(self, out=click, handle=open(os.devnull, 'w'), sleep=time.sleep):
-        self._out = out
-        self._sleep = sleep
+    def __init__(self, out=None, handle=open(os.devnull, 'w'), sleep=None):
         self.handle = handle
 
     def banner(self):
@@ -340,9 +339,9 @@ def get_summary(app):
 def debug(verbose, bot, proxy, exp_config=None):
     """Run the experiment locally."""
     cli = get_cli_printer(verbose)
-    debugger = DebugDeployment(cli, bot, proxy, exp_config)
+    deployment = DebugDeployment(cli, bot, proxy, exp_config)
     cli.banner()
-    debugger.run()
+    deployment.run()
 
 
 def _mturk_service_from_config(sandbox):
@@ -366,7 +365,8 @@ def sandbox(verbose, app):
         verify_id(None, None, app)
     cli = get_cli_printer(verbose)
     cli.banner()
-    _deploy_in_mode('sandbox', app=app, out=cli)
+    deployment = HerokuSandboxDeployment(cli, app)
+    deployment.run()
 
 
 @dallinger.command()
@@ -379,7 +379,8 @@ def deploy(verbose, app):
         verify_id(None, None, app)
     cli = get_cli_printer(verbose)
     cli.banner()
-    _deploy_in_mode('live', app=app, out=cli)
+    deployment = HerokuProductionDeployment(cli, app)
+    deployment.run()
 
 
 @dallinger.command()

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -1,0 +1,641 @@
+import os
+import pkg_resources
+import psycopg2
+import re
+import redis
+import requests
+import shutil
+import six
+from six.moves import shlex_quote as quote
+import sys
+import tempfile
+import threading
+import time
+import webbrowser
+
+from dallinger import data
+from dallinger import db
+from dallinger.heroku.tools import HerokuLocalWrapper
+from dallinger import recruiters
+from dallinger import registration
+from dallinger.compat import is_command
+from dallinger.heroku.tools import HerokuApp
+from dallinger.utils import ensure_directory
+from dallinger.utils import get_base_url
+from dallinger.config import get_config  # TODO: pass me in
+from dallinger import heroku
+from dallinger.utils import GitClient
+
+
+def new_webbrowser_profile():
+    if is_command('google-chrome'):
+        new_chrome = webbrowser.Chrome()
+        new_chrome.name = 'google-chrome'
+        profile_directory = tempfile.mkdtemp()
+        new_chrome.remote_args = webbrowser.Chrome.remote_args + [
+            '--user-data-dir="{}"'.format(profile_directory)
+        ]
+        return new_chrome
+    elif is_command('firefox'):
+        new_firefox = webbrowser.Mozilla()
+        new_firefox.name = 'firefox'
+        profile_directory = tempfile.mkdtemp()
+        new_firefox.remote_args = [
+            '-profile', profile_directory, '-new-instance', '-no-remote', '-url', '%s',
+        ]
+        return new_firefox
+    else:
+        return webbrowser
+
+
+def setup_experiment(log, header, debug=True, app=None, exp_config=None):
+    """Check the app and, if compatible with Dallinger, freeze its state."""
+    log(header, chevrons=False)
+
+    # Verify that the Postgres server is running.
+    try:
+        psycopg2.connect(database="x", user="postgres", password="nada")
+    except psycopg2.OperationalError as e:
+        if "could not connect to server" in str(e):
+            raise RuntimeError("The Postgres server isn't running.")
+
+    # Load configuration.
+    config = get_config()
+    if not config.ready:
+        config.load()
+
+    # Check that the demo-specific requirements are satisfied.
+    try:
+        with open("requirements.txt", "r") as f:
+            dependencies = [r for r in f.readlines() if r[:3] != "-e "]
+    except (OSError, IOError):
+        dependencies = []
+
+    pkg_resources.require(dependencies)
+
+    # Generate a unique id for this experiment.
+    from dallinger.experiment import Experiment
+    generated_uid = public_id = Experiment.make_uuid(app)
+
+    # If the user provided an app name, use it everywhere that's user-facing.
+    if app:
+        public_id = str(app)
+
+    log("Experiment id is " + public_id + "")
+
+    # Copy this directory into a temporary folder, ignoring .git
+    dst = os.path.join(tempfile.mkdtemp(), public_id)
+    to_ignore = shutil.ignore_patterns(
+        os.path.join(".git", "*"),
+        "*.db",
+        "snapshots",
+        "data",
+        "server.log",
+    )
+    shutil.copytree(os.getcwd(), dst, ignore=to_ignore)
+
+    log(dst, chevrons=False)
+
+    # Save the experiment id
+    with open(os.path.join(dst, "experiment_id.txt"), "w") as file:
+        file.write(generated_uid)
+
+    # Change directory to the temporary folder.
+    cwd = os.getcwd()
+    os.chdir(dst)
+
+    # Write the custom config
+    if exp_config:
+        config.extend(exp_config)
+
+    config.extend({'id': six.text_type(generated_uid)})
+
+    config.write(filter_sensitive=True)
+
+    # Zip up the temporary directory and place it in the cwd.
+    if not debug:
+        log("Freezing the experiment package...")
+        shutil.make_archive(
+            os.path.join(cwd, "snapshots", public_id + "-code"), "zip", dst)
+
+    # Check directories.
+    ensure_directory(os.path.join("static", "scripts"))
+    ensure_directory(os.path.join("templates", "default"))
+    ensure_directory(os.path.join("static", "css"))
+
+    # Get dallinger package location.
+    from pkg_resources import get_distribution
+    dist = get_distribution('dallinger')
+    src_base = os.path.join(dist.location, dist.project_name)
+
+    heroku_files = [
+        "Procfile",
+        "launch.py",
+        "worker.py",
+        "clock.py",
+        "runtime.txt",
+    ]
+
+    for filename in heroku_files:
+        src = os.path.join(src_base, "heroku", filename)
+        shutil.copy(src, os.path.join(dst, filename))
+
+    clock_on = config.get('clock_on', False)
+
+    # If the clock process has been disabled, overwrite the Procfile.
+    if not clock_on:
+        src = os.path.join(src_base, "heroku", "Procfile_no_clock")
+        shutil.copy(src, os.path.join(dst, "Procfile"))
+
+    frontend_files = [
+        os.path.join("static", "css", "dallinger.css"),
+        os.path.join("static", "scripts", "dallinger.js"),
+        os.path.join("static", "scripts", "dallinger2.js"),
+        os.path.join("static", "scripts", "reqwest.min.js"),
+        os.path.join("static", "scripts", "require.js"),
+        os.path.join("static", "scripts", "reconnecting-websocket.js"),
+        os.path.join("static", "scripts", "spin.min.js"),
+        os.path.join("static", "scripts", "tracker.js"),
+        os.path.join("templates", "error.html"),
+        os.path.join("templates", "error-complete.html"),
+        os.path.join("templates", "launch.html"),
+        os.path.join("templates", "complete.html"),
+        os.path.join("templates", "questionnaire.html"),
+        os.path.join("templates", "thanks.html"),
+        os.path.join("templates", "waiting.html"),
+        os.path.join("static", "robots.txt")
+    ]
+    frontend_dirs = [
+        os.path.join("templates", "base"),
+    ]
+
+    for filename in frontend_files:
+        src = os.path.join(src_base, "frontend", filename)
+        dst_filepath = os.path.join(dst, filename)
+        if not os.path.exists(dst_filepath):
+            shutil.copy(src, dst_filepath)
+    for filename in frontend_dirs:
+        src = os.path.join(src_base, "frontend", filename)
+        dst_filepath = os.path.join(dst, filename)
+        if not os.path.exists(dst_filepath):
+            shutil.copytree(src, dst_filepath)
+
+    time.sleep(0.25)
+
+    os.chdir(cwd)
+
+    return (public_id, dst)
+
+
+def verify_id(app_id):
+    """Verify the experiment id."""
+    if app_id is None:
+        raise TypeError("Select an experiment using the --app flag.")
+    elif app_id[0:5] == "dlgr-":
+        raise ValueError("The --app flag requires the full "
+                         "UUID beginning with {}-...".format(app_id[5:13]))
+    return app_id
+
+
+INITIAL_DELAY = 5
+RETRIES = 4
+
+
+def _handle_launch_data(url, error, delay=INITIAL_DELAY, remaining=RETRIES):
+    time.sleep(delay)
+    remaining = remaining - 1
+    launch_request = requests.post(url)
+    try:
+        launch_data = launch_request.json()
+    except ValueError:
+        error(
+            "Error parsing response from /launch, check web dyno logs for details: "
+            + launch_request.text
+        )
+        raise
+
+    if not launch_request.ok:
+        if remaining < 1:
+            error('Experiment launch failed, check web dyno logs for details.')
+            if launch_data.get('message'):
+                error(launch_data['message'])
+            launch_request.raise_for_status()
+        delay = 2 * delay
+        error('Experiment launch failed, retrying in {} seconds ...'.format(delay))
+        return _handle_launch_data(url, error, delay, remaining)
+
+    return launch_data
+
+
+def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
+    """Set up Git, push to Heroku, and launch the app."""
+    if verbose:
+        out = None
+    else:
+        out = open(os.devnull, 'w')
+
+    (id, tmp) = setup_experiment(debug=False, app=app, exp_config=exp_config)
+
+    config = get_config()  # We know it's ready; setup_experiment() does this.
+
+    # Register the experiment using all configured registration services.
+    if config.get("mode") == "live":
+        log("Registering the experiment on configured services...")
+        registration.register(id, snapshot=None)
+
+    # Log in to Heroku if we aren't already.
+    log("Making sure that you are logged in to Heroku.")
+    heroku.log_in()
+    config.set("heroku_auth_token", heroku.auth_token())
+    log("", chevrons=False)
+
+    # Change to temporary directory.
+    cwd = os.getcwd()
+    os.chdir(tmp)
+
+    # Commit Heroku-specific files to tmp folder's git repo.
+    git = GitClient(output=out)
+    git.init()
+    git.add("--all")
+    git.commit('"Experiment {}"'.format(id))
+
+    # Initialize the app on Heroku.
+    log("Initializing app on Heroku...")
+    team = config.get("heroku_team", '').strip() or None
+    heroku_app = HerokuApp(dallinger_uid=id, output=out, team=team)
+    heroku_app.bootstrap()
+    heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
+
+    # Set up add-ons and AWS environment variables.
+    database_size = config.get('database_size')
+    redis_size = config.get('redis_size', 'premium-0')
+    addons = [
+        "heroku-postgresql:{}".format(quote(database_size)),
+        "heroku-redis:{}".format(quote(redis_size)),
+        "papertrail"
+    ]
+    if config.get("sentry", False):
+        addons.append("sentry")
+
+    for name in addons:
+        heroku_app.addon(name)
+
+    heroku_config = {
+        "aws_access_key_id": config["aws_access_key_id"],
+        "aws_secret_access_key": config["aws_secret_access_key"],
+        "aws_region": config["aws_region"],
+        "auto_recruit": config["auto_recruit"],
+        "dallinger_email_username": config["dallinger_email_address"],
+        "dallinger_email_key": config["dallinger_email_password"],
+        "whimsical": config["whimsical"],
+    }
+
+    for k, v in sorted(heroku_config.items()):  # sorted for testablility
+        heroku_app.set(k, v)
+
+    # Wait for Redis database to be ready.
+    log("Waiting for Redis...")
+    ready = False
+    while not ready:
+        r = redis.from_url(heroku_app.redis_url)
+        try:
+            r.set("foo", "bar")
+            ready = True
+        except redis.exceptions.ConnectionError:
+            time.sleep(2)
+
+    log("Saving the URL of the postgres database...")
+    # Set the notification URL and database URL in the config file.
+    config.extend({
+        "notification_url": heroku_app.url + "/notifications",
+        "database_url": heroku_app.db_url,
+    })
+    config.write()
+    git.add("config.txt")
+    time.sleep(0.25)
+    git.commit("Save URLs for database and notifications")
+    time.sleep(0.25)
+
+    # Launch the Heroku app.
+    log("Pushing code to Heroku...")
+    git.push(remote="heroku", branch="HEAD:master")
+
+    log("Scaling up the dynos...")
+    size = config.get("dyno_type")
+    for process in ["web", "worker"]:
+        qty = config.get("num_dynos_" + process)
+        heroku_app.scale_up_dyno(process, qty, size)
+    if config.get("clock_on"):
+        heroku_app.scale_up_dyno("clock", 1, size)
+
+    time.sleep(8)
+
+    # Launch the experiment.
+    log("Launching the experiment on the remote server and starting recruitment...")
+    launch_data = _handle_launch_data('{}/launch'.format(heroku_app.url))
+    result = {
+        'app_name': heroku_app.name,
+        'app_home': heroku_app.url,
+        'recruitment_msg': launch_data.get('recruitment_msg', None),
+    }
+    log("Experiment details:")
+    log("App home: {}".format(result['app_home']), chevrons=False)
+    log("Recruiter info:")
+    log(result['recruitment_msg'], chevrons=False)
+
+    # Return to the branch whence we came.
+    os.chdir(cwd)
+
+    log("Completed deployment of experiment " + id + ".")
+    return result
+
+
+def _deploy_in_mode(mode, app, verbose, log):
+    # Load configuration.
+    if app:
+        verify_id(None, None, app)
+
+    config = get_config()
+    config.load()
+
+    # Set the mode.
+    config.extend({
+        "mode": mode,
+        "logfile": "-",
+    })
+
+    # Do shared setup.
+    deploy_sandbox_shared_setup(verbose=verbose, app=app)
+
+
+class HerokuRemoteDeployment(object):
+
+    def __init__(self, config, git, heroku_app, redis):
+        self.config = config
+        self.git = git
+        self.heroku_app = heroku_app
+        self.redis = redis
+
+
+class HerokuSandboxDeployment(HerokuRemoteDeployment):
+    pass
+
+
+class HerokuProductionDeployment(HerokuRemoteDeployment):
+    pass
+
+
+class Output(object):
+
+    def __init__(self, log, error, blather=sys.stdout.write):
+        self.log = log
+        self.error = error
+        self.blather = sys.stdout.write
+
+
+class FancyOutput(Output):
+
+    def __init__(self, log, strong, error, strong_error, blather=sys.stdout.write):
+        super(Output, self).__init__(log, error, blather)
+        self.strong = strong
+        self.strong_err = strong_error
+
+
+class HerokuLocalDeployment(object):
+
+    exp_id = None
+    tmp_dir = None
+    dispatch = {}  # Subclass may provide handlers for Heroku process output
+
+    def __init__(self, output, verbose, exp_config, log, header):
+        self.out = output
+        self.verbose = verbose
+        self.exp_config = exp_config or {}
+        self.original_dir = os.getcwd()
+        self.log = log
+        self.header = header
+
+    def configure(self):
+        self.exp_config.update({
+            "mode": "debug",
+            "loglevel": 0,
+        })
+
+    def setup(self):
+        self.exp_id, self.tmp_dir = setup_experiment(
+            self.log, self.header, exp_config=self.exp_config
+        )
+
+    def update_dir(self):
+        os.chdir(self.tmp_dir)
+        # Update the logfile to the new directory
+        config = get_config()
+        logfile = config.get('logfile')
+        if logfile and logfile != '-':
+            logfile = os.path.join(self.original_dir, logfile)
+            config.extend({'logfile': logfile})
+            config.write()
+
+    def run(self):
+        """Set up the environment, get a HerokuLocalWrapper instance, and pass
+        it to the concrete class's execute() method.
+        """
+        self.configure()
+        self.setup()
+        self.update_dir()
+        db.init_db(drop_all=True)
+        self.out.log("Starting up the server...")
+        config = get_config()
+        with HerokuLocalWrapper(config, self.out, verbose=self.verbose) as wrapper:
+            try:
+                self.execute(wrapper)
+            except KeyboardInterrupt:
+                pass
+            finally:
+                os.chdir(self.original_dir)
+                self.cleanup()
+
+    def notify(self, message):
+        """Callback function which checks lines of output, tries to match
+        against regex defined in subclass's "dispatch" dict, and passes through
+        to a handler on match.
+        """
+        for regex, handler in self.dispatch.items():
+            match = re.search(regex, message)
+            if match:
+                handler = getattr(self, handler)
+                return handler(match)
+
+    def execute(self, heroku):
+        raise NotImplementedError()
+
+
+class DebugDeployment(HerokuLocalDeployment):
+
+    dispatch = {
+        r'[^\"]{} (.*)$'.format(recruiters.NEW_RECRUIT_LOG_PREFIX): 'new_recruit',
+        r'{}$'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
+    }
+
+    def __init__(self, output, verbose, bot, proxy_port, exp_config, log, header):
+        self.out = output
+        self.verbose = verbose
+        self.bot = bot
+        self.exp_config = exp_config or {}
+        self.proxy_port = proxy_port
+        self.original_dir = os.getcwd()
+        self.complete = False
+        self.status_thread = None
+        self.log = log
+        self.header = header
+
+    def configure(self):
+        super(DebugDeployment, self).configure()
+        if self.bot:
+            self.exp_config["recruiter"] = "bots"
+
+    def execute(self, heroku):
+        base_url = get_base_url()
+        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
+        self.out.log("Launching the experiment...")
+        time.sleep(4)
+        try:
+            result = _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
+        except Exception:
+            # Show output from server
+            self.dispatch[r'POST /launch'] = 'launch_request_complete'
+            heroku.monitor(listener=self.notify)
+        else:
+            if result['status'] == 'success':
+                self.out.log(result['recruitment_msg'])
+                self.heroku = heroku
+                heroku.monitor(listener=self.notify)
+
+    def launch_request_complete(self, match):
+        return HerokuLocalWrapper.MONITOR_STOP
+
+    def cleanup(self):
+        self.out.log("Completed debugging of experiment with id " + self.exp_id)
+        self.complete = True
+
+    def new_recruit(self, match):
+        """Dispatched to by notify(). If a recruitment request has been issued,
+        open a browser window for the a new participant (in this case the
+        person doing local debugging).
+        """
+        self.out.log("new recruitment request!")
+        url = match.group(1)
+        if self.proxy_port is not None:
+            self.out.log("Using proxy port {}".format(self.proxy_port))
+            url = url.replace(str(get_config().get('base_port')), self.proxy_port)
+        new_webbrowser_profile().open(url, new=1, autoraise=True)
+
+    def recruitment_closed(self, match):
+        """Recruitment is closed.
+
+        Start a thread to check the experiment summary.
+        """
+        if self.status_thread is None:
+            self.status_thread = threading.Thread(target=self.check_status)
+            self.status_thread.start()
+
+    def check_status(self):
+        """Check the output of the summary route until
+        the experiment is complete, then we can stop monitoring Heroku
+        subprocess output.
+        """
+        self.out.log("Recruitment is complete. Waiting for experiment completion...")
+        base_url = get_base_url()
+        status_url = base_url + '/summary'
+        while not self.complete:
+            time.sleep(10)
+            try:
+                resp = requests.get(status_url)
+                exp_data = resp.json()
+            except (ValueError, requests.exceptions.RequestException):
+                self.out.error('Error fetching experiment status.')
+            else:
+                self.out.log('Experiment summary: {}'.format(exp_data))
+                if exp_data.get('completed', False):
+                    self.out.log('Experiment completed, all nodes filled.')
+                    self.complete = True
+                    self.heroku.stop()
+
+    def notify(self, message):
+        """Monitor output from heroku process.
+
+        This overrides the base class's `notify`
+        to make sure that we stop if the status-monitoring thread
+        has determined that the experiment is complete.
+        """
+        if self.complete:
+            return HerokuLocalWrapper.MONITOR_STOP
+        return super(DebugDeployment, self).notify(message)
+
+
+class ReplayDeployment(HerokuLocalDeployment):
+    dispatch = {
+        'Replay ready: (.*)$': 'start_replay',
+    }
+
+    def __init__(self, app_id, output, verbose, exp_config, log, header):
+        self.app_id = app_id
+        self.out = output
+        self.verbose = verbose
+        self.exp_config = exp_config or {}
+        self.original_dir = os.getcwd()
+        self.zip_path = None
+        self.log = log
+        self.header = header
+
+    def configure(self):
+        self.exp_config.update({
+            "mode": "debug",
+            "loglevel": 0,
+        })
+
+        self.zip_path = data.find_experiment_export(self.app_id)
+        if self.zip_path is None:
+            msg = 'Dataset export for app id "{}" could not be found.'
+            raise IOError(msg.format(self.app_id))
+
+    def setup(self):
+        self.exp_id, self.tmp_dir = setup_experiment(
+            self.log, self.header, app=self.app_id, exp_config=self.exp_config
+        )
+
+    def execute(self, heroku):
+        """Start the server, load the zip file into the database, then loop
+        until terminated with <control>-c.
+        """
+        db.init_db(drop_all=True)
+        self.out.log("Ingesting dataset from {}...".format(os.path.basename(self.zip_path)))
+        data.ingest_zip(self.zip_path)
+        base_url = get_base_url()
+        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
+
+        if self.exp_config.get('replay', False):
+            self.out.log("Launching the experiment...")
+            time.sleep(4)
+            _handle_launch_data('{}/launch'.format(base_url), error=self.out.error)
+            heroku.monitor(listener=self.notify)
+
+        # Just run until interrupted:
+        while(self.keep_running()):
+            time.sleep(1)
+
+    def start_replay(self, match):
+        """Dispatched to by notify(). If a recruitment request has been issued,
+        open a browser window for the a new participant (in this case the
+        person doing local debugging).
+        """
+        self.out.log("replay ready!")
+        url = match.group(1)
+        new_webbrowser_profile().open(url, new=1, autoraise=True)
+
+    def cleanup(self):
+        self.out.log("Terminating dataset load for experiment {}".format(self.exp_id))
+
+    def keep_running(self):
+        # This is a separate method so that it can be replaced in tests
+        return True

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -187,16 +187,6 @@ def setup_experiment(log, header, debug=True, app=None, exp_config=None):
     return (public_id, dst)
 
 
-def verify_id(app_id):
-    """Verify the experiment id."""
-    if app_id is None:
-        raise TypeError("Select an experiment using the --app flag.")
-    elif app_id[0:5] == "dlgr-":
-        raise ValueError("The --app flag requires the full "
-                         "UUID beginning with {}-...".format(app_id[5:13]))
-    return app_id
-
-
 INITIAL_DELAY = 5
 RETRIES = 4
 
@@ -352,9 +342,6 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
 
 def _deploy_in_mode(mode, app, verbose, log):
     # Load configuration.
-    if app:
-        verify_id(None, None, app)
-
     config = get_config()
     config.load()
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -244,7 +244,7 @@ def deploy_sandbox_shared_setup(out, app=None, exp_config=None):
     # Initialize the app on Heroku.
     out.heading("Initializing app on Heroku...")
     team = config.get("heroku_team", '').strip() or None
-    heroku_app = HerokuApp(dallinger_uid=id, output=out, team=team)
+    heroku_app = HerokuApp(dallinger_uid=id, output=out.handle, team=team)
     heroku_app.bootstrap()
     heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -273,8 +273,8 @@ def deploy_sandbox_shared_setup(out, app=None, exp_config=None):
         "aws_secret_access_key": config["aws_secret_access_key"],
         "aws_region": config["aws_region"],
         "auto_recruit": config["auto_recruit"],
-        "dallinger_email_username": config["dallinger_email_address"],
-        "dallinger_email_key": config["dallinger_email_password"],
+        "smtp_username": config["smtp_username"],
+        "smtp_password": config["smtp_password"],
         "whimsical": config["whimsical"],
     }
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -216,11 +216,6 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, remaining=RETRIES):
 
 def deploy_sandbox_shared_setup(out, app=None, exp_config=None):
     """Set up Git, push to Heroku, and launch the app."""
-    # if verbose:
-    #     out = None
-    # else:
-    #     out = open(os.devnull, 'w')
-
     (id, tmp) = setup_experiment(out, debug=False, app=app, exp_config=exp_config)
 
     config = get_config()  # We know it's ready; setup_experiment() does this.
@@ -241,7 +236,7 @@ def deploy_sandbox_shared_setup(out, app=None, exp_config=None):
     os.chdir(tmp)
 
     # Commit Heroku-specific files to tmp folder's git repo.
-    git = GitClient(output=out)
+    git = GitClient(output=out.output_handle)
     git.init()
     git.add("--all")
     git.commit('"Experiment {}"'.format(id))

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -7,7 +7,6 @@ import requests
 import shutil
 import six
 from six.moves import shlex_quote as quote
-import sys
 import tempfile
 import threading
 import time
@@ -371,14 +370,6 @@ class HerokuSandboxDeployment(HerokuRemoteDeployment):
 
 class HerokuProductionDeployment(HerokuRemoteDeployment):
     pass
-
-
-# class Output(object):
-
-#     def __init__(self, log, error, blather=sys.stdout.write):
-#         self.log = log
-#         self.error = error
-#         self.blather = sys.stdout.write
 
 
 class HerokuLocalDeployment(object):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -430,7 +430,7 @@ class HerokuLocalDeployment(object):
         db.init_db(drop_all=True)
         self.out.log("Starting up the server...")
         config = get_config()
-        with HerokuLocalWrapper(config, self.out, verbose=self.verbose) as wrapper:
+        with HerokuLocalWrapper(config, self.out) as wrapper:
             try:
                 self.execute(wrapper)
             except KeyboardInterrupt:

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -335,21 +335,6 @@ def deploy_sandbox_shared_setup(out, app=None, exp_config=None):
     return result
 
 
-def _deploy_in_mode(mode, app, out):
-    # Load configuration.
-    config = get_config()
-    config.load()
-
-    # Set the mode.
-    config.extend({
-        "mode": mode,
-        "logfile": "-",
-    })
-
-    # Do shared setup.
-    deploy_sandbox_shared_setup(out, app=app)
-
-
 class HerokuRemoteDeployment(object):
 
     def __init__(self, cli, app_id=None):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -385,7 +385,7 @@ class HerokuLocalDeployment(object):
 
     def configure(self):
         self.exp_config.update({
-            "mode": "debug",
+            "mode": u"debug",
             "loglevel": 0,
         })
 
@@ -551,10 +551,7 @@ class ReplayDeployment(HerokuLocalDeployment):
         self.zip_path = None
 
     def configure(self):
-        self.exp_config.update({
-            "mode": "debug",
-            "loglevel": 0,
-        })
+        super(ReplayDeployment, self).configure()
 
         self.zip_path = data.find_experiment_export(self.app_id)
         if self.zip_path is None:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -490,19 +490,19 @@ class Experiment(object):
 
         self.app_id = app_id
         self.exp_config = exp_config or kwargs
+        cli = dlgr.command_line.get_cli_printer(self.verbose)
         self.update_status('Starting')
         try:
             if self.exp_config.get("mode") == "debug":
-                dlgr.command_line.debug.callback(
-                    verbose=True,
-                    bot=bot,
-                    proxy=None,
-                    exp_config=self.exp_config
+                debugger = dlgr.deployment.DebugDeployment(
+                    output=cli, bot=bot, proxy_port=None, exp_config=self.exp_config
                 )
+                cli.log(dlgr.command_line.header)
+                debugger.run()
             else:
-                dlgr.command_line.deploy_sandbox_shared_setup(
+                dlgr.deployment.deploy_sandbox_shared_setup(
+                    cli,
                     app=app_id,
-                    verbose=self.verbose,
                     exp_config=self.exp_config
                 )
         except Exception:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -497,7 +497,7 @@ class Experiment(object):
                 debugger = dlgr.deployment.DebugDeployment(
                     output=cli, bot=bot, proxy_port=None, exp_config=self.exp_config
                 )
-                cli.log(dlgr.command_line.header)
+                cli.banner()
                 debugger.run()
             else:
                 dlgr.deployment.deploy_sandbox_shared_setup(

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -223,8 +223,10 @@ class HerokuApp(object):
 
     def _run(self, cmd, pass_stderr=False):
         if pass_stderr:
-            return check_call(cmd, stdout=self.out, stderr=self.out)
-        return check_call(cmd, stdout=self.out)
+            return check_call(
+                cmd, stdout=self.output.handle, stderr=self.output.handle
+            )
+        return check_call(cmd, stdout=self.output.handle)
 
     def _run_quiet(self, cmd):
         # make sure subprocess output doesn't echo secrets to the terminal

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -223,10 +223,8 @@ class HerokuApp(object):
 
     def _run(self, cmd, pass_stderr=False):
         if pass_stderr:
-            return check_call(
-                cmd, stdout=self.output.handle, stderr=self.output.handle
-            )
-        return check_call(cmd, stdout=self.output.handle)
+            return check_call(cmd, stdout=self.out, stderr=self.out)
+        return check_call(cmd, stdout=self.out)
 
     def _run_quiet(self, cmd):
         # make sure subprocess output doesn't echo secrets to the terminal

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -255,7 +255,7 @@ class TestSandboxAndDeploy(object):
                 '--verbose',
             ]
         )
-        assert sandbox_deployment.call_args[0][1] == None
+        assert sandbox_deployment.call_args[0][1] is None
         sandbox_deployment.return_value.run.assert_called_once()
 
     def test_sandbox_with_invalid_app_id(self, sandbox, sandbox_deployment):
@@ -280,6 +280,7 @@ class TestSandboxAndDeploy(object):
         )
         assert prod_deployment.call_args[0][1] == 'some app id'
         prod_deployment.return_value.run.assert_called_once()
+
 
 class TestSummary(object):
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -3,13 +3,13 @@
 import mock
 import os
 import re
+import six
 import subprocess
 from time import sleep
 from uuid import UUID
 
 from click.testing import CliRunner
 import pytest
-from pytest import raises
 
 import dallinger.command_line
 from dallinger.command_line import report_idle_after

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -309,7 +309,7 @@ class TestBot(object):
         from dallinger.command_line import bot_factory
         from dallinger.deployment import setup_experiment
         from dallinger.bots import BotBase
-        setup_experiment(log=mock.Mock(), header='')
+        setup_experiment(log=mock.Mock())
         bot = bot_factory('some url')
         assert isinstance(bot, BotBase)
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -2,13 +2,8 @@
 # -*- coding: utf-8 -*-
 import mock
 import os
-import pexpect
 import re
-import six
 import subprocess
-import sys
-import tempfile
-from six.moves import configparser
 from time import sleep
 from uuid import UUID
 
@@ -17,11 +12,7 @@ import pytest
 from pytest import raises
 
 import dallinger.command_line
-from dallinger.command_line import new_webbrowser_profile
-from dallinger.command_line import verify_package
 from dallinger.command_line import report_idle_after
-from dallinger.config import get_config
-from dallinger import recruiters
 import dallinger.version
 
 
@@ -51,7 +42,7 @@ def sleepless():
 
 @pytest.fixture
 def browser():
-    with mock.patch('dallinger.command_line.is_command') as mock_is_command:
+    with mock.patch('dallinger.deployment.is_command') as mock_is_command:
         mock_is_command.return_value = False
         with mock.patch('dallinger.command_line.webbrowser') as mock_browser:
             yield mock_browser
@@ -88,37 +79,6 @@ def mturk():
         ]
         mock_mturk.return_value = mock_instance
         yield mock_mturk
-
-
-class TestIsolatedWebbrowser(object):
-
-    def test_chrome_isolation(self):
-        import webbrowser
-        with mock.patch('dallinger.command_line.is_command') as is_command:
-            is_command.side_effect = lambda s: s == 'google-chrome'
-            isolated = new_webbrowser_profile()
-        assert isinstance(isolated, webbrowser.Chrome)
-        assert isolated.remote_args[:2] == [r'%action', r'%s']
-        assert isolated.remote_args[-1].startswith(
-            '--user-data-dir="{}'.format(tempfile.gettempdir())
-        )
-
-    def test_firefox_isolation(self):
-        import webbrowser
-        with mock.patch('dallinger.command_line.is_command') as is_command:
-            is_command.side_effect = lambda s: s == 'firefox'
-            isolated = new_webbrowser_profile()
-        assert isinstance(isolated, webbrowser.Mozilla)
-        assert isolated.remote_args[0] == '-profile'
-        assert isolated.remote_args[1].startswith(tempfile.gettempdir())
-        assert isolated.remote_args[2:] == ['-new-instance', '-no-remote', '-url', r'%s']
-
-    def test_fallback_isolation(self):
-        import webbrowser
-        with mock.patch('dallinger.command_line.is_command') as is_command:
-            is_command.return_value = False
-            isolated = new_webbrowser_profile()
-        assert isolated == webbrowser
 
 
 @pytest.mark.usefixtures('bartlett_dir')
@@ -182,136 +142,6 @@ class TestReportAfterIdleDecorator(object):
             messenger.assert_called_once()
 
 
-@pytest.mark.usefixtures('bartlett_dir', 'active_config')
-class TestSetupExperiment(object):
-
-    def test_setup_creates_new_experiment(self):
-        from dallinger.command_line import setup_experiment
-        # Baseline
-        exp_dir = os.getcwd()
-        assert found_in('experiment.py', exp_dir)
-        assert not found_in('experiment_id.txt', exp_dir)
-        assert not found_in('Procfile', exp_dir)
-        assert not found_in('launch.py', exp_dir)
-        assert not found_in('worker.py', exp_dir)
-        assert not found_in('clock.py', exp_dir)
-
-        exp_id, dst = setup_experiment()
-
-        # dst should be a temp dir with a cloned experiment for deployment
-        assert(exp_dir != dst)
-        assert('/tmp' in dst)
-
-        assert found_in('experiment_id.txt', dst)
-        assert found_in('experiment.py', dst)
-        assert found_in('models.py', dst)
-        assert found_in('Procfile', dst)
-        assert found_in('launch.py', dst)
-        assert found_in('worker.py', dst)
-        assert found_in('clock.py', dst)
-
-        assert found_in(os.path.join("static", "css", "dallinger.css"), dst)
-        assert found_in(os.path.join("static", "scripts", "dallinger2.js"), dst)
-        assert found_in(os.path.join("static", "scripts", "reconnecting-websocket.js"), dst)
-        assert found_in(os.path.join("static", "scripts", "reqwest.min.js"), dst)
-        assert found_in(os.path.join("static", "scripts", "spin.min.js"), dst)
-        assert found_in(os.path.join("static", "robots.txt"), dst)
-        assert found_in(os.path.join("templates", "error.html"), dst)
-        assert found_in(os.path.join("templates", "error-complete.html"), dst)
-        assert found_in(os.path.join("templates", "launch.html"), dst)
-        assert found_in(os.path.join("templates", "complete.html"), dst)
-
-    def test_setup_with_custom_dict_config(self):
-        from dallinger.command_line import setup_experiment
-        config = get_config()
-        assert config.get('num_dynos_web') == 1
-
-        exp_id, dst = setup_experiment(exp_config={'num_dynos_web': 2})
-        # Config is updated
-        assert config.get('num_dynos_web') == 2
-
-        # Code snapshot is saved
-        os.path.exists(os.path.join('snapshots', exp_id + '-code.zip'))
-
-        # There should be a modified configuration in the temp dir
-        deploy_config = configparser.SafeConfigParser()
-        deploy_config.read(os.path.join(dst, 'config.txt'))
-        assert int(deploy_config.get('Parameters', 'num_dynos_web')) == 2
-
-    def test_setup_excludes_sensitive_config(self):
-        from dallinger.command_line import setup_experiment
-        config = get_config()
-        # Auto detected as sensitive
-        config.register('a_password', six.text_type)
-        # Manually registered as sensitive
-        config.register('something_sensitive', six.text_type, sensitive=True)
-        # Not sensitive at all
-        config.register('something_normal', six.text_type)
-
-        config.extend({'a_password': u'secret thing',
-                       'something_sensitive': u'hide this',
-                       'something_normal': u'show this'})
-
-        exp_id, dst = setup_experiment()
-
-        # The temp dir should have a config with the sensitive variables missing
-        deploy_config = configparser.SafeConfigParser()
-        deploy_config.read(os.path.join(dst, 'config.txt'))
-        assert(deploy_config.get(
-            'Parameters', 'something_normal') == 'show this'
-        )
-        with raises(configparser.NoOptionError):
-            deploy_config.get('Parameters', 'a_password')
-        with raises(configparser.NoOptionError):
-            deploy_config.get('Parameters', 'something_sensitive')
-
-    def test_payment_type(self):
-        config = get_config()
-        with raises(TypeError):
-            config['base_payment'] = 12
-
-    def test_large_float_payment(self):
-        config = get_config()
-        config['base_payment'] = 1.2342
-        assert verify_package() is False
-
-    def test_negative_payment(self):
-        config = get_config()
-        config['base_payment'] = -1.99
-        assert verify_package() is False
-
-
-@pytest.mark.usefixtures('in_tempdir')
-class TestGitClient(object):
-
-    @pytest.fixture
-    def git(self):
-        from dallinger.utils import GitClient
-        git = GitClient()
-        return git
-
-    def test_client(self, git, stub_config):
-        stub_config.write()
-        config = {'user.name': 'Test User', 'user.email': 'test@example.com'}
-        git.init(config=config)
-        git.add("--all")
-        git.commit("Test Repo")
-        assert b"Test Repo" in subprocess.check_output(['git', 'log'])
-
-    def test_includes_details_in_exceptions(self, git):
-        with pytest.raises(Exception) as ex_info:
-            git.push('foo', 'bar')
-        assert ex_info.match('Not a git repository')
-
-    def test_can_use_alternate_output(self, git):
-        import tempfile
-        git.out = tempfile.NamedTemporaryFile()
-        git.encoding = 'utf8'
-        git.init()
-        git.out.seek(0)
-        assert b"git init" in git.out.read()
-
-
 @pytest.fixture
 def faster(tempdir):
     with mock.patch.multiple('dallinger.command_line',
@@ -363,322 +193,6 @@ def heroku_mock():
             yield instance
 
 
-@pytest.mark.usefixtures('active_config', 'launch', 'fake_git', 'faster')
-class TestDeploySandboxSharedSetupNoExternalCalls(object):
-
-    @pytest.fixture
-    def dsss(self):
-        from dallinger.command_line import deploy_sandbox_shared_setup
-        return deploy_sandbox_shared_setup
-
-    def test_result(self, dsss, heroku_mock):
-        result = dsss()
-        assert result == {
-            'app_home': u'fake-url',
-            'app_name': u'dlgr-fake-uid',
-            'recruitment_msg': 'fake\nrecruitment\nlist'
-        }
-
-    def test_bootstraps_heroku(self, dsss, heroku_mock):
-        dsss()
-        heroku_mock.bootstrap.assert_called_once()
-
-    def test_installs_phantomjs(self, dsss, heroku_mock):
-        dsss()
-        heroku_mock.buildpack.assert_called_once_with(
-            'https://github.com/stomita/heroku-buildpack-phantomjs'
-        )
-
-    def test_installs_addons(self, dsss, heroku_mock):
-        dsss()
-        heroku_mock.addon.assert_has_calls([
-            mock.call('heroku-postgresql:standard-0'),
-            mock.call('heroku-redis:premium-0'),
-            mock.call('papertrail'),
-            mock.call('sentry')
-        ])
-
-    def test_sets_app_properties(self, dsss, heroku_mock):
-        dsss()
-        heroku_mock.set.assert_has_calls([
-            mock.call('auto_recruit', True),
-            mock.call('aws_access_key_id', u'fake aws key'),
-            mock.call('aws_region', u'us-east-1'),
-            mock.call('aws_secret_access_key', u'fake aws secret'),
-            mock.call('smtp_password', u'fake email password'),
-            mock.call('smtp_username', u'fake email username'),
-            mock.call('whimsical', True),
-        ])
-
-    def test_scales_dynos(self, dsss, heroku_mock):
-        dsss()
-        heroku_mock.scale_up_dyno.assert_has_calls([
-            mock.call('web', 1, u'free'),
-            mock.call('worker', 1, u'free'),
-            mock.call('clock', 1, u'free')
-        ])
-
-
-@pytest.mark.skipif(not pytest.config.getvalue("heroku"),
-                    reason="--heroku was not specified")
-@pytest.mark.usefixtures('bartlett_dir', 'active_config', 'launch', 'herokuapp')
-class TestDeploySandboxSharedSetupFullSystem(object):
-
-    @pytest.fixture
-    def dsss(self):
-        from dallinger.command_line import deploy_sandbox_shared_setup
-        return deploy_sandbox_shared_setup
-
-    def test_full_deployment(self, dsss):
-        no_clock = {'clock_on': False}  # can't run clock on free dyno
-        result = dsss(exp_config=no_clock)  # can't run clock on free dyno
-        app_name = result.get('app_name')
-        assert app_name.startswith('dlgr')
-
-
-@pytest.mark.usefixtures('bartlett_dir')
-class Test_handle_launch_data(object):
-
-    @pytest.fixture
-    def handler(self):
-        from dallinger.command_line import _handle_launch_data
-        return _handle_launch_data
-
-    def test_success(self, handler):
-        log = mock.Mock()
-        with mock.patch('dallinger.command_line.requests.post') as mock_post:
-            result = mock.Mock(
-                ok=True,
-                json=mock.Mock(return_value={'message': u'msg!'}),
-            )
-            mock_post.return_value = result
-            assert handler('/some-launch-url', error=log) == {'message': u'msg!'}
-
-    def test_failure(self, handler):
-        from requests.exceptions import HTTPError
-        log = mock.Mock()
-        with mock.patch('dallinger.command_line.requests.post') as mock_post:
-            mock_post.return_value = mock.Mock(
-                ok=False,
-                json=mock.Mock(return_value={'message': u'msg!'}),
-                raise_for_status=mock.Mock(side_effect=HTTPError)
-            )
-            with pytest.raises(HTTPError):
-                handler('/some-launch-url', error=log, delay=0.05, remaining=5)
-
-        log.assert_has_calls([
-            mock.call('Experiment launch failed, retrying in 0.1 seconds ...'),
-            mock.call('Experiment launch failed, retrying in 0.2 seconds ...'),
-            mock.call('Experiment launch failed, retrying in 0.4 seconds ...'),
-            mock.call('Experiment launch failed, retrying in 0.8 seconds ...'),
-            mock.call('Experiment launch failed, check web dyno logs for details.'),
-            mock.call(u'msg!')
-        ])
-
-    def test_non_json_response_error(self, handler):
-        log = mock.Mock()
-        with mock.patch('dallinger.command_line.requests.post') as mock_post:
-            mock_post.return_value = mock.Mock(
-                json=mock.Mock(side_effect=ValueError),
-                text='Big, unexpected problem.'
-            )
-            with pytest.raises(ValueError):
-                handler('/some-launch-url', error=log)
-
-        log.assert_called_once_with(
-            'Error parsing response from /launch, check web dyno logs for details: '
-            'Big, unexpected problem.'
-        )
-
-
-@pytest.mark.usefixtures('bartlett_dir', 'clear_workers', 'env')
-class TestDebugServer(object):
-
-    @pytest.fixture
-    def debugger_unpatched(self, output):
-        from dallinger.command_line import DebugSessionRunner
-        debugger = DebugSessionRunner(
-            output, verbose=True, bot=False, proxy_port=None, exp_config={}
-        )
-        yield debugger
-        if debugger.status_thread:
-            debugger.status_thread.join()
-
-    @pytest.fixture
-    def debugger(self, debugger_unpatched):
-        from dallinger.heroku.tools import HerokuLocalWrapper
-        debugger = debugger_unpatched
-        debugger.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
-        return debugger
-
-    def test_startup(self, debugger):
-        debugger.run()
-        "Server is running" in str(debugger.out.log.call_args_list[0])
-
-    def test_raises_if_heroku_wont_start(self, debugger):
-        mock_wrapper = mock.Mock(
-            __enter__=mock.Mock(side_effect=OSError),
-            __exit__=mock.Mock(return_value=False)
-        )
-        with mock.patch('dallinger.command_line.HerokuLocalWrapper') as Wrapper:
-            Wrapper.return_value = mock_wrapper
-            with pytest.raises(OSError):
-                debugger.run()
-
-    def test_new_participant(self, debugger_unpatched):
-        from dallinger.config import get_config
-        debugger = debugger_unpatched
-        get_config().load()
-        debugger.new_recruit = mock.Mock(return_value=None)
-        assert not debugger.new_recruit.called
-        debugger.notify(' New participant requested: http://example.com')
-        assert debugger.new_recruit.called
-
-    def test_recruitment_closed(self, debugger_unpatched):
-        from dallinger.config import get_config
-        get_config().load()
-        debugger = debugger_unpatched
-        debugger.new_recruit = mock.Mock(return_value=None)
-        debugger.heroku = mock.Mock()
-        response = mock.Mock(
-            json=mock.Mock(return_value={'completed': True})
-        )
-        with mock.patch('dallinger.command_line.requests') as mock_requests:
-            mock_requests.get.return_value = response
-            debugger.notify(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX)
-            debugger.status_thread.join()
-
-        debugger.out.log.assert_called_with('Experiment completed, all nodes filled.')
-        debugger.heroku.stop.assert_called_once()
-
-    def test_new_recruit(self, debugger_unpatched, browser):
-        debugger_unpatched.notify(
-            " {} some-fake-url".format(recruiters.NEW_RECRUIT_LOG_PREFIX)
-        )
-
-        browser.open.assert_called_once_with(
-            'some-fake-url', autoraise=True, new=1
-        )
-
-    def test_new_recruit_not_triggered_if_quoted(self, debugger_unpatched, browser):
-        debugger_unpatched.notify(
-            ' "{}" some-fake-url'.format(recruiters.NEW_RECRUIT_LOG_PREFIX)
-        )
-
-        browser.open.assert_not_called()
-
-    @pytest.mark.skipif(not pytest.config.getvalue("runbot"),
-                        reason="--runbot was specified")
-    def test_debug_bots(self, env):
-        # Make sure debug server runs to completion with bots
-        p = pexpect.spawn(
-            'dallinger',
-            ['debug', '--verbose', '--bot'],
-            env=env,
-            encoding='utf-8',
-        )
-        p.logfile = sys.stdout
-        try:
-            p.expect_exact('Server is running', timeout=300)
-            p.expect_exact('Recruitment is complete', timeout=600)
-            p.expect_exact('Experiment completed', timeout=60)
-            p.expect_exact('Local Heroku process terminated', timeout=10)
-        finally:
-            try:
-                p.sendcontrol('c')
-                p.read()
-            except IOError:
-                pass
-
-
-@pytest.mark.usefixtures('bartlett_dir', 'clear_workers', 'env')
-class TestLoad(object):
-
-    exp_id = "some_experiment_id"
-
-    @pytest.fixture
-    def export(self):
-        # Data export created, then removed after test[s]
-        from dallinger.data import export
-        path = export(self.exp_id, local=True)
-        yield path
-        os.remove(path)
-
-    @pytest.fixture
-    def loader(self, db_session, output, clear_workers):
-        from dallinger.command_line import LoadSessionRunner
-        from dallinger.heroku.tools import HerokuLocalWrapper
-        loader = LoadSessionRunner(self.exp_id, output, verbose=True,
-                                   exp_config={})
-        loader.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
-
-        yield loader
-
-    @pytest.fixture
-    def replay_loader(self, db_session, env, output, clear_workers):
-        from dallinger.command_line import LoadSessionRunner
-        loader = LoadSessionRunner(self.exp_id, output, verbose=True,
-                                   exp_config={'replay': True})
-        loader.keep_running = mock.Mock(return_value=False)
-
-        def launch_and_finish(self):
-            from dallinger.heroku.tools import HerokuLocalWrapper
-            loader.out.log("Launching replay browser...")
-            return HerokuLocalWrapper.MONITOR_STOP
-
-        loader.start_replay = mock.Mock(
-            return_value=None,
-            side_effect=launch_and_finish
-        )
-        yield loader
-
-    def test_load_runs(self, loader, export):
-        loader.keep_running = mock.Mock(return_value=False)
-        loader.run()
-
-        loader.out.log.assert_has_calls([
-            mock.call('Starting up the server...'),
-            mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
-            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
-            mock.call('Terminating dataset load for experiment some_experiment_id'),
-            mock.call('Cleaning up local Heroku process...'),
-            mock.call('Local Heroku process terminated.')
-        ])
-
-    def test_load_raises_on_nonexistent_id(self, loader):
-        loader.app_id = 'nonsense'
-        loader.keep_running = mock.Mock(return_value=False)
-        with pytest.raises(IOError):
-            loader.run()
-
-    def test_load_with_replay(self, replay_loader, export):
-        replay_loader.run()
-
-        replay_loader.out.log.assert_has_calls([
-            mock.call('Starting up the server...'),
-            mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
-            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
-            mock.call('Launching the experiment...'),
-            mock.call('Launching replay browser...'),
-            mock.call('Terminating dataset load for experiment some_experiment_id'),
-            mock.call('Cleaning up local Heroku process...'),
-            mock.call('Local Heroku process terminated.')
-        ])
-
-
-class TestOutput(object):
-
-    @pytest.fixture
-    def output(self):
-        from dallinger.command_line import Output
-        return Output()
-
-    def test_outs(self, output):
-        output.log('logging')
-        output.error('an error')
-        output.blather('blah blah blah')
-
-
 class TestHeader(object):
     def test_header_contains_version_number(self):
         # Make sure header contains the version number.
@@ -698,11 +212,11 @@ class TestSandboxAndDeploy(object):
         return deploy
 
     @pytest.fixture
-    def dsss(self):
-        with mock.patch('dallinger.command_line.deploy_sandbox_shared_setup') as mock_dsss:
-            yield mock_dsss
+    def get_deployer(self):
+        with mock.patch('dallinger.command_line._deploy_in_mode') as mock_get_deployer:
+            yield mock_get_deployer
 
-    def test_sandbox_with_app_id(self, sandbox, dsss):
+    def test_sandbox_with_app_id(self, sandbox, get_deployer):
         CliRunner().invoke(
             sandbox,
             [
@@ -710,20 +224,18 @@ class TestSandboxAndDeploy(object):
                 '--app', 'some app id',
             ]
         )
-        dsss.assert_called_once_with(app='some app id', verbose=True)
-        assert get_config().get('mode') == 'sandbox'
+        get_deployer.assert_called_once_with('sandbox', app='some app id', verbose=True, log=mock.ANY)
 
-    def test_sandbox_with_no_app_id(self, sandbox, dsss):
+    def test_sandbox_with_no_app_id(self, sandbox, get_deployer):
         CliRunner().invoke(
             sandbox,
             [
                 '--verbose',
             ]
         )
-        dsss.assert_called_once_with(app=None, verbose=True)
-        assert get_config().get('mode') == 'sandbox'
+        get_deployer.assert_called_once_with('sandbox', app=None, verbose=True, log=mock.ANY)
 
-    def test_sandbox_with_invalid_app_id(self, sandbox, dsss):
+    def test_sandbox_with_invalid_app_id(self, sandbox, get_deployer):
         result = CliRunner().invoke(
             sandbox,
             [
@@ -731,11 +243,11 @@ class TestSandboxAndDeploy(object):
                 '--app', 'dlgr-some app id',
             ]
         )
-        dsss.assert_not_called()
+        get_deployer.assert_not_called()
         assert result.exit_code == -1
         assert 'The --app flag requires the full UUID' in str(result.exception)
 
-    def test_deploy_with_app_id(self, deploy, dsss):
+    def test_deploy_with_app_id(self, deploy, get_deployer):
         CliRunner().invoke(
             deploy,
             [
@@ -743,8 +255,7 @@ class TestSandboxAndDeploy(object):
                 '--app', 'some app id',
             ]
         )
-        dsss.assert_called_once_with(app='some app id', verbose=True)
-        assert get_config().get('mode') == 'live'
+        get_deployer.assert_called_once_with('live', app='some app id', verbose=True, log=mock.ANY)
 
 
 class TestSummary(object):
@@ -796,9 +307,9 @@ class TestBot(object):
 
     def test_bot_factory(self):
         from dallinger.command_line import bot_factory
-        from dallinger.command_line import setup_experiment
+        from dallinger.deployment import setup_experiment
         from dallinger.bots import BotBase
-        setup_experiment()
+        setup_experiment(log=mock.Mock(), header='')
         bot = bot_factory('some url')
         assert isinstance(bot, BotBase)
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -827,9 +827,9 @@ class TestHits(object):
 
     @pytest.fixture
     def output(self):
-        with mock.patch('dallinger.command_line.Output') as mock_data:
+        with mock.patch('dallinger.command_line.CLIPrinter') as mock_printer:
             output_instance = mock.Mock()
-            mock_data.return_value = output_instance
+            mock_printer.return_value = output_instance
             yield output_instance
 
     @pytest.fixture
@@ -883,15 +883,13 @@ class TestHits(object):
         assert result.exit_code == 1
         mturk_instance.get_hits.assert_called_once()
         mturk_instance.expire_hit.assert_not_called()
-        assert output.log.call_count == 2
-
-        output.log.assert_has_calls([
-            mock.call('No hits found for this application.'),
-            mock.call(
-                'If this experiment was run in the MTurk sandbox, use: '
-                '`dallinger expire --sandbox --app exp-id-2`'
-            )
-        ])
+        output.heading.assert_called_once_with(
+            'No hits found for this application.'
+        )
+        output.log.assert_called_once_with(
+            'If this experiment was run in the MTurk sandbox, use: '
+            '`dallinger expire --sandbox --app exp-id-2`'
+        )
 
     def test_expire_no_hits_sandbox(self, expire, mturk, output):
         mturk_instance = mturk.return_value
@@ -904,7 +902,7 @@ class TestHits(object):
         assert result.exit_code == 1
         mturk_instance.get_hits.assert_called_once()
         mturk_instance.expire_hit.assert_not_called()
-        output.log.assert_called_once_with(
+        output.heading.assert_called_once_with(
             'No hits found for this application.'
         )
 
@@ -924,7 +922,7 @@ class TestHits(object):
         assert result.exit_code == 1
         mturk_instance.get_hits.assert_called_once()
         mturk_instance.expire_hit.call_count = 2
-        assert output.log.call_count == 1
+        assert output.heading.call_count == 1
         assert 'Could not expire 2 hits:' in str(
-            output.log.call_args_list[0]
+            output.heading.call_args_list[0]
         )

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -229,13 +229,11 @@ class TestSandboxAndDeploy(object):
 
     @pytest.fixture
     def sandbox_deployment(self):
-        from dallinger import deployment
         with mock.patch('dallinger.command_line.HerokuSandboxDeployment') as sandbox:
             yield sandbox
 
     @pytest.fixture
     def prod_deployment(self):
-        from dallinger import deployment
         with mock.patch('dallinger.command_line.HerokuProductionDeployment') as prod:
             yield prod
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -21,19 +21,6 @@ def found_in(name, path):
 
 
 @pytest.fixture
-def output():
-
-    class Output(object):
-
-        def __init__(self):
-            self.log = mock.Mock()
-            self.error = mock.Mock()
-            self.blather = mock.Mock()
-
-    return Output()
-
-
-@pytest.fixture
 def sleepless():
     # Use this fixture to ignore sleep() calls, for speed.
     with mock.patch('dallinger.command_line.time.sleep'):
@@ -86,6 +73,35 @@ class TestVerify(object):
 
     def test_verify(self):
         subprocess.check_call(["dallinger", "verify"])
+
+
+class TestCLIPrinter(object):
+
+    @pytest.fixture
+    def cli(self):
+        from dallinger.command_line import CLIPrinter
+        return CLIPrinter(mock.Mock(), mock.Mock(), mock.Mock())
+
+    @pytest.fixture
+    def cli_quiet(self):
+        from dallinger.command_line import QuietCLIPrinter
+        return QuietCLIPrinter()
+
+    def test_printer(self, cli):
+        cli.log('logging')
+        cli.log_fast('logging without delay')
+        cli.heading('A heading')
+        cli.error('an error')
+        cli.error_heading('Ouch!')
+        cli.blather('blah blah blah')
+
+    def test_quiet_printer(self, cli_quiet):
+        cli_quiet.log('logging')
+        cli_quiet.log_fast('logging without delay')
+        cli_quiet.heading('A heading')
+        cli_quiet.error('an error')
+        cli_quiet.error_heading('Ouch!')
+        cli_quiet.blather('blah blah blah')
 
 
 class TestCommandLine(object):
@@ -224,7 +240,7 @@ class TestSandboxAndDeploy(object):
                 '--app', 'some app id',
             ]
         )
-        get_deployer.assert_called_once_with('sandbox', app='some app id', verbose=True, log=mock.ANY)
+        get_deployer.assert_called_once_with('sandbox', app='some app id', out=mock.ANY)
 
     def test_sandbox_with_no_app_id(self, sandbox, get_deployer):
         CliRunner().invoke(
@@ -233,7 +249,7 @@ class TestSandboxAndDeploy(object):
                 '--verbose',
             ]
         )
-        get_deployer.assert_called_once_with('sandbox', app=None, verbose=True, log=mock.ANY)
+        get_deployer.assert_called_once_with('sandbox', app=None, out=mock.ANY)
 
     def test_sandbox_with_invalid_app_id(self, sandbox, get_deployer):
         result = CliRunner().invoke(
@@ -255,7 +271,7 @@ class TestSandboxAndDeploy(object):
                 '--app', 'some app id',
             ]
         )
-        get_deployer.assert_called_once_with('live', app='some app id', verbose=True, log=mock.ANY)
+        get_deployer.assert_called_once_with('live', app='some app id', out=mock.ANY)
 
 
 class TestSummary(object):
@@ -309,7 +325,7 @@ class TestBot(object):
         from dallinger.command_line import bot_factory
         from dallinger.deployment import setup_experiment
         from dallinger.bots import BotBase
-        setup_experiment(log=mock.Mock())
+        setup_experiment(out=mock.Mock())
         bot = bot_factory('some url')
         assert isinstance(bot, BotBase)
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -26,6 +26,7 @@ def output():
     from dallinger.command_line import CLIPrinter
     return mock.Mock(spec=CLIPrinter)
 
+
 @pytest.fixture
 def sleepless():
     # Use this fixture to ignore sleep() calls, for speed.

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -328,8 +328,8 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
             mock.call('aws_access_key_id', u'fake aws key'),
             mock.call('aws_region', u'us-east-1'),
             mock.call('aws_secret_access_key', u'fake aws secret'),
-            mock.call('dallinger_email_key', u'fake password'),
-            mock.call('dallinger_email_username', u'test@example.com'),
+            mock.call('smtp_password', u'fake email password'),
+            mock.call('smtp_username', u'fake email username'),
             mock.call('whimsical', True),
         ])
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -355,7 +355,9 @@ class TestDeploySandboxSharedSetupFullSystem(object):
 
     def test_full_deployment(self, dsss):
         no_clock = {'clock_on': False}  # can't run clock on free dyno
-        result = dsss(exp_config=no_clock)  # can't run clock on free dyno
+        from dallinger.command_line import QuietCLIPrinter
+        output = QuietCLIPrinter()
+        result = dsss(output, exp_config=no_clock)  # can't run clock on free dyno
         app_name = result.get('app_name')
         assert app_name.startswith('dlgr')
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -127,7 +127,7 @@ class TestSetupExperiment(object):
         assert not found_in('worker.py', exp_dir)
         assert not found_in('clock.py', exp_dir)
 
-        exp_id, dst = setup_experiment(log=mock.Mock(), header='')
+        exp_id, dst = setup_experiment(log=mock.Mock())
 
         # dst should be a temp dir with a cloned experiment for deployment
         assert(exp_dir != dst)
@@ -157,7 +157,7 @@ class TestSetupExperiment(object):
         config = get_config()
         assert config.get('num_dynos_web') == 1
 
-        exp_id, dst = setup_experiment(log=mock.Mock(), header='', exp_config={'num_dynos_web': 2})
+        exp_id, dst = setup_experiment(log=mock.Mock(), exp_config={'num_dynos_web': 2})
         # Config is updated
         assert config.get('num_dynos_web') == 2
 
@@ -183,7 +183,7 @@ class TestSetupExperiment(object):
                        'something_sensitive': u'hide this',
                        'something_normal': u'show this'})
 
-        exp_id, dst = setup_experiment(log=mock.Mock(), header='')
+        exp_id, dst = setup_experiment(log=mock.Mock())
 
         # The temp dir should have a config with the sensitive variables missing
         deploy_config = configparser.SafeConfigParser()
@@ -430,7 +430,7 @@ class TestDebugServer(object):
         from dallinger.deployment import DebugDeployment
         debugger = DebugDeployment(
             output, verbose=True, bot=False, proxy_port=None, exp_config={},
-            log=mock.Mock(), header=''
+            log=mock.Mock()
         )
         yield debugger
         if debugger.status_thread:
@@ -541,8 +541,7 @@ class TestLoad(object):
         from dallinger.deployment import ReplayDeployment
         from dallinger.heroku.tools import HerokuLocalWrapper
         loader = ReplayDeployment(
-            self.exp_id, output, verbose=True, exp_config={},
-            log=mock.Mock(), header=''
+            self.exp_id, output, verbose=True, exp_config={}, log=mock.Mock()
         )
         loader.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
 
@@ -553,7 +552,7 @@ class TestLoad(object):
         from dallinger.deployment import ReplayDeployment
         loader = ReplayDeployment(
             self.exp_id, output, verbose=True, exp_config={'replay': True},
-            log=mock.Mock(), header=''
+            log=mock.Mock()
         )
         loader.keep_running = mock.Mock(return_value=False)
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,0 +1,615 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+import mock
+import os
+import pexpect
+import pytest
+import six
+import subprocess
+import sys
+import tempfile
+from pytest import raises
+from six.moves import configparser
+
+from dallinger.deployment import new_webbrowser_profile
+from dallinger.command_line import verify_package
+from dallinger.config import get_config
+from dallinger import recruiters
+
+
+def found_in(name, path):
+    return os.path.exists(os.path.join(path, name))
+
+
+@pytest.fixture
+def output():
+
+    class Output(object):
+
+        def __init__(self):
+            self.log = mock.Mock()
+            self.error = mock.Mock()
+            self.blather = mock.Mock()
+
+    return Output()
+
+
+@pytest.fixture
+def sleepless():
+    # Use this fixture to ignore sleep() calls, for speed.
+    with mock.patch('dallinger.deployment.time.sleep'):
+        yield
+
+
+@pytest.fixture
+def browser():
+    with mock.patch('dallinger.deployment.is_command') as mock_is_command:
+        mock_is_command.return_value = False
+        with mock.patch('dallinger.deployment.webbrowser') as mock_browser:
+            yield mock_browser
+
+
+@pytest.fixture
+def heroku():
+    from dallinger.heroku.tools import HerokuApp
+    instance = mock.Mock(spec=HerokuApp)
+    with mock.patch('dallinger.deployment.HerokuApp') as mock_app_class:
+        mock_app_class.return_value = instance
+        yield instance
+
+
+@pytest.fixture
+def data():
+    with mock.patch('dallinger.deployment.data') as mock_data:
+        mock_data.backup.return_value = 'fake backup url'
+        mock_bucket = mock.Mock()
+        mock_key = mock.Mock()
+        mock_key.generate_url.return_value = 'fake restore url'
+        mock_bucket.lookup.return_value = mock_key
+        mock_data.user_s3_bucket.return_value = mock_bucket
+        yield mock_data
+
+
+@pytest.fixture
+def mturk():
+    with mock.patch('dallinger.deployment.MTurkService') as mock_mturk:
+        mock_instance = mock.Mock()
+        mock_instance.get_hits.return_value = [
+            {'id': 'hit-id-1'},
+            {'id': 'hit-id-2', 'annotation': 'exp-id-2'}
+        ]
+        mock_mturk.return_value = mock_instance
+        yield mock_mturk
+
+
+class TestIsolatedWebbrowser(object):
+
+    def test_chrome_isolation(self):
+        import webbrowser
+        with mock.patch('dallinger.deployment.is_command') as is_command:
+            is_command.side_effect = lambda s: s == 'google-chrome'
+            isolated = new_webbrowser_profile()
+        assert isinstance(isolated, webbrowser.Chrome)
+        assert isolated.remote_args[:2] == [r'%action', r'%s']
+        assert isolated.remote_args[-1].startswith(
+            '--user-data-dir="{}'.format(tempfile.gettempdir())
+        )
+
+    def test_firefox_isolation(self):
+        import webbrowser
+        with mock.patch('dallinger.deployment.is_command') as is_command:
+            is_command.side_effect = lambda s: s == 'firefox'
+            isolated = new_webbrowser_profile()
+        assert isinstance(isolated, webbrowser.Mozilla)
+        assert isolated.remote_args[0] == '-profile'
+        assert isolated.remote_args[1].startswith(tempfile.gettempdir())
+        assert isolated.remote_args[2:] == ['-new-instance', '-no-remote', '-url', r'%s']
+
+    def test_fallback_isolation(self):
+        import webbrowser
+        with mock.patch('dallinger.deployment.is_command') as is_command:
+            is_command.return_value = False
+            isolated = new_webbrowser_profile()
+        assert isolated == webbrowser
+
+
+@pytest.mark.usefixtures('bartlett_dir', 'active_config')
+class TestSetupExperiment(object):
+
+    def test_setup_creates_new_experiment(self):
+        from dallinger.deployment import setup_experiment
+        # Baseline
+        exp_dir = os.getcwd()
+        assert found_in('experiment.py', exp_dir)
+        assert not found_in('experiment_id.txt', exp_dir)
+        assert not found_in('Procfile', exp_dir)
+        assert not found_in('launch.py', exp_dir)
+        assert not found_in('worker.py', exp_dir)
+        assert not found_in('clock.py', exp_dir)
+
+        exp_id, dst = setup_experiment(log=mock.Mock(), header='')
+
+        # dst should be a temp dir with a cloned experiment for deployment
+        assert(exp_dir != dst)
+        assert('/tmp' in dst)
+
+        assert found_in('experiment_id.txt', dst)
+        assert found_in('experiment.py', dst)
+        assert found_in('models.py', dst)
+        assert found_in('Procfile', dst)
+        assert found_in('launch.py', dst)
+        assert found_in('worker.py', dst)
+        assert found_in('clock.py', dst)
+
+        assert found_in(os.path.join("static", "css", "dallinger.css"), dst)
+        assert found_in(os.path.join("static", "scripts", "dallinger2.js"), dst)
+        assert found_in(os.path.join("static", "scripts", "reconnecting-websocket.js"), dst)
+        assert found_in(os.path.join("static", "scripts", "reqwest.min.js"), dst)
+        assert found_in(os.path.join("static", "scripts", "spin.min.js"), dst)
+        assert found_in(os.path.join("static", "robots.txt"), dst)
+        assert found_in(os.path.join("templates", "error.html"), dst)
+        assert found_in(os.path.join("templates", "error-complete.html"), dst)
+        assert found_in(os.path.join("templates", "launch.html"), dst)
+        assert found_in(os.path.join("templates", "complete.html"), dst)
+
+    def test_setup_with_custom_dict_config(self):
+        from dallinger.deployment import setup_experiment
+        config = get_config()
+        assert config.get('num_dynos_web') == 1
+
+        exp_id, dst = setup_experiment(log=mock.Mock(), header='', exp_config={'num_dynos_web': 2})
+        # Config is updated
+        assert config.get('num_dynos_web') == 2
+
+        # Code snapshot is saved
+        os.path.exists(os.path.join('snapshots', exp_id + '-code.zip'))
+
+        # There should be a modified configuration in the temp dir
+        deploy_config = configparser.SafeConfigParser()
+        deploy_config.read(os.path.join(dst, 'config.txt'))
+        assert int(deploy_config.get('Parameters', 'num_dynos_web')) == 2
+
+    def test_setup_excludes_sensitive_config(self):
+        from dallinger.deployment import setup_experiment
+        config = get_config()
+        # Auto detected as sensitive
+        config.register('a_password', six.text_type)
+        # Manually registered as sensitive
+        config.register('something_sensitive', six.text_type, sensitive=True)
+        # Not sensitive at all
+        config.register('something_normal', six.text_type)
+
+        config.extend({'a_password': u'secret thing',
+                       'something_sensitive': u'hide this',
+                       'something_normal': u'show this'})
+
+        exp_id, dst = setup_experiment(log=mock.Mock(), header='')
+
+        # The temp dir should have a config with the sensitive variables missing
+        deploy_config = configparser.SafeConfigParser()
+        deploy_config.read(os.path.join(dst, 'config.txt'))
+        assert(deploy_config.get(
+            'Parameters', 'something_normal') == 'show this'
+        )
+        with raises(configparser.NoOptionError):
+            deploy_config.get('Parameters', 'a_password')
+        with raises(configparser.NoOptionError):
+            deploy_config.get('Parameters', 'something_sensitive')
+
+    def test_payment_type(self):
+        config = get_config()
+        with raises(TypeError):
+            config['base_payment'] = 12
+
+    def test_large_float_payment(self):
+        config = get_config()
+        config['base_payment'] = 1.2342
+        assert verify_package() is False
+
+    def test_negative_payment(self):
+        config = get_config()
+        config['base_payment'] = -1.99
+        assert verify_package() is False
+
+
+@pytest.mark.usefixtures('in_tempdir')
+class TestGitClient(object):
+
+    @pytest.fixture
+    def git(self):
+        from dallinger.utils import GitClient
+        git = GitClient()
+        return git
+
+    def test_client(self, git, stub_config):
+        stub_config.write()
+        config = {'user.name': 'Test User', 'user.email': 'test@example.com'}
+        git.init(config=config)
+        git.add("--all")
+        git.commit("Test Repo")
+        assert b"Test Repo" in subprocess.check_output(['git', 'log'])
+
+    def test_includes_details_in_exceptions(self, git):
+        with pytest.raises(Exception) as ex_info:
+            git.push('foo', 'bar')
+        assert ex_info.match('Not a git repository')
+
+    def test_can_use_alternate_output(self, git):
+        import tempfile
+        git.out = tempfile.NamedTemporaryFile()
+        git.encoding = 'utf8'
+        git.init()
+        git.out.seek(0)
+        assert b"git init" in git.out.read()
+
+
+@pytest.fixture
+def faster(tempdir):
+    with mock.patch.multiple('dallinger.deployment',
+                             time=mock.DEFAULT,
+                             setup_experiment=mock.DEFAULT) as mocks:
+        mocks['setup_experiment'].return_value = ('fake-uid', tempdir)
+
+        yield mocks
+
+
+@pytest.fixture
+def launch():
+    with mock.patch('dallinger.deployment._handle_launch_data') as hld:
+        hld.return_value = {'recruitment_msg': 'fake\nrecruitment\nlist'}
+        yield hld
+
+
+@pytest.fixture
+def fake_git():
+    with mock.patch('dallinger.deployment.GitClient') as git:
+        yield git
+
+
+@pytest.fixture
+def herokuapp():
+    # Patch addon since we're using a free app which doesn't support them:
+    from dallinger.heroku.tools import HerokuApp
+    instance = HerokuApp('fake-uid', output=None, team=None)
+    instance.addon = mock.Mock()
+    with mock.patch('dallinger.deployment.HerokuApp') as mock_app_class:
+        mock_app_class.return_value = instance
+        yield instance
+        instance.destroy()
+
+
+@pytest.fixture
+def heroku_mock():
+    # Patch addon since we're using a free app which doesn't support them:
+    from dallinger.heroku.tools import HerokuApp
+    instance = mock.Mock(spec=HerokuApp)
+    instance.redis_url = '\n'
+    instance.name = u'dlgr-fake-uid'
+    instance.url = u'fake-url'
+    instance.db_url = u'fake-url'
+    with mock.patch('dallinger.deployment.heroku') as heroku_module:
+        heroku_module.auth_token.return_value = u'fake token'
+        with mock.patch('dallinger.deployment.HerokuApp') as mock_app_class:
+            mock_app_class.return_value = instance
+            yield instance
+
+
+@pytest.mark.usefixtures('active_config', 'launch', 'fake_git', 'faster')
+class TestDeploySandboxSharedSetupNoExternalCalls(object):
+
+    @pytest.fixture
+    def dsss(self):
+        from dallinger.deployment import deploy_sandbox_shared_setup
+        return deploy_sandbox_shared_setup
+
+    def test_result(self, dsss, heroku_mock):
+        result = dsss(log=mock.Mock())
+        assert result == {
+            'app_home': u'fake-url',
+            'app_name': u'dlgr-fake-uid',
+            'recruitment_msg': 'fake\nrecruitment\nlist'
+        }
+
+    def test_bootstraps_heroku(self, dsss, heroku_mock):
+        dsss(log=mock.Mock())
+        heroku_mock.bootstrap.assert_called_once()
+
+    def test_installs_phantomjs(self, dsss, heroku_mock):
+        dsss(log=mock.Mock())
+        heroku_mock.buildpack.assert_called_once_with(
+            'https://github.com/stomita/heroku-buildpack-phantomjs'
+        )
+
+    def test_installs_addons(self, dsss, heroku_mock):
+        dsss(log=mock.Mock())
+        heroku_mock.addon.assert_has_calls([
+            mock.call('heroku-postgresql:standard-0'),
+            mock.call('heroku-redis:premium-0'),
+            mock.call('papertrail'),
+            mock.call('sentry')
+        ])
+
+    def test_sets_app_properties(self, dsss, heroku_mock):
+        dsss(log=mock.Mock())
+        heroku_mock.set.assert_has_calls([
+            mock.call('auto_recruit', True),
+            mock.call('aws_access_key_id', u'fake aws key'),
+            mock.call('aws_region', u'us-east-1'),
+            mock.call('aws_secret_access_key', u'fake aws secret'),
+            mock.call('dallinger_email_key', u'fake password'),
+            mock.call('dallinger_email_username', u'test@example.com'),
+            mock.call('whimsical', True),
+        ])
+
+    def test_scales_dynos(self, dsss, heroku_mock):
+        dsss(log=mock.Mock())
+        heroku_mock.scale_up_dyno.assert_has_calls([
+            mock.call('web', 1, u'free'),
+            mock.call('worker', 1, u'free'),
+            mock.call('clock', 1, u'free')
+        ])
+
+
+@pytest.mark.skipif(not pytest.config.getvalue("heroku"),
+                    reason="--heroku was not specified")
+@pytest.mark.usefixtures('bartlett_dir', 'active_config', 'launch', 'herokuapp')
+class TestDeploySandboxSharedSetupFullSystem(object):
+
+    @pytest.fixture
+    def dsss(self):
+        from dallinger.deployment import deploy_sandbox_shared_setup
+        return deploy_sandbox_shared_setup
+
+    def test_full_deployment(self, dsss):
+        no_clock = {'clock_on': False}  # can't run clock on free dyno
+        result = dsss(exp_config=no_clock)  # can't run clock on free dyno
+        app_name = result.get('app_name')
+        assert app_name.startswith('dlgr')
+
+
+@pytest.mark.usefixtures('bartlett_dir')
+class Test_handle_launch_data(object):
+
+    @pytest.fixture
+    def handler(self):
+        from dallinger.deployment import _handle_launch_data
+        return _handle_launch_data
+
+    def test_success(self, handler):
+        log = mock.Mock()
+        with mock.patch('dallinger.deployment.requests.post') as mock_post:
+            result = mock.Mock(
+                ok=True,
+                json=mock.Mock(return_value={'message': u'msg!'}),
+            )
+            mock_post.return_value = result
+            assert handler('/some-launch-url', error=log) == {'message': u'msg!'}
+
+    def test_failure(self, handler):
+        from requests.exceptions import HTTPError
+        log = mock.Mock()
+        with mock.patch('dallinger.deployment.requests.post') as mock_post:
+            mock_post.return_value = mock.Mock(
+                ok=False,
+                json=mock.Mock(return_value={'message': u'msg!'}),
+                raise_for_status=mock.Mock(side_effect=HTTPError)
+            )
+            with pytest.raises(HTTPError):
+                handler('/some-launch-url', error=log, delay=0.05, remaining=5)
+
+        log.assert_has_calls([
+            mock.call('Experiment launch failed, retrying in 0.1 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.2 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.4 seconds ...'),
+            mock.call('Experiment launch failed, retrying in 0.8 seconds ...'),
+            mock.call('Experiment launch failed, check web dyno logs for details.'),
+            mock.call(u'msg!')
+        ])
+
+    def test_non_json_response_error(self, handler):
+        log = mock.Mock()
+        with mock.patch('dallinger.deployment.requests.post') as mock_post:
+            mock_post.return_value = mock.Mock(
+                json=mock.Mock(side_effect=ValueError),
+                text='Big, unexpected problem.'
+            )
+            with pytest.raises(ValueError):
+                handler('/some-launch-url', error=log)
+
+        log.assert_called_once_with(
+            'Error parsing response from /launch, check web dyno logs for details: '
+            'Big, unexpected problem.'
+        )
+
+
+@pytest.mark.usefixtures('bartlett_dir', 'clear_workers', 'env')
+class TestDebugServer(object):
+
+    @pytest.fixture
+    def debugger_unpatched(self, output):
+        from dallinger.deployment import DebugDeployment
+        debugger = DebugDeployment(
+            output, verbose=True, bot=False, proxy_port=None, exp_config={},
+            log=mock.Mock(), header=''
+        )
+        yield debugger
+        if debugger.status_thread:
+            debugger.status_thread.join()
+
+    @pytest.fixture
+    def debugger(self, debugger_unpatched):
+        from dallinger.heroku.tools import HerokuLocalWrapper
+        debugger = debugger_unpatched
+        debugger.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
+        return debugger
+
+    def test_startup(self, debugger):
+        debugger.run()
+        "Server is running" in str(debugger.out.log.call_args_list[0])
+
+    def test_raises_if_heroku_wont_start(self, debugger):
+        mock_wrapper = mock.Mock(
+            __enter__=mock.Mock(side_effect=OSError),
+            __exit__=mock.Mock(return_value=False)
+        )
+        with mock.patch('dallinger.deployment.HerokuLocalWrapper') as Wrapper:
+            Wrapper.return_value = mock_wrapper
+            with pytest.raises(OSError):
+                debugger.run()
+
+    def test_new_participant(self, debugger_unpatched):
+        from dallinger.config import get_config
+        debugger = debugger_unpatched
+        get_config().load()
+        debugger.new_recruit = mock.Mock(return_value=None)
+        assert not debugger.new_recruit.called
+        debugger.notify(' New participant requested: http://example.com')
+        assert debugger.new_recruit.called
+
+    def test_recruitment_closed(self, debugger_unpatched):
+        from dallinger.config import get_config
+        get_config().load()
+        debugger = debugger_unpatched
+        debugger.new_recruit = mock.Mock(return_value=None)
+        debugger.heroku = mock.Mock()
+        response = mock.Mock(
+            json=mock.Mock(return_value={'completed': True})
+        )
+        with mock.patch('dallinger.deployment.requests') as mock_requests:
+            mock_requests.get.return_value = response
+            debugger.notify(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX)
+            debugger.status_thread.join()
+
+        debugger.out.log.assert_called_with('Experiment completed, all nodes filled.')
+        debugger.heroku.stop.assert_called_once()
+
+    def test_new_recruit(self, debugger_unpatched, browser):
+        debugger_unpatched.notify(
+            " {} some-fake-url".format(recruiters.NEW_RECRUIT_LOG_PREFIX)
+        )
+
+        browser.open.assert_called_once_with(
+            'some-fake-url', autoraise=True, new=1
+        )
+
+    def test_new_recruit_not_triggered_if_quoted(self, debugger_unpatched, browser):
+        debugger_unpatched.notify(
+            ' "{}" some-fake-url'.format(recruiters.NEW_RECRUIT_LOG_PREFIX)
+        )
+
+        browser.open.assert_not_called()
+
+    @pytest.mark.skipif(not pytest.config.getvalue("runbot"),
+                        reason="--runbot was specified")
+    def test_debug_bots(self, env):
+        # Make sure debug server runs to completion with bots
+        p = pexpect.spawn(
+            'dallinger',
+            ['debug', '--verbose', '--bot'],
+            env=env,
+            encoding='utf-8',
+        )
+        p.logfile = sys.stdout
+        try:
+            p.expect_exact('Server is running', timeout=300)
+            p.expect_exact('Recruitment is complete', timeout=600)
+            p.expect_exact('Experiment completed', timeout=60)
+            p.expect_exact('Local Heroku process terminated', timeout=10)
+        finally:
+            try:
+                p.sendcontrol('c')
+                p.read()
+            except IOError:
+                pass
+
+
+@pytest.mark.usefixtures('bartlett_dir', 'clear_workers', 'env')
+class TestLoad(object):
+
+    exp_id = "some_experiment_id"
+
+    @pytest.fixture
+    def export(self):
+        # Data export created, then removed after test[s]
+        from dallinger.data import export
+        path = export(self.exp_id, local=True)
+        yield path
+        os.remove(path)
+
+    @pytest.fixture
+    def loader(self, db_session, output, clear_workers):
+        from dallinger.deployment import ReplayDeployment
+        from dallinger.heroku.tools import HerokuLocalWrapper
+        loader = ReplayDeployment(
+            self.exp_id, output, verbose=True, exp_config={},
+            log=mock.Mock(), header=''
+        )
+        loader.notify = mock.Mock(return_value=HerokuLocalWrapper.MONITOR_STOP)
+
+        yield loader
+
+    @pytest.fixture
+    def replay_loader(self, db_session, env, output, clear_workers):
+        from dallinger.deployment import ReplayDeployment
+        loader = ReplayDeployment(
+            self.exp_id, output, verbose=True, exp_config={'replay': True},
+            log=mock.Mock(), header=''
+        )
+        loader.keep_running = mock.Mock(return_value=False)
+
+        def launch_and_finish(self):
+            from dallinger.heroku.tools import HerokuLocalWrapper
+            loader.out.log("Launching replay browser...")
+            return HerokuLocalWrapper.MONITOR_STOP
+
+        loader.start_replay = mock.Mock(
+            return_value=None,
+            side_effect=launch_and_finish
+        )
+        yield loader
+
+    def test_load_runs(self, loader, export):
+        loader.keep_running = mock.Mock(return_value=False)
+        loader.run()
+
+        loader.out.log.assert_has_calls([
+            mock.call('Starting up the server...'),
+            mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
+            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
+            mock.call('Terminating dataset load for experiment some_experiment_id'),
+            mock.call('Cleaning up local Heroku process...'),
+            mock.call('Local Heroku process terminated.')
+        ])
+
+    def test_load_raises_on_nonexistent_id(self, loader):
+        loader.app_id = 'nonsense'
+        loader.keep_running = mock.Mock(return_value=False)
+        with pytest.raises(IOError):
+            loader.run()
+
+    def test_load_with_replay(self, replay_loader, export):
+        replay_loader.run()
+
+        replay_loader.out.log.assert_has_calls([
+            mock.call('Starting up the server...'),
+            mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
+            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
+            mock.call('Launching the experiment...'),
+            mock.call('Launching replay browser...'),
+            mock.call('Terminating dataset load for experiment some_experiment_id'),
+            mock.call('Cleaning up local Heroku process...'),
+            mock.call('Local Heroku process terminated.')
+        ])
+
+
+class TestOutput(object):
+
+    @pytest.fixture
+    def output(self):
+        from dallinger.deployment import Output
+        return Output(mock.Mock(), mock.Mock(), mock.Mock())
+
+    def test_outs(self, output):
+        output.log('logging')
+        output.error('an error')
+        output.blather('blah blah blah')

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -645,13 +645,13 @@ class TestHerokuLocalWrapper(object):
 
     @pytest.fixture
     def config(self):
-        from dallinger.command_line import setup_experiment
+        from dallinger.deployment import setup_experiment
         cwd = os.getcwd()
         config = get_config()
         if not config.ready:
             config.load()
 
-        (id, tmp) = setup_experiment(verbose=True, exp_config={})
+        (id, tmp) = setup_experiment(log=mock.Mock(), exp_config={})
 
         os.chdir(tmp)
         yield config

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -651,7 +651,7 @@ class TestHerokuLocalWrapper(object):
         if not config.ready:
             config.load()
 
-        (id, tmp) = setup_experiment(log=mock.Mock(), exp_config={})
+        (id, tmp) = setup_experiment(out=mock.Mock(), exp_config={})
 
         os.chdir(tmp)
         yield config
@@ -659,15 +659,8 @@ class TestHerokuLocalWrapper(object):
 
     @pytest.fixture
     def output(self):
-
-        class Output(object):
-
-            def __init__(self):
-                self.log = mock.Mock()
-                self.error = mock.Mock()
-                self.blather = mock.Mock()
-
-        return Output()
+        from dallinger.command_line import CLIPrinter
+        return mock.Mock(spec=CLIPrinter)
 
     @pytest.fixture
     def heroku(self, config, env, output, clear_workers):
@@ -728,11 +721,11 @@ class TestHerokuLocalWrapper(object):
         mock.call("Local Heroku was already terminated.") in heroku.out.log.mock_calls
 
     def test_start_when_shell_command_fails(self, heroku):
+        from dallinger.heroku.tools import HerokuStartupError
         heroku.shell_command = 'nonsense'
-        with pytest.raises(OSError):
+        with pytest.raises(HerokuStartupError) as ex_info:
             heroku.start()
-            heroku.out.error.assert_called_with(
-                "Couldn't start Heroku for local debugging.")
+        assert ex_info.match("Couldn't start Heroku for local debugging.")
 
     def test_stop_before_start_is_noop(self, heroku):
         heroku.stop()


### PR DESCRIPTION
## Description
- Extracts code which performs deployments from `command_line` module to a new `deployments` module
- Encapsulates logging/CLI output verbosity to a single configuration point so `if verbose:` checks don't need to propagate throughout the app
- Simplifies `HerokuLocalWrapper`, and updates it so that it shuts down its own subprocess if it detects an error during startup, reducing the chance of a lingering zombie process

**In retrospect, this PR is really too big** (it should probably be three separate ones), but I'm not sure it's worth trying to split it.

## Motivation and Context
- `dallinger.command_line` is an overly large module with a lot of churn (the most of any module in the codebase), and would benefit from being smaller
- "deployment" is a first-class concept in the dallinger universe, and is really distinct from the `dallinger [x]` CLI, which includes many non-deployment commands
- the `if verbose` checks added a lot of conditionals (and nested conditionals) throughout the codebase, for a decision which is really made just once
- the clarity gained by removing some conditionals in `HerokuLocalWrapper` exposed an opportunity for better error handling there

There is almost definitely more useful refactoring to be done here, but I wanted to leave `setup_experiment()` and `deploy_sandbox_shared_setup()` unchanged for now, since they're complex mega-functions and this PR is already too big.

## How Has This Been Tested?
- Automated tests
- Bartlett and MemoryExpt2 in debug and sandbox modes
- Bartlett via the python API (`Bartlett1932().run()`)
- (could use more testing)

