### PR TITLE
Story 389: Don't grant MTurk Qualifications to over-recruited participants

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -805,6 +805,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     # Count working or beyond participants.
     nonfailed_count = models.Participant.query.filter(
         (models.Participant.status == "working") |
+        (models.Participant.status == "overrecruited") |
         (models.Participant.status == "submitted") |
         (models.Participant.status == "approved")
     ).count() + 1
@@ -824,21 +825,24 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
         mode=mode,
         fingerprint_hash=fingerprint_hash,
     )
-    session.add(participant)
-    session.flush()  # Make sure we know the id for the new row
-    result = {
-        'participant': participant.__json__()
-    }
 
     exp = Experiment(session)
 
     # Ping back to the recruiter that one of their participants has joined:
     recruiter.notify_recruited(participant)
     overrecruited = exp.is_overrecruited(nonfailed_count)
-    if not overrecruited:
+    if overrecruited:
+        participant.status = 'overrecruited'
+    else:
         # We either had no quorum or we have not overrecruited, inform the
         # recruiter that this participant will be seeing the experiment
         recruiter.notify_using(participant)
+
+    session.add(participant)
+    session.flush()  # Make sure we know the id for the new row
+    result = {
+        'participant': participant.__json__()
+    }
 
     # Queue notification to others in waiting room
     if exp.quorum:
@@ -1603,7 +1607,7 @@ def _worker_complete(participant_id):
     session.add(participant)
     session.commit()
 
-    # let recruiter know when completed, for possible qualification assignment, etc.
+    # Notify recruiter for possible qualification assignment, etc.
     participant.recruiter.notify_completed(participant)
 
     event_type = participant.recruiter.submitted_event()
@@ -1648,6 +1652,7 @@ def _worker_failed(participant_id):
     participant.end_time = datetime.now()
     session.add(participant)
     session.commit()
+    # TODO: Recruiter.rejected_event/failed_event (replace conditional w/ polymorphism)
     if participant.recruiter_id == 'bots':
         _handle_worker_event(
             assignment_id=participant.assignment_id,

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -834,7 +834,6 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
 
     # Ping back to the recruiter that one of their participants has joined:
     recruiter.notify_recruited(participant)
-
     overrecruited = exp.is_overrecruited(nonfailed_count)
     if not overrecruited:
         # We either had no quorum or we have not overrecruited, inform the
@@ -1604,7 +1603,7 @@ def _worker_complete(participant_id):
     session.add(participant)
     session.commit()
 
-    # let recruiter know when completed, for qualification assignment
+    # let recruiter know when completed, for possible qualification assignment, etc.
     participant.recruiter.notify_completed(participant)
 
     event_type = participant.recruiter.submitted_event()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -828,15 +828,9 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
 
     exp = Experiment(session)
 
-    # Ping back to the recruiter that one of their participants has joined:
-    recruiter.notify_recruited(participant)
     overrecruited = exp.is_overrecruited(nonfailed_count)
     if overrecruited:
         participant.status = 'overrecruited'
-    else:
-        # We either had no quorum or we have not overrecruited, inform the
-        # recruiter that this participant will be seeing the experiment
-        recruiter.notify_using(participant)
 
     session.add(participant)
     session.flush()  # Make sure we know the id for the new row

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -65,7 +65,7 @@ class AssignmentSubmitted(WorkerEvent):
     min_real_bonus = 0.01
 
     def __call__(self):
-        if self.participant.status not in ["working", "returned", "abandoned"]:
+        if not self.is_eligible(self.participant):
             return
 
         self.update_particant_end_time()
@@ -95,6 +95,10 @@ class AssignmentSubmitted(WorkerEvent):
         else:
             self.fail_submission()
             self.experiment.recruiter.recruit(n=1)
+
+    def is_eligible(self, particpant):
+        eligible_statuses = ("working", "overrecruited", "returned", "abandoned")
+        return particpant.status in eligible_statuses
 
     def data_is_ok(self):
         """Run a check on our participant's data"""

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -133,6 +133,7 @@ class Participant(Base, SharedMixin):
     status = Column(
         Enum(
             "working",
+            "overrecruited",
             "submitted",
             "approved",
             "rejected",

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -353,8 +353,12 @@ class MTurkRecruiter(Recruiter):
     def notify_completed(self, participant):
         """Assign a Qualification to the Participant for the experiment ID,
         and for the configured group_name, if it's been set.
+
+        Overrecruited participants don't receive qualifications, since they
+        haven't actually completed the experiment. This allows them to remain
+        eligible for future runs.
         """
-        if not self.config.get('assign_qualifications'):
+        if participant.status == 'overrecruited' or not self.qualification_active:
             return
 
         worker_id = participant.worker_id
@@ -397,6 +401,10 @@ class MTurkRecruiter(Recruiter):
     @property
     def is_in_progress(self):
         return bool(Participant.query.first())
+
+    @property
+    def qualification_active(self):
+        return bool(self.config.get('assign_qualifications', False))
 
     def current_hit_id(self):
         any_participant_record = Participant.query.with_entities(

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -75,18 +75,6 @@ class Recruiter(object):
         """Throw an error."""
         raise NotImplementedError
 
-    def notify_recruited(self, participant):
-        """Allow the Recruiter to be notified when an recruited Participant
-        has joined an experiment.
-        """
-        pass
-
-    def notify_using(self, participant):
-        """Allow the Recruiter to be notified when a recruited Participant
-        has been chosen to participate in an experiment they joined.
-        """
-        pass
-
     def notify_completed(self, participant):
         """Allow the Recruiter to be notified when a recruited Participant
         has completed an experiment they joined.

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -611,6 +611,19 @@ class TestParticipantRoute(object):
         args, _ = recruiter.notify_using.call_args
         assert isinstance(args[0], Participant)
 
+    def test_sets_status_when_participant_is_overrecruited(
+        self, webapp, overrecruited, recruiter
+    ):
+        worker_id = '1'
+        hit_id = '1'
+        assignment_id = '1'
+        resp = webapp.post('/participant/{}/{}/{}/debug'.format(
+            worker_id, hit_id, assignment_id
+        ))
+        data = json.loads(resp.data.decode('utf8'))
+
+        assert data.get('participant').get('status') == u'overrecruited'
+
     def test_does_not_notify_recruiter_when_participant_is_overrecruited(
         self, webapp, overrecruited, recruiter
     ):
@@ -1431,6 +1444,11 @@ class TestAssignmentSubmitted(object):
         assert runner.participant.base_pay == 1.0
 
     def test_participant_status_set(self, runner):
+        runner()
+        assert runner.participant.status == 'approved'
+
+    def test_approves_overrecruited_participants(self, runner):
+        runner.participant.status = 'overrecruited'
         runner()
         assert runner.participant.status == 'approved'
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -89,14 +89,6 @@ class TestRecruiter(object):
         with pytest.raises(NotImplementedError):
             recruiter.reward_bonus('any assignment id', 0.01, "You're great!")
 
-    def test_notify_recruited(self, recruiter):
-        dummy = mock.NonCallableMock()
-        recruiter.notify_recruited(participant=dummy)
-
-    def test_notify_using(self, recruiter):
-        dummy = mock.NonCallableMock()
-        recruiter.notify_using(participant=dummy)
-
     def test_external_submission_url(self, recruiter):
         assert recruiter.external_submission_url is None
 


### PR DESCRIPTION
## Description
Prevent MTurk workers who are over-recruited for an experiment from receiving any configured qualifications. 

## Motivation and Context
Addresses issue #1270 

## How Has This Been Tested?
* automated tests 
* testing in debug mode to verify succession of participant status values and overall flow
* **I could use help with sandbox testing**

## Overview of Participant Lifecycles
(Difference in bold)

### Utilized MTurk Participants

1. Participant created with status of `working`
2. proceeds from waiting room to experiment and completes experiment
3. Submits questionnaire, which triggers a call to `/worker_complete` route
4. **Recruiter receives `notify_completed()` message, and based on the Participant status being other than `overrecruited`, requests MTurk qualifications**
5. No `AssignmentSubmitted` event is immediately processed, because the `MTurkRecruiter` returns `None` from `submitted_event()`
6. Worker submits HIT on MTurk, and `/notification` route is called
7. `AssignmentSubmitted` event is processed, triggering payments, running data/attention checks, etc., and `status` is updated based on experiment policies

### Overrecruited MTurk Participants

1. Participant created with status of `working`, **but immediately updated to `overrecruited` based on return value of `Experiment.is_overrecruited(nonfailed_count)`**
2. After completing `/ad` and `/instructions`, sent to over-recruitment explanation, where they submit a call to `/worker_complete`
3. **Recruiter receives `notify_completed()` message, and based on the Participant status being `overrecruited`, no MTurk qualifications are requested**
4. No `AssignmentSubmitted` event is immediately processed, because the `MTurkRecruiter` returns `None` from `submitted_event()`
5. Worker submits HIT on MTurk, and `/notification` route is called
6. `AssignmentSubmitted` event is processed, triggering payments, running data/attention checks, etc., and `status` is updated based on experiment policies

