### PR TITLE
Close connections no longer being used

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -181,7 +181,7 @@ def copy_db_to_csv(dsn, path, scrub_pii=False):
         with open(csv_path, "w") as f:
             sql = "COPY {} TO STDOUT WITH CSV HEADER".format(table)
             cur.copy_expert(sql, f)
-
+    conn.close()
     if scrub_pii:
         _scrub_participant_table(path)
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -701,6 +701,7 @@ class Experiment(object):
             conn = create_db_engine.connect()
             conn.execute('COMMIT;')
             conn.execute('CREATE DATABASE "{}"'.format(specific_db_url.rsplit('/', 1)[1]))
+            conn.close()
             import_engine = create_engine(
                 specific_db_url
             )


### PR DESCRIPTION
## Description
This prevents leaked connetions, which would prevent future
calls that need to lock the whole database, such as dropdb
during Griduniverse's tests.

## Motivation and Context
It is hoped that this will improve test reliability in Griduniverse, as they currently fail most of the time on Travis.

## How Has This Been Tested?
Using tox on Griduniverse with test order randomisation and a fixed seed that reliably triggers the same exception as on travis.