### PR TITLE
Make HighPerformanceBots set recruiter explicitly

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -225,10 +225,11 @@ class HighPerformanceBotBase(BotBase):
             url = (
                 "{host}/participant/{self.worker_id}/"
                 "{self.hit_id}/{self.assignment_id}/"
-                "debug?fingerprint_hash={hash}".format(
+                "debug?fingerprint_hash={hash}&recruiter=bot:{bot_name}".format(
                     host=self.host,
                     self=self,
-                    hash=uuid.uuid4().hex
+                    hash=uuid.uuid4().hex,
+                    bot_name=self.__class__.__name__
                 )
             )
             result = requests.post(url)

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -225,7 +225,7 @@ class HighPerformanceBotBase(BotBase):
             url = (
                 "{host}/participant/{self.worker_id}/"
                 "{self.hit_id}/{self.assignment_id}/"
-                "debug?fingerprint_hash={hash}&recruiter=bot:{bot_name}".format(
+                "debug?fingerprint_hash={hash}&recruiter=bots:{bot_name}".format(
                     host=self.host,
                     self=self,
                     hash=uuid.uuid4().hex,

--- a/dallinger/frontend/templates/base/ad.html
+++ b/dallinger/frontend/templates/base/ad.html
@@ -54,7 +54,7 @@
                     {% block ad %}
 
                     {% if (mode == "sandbox") or (mode == "debug") %}
-                        {% block sandbox_or_debug %}    
+                        {% block sandbox_or_debug %}
                             <p>
                                 <b>Application ID:</b> {{ app_id }}.
                             </p>

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -40,7 +40,8 @@ def run_check(config, mturk, participants, session, reference_time):
             assignment_id = p.assignment_id
 
             # First see if we have a bot participant
-            if p.recruiter_id == BotRecruiter.nickname:
+            if (p.recruiter_id == BotRecruiter.nickname or
+                    p.recruiter_id.startswith('bots:')):
                 # Bot somehow did not finish (phantomjs?). Just get rid of it.
                 p.status = "rejected"
                 session.commit()

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -270,7 +270,10 @@ class Participant(Base, SharedMixin):
     @property
     def recruiter(self):
         from dallinger import recruiters
-        return recruiters.by_name(self.recruiter_id or 'hotair')
+        recruiter_name = self.recruiter_id or 'hotair'
+        if recruiter_name.startswith('bots:'):
+            recruiter_name = 'bots'
+        return recruiters.by_name(recruiter_name)
 
 
 class Question(Base, SharedMixin):

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -155,7 +155,7 @@ class TestHighPerformanceBot(object):
         assert bot.subscribe_to_quorum_channel.called_once_with()
         assert req_post.called_once_with(
             'https://dallinger.io/participant/worker1/hit1/assignment1/debug?'
-            'fingerprint_hash=fakehash&recruiter=bot:HighPerformanceBotBase'
+            'fingerprint_hash=fakehash&recruiter=bots:HighPerformanceBotBase'
         )
         assert bot.participant_id == 4
 

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -1,3 +1,5 @@
+import json
+import mock
 import pytest
 from selenium import webdriver
 
@@ -94,3 +96,89 @@ class TestBots(object):
         bot = BotBase("http://dallinger.io")
         assert isinstance(bot.driver, webdriver.Remote)
         assert bot.driver.capabilities['browserName'] == 'chrome'
+
+
+class TestHighPerformanceBot(object):
+
+    @pytest.fixture
+    def bot(self):
+        config.ready = True
+        from dallinger.bots import HighPerformanceBotBase
+        bot = HighPerformanceBotBase(
+            'https://dallinger.io/ad?assignment_id=assignment1&'
+            'worker_id=worker1&participant_id=1&'
+            'hit_id=hit1&recruiter=bogus'
+        )
+        # Override sleep and quorum subscribe for testing
+        bot.stochastic_sleep = mock.Mock()
+        bot.subscribe_to_quorum_channel = mock.Mock()
+        return bot
+
+    @pytest.fixture
+    def req_post(self):
+        with mock.patch('requests.post') as patch_post:
+            yield patch_post
+
+    @pytest.fixture
+    def req_get(self):
+        with mock.patch('requests.get') as patch_get:
+            yield patch_get
+
+    @pytest.fixture
+    def fake_uuid(self):
+        with mock.patch('uuid.uuid4') as patch_uuid4:
+            patch_uuid4.hex.return_value = 'fakehash'
+            yield patch_uuid4
+
+    def test_create_bot(self, bot):
+        """Create a bot."""
+        from dallinger.bots import HighPerformanceBotBase
+        assert isinstance(bot, HighPerformanceBotBase)
+        assert bot.assignment_id == 'assignment1'
+        assert bot.participant_id == '1'
+        assert bot.hit_id == 'hit1'
+        assert bot.worker_id == 'worker1'
+        assert bot.unique_id == 'worker1:assignment1'
+
+    def test_host(self, bot):
+        assert bot.host == 'https://dallinger.io'
+
+    def test_sign_up(self, bot, req_post, fake_uuid):
+        mock_return = mock.Mock()
+        mock_return.json.return_value = {
+            "status": "OK",
+            "participant": {"id": 4}
+        }
+        req_post.return_value = mock_return
+
+        bot.sign_up()
+        assert bot.subscribe_to_quorum_channel.called_once_with()
+        assert req_post.called_once_with(
+            'https://dallinger.io/participant/worker1/hit1/assignment1/debug?'
+            'fingerprint_hash=fakehash&recruiter=bot:HighPerformanceBotBase'
+        )
+        assert bot.participant_id == 4
+
+    def test_sign_off(self, bot, req_post):
+        value = bot.sign_off()
+        assert req_post.called_once_with(
+            'https://dallinger.io/question/participant1',
+            data={
+                'question': 'questionnaire',
+                'number': 1,
+                'response': json.dumps({"engagement": 4, "difficulty": 3}),
+            }
+        )
+        assert value is True
+
+    def test_complete_experiment(self, bot, req_get):
+        mock_return = mock.Mock()
+        mock_return.dummy = 1
+        req_get.return_value = mock_return
+
+        response = bot.complete_experiment('worker_complete')
+        assert req_get.called_once_with(
+            'https://dallinger.io/worker_complete?participant_id=1'
+        )
+        # returns the response object
+        assert response.dummy == 1

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -589,6 +589,16 @@ class TestParticipantRoute(object):
 
         assert data.get('participant').get('status') == u'overrecruited'
 
+    def test_creates_participant_with_unknown_recruiter(self, webapp):
+        worker_id = '1'
+        hit_id = '1'
+        assignment_id = '1'
+        resp = webapp.post('/participant/{}/{}/{}/debug?recruiter=test-recruiter'.format(
+            worker_id, hit_id, assignment_id
+        ))
+
+        assert resp.status_code == 200
+
 
 @pytest.mark.usefixtures('experiment_dir', 'db_session')
 class TestAPINotificationRoute(object):


### PR DESCRIPTION
## Description
Fix for issue #1367, which turns out to be specific to the `HighPerformanceBotBase`. Sets a recruiter during participant `sign_up` with the name `bots:BotClassName`.

## Motivation and Context
The prior behavior didn't allow distinguishing `HighPerformanceBotBase` participants from humans when using the `MultiRecruiter`. This change will allow distinguishing bots from humans and bots of varying classes.

## How Has This Been Tested?
Added new automated tests for the `HighPerformanceBotBase` class. Ran `GridUniverse` experiments locally with and without bots.
