### PR TITLE
Add rtd configuration

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,7 @@
+build:
+  image: latest
+
+python:
+  version: 3.6
+
+requirements_file: dev-requirements.txt


### PR DESCRIPTION
Adding this file allows RTD to set up the dependencies for the Javascript docs.

## Motivation and Context
THe RTD build was broken.

## How Has This Been Tested?
Forked the project and generated a build with this file.
