### PR TITLE
Log recruiter class on initialization

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -43,7 +43,7 @@ class Recruiter(object):
         """For now, the contract of a Recruiter is that it takes no
         arguments.
         """
-        pass
+        logger.info("Initializing {}...".format(self.__class__.__name__))
 
     def __call__(self):
         """For backward compatibility with experiments invoking recruiter()
@@ -484,7 +484,6 @@ class BotRecruiter(Recruiter):
     def __init__(self):
         super(BotRecruiter, self).__init__()
         self.config = get_config()
-        logger.info("Initialized BotRecruiter.")
 
     def open_recruitment(self, n=1):
         """Start recruiting right away."""
@@ -549,6 +548,7 @@ class MultiRecruiter(Recruiter):
     SPEC_RE = re.compile(r'(\w+):\s*(\d+)')
 
     def __init__(self):
+        super(MultiRecruiter, self).__init__()
         self.spec = self.parse_spec()
 
     def parse_spec(self):


### PR DESCRIPTION
## Description
Make all recruiters log their class name on initialization, to make it easier to track which recruiters are in use when reviewing logs. This is particularly helpful when using the MultiRecruiter.

Only the BotRecruiter does this currently.

## Motivation and Context
Confusion over recruiters encountered when helping experiment author. 

## How Has This Been Tested?
Change covered by current tests

## Screenshots (if appropriate):
```
11:18:44 AM web.2   |  >>>> ----- Launching experiment...
11:18:44 AM web.2   |  2018-08-31 11:18:44,824 Initializing HotAirRecruiter...
11:18:44 AM web.2   |  2018-08-31 11:18:44,824 Opening recruitment.
11:18:44 AM web.2   |  2018-08-31 11:18:44,824 New participant requested: http://0.0.0.0:5001/ad?recruiter=hotair&assignmentId=EEAM5W&hitId=L169T9&workerId=52DK2P&mode=debug
```