### PR TITLE
Story 345: Change postgres status check to be more context agnostic

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -56,14 +56,10 @@ def check_connection():
     """Test that postgres is running and that we can connect using the
     configured URI.
 
-    Returns None if successfuly, and re-raises the DB exception on failure.
+    Raises a psycopg2.OperationalError on failure.
     """
-    try:
-        conn = psycopg2.connect(db_url)
-    except psycopg2.OperationalError:
-        raise
-    else:
-        conn.close()
+    conn = psycopg2.connect(db_url)
+    conn.close()
 
 
 @contextmanager

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -4,6 +4,7 @@ from contextlib import contextmanager
 from functools import wraps
 import logging
 import os
+import psycopg2
 import sys
 
 from psycopg2.extensions import TransactionRollbackError
@@ -49,6 +50,20 @@ Consult the developer guide for more information.
 *********************************************************
 
 """
+
+
+def check_connection():
+    """Test that postgres is running and that we can connect using the
+    configured URI.
+
+    Returns None if successfuly, and re-raises the DB exception on failure.
+    """
+    try:
+        conn = psycopg2.connect(db_url)
+    except psycopg2.OperationalError:
+        raise
+    else:
+        conn.close()
 
 
 @contextmanager

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -1,6 +1,5 @@
 import os
 import pkg_resources
-import psycopg2
 import re
 import redis
 import requests
@@ -51,12 +50,10 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
     """Check the app and, if compatible with Dallinger, freeze its state."""
     # Verify that the Postgres server is running.
     try:
-        conn = psycopg2.connect(db.db_url)
-    except psycopg2.OperationalError:
+        db.check_connection()
+    except Exception:
         log("There was a problem connecting to the Postgres database!")
         raise
-    else:
-        conn.close()
 
     # Load configuration.
     config = get_config()

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -51,10 +51,12 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
     """Check the app and, if compatible with Dallinger, freeze its state."""
     # Verify that the Postgres server is running.
     try:
-        psycopg2.connect(database="x", user="postgres", password="nada")
-    except psycopg2.OperationalError as e:
-        if "could not connect to server" in str(e):
-            raise RuntimeError("The Postgres server isn't running.")
+        conn = psycopg2.connect(db.db_url)
+    except psycopg2.OperationalError:
+        log("There was a problem connecting to the Postgres database!")
+        raise
+    else:
+        conn.close()
 
     # Load configuration.
     config = get_config()


### PR DESCRIPTION
## Description
Don't make assumptions about how postgres is running when testing connection in experiment setup.

## Motivation and Context
When running inside a Docker container, the check of whether postgresql is running fails spuriously due to hard-coding connection parameters which don't work in Docker. This PR inverts the check from trying to raise an expected failure using bad credentials to simply using the configured `db_uri` from `dallinger.db` and attempting to make a successful connection, which is then immediately dropped if it succeeds. 

As an added benefit, the original psycopg2.OperationalError is re-raised to provide more detail than a generic RuntimeError.

## How Has This Been Tested?
* Automated tests
* Manual testing with postgresql running and not, both "natively" (outside of Docker) and in a Docker container.

