### PR TITLE
Final (?) PyUp config updates

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,11 +1,11 @@
 label_prs: "enhancement"
 requirements:
-  - constraints.txt
+  - constraints.txt:
       update: all
       pin: True
-  - requirements.txt
+  - requirements.txt:
       update: False
       pin: False
-  - dev-requirements.txt
+  - dev-requirements.txt:
       update: False
       pin: False

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,11 +1,11 @@
 label_prs: "enhancement"
 requirements:
   - constraints.txt
-    update: all
-    pin: True
+      update: all
+      pin: True
   - requirements.txt
-    update: False
-    pin: False
+      update: False
+      pin: False
   - dev-requirements.txt
-    update: False
-    pin: False
+      update: False
+      pin: False

--- a/constraints.txt
+++ b/constraints.txt
@@ -1,4 +1,3 @@
-Dallinger>=4.0.0
 alabaster==0.7.11
 APScheduler==3.5.1
 atomicwrites==1.1.5

--- a/constraints.txt
+++ b/constraints.txt
@@ -13,18 +13,14 @@ chardet==3.0.4
 click==6.7
 codecov==2.0.15
 CommonMark==0.5.4
-configparser==3.5.0
 coverage==4.5.1
 coverage-pth==0.0.2
 docutils==0.14
-enum34==1.1.6
 flake8==3.5.0
 Flask==1.0.2
 flask-crossdomain==0.1
 Flask-Sockets==0.2.1
-funcsigs==1.0.2
 future==0.16.0
-futures==3.2.0
 gevent==1.3.5
 gevent-websocket==0.10.1
 greenlet==0.4.14
@@ -34,7 +30,7 @@ imagesize==1.0.0
 itsdangerous==0.24
 Jinja2==2.10
 jmespath==0.9.3
-localconfig==1.1.1
+localconfig==1.1.2
 MarkupSafe==1.0
 mccabe==0.6.1
 mock==2.0.0
@@ -73,7 +69,6 @@ sphinxcontrib-websupport==1.1.0
 SQLAlchemy==1.2.10
 sqlalchemy-postgres-copy==0.5.0
 tox==3.1.2
-typing==3.6.4
 tzlocal==1.5.1
 ua-parser==0.8.0
 urllib3==1.23

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
--c constraints.txt
 APScheduler
 cached-property
 boto3


### PR DESCRIPTION
This seems to fix the syntax issue and should exclude `requirements.txt` and `dev-requirements.txt` from pyup updates while including `constraints.txt`.