### PR TITLE
Stories/332 qualify after completion

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1603,6 +1603,10 @@ def _worker_complete(participant_id):
         raise KeyError()
 
     participant = participants[0]
+
+    # let recruiter know when completed, for qualification assignment
+    participant.recruiter.notify_completed(participant)
+
     participant.end_time = datetime.now()
     session.add(participant)
     session.commit()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1604,12 +1604,12 @@ def _worker_complete(participant_id):
 
     participant = participants[0]
 
-    # let recruiter know when completed, for qualification assignment
-    participant.recruiter.notify_completed(participant)
-
     participant.end_time = datetime.now()
     session.add(participant)
     session.commit()
+
+    # let recruiter know when completed, for qualification assignment
+    participant.recruiter.notify_completed(participant)
 
     event_type = participant.recruiter.submitted_event()
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -82,8 +82,14 @@ class Recruiter(object):
         pass
 
     def notify_using(self, participant):
-        """Allow the Recruiter to be notified when an recruited Participant
+        """Allow the Recruiter to be notified when a recruited Participant
         has been chosen to participate in an experiment they joined.
+        """
+        pass
+
+    def notify_completed(self, participant):
+        """Allow the Recruiter to be notified when a recruited Participant
+        has completed an experiment they joined.
         """
         pass
 
@@ -344,7 +350,7 @@ class MTurkRecruiter(Recruiter):
         except MTurkServiceException as ex:
             logger.exception(str(ex))
 
-    def notify_using(self, participant):
+    def notify_completed(self, participant):
         """Assign a Qualification to the Participant for the experiment ID,
         and for the configured group_name, if it's been set.
         """

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -267,6 +267,16 @@ class TestWorkerComplete(object):
         )
         assert models.Notification.query.one().event_type == u'AssignmentSubmitted'
 
+    def test_notifies_recruiter_when_participant_completes(self, a, webapp):
+        from dallinger.models import Participant
+
+        with mock.patch('dallinger.recruiters.HotAirRecruiter.notify_completed') as notify_completed:
+            webapp.get('/worker_complete?participant_id={}'.format(
+                a.participant().id
+            ))
+            args, _ = notify_completed.call_args
+            assert isinstance(args[0], Participant)
+
 
 @pytest.fixture
 def mock_messenger():

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -509,39 +509,39 @@ class TestMTurkRecruiter(object):
             fake_hit_id
         )
 
-    def test_notify_using_when_group_name_not_specified(self, recruiter):
+    def test_notify_completed_when_group_name_not_specified(self, recruiter):
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
-        recruiter.notify_using(participant)
+        recruiter.notify_completed(participant)
 
         recruiter.mturkservice.increment_qualification_score.assert_called_once_with(
             'some experiment uid',
             'some worker id',
         )
 
-    def test_notify_using_when_group_name_specified(self, recruiter):
+    def test_notify_completed_when_group_name_specified(self, recruiter):
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
         recruiter.config.set('group_name', u'some existing group_name')
-        recruiter.notify_using(participant)
+        recruiter.notify_completed(participant)
 
         recruiter.mturkservice.increment_qualification_score.assert_has_calls([
             mock.call('some experiment uid', 'some worker id'),
             mock.call('some existing group_name', 'some worker id')
         ], any_order=True)
 
-    def test_notify_using_nonexistent_qualification(self, recruiter):
+    def test_notify_completed_nonexistent_qualification(self, recruiter):
         from dallinger.mturk import QualificationNotFoundException
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
         error = QualificationNotFoundException("Ouch!")
         recruiter.mturkservice.increment_qualification_score.side_effect = error
 
         # logs, but does not raise:
-        recruiter.notify_using(participant)
+        recruiter.notify_completed(participant)
 
-    def test_notify_using_skips_assigning_qualification_if_so_configured(self, recruiter):
+    def test_notify_completed_skips_assigning_qualification_if_so_configured(self, recruiter):
         participant = mock.Mock(spec=Participant, worker_id='some worker id')
         recruiter.config.set('group_name', u'some existing group_name')
         recruiter.config.set('assign_qualifications', False)
-        recruiter.notify_using(participant)
+        recruiter.notify_completed(participant)
 
         recruiter.mturkservice.increment_qualification_score.assert_not_called()
 


### PR DESCRIPTION
As an experimeter, I want participants who are over-recruited and immediately sent to the end of the game to not receive the qualification of having completed the experiment.