### PR TITLE
Add JS API docs using JSDoc and Sphinx-JS

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1366,15 +1366,11 @@ def node_transmit(node_id):
     transmissions created with the values you specified.
 
     For example, to transmit all infos of type Meme to the node with id 10:
-    reqwest({
-        url: "/node/" + my_node_id + "/transmit",
-        method: 'post',
-        type: 'json',
-        data: {
-            what: "Meme",
-            to_whom: 10,
-        },
-    });
+    dallinger.post(
+        "/node/" + my_node_id + "/transmit",
+        {what: "Meme",
+         to_whom: 10}
+    );
     """
     exp = Experiment(session)
     what = request_parameter(parameter="what", optional=True)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,4 +12,5 @@ recommonmark==0.4.0
 sphinxcontrib-spelling==4.2.0
 Sphinx==1.7.5
 tox==3.1.2
+sphinx-js==2.5
 -r requirements.txt

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -21,7 +21,13 @@ import os
 import sys
 here = os.path.dirname(os.path.abspath(__file__))
 src = os.path.abspath(os.path.join(here, '..', '..'))
+js_source_path = os.path.join(src, 'dallinger', 'frontend', 'static', 'scripts')
 sys.path.insert(0, src)
+
+# Add path for node binaries
+os.environ['PATH'] = (
+    os.environ.get('PATH', '') + ':' + os.path.join(src, 'node_modules', '.bin')
+)
 
 # -- General configuration ------------------------------------------------
 
@@ -36,7 +42,8 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
-    'sphinx.ext.napoleon'
+    'sphinx.ext.napoleon',
+    'sphinx_js'
 ]
 
 try:

--- a/docs/source/contributing_to_dallinger.rst
+++ b/docs/source/contributing_to_dallinger.rst
@@ -1,5 +1,6 @@
 Releasing a new version of Dallinger.
-=============================
+=====================================
+
 The Dallinger branch `master` features the latest official release for 3.X.X, and `2.x-maintenance` features the latest official 2.X.X release.
 
 1. After you've merged the changes you want into both `master` and `2.x-maintenance`, the branches are ready for the version upgrade. We’re using semantic versioning, so there are three parts to the version number. when making a release you need to decide which parts should get bumped, which determines what command you give to `bumpversion`. `major` is for breaking changes, `minor` for features, `patch` for bug fixes.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -42,6 +42,7 @@ Laboratory automation for the behavioral and social sciences.
     rewarding_participants
     web_api
     communicating_with_the_server
+    javascript_api
     extra_configuration
     writing_bots
     contributing_to_dallinger

--- a/docs/source/javascript_api.rst
+++ b/docs/source/javascript_api.rst
@@ -2,7 +2,7 @@ Javascript API
 ==============
 
 Dallinger provides a javascript API to facilitate creating web-based
-experiments. ll of the dallinger demos use this API to communicate
+experiments. All of the dallinger demos use this API to communicate
 with the experiment server. The API is defined in the `dallinger2.js`
 script, which is included in the default experiment templates.
 
@@ -25,7 +25,7 @@ interact with any of the experiment routes described in
 .. js:autofunction:: dallinger.post
 
 
-Additionally, the `dallinger` object provides functions that make requests
+The `dallinger` object also provides functions that make requests
 to specific experiment routes:
 
 .. js:autofunction:: dallinger.createAgent
@@ -41,6 +41,12 @@ to specific experiment routes:
 .. js:autofunction:: dallinger.getTransmissions
 
 
+Additionally, there is a helper method to handle error responses
+from experiment API calls (see :ref:`deferreds-label` below):
+
+.. js:autofunction:: dallinger.error
+
+
 .. _deferreds-label:
 
 `Deferred` objects
@@ -50,9 +56,15 @@ All of the above functions make use of `jQuery.Deferred <https://api.jquery.com/
 and return `Deferred` objects. These `Deferred` objects provide the following
 methods to facilitate handling asynchronous responses once they've completed:
 
-    * ``.done(callback)``: Provide a callback to handle data from a successful response
-    * ``.fail(callback)``: Provide a callback to handle error responses
-    * ``.then(doneFilter[, failFilter, progressFilter])``: Provide callbacks to handle successes, failures, and progress updates.
+    * ``.done(callback)``: Provide a callback to handle data from a successful
+      response
+    * ``.fail(fail_callback)``: Provide a callback to handle error responses
+    * ``.then(callback[, fail_callback, progress_callback])``: Provide
+      callbacks to handle successes, failures, and progress updates.
+
+The fail_callback function will be passed a `dallinger.AjaxRejection` object which
+includes detailted information about the error. Unexpected errors should be handled
+by calling the :func:`dallinger.error` method with the `AjaxRejection` object.
 
 
 Experiment Initialization and Completion
@@ -61,7 +73,7 @@ Experiment Initialization and Completion
 In addition to the request functions above, there are a few functions that are
 used by the default experiment templates to setup and complete an experiment.
 If you are writing a highly customized experiment, you may need to use
-these excplicitly:
+these explicitly:
 
 .. js:autofunction:: dallinger.createParticipant
 

--- a/docs/source/javascript_api.rst
+++ b/docs/source/javascript_api.rst
@@ -1,0 +1,87 @@
+Javascript API
+==============
+
+Dallinger provides a javascript API to facilitate creating web-based
+experiments. ll of the dallinger demos use this API to communicate
+with the experiment server. The API is defined in the `dallinger2.js`
+script, which is included in the default experiment templates.
+
+The `dallinger` object
+----------------------
+
+Any page that includes `dallinger2.js` script will have a `dallinger`
+object added to the `window` global namespace. This object defines a
+number of functions for interacting with Dallinger experiments.
+
+Making requests to experiment routes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`dallinger` provides functions which can be used to asynchronously
+interact with any of the experiment routes described in
+:doc:`Web API <web_api>`:
+
+.. js:autofunction:: dallinger.get
+
+.. js:autofunction:: dallinger.post
+
+
+Additionally, the `dallinger` object provides functions that make requests
+to specific experiment routes:
+
+.. js:autofunction:: dallinger.createAgent
+
+.. js:autofunction:: dallinger.createInfo
+
+.. js:autofunction:: dallinger.getInfo
+
+.. js:autofunction:: dallinger.getInfos
+
+.. js:autofunction:: dallinger.getReceivedInfos
+
+.. js:autofunction:: dallinger.getTransmissions
+
+
+.. _deferreds-label:
+
+`Deferred` objects
+~~~~~~~~~~~~~~~~~~
+
+All of the above functions make use of `jQuery.Deferred <https://api.jquery.com/jquery.deferred/>`__,
+and return `Deferred` objects. These `Deferred` objects provide the following
+methods to facilitate handling asynchronous responses once they've completed:
+
+    * ``.done(callback)``: Provide a callback to handle data from a successful response
+    * ``.fail(callback)``: Provide a callback to handle error responses
+    * ``.then(doneFilter[, failFilter, progressFilter])``: Provide callbacks to handle successes, failures, and progress updates.
+
+
+Experiment Initialization and Completion
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the request functions above, there are a few functions that are
+used by the default experiment templates to setup and complete an experiment.
+If you are writing a highly customized experiment, you may need to use
+these excplicitly:
+
+.. js:autofunction:: dallinger.createParticipant
+
+.. js:autofunction:: dallinger.hasAdBlocker
+
+.. js:autofunction:: dallinger.submitAssignment
+
+.. js:autofunction:: dallinger.submitQuestionnaire
+
+.. js:autofunction:: dallinger.waitForQuorum
+
+
+Helper functions and properties
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Finally, there are a few miscellaneous utility functions and properties
+which are useful when writing a custom experiment:
+
+.. js:autofunction:: dallinger.getUrlParameter
+
+.. js:autofunction:: dallinger.goToPage
+
+.. js:autoattribute:: dallinger.identity

--- a/package.json
+++ b/package.json
@@ -2,13 +2,13 @@
   "name": "dallinger",
   "version": "0.1.0",
   "description": "Dallinger experiment server",
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "browser-sync": "^2.18.8",
     "browser-sync-webpack-plugin": "^1.1.4",
-    "webpack": "^2.4.1",
-    "uglify-es": "^3.0.28"
+    "jsdoc": "^3.5.5",
+    "uglify-es": "^3.0.28",
+    "webpack": "^2.4.1"
   },
   "scripts": {
     "build": "webpack",

--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,5 @@ deps =
 whitelist_externals = make
 commands =
     pip install -r dev-requirements.txt
+    yarn
     make -C docs html

--- a/yarn.lock
+++ b/yarn.lock
@@ -157,6 +157,10 @@ aws4@^1.2.1:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.6.0.tgz#83ef5ca860b2b32e4a0deedee8c771b9db57471e"
 
+babylon@7.0.0-beta.19:
+  version "7.0.0-beta.19"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
+
 backo2@1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
@@ -210,6 +214,10 @@ block-stream@*:
   resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
   dependencies:
     inherits "~2.0.0"
+
+bluebird@~3.5.0:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
 
 bn.js@^4.0.0, bn.js@^4.1.0, bn.js@^4.1.1, bn.js@^4.4.0:
   version "4.11.8"
@@ -385,6 +393,12 @@ camelcase@^3.0.0:
 caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
+
+catharsis@~0.8.9:
+  version "0.8.9"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.9.tgz#98cc890ca652dd2ef0e70b37925310ff9e90fc8b"
+  dependencies:
+    underscore-contrib "~0.3.0"
 
 center-align@^0.1.1:
   version "0.1.3"
@@ -761,7 +775,7 @@ escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
 
-escape-string-regexp@^1.0.2:
+escape-string-regexp@^1.0.2, escape-string-regexp@~1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
@@ -967,7 +981,7 @@ glob@^7.0.5:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-graceful-fs@^4.1.2, graceful-fs@^4.1.6:
+graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
 
@@ -1234,9 +1248,32 @@ isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
+js2xmlparser@~3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/js2xmlparser/-/js2xmlparser-3.0.0.tgz#3fb60eaa089c5440f9319f51760ccd07e2499733"
+  dependencies:
+    xmlcreate "^1.0.1"
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
+
+jsdoc@^3.5.5:
+  version "3.5.5"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.5.5.tgz#484521b126e81904d632ff83ec9aaa096708fa4d"
+  dependencies:
+    babylon "7.0.0-beta.19"
+    bluebird "~3.5.0"
+    catharsis "~0.8.9"
+    escape-string-regexp "~1.0.5"
+    js2xmlparser "~3.0.0"
+    klaw "~2.0.0"
+    marked "~0.3.6"
+    mkdirp "~0.5.1"
+    requizzle "~0.2.1"
+    strip-json-comments "~2.0.1"
+    taffydb "2.6.2"
+    underscore "~1.8.3"
 
 json-loader@^0.5.4:
   version "0.5.7"
@@ -1294,6 +1331,12 @@ kind-of@^4.0.0:
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-4.0.0.tgz#20813df3d712928b207378691a45066fae72dd57"
   dependencies:
     is-buffer "^1.1.5"
+
+klaw@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/klaw/-/klaw-2.0.0.tgz#59c128e0dc5ce410201151194eeb9cbf858650f6"
+  dependencies:
+    graceful-fs "^4.1.9"
 
 lazy-cache@^1.0.3:
   version "1.0.4"
@@ -1356,6 +1399,10 @@ lodash@^4, lodash@^4.14.0:
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
+
+marked@~0.3.6:
+  version "0.3.19"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-0.3.19.tgz#5d47f709c4c9fc3c216b6d46127280f40b39d790"
 
 md5.js@^1.3.4:
   version "1.3.4"
@@ -1444,7 +1491,7 @@ mkdirp@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.3.0.tgz#1bbf5ab1ba827af23575143490426455f481fe1e"
 
-"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0:
+"mkdirp@>=0.5 0", mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
   dependencies:
@@ -1925,6 +1972,12 @@ requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
+requizzle@~0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/requizzle/-/requizzle-0.2.1.tgz#6943c3530c4d9a7e46f1cddd51c158fc670cdbde"
+  dependencies:
+    underscore "~1.6.0"
+
 resp-modifier@6.0.2:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/resp-modifier/-/resp-modifier-6.0.2.tgz#b124de5c4fbafcba541f48ffa73970f4aa456b4f"
@@ -2198,6 +2251,10 @@ supports-color@^3.1.0:
   dependencies:
     has-flag "^1.0.0"
 
+taffydb@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
+
 tapable@^0.2.7, tapable@~0.2.5:
   version "0.2.8"
   resolved "https://registry.yarnpkg.com/tapable/-/tapable-0.2.8.tgz#99372a5c999bf2df160afc0d74bed4f47948cd22"
@@ -2296,9 +2353,23 @@ ultron@1.0.x:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/ultron/-/ultron-1.0.2.tgz#ace116ab557cd197386a4e88f4685378c8b2e4fa"
 
+underscore-contrib@~0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/underscore-contrib/-/underscore-contrib-0.3.0.tgz#665b66c24783f8fa2b18c9f8cbb0e2c7d48c26c7"
+  dependencies:
+    underscore "1.6.0"
+
+underscore@1.6.0, underscore@~1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
+
 underscore@1.7.x:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
+
+underscore@~1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 universalify@^0.1.0:
   version "0.1.1"
@@ -2450,6 +2521,10 @@ ws@1.1.1:
 wtf-8@1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/wtf-8/-/wtf-8-1.0.0.tgz#392d8ba2d0f1c34d1ee2d630f15d0efb68e1048a"
+
+xmlcreate@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/xmlcreate/-/xmlcreate-1.0.2.tgz#fa6bf762a60a413fb3dd8f4b03c5b269238d308f"
 
 xmlhttprequest-ssl@1.5.3:
   version "1.5.3"


### PR DESCRIPTION
Add documentation for `dallinger` javascript API as defined in `dallinger2.js`

## Description
This PR uses JSDoc comment conventions integrated into the Sphinx documentation setup to
include API documentation for Dallinger's JS API.

## Motivation and Context
Implements [ScrumDo Story 360](https://app.scrumdo.com/projects/story_permalink/1600086)

## ToDo
This may still need information about recommended JS build systems and such, if desired. We currently use `webpack` and `yarn` for both Dallinger and Griduniverse. Should we recommend those for custom experiments that wish to make use of external JS dependencies?