### PR TITLE
Add documentation for python Experiment API

### DIFF
--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -1,15 +1,13 @@
 Database API
 ============
 
+.. module:: dallinger.models
 .. _classes:
 
 The classes involved in a Dallinger experiment are:
-:class:`~dallinger.models.Network`, :class:`~dallinger.models.Node`,
-:class:`~dallinger.models.Vector`, :class:`~dallinger.models.Info`,
-:class:`~dallinger.models.Transmission`,
-:class:`~dallinger.models.Transformation`,
-:class:`~dallinger.models.Participant`, and
-:class:`~dallinger.models.Question`. The code for all these classes can
+:class:`Network`, :class:`~Node`, :class:`~Vector`, :class:`~Info`,
+:class:`~Transmission`, :class:`~Transformation`, :class:`~Participant`, and
+:class:`~Question`. The code for all these classes can
 be seen in ``models.py``. Each class has a corresponding table in the
 database, with each instance stored as a row in the table. Accordingly,
 each class is defined, in part, by the columns that constitute the table
@@ -17,14 +15,14 @@ it is stored in. In addition, the classes have relationships to other
 objects and a number of functions.
 
 The classes have relationships to each other as shown in the diagram
-below. Be careful to note which way the arrows point. A :class:`~dallinger.models.Node` is a
-point in a :class:`~dallinger.models.Network` that might be associated with a :class:`~dallinger.models.Participant`.
-A :class:`~dallinger.models.Vector` is a directional connection between a :class:`~dallinger.models.Node` and another
-:class:`~dallinger.models.Node`. An :class:`~dallinger.models.Info` is information created by a :class:`~dallinger.models.Node`. A
-:class:`~dallinger.models.Transmission` is an instance of an :class:`~dallinger.models.Info` being sent along a
-:class:`~dallinger.models.Vector`. A :class:`~dallinger.models.Transformation` is a relationship between an :class:`~dallinger.models.Info`
-and another :class:`~dallinger.models.Info`. A :class:`~dallinger.models.Question` is a survey response created by a
-:class:`~dallinger.models.Participant`.
+below. Be careful to note which way the arrows point. A :class:`~Node` is a
+point in a :class:`~Network` that might be associated with a :class:`Participant`.
+A :class:`Vector` is a directional connection between a :class:`Node` and another
+:class:`Node`. An :class:`Info` is information created by a :class:`Node`. A
+:class:`Transmission` is an instance of an :class:`Info` being sent along a
+:class:`Vector`. A :class:`Transformation` is a relationship between an :class:`Info`
+and another :class:`Info`. A :class:`Question` is a survey response created by a
+:class:`Participant`.
 
 .. figure:: _static/class_chart.jpg
    :alt: 
@@ -65,10 +63,10 @@ columns that are common across tables:
 Network
 -------
 
-The :class:`~dallinger.models.Network` object can be imagined as a set of other objects with
+The :class:`Network` object can be imagined as a set of other objects with
 some functions that perform operations over those objects. The objects
-that :class:`~dallinger.models.Network`'s have direct access to are all the :class:`~dallinger.models.Node`'s in the
-network, the :class:`~dallinger.models.Vector`'s between those Nodes, Infos created by those
+that :class:`Network`'s have direct access to are all the :class:`Node`'s in the
+network, the :class:`Vector`'s between those Nodes, Infos created by those
 Nodes, Transmissions sent along the Vectors by those Nodes and
 Transformations of those Infos. Participants and Questions do not exist
 within Networks. An experiment may involve multiple Networks,
@@ -140,6 +138,7 @@ Methods
 .. automethod:: dallinger.models.Network.transmissions
 
 .. automethod:: dallinger.models.Network.vectors
+
 
 Node
 ----

--- a/docs/source/python_module.rst
+++ b/docs/source/python_module.rst
@@ -53,7 +53,7 @@ Parameterized Experiment Runs
 -----------------------------
 
 This high-level API is particularly useful for running an experiment in a
-loop with modifed configuration for each run. For example an experimenter
+loop with modifed configuration for each run. For example, an experimenter
 could run repeated ConcentrationGame experiments with varying numbers of
 participants::
 
@@ -86,7 +86,7 @@ saved under the provided `app_id` so that subsequent calls to
 :meth:`~Experiment.collect` with that `app_id` will retrieve the data instead
 of re-running the experiment.
 
-For example an experimenter could pre-generate a UUID using `dallinger uuid`,
+For example, an experimenter could pre-generate a UUID using `dallinger uuid`,
 then collect data using that UUID::
 
     import dallinger

--- a/docs/source/python_module.rst
+++ b/docs/source/python_module.rst
@@ -1,5 +1,7 @@
-Python module
-=============
+Running Experiments Programatically
+===================================
+
+.. currentmodule:: dallinger.experiment
 
 Dallinger experiments can be run through a high-level Python API.
 
@@ -14,11 +16,11 @@ Dallinger experiments can be run through a high-level Python API.
     })
 
 All parameters in ``config.txt`` and ``.dallingerconfig`` can be specified
-in the configuration dictionary passed to the ``run`` function. The return
+in the configuration dictionary passed to the
+:meth:`~Experiment.run` function. The return
 value is an object that allows you to access all the Dallinger data tables
-in a variety of useful formats. Here are all the tables:
+in a variety of useful formats. The following data tables are available::
 
-::
     data.infos
     data.networks
     data.nodes
@@ -29,10 +31,8 @@ in a variety of useful formats. Here are all the tables:
     data.transmissions
     data.vectors
 
-For each of these tables, e.g. ``networks``, you can access it in a variety of
-formats, including:
-
-::
+For each of these tables, e.g. ``networks``, you can access the data in a
+variety of formats, including::
 
     data.networks.csv    # Comma-separated value
     data.networks.dict   # Python dictionary
@@ -46,5 +46,91 @@ formats, including:
     data.networks.xlsx   # Modern Excel spreadsheet
     data.networks.yaml   # YAML
 
+See :doc:`classes` for more details about these tables.
 
-Note that, at the moment, only the Bartlett1932 demo can be run in this way.
+
+Parameterized Experiment Runs
+-----------------------------
+
+This high-level API is particularly useful for running an experiment in a
+loop with modifed configuration for each run. For example an experimenter
+could run repeated ConcentrationGame experiments with varying numbers of
+participants::
+
+    import dallinger
+
+    collected = []
+    experiment = dallinger.experiments.ConcentrationGame()
+    for run_num in range(1, 10):
+        data = experiment.run({
+            mode=live,
+            num_participants=run_num,
+        })
+        collected.append(data)
+
+With this technique, an experimenter can use data from prior runs to
+modify the configuration for subsequent experiment runs.
+
+
+Repeatability
+-------------
+
+It is often useful to share the code used to run an experiment in a way
+that ensures that re-running it will retrieve the same results. Dallinger
+provides a special method for that purpose: :meth:`~Experiment.collect`.
+This method is similar to :meth:`~Experiment.run` but it requires an `app_id`
+parameter. When that `app_id` corresponds to existing experiment data that
+can be retrieved (from either a local export or stored remotely), that data
+will be loaded. Otherwise, the experiment is run and the data is
+saved under the provided `app_id` so that subsequent calls to
+:meth:`~Experiment.collect` with that `app_id` will retrieve the data instead
+of re-running the experiment.
+
+For example an experimenter could pre-generate a UUID using `dallinger uuid`,
+then collect data using that UUID::
+
+    import dallinger
+
+    my_app_id = "68f73876-48f3-d1e2-4df7-25e46c99ce28"
+    experiment = dallinger.experiments.Bartlett1932()
+    data = experiment.collect(my_app_id, {
+        mode=live,
+        base_payment=1.00,
+    })
+
+The first run of the above code will run a live experiment and collect data.
+Subsequent runs will retrieve the data collected during the first run.
+
+
+Importing Your Experiment
+-------------------------
+
+You can use this API directly on an imported experiment class if it is
+available in your python path::
+
+    from mypackage.experiment import MyFancyExperiment
+    data = MyFancyExperiment().run(...)
+
+
+Alternatively, an experiment installed as a python package can register itself
+with Dallinger and appear in the experiments module. This is done by including
+a `dallinger.experiments` item in the `entry_points` argument in the call to
+`setup` in an experiment's `setup.py`. For example::
+
+    ...
+    setup(
+        ...,
+        entry_points={'dallinger.experiments': ['mypackage.MyFancyExperiment']},
+        ...
+    )
+
+
+An experiment package registered in this manner can be imported from
+`dallinger.experiments`::
+
+    import dallinger
+
+    experiment = dallinger.experiments.MyFancyExperiment()
+    experiment.run(...)
+
+See the `setup.py` from `dlgr.demos` for more examples.

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -8,7 +8,7 @@ single Experiment object and it is not stored as an entry in a corresponding
 table, rather each Experiment is a set of instructions that tell the server
 what to do with the database when the server receives requests from outside.
 
-.. currentmodule:: dallinger.experiments
+.. module:: dallinger.experiment
 
 .. autoclass:: Experiment
 
@@ -45,6 +45,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: assignment_abandoned
 
+  .. automethod:: assignment_reassigned
+
   .. automethod:: assignment_returned
 
   .. automethod:: attention_check
@@ -55,6 +57,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: bonus_reason
 
+  .. automethod:: collect
+
   .. automethod:: create_network
 
   .. automethod:: create_node
@@ -62,6 +66,8 @@ what to do with the database when the server receives requests from outside.
   .. automethod:: data_check
 
   .. automethod:: data_check_failed
+
+  .. automethod:: events_for_replay
 
   .. automethod:: fail_participant
 
@@ -71,9 +77,13 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: info_post_request
 
+  .. automethod:: is_complete
+
   .. automethod:: log
 
   .. automethod:: log_summary
+
+  .. automethod:: make_uuid
 
   .. automethod:: networks
 
@@ -82,6 +92,14 @@ what to do with the database when the server receives requests from outside.
   .. automethod:: node_post_request
 
   .. automethod:: recruit
+
+  .. automethod:: replay_event
+
+  .. automethod:: replay_start
+
+  .. automethod:: replay_finish
+
+  .. automethod:: replay_started
 
   .. automethod:: run
 


### PR DESCRIPTION
Improve documentation for `dallinger` python API for running experiments.

## Description
This PR extends the python module documentation to provide information about running
experiments repeatably and registering experiments. It also makes some changes to
existing API documents to facilitate cross-linking API documentation.

## Motivation and Context
Implements [ScrumDo Story 358](https://app.scrumdo.com/projects/story_permalink/1600084)

## Testing
Ideally, one would test this by pulling down the branch, `cd docs; make html; open build/html/python_module.html` and reviewing the HTML output, along with the source changes.