### PR TITLE
Story 396: overrecruited MTurk workers should be prompted to submit HIT

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -545,13 +545,8 @@ def advertisement():
         recruiter = recruiters.from_config(config)
         recruiter_name = recruiter.nickname
 
-    ready_for_external_submission = status == 'working' and part.end_time is not None
+    ready_for_external_submission = status in ('overrecruited', 'working') and part.end_time is not None
     assignment_complete = status in ('submitted', 'approved')
-    import logging
-    logger = logging.getLogger(__name__)
-    logger.info("Status: {}".format(status))
-    logger.info("ready_for_external_submission: {}".format(ready_for_external_submission))
-    logger.info("assignment_complete: {}".format(assignment_complete))
     if assignment_complete or ready_for_external_submission:
         # They've either done, or they're from a recruiter that requires
         # submission of an external form to complete their participation.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -544,9 +544,14 @@ def advertisement():
     else:
         recruiter = recruiters.from_config(config)
         recruiter_name = recruiter.nickname
+
     ready_for_external_submission = status == 'working' and part.end_time is not None
     assignment_complete = status in ('submitted', 'approved')
-
+    import logging
+    logger = logging.getLogger(__name__)
+    logger.info("Status: {}".format(status))
+    logger.info("ready_for_external_submission: {}".format(ready_for_external_submission))
+    logger.info("assignment_complete: {}".format(assignment_complete))
     if assignment_complete or ready_for_external_submission:
         # They've either done, or they're from a recruiter that requires
         # submission of an external form to complete their participation.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -9,7 +9,6 @@ from operator import attrgetter
 import os
 import re
 import sys
-import user_agents
 
 from flask import (
     abort,
@@ -42,6 +41,8 @@ from dallinger.heroku.messages import HITSummary
 from .replay import ReplayBackend
 from .worker_events import WorkerEvent
 from .utils import nocache
+from .utils import ValidatesBrowser
+
 
 # Initialize the Dallinger database.
 session = db.session
@@ -496,24 +497,11 @@ def advertisement():
     if not ('hitId' in request.args and 'assignmentId' in request.args):
         raise ExperimentError('hit_assign_worker_id_not_set_in_mturk')
 
-    # Browser rule validation, if configured:
-    user_agent_string = request.user_agent.string
-    user_agent_obj = user_agents.parse(user_agent_string)
-    browser_ok = True
     config = _config()
-    for rule in config.get('browser_exclude_rule', '').split(','):
-        myrule = rule.strip()
-        if myrule in ["mobile", "tablet", "touchcapable", "pc", "bot"]:
-            if (myrule == "mobile" and user_agent_obj.is_mobile) or\
-               (myrule == "tablet" and user_agent_obj.is_tablet) or\
-               (myrule == "touchcapable" and user_agent_obj.is_touch_capable) or\
-               (myrule == "pc" and user_agent_obj.is_pc) or\
-               (myrule == "bot" and user_agent_obj.is_bot):
-                browser_ok = False
-        elif myrule and myrule in user_agent_string:
-            browser_ok = False
 
-    if not browser_ok:
+    # Browser rule validation, if configured:
+    browser = ValidatesBrowser(config)
+    if not browser.is_supported(request.user_agent.string):
         raise ExperimentError('browser_type_not_allowed')
 
     hit_id = request.args['hitId']

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -1,3 +1,4 @@
+import user_agents
 from functools import update_wrapper
 from flask import make_response
 
@@ -10,3 +11,38 @@ def nocache(func):
         resp.cache_control.no_cache = True
         return resp
     return update_wrapper(new_func, func)
+
+
+class ValidatesBrowser(object):
+    """Checks if participant's browser has been excluded via the Configuration.
+    """
+    def __init__(self, config):
+        self.config = config
+
+    @property
+    def exclusions(self):
+        """Return list of browser exclusion rules defined in the Configuration.
+        """
+        exclusion_rules = [
+            r.strip() for r in self.config.get('browser_exclude_rule', '').split(',')
+            if r.strip()
+        ]
+        return exclusion_rules
+
+    def is_supported(self, user_agent_string):
+        """Check user agent against configured exclusions.
+        """
+        user_agent_obj = user_agents.parse(user_agent_string)
+        browser_ok = True
+        for rule in self.exclusions:
+            if rule in ["mobile", "tablet", "touchcapable", "pc", "bot"]:
+                if (rule == "mobile" and user_agent_obj.is_mobile) or\
+                   (rule == "tablet" and user_agent_obj.is_tablet) or\
+                   (rule == "touchcapable" and user_agent_obj.is_touch_capable) or\
+                   (rule == "pc" and user_agent_obj.is_pc) or\
+                   (rule == "bot" and user_agent_obj.is_bot):
+                    browser_ok = False
+            elif rule in user_agent_string:
+                browser_ok = False
+
+        return browser_ok

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -154,6 +154,30 @@ class TestAdvertisement(object):
         )
         assert b'action="https://www.mturk.com/mturk/externalSubmit"' in resp.data
 
+    def test_overrecruit_sees_thanks_page_in_sandbox(self, a, webapp, active_config):
+        active_config.extend({'mode': u'sandbox'})
+        p = a.participant()
+        p.end_time = datetime.now()
+        p.status = u'overrecruited'
+        resp = webapp.get(
+            '/ad?hitId={}&assignmentId={}&workerId={}'.format(
+                p.hit_id, p.assignment_id, p.worker_id
+            )
+        )
+        assert b'action="https://workersandbox.mturk.com/mturk/externalSubmit"' in resp.data
+
+    def test_overrecruit_sees_thanks_page_in_live_mode(self, a, webapp, active_config):
+        active_config.extend({'mode': u'live'})
+        p = a.participant()
+        p.end_time = datetime.now()
+        p.status = u'overrecruited'
+        resp = webapp.get(
+            '/ad?hitId={}&assignmentId={}&workerId={}'.format(
+                p.hit_id, p.assignment_id, p.worker_id
+            )
+        )
+        assert b'action="https://www.mturk.com/mturk/externalSubmit"' in resp.data
+
     @pytest.mark.skip(reason="fails pending support for different recruiters")
     def test_submitted_hit_shows_thanks_page_in_sandbox(self, a, webapp, active_config):
         active_config.extend({'mode': u'sandbox'})


### PR DESCRIPTION

## Description
Fixes https://github.com/Dallinger/Dallinger/issues/1342

## Motivation and Context
MTurk workers who are overrecruited should be shown the "thanks.html" page when then are returned to the /ad page, rather than the template for opting into an experiment run.

## How Has This Been Tested?
* Automated tests
* MTurk sandbox tests


