### PR TITLE
Better organise documentation for different users

### DIFF
--- a/docs/source/dallinger_with_anaconda.rst
+++ b/docs/source/dallinger_with_anaconda.rst
@@ -9,20 +9,16 @@ the standard instructions slightly.
 Install psycopg2
 ----------------
 
-In order to get the correct bindings, you need to install ``psycopg2``
-before you use ``requirements.txt``; otherwise, everything will fail and
-you will be endlessly frustrated.
+In order to get the correct bindings, you need to install ``psycopg2`` before
+installing Dallinger.
 
 ::
 
     conda install psycopg2
+    conda install Dallinger[data]
 
-Install Dallinger
------------------
-
-You'll follow all of the :doc:`Dallinger development installation
-instructions <developing_dallinger_setup_guide>`,
-**with the exception of the virtual environment step**.  Then return here.
+The `[data]` optional extra makes sure that all the data analysis dependencies
+are installed.
 
 Confirm Dallinger works
 -----------------------
@@ -35,7 +31,8 @@ installed by typing
 
     dallinger --version
 
-into the command line. For those of us with Anaconda, we'll get a long
+
+into the command line. You may get a long
 error message. Don't panic! Add the following to your ``.bash_profile``:
 
 ::

--- a/docs/source/demo_index.rst
+++ b/docs/source/demo_index.rst
@@ -1,0 +1,14 @@
+Dallinger Demos
+===============
+
+The demos can be run locally on your machine in "debug" mode.
+Running the demos in "sandbox" mode will require a Heroku account.
+
+More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
+
+.. toctree::
+    :maxdepth: 1
+    :caption: Demos
+    :glob:
+
+    demos/*/*

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -7,22 +7,18 @@ First, make sure you have Dallinger installed:
 -  :doc:`developing_dallinger_setup_guide`
 
 To test out Dallinger, we'll run a demo experiment in debug mode.
-Navigate to the bartlett1932 directory, found in::
 
-    /Dallinger/demos/dlgr/demos/bartlett1932
+You can read more about this experiment here:
+`Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__ and download the experiment files.
 
-and run
+Navigate to the bartlett1932 directory and run
 
 ::
 
     dallinger debug
 
-You can read more about this experiment here:
-`Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__
 
-You can also run the demo from another location in which case follow the link above to download and unzip the experiment files.
-Then run Dallinger in debug mode from within that demo directory. Make sure that the dallinger virtualenv is enabled
-so that the dallinger command is available to you from outside the core dallinger directory structure.
+Make sure that the dallinger virtualenv is enabled so that the dallinger command is available to you.
 
 You will see some output as Dallinger loads. When it is finished, you will
 see something that looks like:

--- a/docs/source/demos_on_heroku.rst
+++ b/docs/source/demos_on_heroku.rst
@@ -1,0 +1,25 @@
+Running demos on Heroku
+=======================
+
+Running the demos of Dallinger in "sandbox" mode, will require a Heroku account and verification by providing a credit card in your Heroku account.
+If you only make use of Heroku's free tier offerings, you will not be charged.
+
+Heroku states that the use of any add-on requires account verification (even free tier add-ons). Redis is a requirement for Dallinger to run and is considered by Heroku as an add-on feature.
+More information on account verification can be found `here <https://devcenter.heroku.com/articles/account-verification/>`__.
+
+If you wish to only make use of Heroku's free tier offerings, set the following in the demo's config.txt file:
+::
+
+    database_size = hobby-dev
+    redis_size = hobby-dev
+
+
+You can read more about Heroku's `Postgres Plans <https://devcenter.heroku.com/articles/heroku-postgres-plans/>`__ and
+their `Redis add-on <https://elements.heroku.com/addons/heroku-redis/>`__ offering.
+
+Also note that you may also need to set:
+::
+
+    dyno_type = hobby
+
+Read more about Heroku's `Dyno Types <https://devcenter.heroku.com/articles/dyno-types/>`__.

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -9,7 +9,7 @@ You can also install Dallinger using :doc:`Docker <docker_setup>`.
 Install Python
 --------------
 
-It recommended that you run Dallinger on Python 3. Dallinger has been tested to work on Python 3.5 and up.
+It recommended that you run Dallinger on Python 3. Dallinger has been tested to work on Python 3.6 and up.
 Dallinger also supports Python 2.7
 
 You can check what version of Python you have by running:

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -4,6 +4,8 @@ Developer Installation
 We recommend installing Dallinger on Mac OS X. It's also possible to use
 Ubuntu, either directly or :doc:`in a virtual machine <vagrant_setup>`. Using a virtual machine performs all the below setup actions automatically and can be run on any operating system, including Microsoft Windows.
 
+You can also install Dallinger using :doc:`Docker <docker_setup>`.
+
 Install Python
 --------------
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,12 +27,10 @@ and setting up Dallinger, as well as use of the command line tools.
     registration_on_OSF
     troubleshooting
 
-.. toctree::
-    :maxdepth: 1
-    :caption: Demos
-    :glob:
+Dallinger Demos
+^^^^^^^^^^^^^^^
 
-    demos/*/*
+Several demos that demonstrate Dallinger in action can be found :doc:`here <demo_index>`.
 
 
 Experiment Author Documentation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,22 +3,27 @@ Dallinger
 
 Laboratory automation for the behavioral and social sciences.
 
+User Documentation
+^^^^^^^^^^^^^^^^^^
+
+These documentation topics are intended to assist people who are attempting
+to launch experiments and analyse their data. They cover the basics of installing
+and setting up Dallinger, as well as use of the command line tools.
+
 .. toctree::
     :maxdepth: 1
-    :caption: User Documentation
 
     installing_dallinger_for_users
     dallinger_with_anaconda
     aws_etc_keys
-    demoing_dallinger
-    running_bots
-    learning_to_use_dallinger
-    monitoring_a_live_experiment
-    email_setup
-    postico_and_postgres
     command_line_utility
+    demoing_dallinger
     configuration
+    email_setup
     python_module
+    monitoring_a_live_experiment
+    postico_and_postgres
+    running_bots
     registration_on_OSF
     troubleshooting
 
@@ -29,27 +34,46 @@ Laboratory automation for the behavioral and social sciences.
 
     demos/*/*
 
+
+Experiment Author Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These documentation topics build on the previous set to include help with
+designing new experiments for others to use.
+
 .. toctree::
     :maxdepth: 1
-    :caption: Developer documentation
 
-    developing_dallinger_setup_guide
-    docker_setup
-    running_the_tests
     required_experiment_files
-    classes
     the_experiment_class
-    rewarding_participants
+    classes
     web_api
     communicating_with_the_server
     javascript_api
-    extra_configuration
+    rewarding_participants
+    waiting_rooms
     writing_bots
-    contributing_to_dallinger
+    extra_configuration
+
+Core Contribution Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+These documentation topics cover setting up a development version of Dallinger,
+in order to contribute to the development of Dallinger itself. This is not needed
+in order to develop new experiments.
 
 .. toctree::
     :maxdepth: 1
-    :caption: Miscellaneous
+    
+    developing_dallinger_setup_guide
+    running_the_tests
+    contributing_to_dallinger
+
+General Information
+^^^^^^^^^^^^^^^^^^^
+
+.. toctree::
+    :maxdepth: 1
 
     acknowledgments
     dallinger_the_scientist

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -20,7 +20,7 @@ Install Python
 --------------
 
 Dallinger is written in the language Python. For it to work, you will need
-to have Python 2.7 installed, or alternatively Python 3.5 or higher. Python 3 is the preferred option.
+to have Python 2.7 installed, or alternatively Python 3.6 or higher. Python 3 is the preferred option.
 You can check what version of Python you have by running:
 ::
 

--- a/docs/source/installing_python.rst
+++ b/docs/source/installing_python.rst
@@ -32,10 +32,12 @@ Should that not work for whatever reason, you can search `here <https://docs.pyt
 Ubuntu
 ~~~~~~
 
-Ubuntu 18.04 LTS ships with Python 3.6 while Ubuntu 16.04 LTS ships with Python 3.5. (Both also ship a version of Python 2.7)
+Ubuntu 18.04 LTS ships with Python 3.6.
 
-Ubuntu 14.04 LTS ships with Python 3.4, in case you are using this distribution of Ubuntu, you can use
+Ubuntu 16.04 LTS ships with Python 3.5, while Ubuntu 14.04 LTS ships with Python 3.4. In case you are using these distribution of Ubuntu, you can use
 dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
+
+(All three of these Ubuntu versions also provide a version of Python 2.7)
 
 If you do not have Python 3 installed, you can install it from the
 `Python website <https://www.python.org/downloads/>`__.

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -110,8 +110,8 @@ Common Sandbox Error
 If you get this from the sandbox, this usually means there's a deeper issue that requires `dallinger logs --app XXXXXX.` Usually this could be a requirements.txt file error (missing dependency or reference to an incorrect branch).
 
 
-Changes to Some Dallinger Files not Taking Effect on Experiments
-----------------------------------------------------------------
+Combining Dallinger core development and running experiments
+------------------------------------------------------------
 
 A common pitfall while doing development on the dallinger codebase while also
 working on external experiments which include dallinger as a dependency: you


### PR DESCRIPTION
## Description
Make a clear distinction between Users, Experimenters and Core Developers,
and modify a few documents to not give core dev instructions to users.

## Motivation and Context
The documentation is unclear, leaving users of Dallinger setting themselves up as core developers, creating problems as they aren't on a stable release.

## How Has This Been Tested?
Built and checked the docs by hand
