### PR TITLE
App Listing Command

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -13,6 +13,7 @@ import os
 import shutil
 import signal
 import sys
+import tabulate
 import tempfile
 import time
 import webbrowser
@@ -35,6 +36,7 @@ from dallinger.heroku.messages import get_messenger
 from dallinger.heroku.messages import HITSummary
 from dallinger.heroku.worker import conn
 from dallinger.heroku.tools import HerokuApp
+from dallinger.heroku.tools import HerokuInfo
 from dallinger.mturk import MTurkService
 from dallinger.mturk import MTurkServiceException
 from dallinger.utils import check_call
@@ -664,3 +666,37 @@ def rq_worker():
         # right now we care about low queue for bots
         worker = Worker('low')
         worker.work()
+
+
+@dallinger.command()
+def apps():
+    config = get_config()
+    if not config.ready:
+        config.load()
+    team = config.get("heroku_team", '').strip() or None
+    command_runner = HerokuInfo(team=team)
+    my_apps = command_runner.my_apps()
+    my_user = command_runner.login_name()
+    listing = []
+    header_map = [
+        {'title': 'UID', 'id': 'dallinger_uid'},
+        {'title': 'Started', 'id': 'created_at'},
+        {'title': 'URL', 'id': 'web_url'},
+    ]
+    headers = [h['title'] for h in header_map]
+    for app in my_apps:
+        app_info = []
+        for detail in header_map:
+            val = ''
+            key = detail.get('id')
+            if key:
+                val = app.get(key, '')
+            app_info.append(val)
+        listing.append(app_info)
+    if listing:
+        click.echo('Found {} heroku apps running for user {}'.format(
+            len(listing), my_user
+        ))
+        click.echo(tabulate.tabulate(listing, headers, tablefmt='psql'))
+    else:
+        click.echo('No heroku apps found for user {}'.format(my_user))

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -670,6 +670,7 @@ def rq_worker():
 
 @dallinger.command()
 def apps():
+    out = Output()
     config = get_config()
     if not config.ready:
         config.load()
@@ -694,9 +695,10 @@ def apps():
             app_info.append(val)
         listing.append(app_info)
     if listing:
-        click.echo('Found {} heroku apps running for user {}'.format(
+        out.log('Found {} heroku apps running for user {}'.format(
             len(listing), my_user
         ))
-        click.echo(tabulate.tabulate(listing, headers, tablefmt='psql'))
+        out.log(tabulate.tabulate(listing, headers, tablefmt='psql'),
+                chevrons=False)
     else:
-        click.echo('No heroku apps found for user {}'.format(my_user))
+        out.log('No heroku apps found for user {}'.format(my_user))

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -278,8 +278,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         "whimsical": config["whimsical"],
     }
 
-    for k, v in sorted(heroku_config.items()):  # sorted for testablility
-        heroku_app.set(k, v)
+    heroku_app.set_multiple(**heroku_config)
 
     # Wait for Redis database to be ready.
     log("Waiting for Redis...")

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -35,7 +35,7 @@ class HerokuCommandRunner(object):
         return getattr(sys.stdout, 'encoding', sys.getdefaultencoding())
 
     def login_name(self):
-        """Capture a backup of the app."""
+        """Returns the current logged-in heroku user"""
         return self._result(["heroku", "auth:whoami"]).strip()
 
     def _run(self, cmd, pass_stderr=False):
@@ -278,7 +278,7 @@ class HerokuApp(HerokuCommandRunner):
             self._run(cmd)
 
     def set_multiple(self, **kwargs):
-        """Configure an app key/value pair"""
+        """Configure multiple app key/value pairs"""
         quiet = False
         if not kwargs:
             return

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -48,7 +48,10 @@ class HerokuCommandRunner(object):
         return subprocess.check_call(cmd, stdout=self.out_muted)
 
     def _result(self, cmd):
-        return check_output(cmd).decode(self.sys_encoding)
+        output = check_output(cmd)
+        if six.PY3:
+            return output
+        return output.decode(self.sys_encoding)
 
 
 class HerokuInfo(HerokuCommandRunner):

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -49,9 +49,10 @@ class HerokuCommandRunner(object):
 
     def _result(self, cmd):
         output = check_output(cmd)
-        if six.PY3:
+        try:
+            return output.decode(self.sys_encoding)
+        except AttributeError:
             return output
-        return output.decode(self.sys_encoding)
 
 
 class HerokuInfo(HerokuCommandRunner):

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -99,5 +99,29 @@ experiment by its id.
 destroy
 ^^^^^^^
 
-Tear down an experiment server. A required ``--app <app>`` flag specifies
-the experiment by its id.
+Tear down an experiment server. A required ``--app <app>`` parameter
+specifies the experiment by its id. Optional ``--expire-hit`` flag
+can be provided to force expiration of MTurk hits associated with the
+app. If app is sandboxed, you will need to use the ``--sandbox`` flag
+to expire HITs from the MTurk sandbox.
+
+hits
+^^^^
+
+List all MTurk HITs for a dallinger app. A required ``--app <app>``
+parameter specifies the experiment by its id. An optional ``--sandbox``
+flag indicates to look for HITs in the MTurk sandbox.
+
+expire
+^^^^^^
+
+Expire all MTurk HITs for a dallinger app. A required ``--app <app>``
+parameter specifies the experiment by its id. An optional ``--sandbox``
+flag indicates to look for HITs in the MTurk sandbox.
+
+apps
+^^^^
+
+List all running heroku apps associated with the currently logged in
+heroku account. Returns the Dallinger app UID, app launch timestamp,
+and heroku app url for each running app.

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,6 @@ selenium
 six
 SQLAlchemy
 sqlalchemy-postgres-copy
+tabulate
 ua-parser
 user-agents

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -923,15 +923,15 @@ class TestApps(object):
         with mock.patch('dallinger.heroku.tools.check_output') as check_output:
             def my_check_output(cmd):
                 if 'auth:whoami' in cmd:
-                    return 'test@example.com'
+                    return b'test@example.com'
                 elif 'config:get' in cmd:
                     if 'CREATOR' in cmd and 'dlgr-my-uid' in cmd:
-                        return 'test@example.com'
+                        return b'test@example.com'
                     elif 'DALLINGER_UID' in cmd:
                         return cmd[-1].replace('dlgr-', '')
-                    return ''
+                    return b''
                 elif 'apps' in cmd:
-                    return '''[
+                    return b'''[
     {"name": "dlgr-my-uid",
      "created_at": "2018-01-01T12:00Z",
      "web_url": "https://dlgr-my-uid.herokuapp.com"},

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -907,3 +907,65 @@ class TestHits(object):
         assert 'Could not expire 2 hits:' in str(
             output.log.call_args_list[0]
         )
+
+
+class TestApps(object):
+
+    @pytest.fixture
+    def console_output(self):
+        with mock.patch('dallinger.command_line.Output') as mock_data:
+            output_instance = mock.Mock()
+            mock_data.return_value = output_instance
+            yield output_instance
+
+    @pytest.fixture
+    def check_output(self):
+        with mock.patch('dallinger.heroku.tools.check_output') as check_output:
+            def my_check_output(cmd):
+                if 'auth:whoami' in cmd:
+                    return 'test@example.com'
+                elif 'config:get' in cmd:
+                    if 'CREATOR' in cmd and 'dlgr-my-uid' in cmd:
+                        return 'test@example.com'
+                    elif 'DALLINGER_UID' in cmd:
+                        return cmd[-1].replace('dlgr-', '')
+                    return ''
+                elif 'apps' in cmd:
+                    return '''[
+    {"name": "dlgr-my-uid",
+     "created_at": "2018-01-01T12:00Z",
+     "web_url": "https://dlgr-my-uid.herokuapp.com"},
+    {"name": "dlgr-another-uid",
+     "created_at": "2018-01-02T00:00Z",
+     "web_url": "https://dlgr-another-uid.herokuapp.com"}
+]'''
+            check_output.side_effect = my_check_output
+            yield check_output
+
+    @pytest.fixture
+    def tabulate(self):
+        with mock.patch('tabulate.tabulate') as tabulate:
+            yield tabulate
+
+    @pytest.fixture
+    def apps(self):
+        from dallinger.command_line import apps
+        return apps
+
+    def test_apps(self, apps, check_output, console_output,
+                  tabulate, active_config):
+        active_config['team'] = u'fake team'
+        result = CliRunner().invoke(apps)
+        assert result.exit_code == 0
+        check_output.assert_has_calls([
+            mock.call(['heroku', 'auth:whoami']),
+            mock.call(['heroku', 'apps', '--json', '--org', 'fake team']),
+            mock.call(['heroku', 'config:get', 'CREATOR', '--app', 'dlgr-my-uid']),
+            mock.call(['heroku', 'config:get', 'DALLINGER_UID', '--app', 'dlgr-my-uid']),
+            mock.call(['heroku', 'config:get', 'CREATOR', '--app', 'dlgr-another-uid']),
+            mock.call(['heroku', 'auth:whoami'])
+        ])
+        tabulate.assert_called_with(
+            [['my-uid', '2018-01-01T12:00Z', 'https://dlgr-my-uid.herokuapp.com']],
+            ['UID', 'Started', 'URL'], tablefmt=u'psql'
+        )

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -286,15 +286,13 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
 
     def test_sets_app_properties(self, dsss, heroku_mock):
         dsss(log=mock.Mock())
-        heroku_mock.set.assert_has_calls([
-            mock.call('auto_recruit', True),
-            mock.call('aws_access_key_id', u'fake aws key'),
-            mock.call('aws_region', u'us-east-1'),
-            mock.call('aws_secret_access_key', u'fake aws secret'),
-            mock.call('smtp_password', u'fake email password'),
-            mock.call('smtp_username', u'fake email username'),
-            mock.call('whimsical', True),
-        ])
+        heroku_mock.set_multiple.assert_called_once_with(
+            auto_recruit=True, aws_access_key_id=u'fake aws key',
+            aws_region=u'us-east-1',
+            aws_secret_access_key=u'fake aws secret',
+            smtp_password=u'fake email password',
+            smtp_username=u'fake email username', whimsical=True
+        )
 
     def test_scales_dynos(self, dsss, heroku_mock):
         dsss(log=mock.Mock())

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -413,7 +413,7 @@ class TestHerokuApp(object):
         assert app.dashboard_url == u'https://dashboard.heroku.com/apps/dlgr-fake-uid'
 
     def test_bootstrap_creates_app_with_team(self, app, check_call, check_output):
-        check_output.side_effect = lambda cmd, **kw: 'test@example.com'
+        check_output.return_value = 'test@example.com'
         app.team = 'some-team'
         app.bootstrap()
         check_call.assert_has_calls([
@@ -422,8 +422,8 @@ class TestHerokuApp(object):
                        '--org', 'some-team'], stdout=None),
         ])
 
-    def test_bootstrap_sets_hostname(self, app, check_call, check_output):
-        check_output.side_effect = lambda cmd, **kw: 'test@example.com'
+    def test_bootstrap_sets_variables(self, app, check_call, check_output):
+        check_output.return_value = 'test@example.com'
         app.team = 'some-team'
         app.bootstrap()
         check_call.assert_called_with(
@@ -806,7 +806,14 @@ class TestHerokuInfo(object):
         custom_app_output.assert_has_calls([
             mock.call(['heroku', 'apps', '--json', '--org', 'fake team'])
         ])
-        assert len(app_info) == 2
+        assert app_info == [
+            {'created_at': '2018-01-01T12:00Z',
+             'name': 'dlgr-my-uid',
+             'web_url': 'https://dlgr-my-uid.herokuapp.com'},
+            {'created_at': '2018-01-02T00:00Z',
+             'name': 'dlgr-another-uid',
+             'web_url': 'https://dlgr-another-uid.herokuapp.com'}
+        ]
 
     def test_my_apps(self, info, custom_app_output):
         app_info = info.my_apps()
@@ -817,5 +824,9 @@ class TestHerokuInfo(object):
             mock.call(['heroku', 'config:get', 'DALLINGER_UID', '--app', 'dlgr-my-uid']),
             mock.call(['heroku', 'config:get', 'CREATOR', '--app', 'dlgr-another-uid'])
         ])
-        assert len(app_info) == 1
-        assert app_info[0]['dallinger_uid'] == 'my-uid'
+        assert app_info == [
+            {'created_at': '2018-01-01T12:00Z',
+             'dallinger_uid': 'my-uid',
+             'name': 'dlgr-my-uid',
+             'web_url': 'https://dlgr-my-uid.herokuapp.com'}
+        ]

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -798,15 +798,15 @@ class TestHerokuInfo(object):
     def custom_output(self, check_output):
         def my_check_output(cmd):
             if 'auth:whoami' in cmd:
-                return 'test@example.com'
+                return b'test@example.com'
             elif 'config:get' in cmd:
                 if 'CREATOR' in cmd and 'dlgr-my-uid' in cmd:
-                    return 'test@example.com'
+                    return b'test@example.com'
                 elif 'DALLINGER_UID' in cmd:
                     return cmd[-1].replace('dlgr-', '')
-                return ''
+                return b''
             elif 'apps' in cmd:
-                return '''[
+                return b'''[
     {"name": "dlgr-my-uid",
      "created_at": "2018-01-01T12:00Z",
      "web_url": "https://dlgr-my-uid.herokuapp.com"},

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -412,7 +412,8 @@ class TestHerokuApp(object):
     def test_dashboard_url(self, app):
         assert app.dashboard_url == u'https://dashboard.heroku.com/apps/dlgr-fake-uid'
 
-    def test_bootstrap_creates_app_with_team(self, app, check_call):
+    def test_bootstrap_creates_app_with_team(self, app, check_call, check_output):
+        check_output.side_effect = lambda cmd, **kw: 'test@example.com'
         app.team = 'some-team'
         app.bootstrap()
         check_call.assert_has_calls([
@@ -422,7 +423,7 @@ class TestHerokuApp(object):
         ])
 
     def test_bootstrap_sets_hostname(self, app, check_call, check_output):
-        check_output.side_effect = lambda *args, **kw: 'test@example.com'
+        check_output.side_effect = lambda cmd, **kw: 'test@example.com'
         app.team = 'some-team'
         app.bootstrap()
         check_call.assert_called_with(

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -421,14 +421,17 @@ class TestHerokuApp(object):
                        '--org', 'some-team'], stdout=None),
         ])
 
-    def test_bootstrap_sets_hostname(self, app, check_call):
+    def test_bootstrap_sets_hostname(self, app, check_call, check_output):
+        check_output.side_effect = lambda *args, **kw: 'test@example.com'
         app.team = 'some-team'
         app.bootstrap()
-        check_call.assert_has_calls([
-            mock.call(['heroku', 'config:set',
-                       'HOST=https://dlgr-fake-uid.herokuapp.com',
-                       '--app', 'dlgr-fake-uid'], stdout=None)
-        ])
+        check_call.assert_called_with(
+            ['heroku', 'config:set',
+             'CREATOR=test@example.com',
+             'DALLINGER_UID=fake-uid',
+             'HOST=https://dlgr-fake-uid.herokuapp.com',
+             '--app', 'dlgr-fake-uid'], stdout=None
+        )
 
     def test_addon(self, app, check_call):
         app.addon('some-fake-addon')
@@ -620,6 +623,20 @@ class TestHerokuApp(object):
             stdout=None
         )
 
+    def test_set_multiple(self, app, check_call):
+        app.set_multiple(key1='some value', key2='another value')
+        check_call.assert_called_once_with(
+            [
+                "heroku",
+                "config:set",
+                "key1='some value'",
+                "key2='another value'",
+                "--app",
+                app.name,
+            ],
+            stdout=None
+        )
+
     def test_set_called_with_nonsensitive_key_uses_stdoutput(self, app, check_call):
         app.set('some_nonsensitive_key', 'some value')
         assert check_call.call_args_list[0][-1]['stdout'] is app.out
@@ -766,3 +783,62 @@ class TestHerokuLocalWrapper(object):
         with HerokuLocalWrapper(config, output, env=env) as heroku:
             assert heroku.is_running
         assert not heroku.is_running
+
+
+class TestHerokuInfo(object):
+
+    @pytest.fixture
+    def info(self):
+
+        from dallinger.heroku.tools import HerokuInfo
+        yield HerokuInfo(team="fake team")
+
+    @pytest.fixture
+    def custom_output(self, check_output):
+        def my_check_output(cmd):
+            if 'auth:whoami' in cmd:
+                return 'test@example.com'
+            elif 'config:get' in cmd:
+                if 'CREATOR' in cmd and 'dlgr-my-uid' in cmd:
+                    return 'test@example.com'
+                elif 'DALLINGER_UID' in cmd:
+                    return cmd[-1].replace('dlgr-', '')
+                return ''
+            elif 'apps' in cmd:
+                return '''[
+    {"name": "dlgr-my-uid",
+     "created_at": "2018-01-01T12:00Z",
+     "web_url": "https://dlgr-my-uid.herokuapp.com"},
+    {"name": "dlgr-another-uid",
+     "created_at": "2018-01-02T00:00Z",
+     "web_url": "https://dlgr-another-uid.herokuapp.com"}
+]'''
+
+        check_output.side_effect = my_check_output
+        yield check_output
+
+    def test_login_name(self, info, custom_output):
+        login_name = info.login_name()
+        custom_output.assert_has_calls([
+            mock.call(['heroku', 'auth:whoami'])
+        ])
+        assert login_name == 'test@example.com'
+
+    def test_all_apps(self, info, custom_output):
+        app_info = info.all_apps()
+        custom_output.assert_has_calls([
+            mock.call(['heroku', 'apps', '--json', '--org', 'fake team'])
+        ])
+        assert len(app_info) == 2
+
+    def test_my_apps(self, info, custom_output):
+        app_info = info.my_apps()
+        custom_output.assert_has_calls([
+            mock.call(['heroku', 'auth:whoami']),
+            mock.call(['heroku', 'apps', '--json', '--org', 'fake team']),
+            mock.call(['heroku', 'config:get', 'CREATOR', '--app', 'dlgr-my-uid']),
+            mock.call(['heroku', 'config:get', 'DALLINGER_UID', '--app', 'dlgr-my-uid']),
+            mock.call(['heroku', 'config:get', 'CREATOR', '--app', 'dlgr-another-uid'])
+        ])
+        assert len(app_info) == 1
+        assert app_info[0]['dallinger_uid'] == 'my-uid'


### PR DESCRIPTION
## Description
Implements a `dallinger apps` command to list all currently running experiment started by the current heroku user. Relies on setting heroku config variables with the current username and full dallinger experiment UID on experiment startup. As a result it will only work for experiments started using this updated code. This PR also includes documentation updates for to include this command as well as other undocumented commands.

## Motivation and Context
This is an implementation of [ScrumDo story 387](https://app.scrumdo.com/projects/story_permalink/1645295). It make it easier for people to find and destroy long running apps.

## How Has This Been Tested?
This PR includes automated tests of all new methods and commands. In addition, I manually tested the command by starting sandbox apps and verifying that they were listed by the command.
