### PR TITLE
Fail early on heroku misconfiguration

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -214,6 +214,7 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, remaining=RETRIES):
 
     return launch_data
 
+
 def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     """Set up Git, push to Heroku, and launch the app."""
     if verbose:

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -214,18 +214,6 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, remaining=RETRIES):
 
     return launch_data
 
-
-def heroku_config_sanity_check(config):
-    # check if dyno size is compatible with team configuration.
-    size = config.get('dyno_type').strip() or None
-    team = config.get('heroku_team').strip() or None
-    if team and size == 'free':
-        raise RuntimeError('Heroku "free" dyno type not compatible '
-                           'with team/org deployment. Please use a '
-                           'different "dyno_type" or unset the '
-                           '"heroku_team" configuration.')
-
-
 def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     """Set up Git, push to Heroku, and launch the app."""
     if verbose:
@@ -236,7 +224,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     config = get_config()
     if not config.ready:
         config.load()
-    heroku_config_sanity_check(config)
+    heroku.sanity_check(config)
 
     (id, tmp) = setup_experiment(log, debug=False, app=app, exp_config=exp_config)
 

--- a/dallinger/heroku/__init__.py
+++ b/dallinger/heroku/__init__.py
@@ -4,10 +4,12 @@ from .tools import (
     app_name,
     auth_token,
     log_in,
+    sanity_check,
 )
 
 __all__ = (
     "app_name",
     "auth_token",
     "log_in",
+    "sanity_check",
 )

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -516,3 +516,14 @@ class HerokuLocalWrapper(object):
         return "<{} pid='{}', children: {}>".format(
             classname, self._process.pid, reprs
         )
+
+
+def sanity_check(config):
+    # check if dyno size is compatible with team configuration.
+    size = config.get('dyno_type').strip() or None
+    team = config.get('heroku_team').strip() or None
+    if team and size == 'free':
+        raise RuntimeError('Heroku "free" dyno type not compatible '
+                           'with team/org deployment. Please use a '
+                           'different "dyno_type" or unset the '
+                           '"heroku_team" configuration.')

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -307,13 +307,13 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=log)
         launch.assert_called_once_with('fake-url/launch', error=log)
 
-    def test_fails_fast_on_bad_config(self, dsss, active_config):
+    def test_heroku_sanity_check(self, dsss, active_config):
         log = mock.Mock()
         active_config.set('heroku_team', u'my_team')
         active_config.set('dyno_type', u'free')
-        with pytest.raises(RuntimeError) as exc_info:
+        with pytest.raises(RuntimeError) as excinfo:
             dsss(log=log)
-        assert 'dyno type not compatible' in str(exc_info)
+        assert excinfo.match('dyno type not compatible')
 
 
 @pytest.mark.skipif(not pytest.config.getvalue("heroku"),

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -307,13 +307,12 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=log)
         launch.assert_called_once_with('fake-url/launch', error=log)
 
-    def test_heroku_sanity_check(self, dsss, active_config):
+    def test_heroku_sanity_check(self, dsss, heroku_mock, active_config):
         log = mock.Mock()
-        active_config.set('heroku_team', u'my_team')
-        active_config.set('dyno_type', u'free')
-        with pytest.raises(RuntimeError) as excinfo:
-            dsss(log=log)
-        assert excinfo.match('dyno type not compatible')
+        dsss(log=log)
+        # Get the patched heroku module
+        from dallinger.deployment import heroku
+        heroku.sanity_check.assert_called_once_with(active_config)
 
 
 @pytest.mark.skipif(not pytest.config.getvalue("heroku"),

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -307,6 +307,14 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=log)
         launch.assert_called_once_with('fake-url/launch', error=log)
 
+    def test_fails_fast_on_bad_config(self, dsss, active_config):
+        log = mock.Mock()
+        active_config.set('heroku_team', u'my_team')
+        active_config.set('dyno_type', u'free')
+        with pytest.raises(RuntimeError) as exc_info:
+            dsss(log=log)
+        assert 'dyno type not compatible' in str(exc_info)
+
 
 @pytest.mark.skipif(not pytest.config.getvalue("heroku"),
                     reason="--heroku was not specified")

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -374,6 +374,15 @@ class TestHerokuUtilFunctions(object):
             heroku.log_in()
         assert excinfo.match('You are not logged into Heroku.')
 
+    def test_sanity_check(self, heroku, active_config):
+        assert heroku.sanity_check(active_config) is None
+
+        active_config.set('heroku_team', u'my_team')
+        active_config.set('dyno_type', u'free')
+        with pytest.raises(RuntimeError) as excinfo:
+            heroku.sanity_check(active_config)
+        assert excinfo.match('dyno type not compatible')
+
 
 class TestHerokuApp(object):
 


### PR DESCRIPTION
## Description
Raises a `RuntimeError` early in sandbox or deploy runs when dyno type `free` is combined with a heroku team. The new `heroku_config_sanity_check()` function can be extended to handle other known misconfigurations.

## Motivation and Context
See [ScrumDo Story #393](https://app.scrumdo.com/projects/story_permalink/1658255). Ensures failure due to common misconfiguration happens quickly to avoid user frustration.

## How Has This Been Tested?
Branch includes new automated test.
