### PR TITLE
Expire hits before destroying application

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -474,7 +474,7 @@ def hits(app, sandbox):
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 @click.option('--sandbox', is_flag=True, flag_value=True,
               help='Is the app running in the sandbox?')
-def expire(app, sandbox):
+def expire(app, sandbox, exit=True):
     """Expire hits for an experiment id."""
     success = []
     failures = []
@@ -501,7 +501,7 @@ def expire(app, sandbox):
                 'If this experiment was run in the MTurk sandbox, use: '
                 '`dallinger expire --sandbox --app {}`'.format(app)
             )
-    if not success:
+    if exit and not success:
         sys.exit(1)
 
 
@@ -509,17 +509,17 @@ def expire(app, sandbox):
 @click.option('--app', default=None, callback=verify_id, help='Experiment id')
 @click.confirmation_option(prompt='Are you sure you want to destroy the app?')
 @click.option(
-    '--expire-hit', is_flag=True, flag_value=True,
-    prompt='Would you like to expire all hits associated with this experiment id?',
-    help='Expire any hits associated with this experiment.')
+    '--expire-hit/--no-expire-hit', flag_value=True, default=True,
+    prompt='Would you like to expire all MTurk HITs associated with this experiment id?',
+    help='Expire any MTurk HITs associated with this experiment.')
 @click.option('--sandbox', is_flag=True, flag_value=True,
               help='Is the app running in the sandbox?')
 @click.pass_context
 def destroy(ctx, app, expire_hit, sandbox):
     """Tear down an experiment server."""
-    HerokuApp(app).destroy()
     if expire_hit:
-        ctx.invoke(expire, app=app, sandbox=sandbox)
+        ctx.invoke(expire, app=app, sandbox=sandbox, exit=False)
+    HerokuApp(app).destroy()
 
 
 @dallinger.command()

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -101,9 +101,10 @@ destroy
 
 Tear down an experiment server. A required ``--app <app>`` parameter
 specifies the experiment by its id. Optional ``--expire-hit`` flag
-can be provided to force expiration of MTurk hits associated with the
-app. If app is sandboxed, you will need to use the ``--sandbox`` flag
-to expire HITs from the MTurk sandbox.
+can be provided to force expiration of MTurk HITs associated with the
+app (``--no-expire-hit`` can be used to disable HIT expiration). If app
+is sandboxed, you will need to use the ``--sandbox`` flag to expire HITs
+from the MTurk sandbox.
 
 hits
 ^^^^

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -695,6 +695,16 @@ class TestDestroy(object):
         mturk_instance.get_hits.assert_called_once()
         mturk_instance.expire_hit.assert_called()
 
+    def test_destroy_no_expire_hits(self, destroy, heroku, mturk):
+        CliRunner().invoke(
+            destroy,
+            ['--app', 'some-app-uid', '--yes', '--no-expire-hit']
+        )
+        heroku.destroy.assert_called_once()
+        mturk_instance = mturk.return_value
+        mturk_instance.get_hits.not_called()
+        mturk_instance.expire_hit.not_called()
+
     def test_requires_confirmation(self, destroy, heroku):
         CliRunner().invoke(
             destroy,


### PR DESCRIPTION
## Description
Changes default for `destroy` command to automatically attempt to expire any HITs for the app.  Updates order of existing operations in `destroy` command to ensure HIT expiry happens before Heroku app destruction. Adds a `--no-expire-hit` flag to disable HIT expiry explicitly.

The implementation is for MTurk recruiters only. It is not aware of other recruiters. It is also not aware of which recruiter was used for the requested app id, it simply assumes MTurk for any request that wants to expire HITs.

Ideally the Recruiter class itself would manage expiring recruitment, but the command line isn't aware of recruiter configuration nor can it interact with a recruiter directly. Ideally, the command line would attempt to securely contact an experiment route that instruct the recruiter to complete recruitment, in order to allow different recruiters to implement different strategies for completing recruitment. Even if such a solution were in place, a naive command line solution like the one here would probably still be necessary for cases where the application server is not available or working.

## Motivation and Context
This attempts to address the concerns expressed in [ScrumDo Story #394](https://app.scrumdo.com/projects/story_permalink/1658910). It should help avoid situations where an app is shut down with live HITs still running.

## How Has This Been Tested?
An additional automated test was added to test the new ``--no-expire-hit`` flag. The command was run manually with various options.
