### PR TITLE
Review Docker specific postgres detection code in Dallinger - NOT MERGE READY

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -283,7 +283,10 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
     # Verify that the Postgres server is running.
     try:
-        psycopg2.connect(database="x", user="postgres", password="nada")
+#        psycopg2.connect(database="x", user="postgres", password="nada")
+        db_url_default = "postgresql://dallinger:dallinger@localhost/dallinger"
+        db_url = os.environ.get("DATABASE_URL", db_url_default)
+        psycopg2.connect(dsn=db_url)
     except psycopg2.OperationalError as e:
         if "could not connect to server" in str(e):
             raise RuntimeError("The Postgres server isn't running.")

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -283,8 +283,10 @@ def setup_experiment(debug=True, verbose=False, app=None, exp_config=None):
 
     # Verify that the Postgres server is running.
     try:
-#        psycopg2.connect(database="x", user="postgres", password="nada")
-        db_url_default = "postgresql://dallinger:dallinger@localhost/dallinger"
+        # The purpose of this check is to send an incorrect url to postgres.
+        # If it is up and running, it will throw an error but not the one
+        # that is being 'caught for', thus proving that postgres is up.
+        db_url_default = "postgresql://nonsense:nonsense@localhost/dallinger"
         db_url = os.environ.get("DATABASE_URL", db_url_default)
         psycopg2.connect(dsn=db_url)
     except psycopg2.OperationalError as e:


### PR DESCRIPTION
This "patch" allows Dallinger, running in a Docker container as part of a docker-compose configuration, to see that Postgres is up and running in another container.

## Description
I would like feedback from someone more versed with the code as to how we can handle both the normal case
```
 psycopg2.connect(database="x", user="postgres", password="nada")
```
and the docker case 
```
db_url_default = "postgresql://dallinger:dallinger@localhost/dallinger"
db_url = os.environ.get("DATABASE_URL", db_url_default)
psycopg2.connect(dsn=db_url)
```
together gracefully, without them interfering with each other.

The docker-compose.yml configuration is here:
https://github.com/Dallinger/Dockerfiles/blob/stories/345-dockerfile-windows/docker-compose/docker-compose.yml

## Motivation and Context
I think it is important for this (once polished) to be part of core so that any version of Dallinger going forward from the merge is able to be used with docker-compose.

## How Has This Been Tested?
Without this, Dallinger running in a docker-compose configuration, would exit thinking that Postgresql is not running.

## Other
A big thank you to the IST RESEARCH team for providing the groundwork to make this possible:
https://github.com/istresearch/Dallinger/tree/pulse-integration
