### PR TITLE
Performance improvements for jupyter widget support

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -802,7 +802,7 @@ class Scrubber(object):
         which is a datetime object."""
         if self.experiment._replay_time_index > time:
             self.experiment.revert_to_time(session=self.session, target=time)
-        events = self.experiment.events_for_replay(session=self.session, target=time)
+        events = self.experiment.events_for_replay(session=self.session, target=time).all()
         for event in events:
             if event.creation_time <= self.experiment._replay_time_index:
                 # Skip events we've already handled

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -35,7 +35,7 @@ class SharedMixin(object):
     id = Column(Integer, primary_key=True, index=True)
 
     #: the time at which the Network was created.
-    creation_time = Column(DateTime, nullable=False, default=timenow)
+    creation_time = Column(DateTime, nullable=False, default=timenow, index=True)
 
     #: a generic column that can be used to store experiment-specific details in
     #: String form.

--- a/dallinger/nodes.py
+++ b/dallinger/nodes.py
@@ -108,8 +108,8 @@ class Environment(Node):
                 s for s in self.infos(type=State) if s.creation_time < time]
             return max(states, key=attrgetter('creation_time'))
 
-    def update(self, contents):
-        state = State(origin=self, contents=contents)
+    def update(self, contents, **kwargs):
+        state = State(origin=self, contents=contents, **kwargs)
         return state
 
     def _what(self):


### PR DESCRIPTION
## Description
Some minor changes to improve speed of replaying events in Jupyter widgets

## Motivation and Context
Some jupyter hosts do not provide much processing power, these changes reduce the time spent in sql queries for replays.

## How Has This Been Tested?
Manual testing with GU
