### PR TITLE
Fix PyPI deploys from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -62,12 +62,12 @@ before_deploy:
 deploy:
   - provider: pypi  # production pypi
     distributions: sdist
-    server: https://pypi.org/
+    server: https://upload.pypi.org/legacy/
     user: "suchow"
     password:
       secure: "A8nIC9tLyVV1X5020JbJwpBCSS7kQvuXP2pLIgu40CPB/ZfU3OOC5IyjfFWypIP/CCExM8o6Spb5UJccgLLUy7OLGMPaO/8Ne7BCyh75uvav5iX4KlP/j8eWih+CPGWPhO4pYsXnzpGi+GSQnwmhxdoPmllUbyLvmppsfI+vBf9pYGRpF8BgjIt0S3ffYRh030S6jFSQ1HCEz/JDIaHn4eh+nn/squVXKHMbejR8IaMnVc+Xus8mT7yzQhdIWn/jCV7GCq1uvBU1Jieh9lR18ohwT3FE51rnPZvVEGUmW0JaWmVYjwKRevXPfS9gbDSGBOAwMypVk5lPSoJlXhUpfuUEEbWvl/XpO+B9C3VGgtFSR3R+9zN7Vhg89FkVjxBIEVV6t5p+7RRtKYkyp08T9B72wzwG8Xq2XMFNb9/w1hJsx5YuZZVLQOHJlae64jstJOzAiQUXN0ZAsSU6lyH2MXJPLhgqc8Lfd05/5swnkrbj/PxchawbwwnmLps9DlyVVcxH8XdW3n8NYU4tzc+2NwM0/+AMhQQ7hQ5YTz1YSDiHNUTmFqFoawUzeDUT+5NDfy+DYk8SkIj8i6gWsEES1fPkckTvsuKrJUEy781Ff5dl/nb8xsX8UC3DhcEqYkYkr+3bgmKydMCOGGB9k+/2/p0AS67Rmu+/Vs5op6jGhp8="
     on:
       branch: master
       tags: true
-      condition: $TRAVIS_PYTHON_VERSION = "3.6"
+      condition: $TOXENV = "py36"
     skip_cleanup: true


### PR DESCRIPTION
## Description
Update the PyPI upload url and the deploy conditions to ensure pushing a git tag will cause one successful deploy to travis. It's important that tags be pushed as they are created, because a `git push --tags` with more than three tags will not trigger builds (see https://github.com/travis-ci/travis-ci/issues/9690).

## Motivation and Context
See [ScrumDo Story #391](https://app.scrumdo.com/projects/story_permalink/1658253)

## How Has This Been Tested?
This change was cherry-picked into the v4.0.0 tag which was re-pushed to the origin. That successfully triggered a single deploy resulting in a [successful release](https://pypi.org/project/dallinger/4.0.0/).
