### PR TITLE
Improve reliability of bots

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -246,24 +246,7 @@ class HighPerformanceBotBase(BotBase):
         This is done using a POST request to the /question/ endpoint.
         """
         self.log('Bot player signing off.')
-        while True:
-            question_responses = {"engagement": 4, "difficulty": 3}
-            data = {
-                'question': 'questionnaire',
-                'number': 1,
-                'response': json.dumps(question_responses),
-            }
-            url = (
-                "{host}/question/{self.participant_id}".format(
-                    host=self.host,
-                    self=self,
-                )
-            )
-            result = requests.post(url, data=data)
-            if result.status_code == 500:
-                self.stochastic_sleep()
-                continue
-            return True
+        return self.complete_questionnaire()
 
     def complete_experiment(self, status):
         """Record worker completion status to the experiment server.
@@ -301,3 +284,30 @@ class HighPerformanceBotBase(BotBase):
     def on_signup(self, data):
         """Take any needed action on response from /participant call."""
         self.participant_id = data['participant']['id']
+
+    @property
+    def question_responses(self):
+        return {"engagement": 4, "difficulty": 3}
+
+    def complete_questionnaire(self):
+        """Complete the standard debriefing form.
+
+        Answers the questions in the base questionnaire.
+        """
+        while True:
+            data = {
+                'question': 'questionnaire',
+                'number': 1,
+                'response': json.dumps(self.question_responses),
+            }
+            url = (
+                "{host}/question/{self.participant_id}".format(
+                    host=self.host,
+                    self=self,
+                )
+            )
+            result = requests.post(url, data=data)
+            if result.status_code == 500:
+                self.stochastic_sleep()
+                continue
+            return True

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from six.moves import urllib
 import gevent
 import requests
+from requests.exceptions import ConnectionError
 
 logger = logging.getLogger(__file__)
 
@@ -232,7 +233,12 @@ class HighPerformanceBotBase(BotBase):
                     bot_name=self.__class__.__name__
                 )
             )
-            result = requests.post(url)
+            try:
+                result = requests.post(url)
+            except ConnectionError:
+                self.stochastic_sleep()
+                continue
+
             if result.status_code == 500 or result.json()['status'] == 'error':
                 self.stochastic_sleep()
                 continue
@@ -263,7 +269,11 @@ class HighPerformanceBotBase(BotBase):
                     status=status
                 )
             )
-            result = requests.get(url)
+            try:
+                result = requests.get(url)
+            except ConnectionError:
+                self.stochastic_sleep()
+                continue
             if result.status_code == 500:
                 self.stochastic_sleep()
                 continue
@@ -306,7 +316,12 @@ class HighPerformanceBotBase(BotBase):
                     self=self,
                 )
             )
-            result = requests.post(url, data=data)
+            try:
+                result = requests.post(url, data=data)
+            except ConnectionError:
+                self.stochastic_sleep()
+                continue
+
             if result.status_code == 500:
                 self.stochastic_sleep()
                 continue

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -6,6 +6,8 @@ import logging
 import os
 import psycopg2
 import sys
+import time
+import random
 
 from psycopg2.extensions import TransactionRollbackError
 from sqlalchemy import create_engine
@@ -147,6 +149,7 @@ def serialized(func):
                     raise
             finally:
                 session.remove()
+            time.sleep(random.expovariate(0.5))
     return wrapper
 
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -419,7 +419,7 @@ class DebugDeployment(HerokuLocalDeployment):
 
     dispatch = {
         r'[^\"]{} (.*)$'.format(recruiters.NEW_RECRUIT_LOG_PREFIX): 'new_recruit',
-        r'{}$'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
+        r'{}'.format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): 'recruitment_closed',
     }
 
     def __init__(self, output, verbose, bot, proxy_port, exp_config):

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -836,7 +836,6 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
         (models.Participant.status == "approved")
     ).count() + 1
 
-
     recruiter_name = request.args.get('recruiter', 'undefined')
     if not recruiter_name or recruiter_name == 'undefined':
         db.logger.warning("FALLING BACK TO CONFIG RECRUITER VALUE")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -757,7 +757,7 @@ def assign_properties(thing):
 @app.route("/participant/<worker_id>/<hit_id>/<assignment_id>/<mode>",
            methods=["POST"])
 @db.serialized
-def create_participant(worker_id, hit_id, assignment_id, mode, session=None):
+def create_participant(worker_id, hit_id, assignment_id, mode):
     """Create a participant.
 
     This route is hit early on. Any nodes the participant creates will be

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -642,7 +642,6 @@ def summary():
         }
         db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
 
-
     return Response(
         dumps(state),
         status=200,

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -836,11 +836,15 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
         (models.Participant.status == "approved")
     ).count() + 1
 
+
     recruiter_name = request.args.get('recruiter', 'undefined')
     if not recruiter_name or recruiter_name == 'undefined':
+        db.logger.warning("FALLING BACK TO CONFIG RECRUITER VALUE")
         recruiter = recruiters.from_config(_config())
         if recruiter:
             recruiter_name = recruiter.nickname
+    else:
+        db.logger.warning("Using recruiter request param")
 
     # Create the new participant.
     participant = models.Participant(

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -785,7 +785,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     """
     # Lock the table, triggering multiple simultaneous accesses to fail
     try:
-        session.connection().execute("LOCK TABLE participant IN ACCESS EXCLUSIVE MODE NOWAIT")
+        session.connection().execute("LOCK TABLE participant IN EXCLUSIVE MODE NOWAIT")
     except exc.OperationalError as e:
         e.orig = TransactionRollbackError()
         raise e

--- a/dallinger/heroku/worker.py
+++ b/dallinger/heroku/worker.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':  # pragma: nocover
     initialize_experiment_package(os.getcwd())
 
     import logging
-    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
 
     with Connection(conn):
         worker = Worker(list(map(Queue, listen)))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -510,6 +510,7 @@ class BotRecruiter(Recruiter):
     """Recruit bot participants using a queue"""
 
     nickname = 'bots'
+    _timeout = '1h'
 
     def __init__(self):
         super(BotRecruiter, self).__init__()
@@ -545,7 +546,7 @@ class BotRecruiter(Recruiter):
             url = '{}/ad?{}'.format(base_url, ad_parameters)
             urls.append(url)
             bot = factory(url, assignment_id=assignment, worker_id=worker, hit_id=hit)
-            job = q.enqueue(bot.run_experiment, timeout=60 * 20)
+            job = q.enqueue(bot.run_experiment, timeout=self._timeout)
             logger.warn("Created job {} for url {}.".format(job.id, url))
 
         return urls

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -114,7 +114,9 @@ class CLIRecruiter(Recruiter):
         """Return initial experiment URL list, plus instructions
         for finding subsequent recruitment events in experiemnt logs.
         """
-        logger.info("Opening CLI recruitment.")
+        logger.info("Opening CLI recruitment for {} participants".format(
+            n
+        ))
         recruitments = self.recruit(n)
         message = (
             'Search for "{}" in the logs for subsequent recruitment URLs.\n'
@@ -130,6 +132,9 @@ class CLIRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Generate experiemnt URLs and print them to the console."""
+        logger.info("Recruiting {} CLI participants".format(
+            n
+        ))
         urls = []
         template = "{}/ad?recruiter={}&assignmentId={}&hitId={}&workerId={}&mode={}"
         for i in range(n):
@@ -148,7 +153,7 @@ class CLIRecruiter(Recruiter):
 
     def close_recruitment(self):
         """Talk about closing recruitment."""
-        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX)
+        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX + ' cli')
 
     def approve_hit(self, assignment_id):
         """Approve the HIT."""
@@ -181,7 +186,9 @@ class HotAirRecruiter(CLIRecruiter):
         """Return initial experiment URL list, plus instructions
         for finding subsequent recruitment events in experiemnt logs.
         """
-        logger.info("Opening HotAir recruitment.")
+        logger.info("Opening HotAir recruitment for {} participants".format(
+            n
+        ))
         recruitments = self.recruit(n)
         message = "Recruitment requests will open browser windows automatically."
 
@@ -209,7 +216,9 @@ class SimulatedRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Open recruitment."""
-        logger.info("Opening Sim recruitment.")
+        logger.info("Opening Sim recruitment for {} participants".format(
+            n
+        ))
         return {
             'items': self.recruit(n),
             'message': 'Simulated recruitment only'
@@ -217,6 +226,9 @@ class SimulatedRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n participants."""
+        logger.info("Recruiting {} Sim participants".format(
+            n
+        ))
         return []
 
     def close_recruitment(self):
@@ -281,9 +293,11 @@ class MTurkRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Open a connection to AWS MTurk and create a HIT."""
-        logger.info("Opening MTurk recruitment.")
+        logger.info("Opening MTurk recruitment for {} participants".format(
+            n
+        ))
         if self.is_in_progress:
-            raise RuntimeError(
+            raise MTurkRecruiterException(
                 "Tried to open_recruitment on already open recruiter."
             )
 
@@ -323,6 +337,9 @@ class MTurkRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n new participants to an existing HIT"""
+        logger.info("Recruiting {} MTurk participants".format(
+            n
+        ))
         if not self.config.get('auto_recruit', False):
             logger.info('auto_recruit is False: recruitment suppressed')
             return
@@ -420,7 +437,7 @@ class MTurkRecruiter(Recruiter):
         expire_hit rather than the disable_hit API call. This allows people
         who have already picked up the hit to complete it as normal.
         """
-        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX)
+        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX + ' mturk')
         # We are not expiring the hit currently as notifications are failing
         # TODO: Reinstate this
         # try:
@@ -457,9 +474,11 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         super(MTurkLargeRecruiter, self).__init__(*args, **kwargs)
 
     def open_recruitment(self, n=1):
-        logger.info("Opening MTurkLarge recruitment.")
+        logger.info("Opening MTurkLarge recruitment for {} participants".format(
+            n
+        ))
         if self.is_in_progress:
-            raise RuntimeError(
+            raise MTurkRecruiterException(
                 "Tried to open_recruitment on already open recruiter."
             )
         conn.incr('num_recruited', n)
@@ -467,6 +486,9 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         return super(MTurkLargeRecruiter, self).open_recruitment(to_recruit)
 
     def recruit(self, n=1):
+        logger.info("Recruiting {} MTurkLarge participants".format(
+            n
+        ))
         if not self.config.get('auto_recruit', False):
             logger.info('auto_recruit is False: recruitment suppressed')
             return
@@ -495,7 +517,9 @@ class BotRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Start recruiting right away."""
-        logger.info("Opening Bot recruitment.")
+        logger.info("Opening Bot recruitment for {} participants".format(
+            n
+        ))
         factory = self._get_bot_factory()
         bot_class_name = factory('', '', '').__class__.__name__
         return {
@@ -505,6 +529,9 @@ class BotRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n new participant bots to the queue"""
+        logger.info("Recruiting {} Bot participants".format(
+            n
+        ))
         factory = self._get_bot_factory()
         urls = []
         q = _get_queue()
@@ -531,7 +558,7 @@ class BotRecruiter(Recruiter):
 
         This does nothing at this time.
         """
-        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX)
+        logger.info(CLOSE_RECRUITMENT_LOG_PREFIX + ' bot')
 
     def reward_bonus(self, assignment_id, amount, reason):
         """Logging only. These are bots."""
@@ -572,61 +599,77 @@ class MultiRecruiter(Recruiter):
             recruiters.append((name, count))
         return recruiters
 
-    def pick_recruiter(self):
-        """Pick the next recruiter to use.
+    def recruiters(self, n=1):
+        """Iterator that provides recruiters along with the participant
+        count to be recruited for up to `n` participants.
 
         We use the `Recruitment` table in the db to keep track of
         how many recruitments have been requested using each recruiter.
         We'll use the first one from the specification that
         hasn't already reached its quota.
         """
-        counts = dict(
-            session.query(
-                Recruitment.recruiter_id,
-                func.count(Recruitment.id)
-            ).group_by(Recruitment.recruiter_id).all()
-        )
-
-        for recruiter_id, target_count in self.spec:
-            count = counts.get(recruiter_id, 0)
-            if count >= target_count:
-                # This recruiter quota was reached;
-                # move on to the next one.
-                counts[recruiter_id] = count - target_count
-                continue
+        recruit_count = 0
+        while recruit_count <= n:
+            counts = dict(
+                session.query(
+                    Recruitment.recruiter_id,
+                    func.count(Recruitment.id)
+                ).group_by(Recruitment.recruiter_id).all()
+            )
+            for recruiter_id, target_count in self.spec:
+                remaining = 0
+                count = counts.get(recruiter_id, 0)
+                if count >= target_count:
+                    # This recruiter quota was reached;
+                    # move on to the next one.
+                    counts[recruiter_id] = count - target_count
+                    continue
+                else:
+                    # Quota is still available; let's use it.
+                    remaining = target_count - count
+                    break
             else:
-                # Quota is still available; let's use it.
-                break
-        else:
-            return None
+                raise StopIteration
 
-        # record the recruitment
-        session.add(Recruitment(recruiter_id=recruiter_id))
-        session.commit()
+            num_recruits = min(n - recruit_count, remaining)
+            # record the recruitments and commit
+            for i in range(num_recruits):
+                session.add(Recruitment(recruiter_id=recruiter_id))
+            session.commit()
 
-        # return an instance of the recruiter
-        return by_name(recruiter_id)
+            recruit_count += num_recruits
+            yield by_name(recruiter_id), num_recruits
 
     def open_recruitment(self, n=1):
         """Return initial experiment URL list.
         """
-        logger.info("Opening Multi recruitment.")
+        logger.info("Multi recruitment running for {} participants".format(
+            n
+        ))
         recruitments = []
         messages = {}
-        count = 0
-        recruiter = self.pick_recruiter()
-        while recruiter is not None:
+        remaining = n
+        for recruiter, count in self.recruiters(n):
+            if not count:
+                break
             if recruiter.nickname in messages:
-                result = recruiter.recruit(1)
+                result = recruiter.recruit(count)
                 recruitments.extend(result)
             else:
-                result = recruiter.open_recruitment(1)
+                result = recruiter.open_recruitment(count)
                 recruitments.extend(result['items'])
                 messages[recruiter.nickname] = result['message']
-            count += 1
-            if count >= n:
+
+            remaining -= count
+            if remaining <= 0:
                 break
-            recruiter = self.pick_recruiter()
+
+        logger.info((
+            'Multi-recruited {} out of {} participants, '
+            'using {} recruiters.').format(
+                n - remaining, n, len(messages)
+            )
+        )
 
         return {
             'items': recruitments,
@@ -634,11 +677,11 @@ class MultiRecruiter(Recruiter):
         }
 
     def recruit(self, n=1):
-        urls = []
-        for i in range(n):
-            recruiter = self.pick_recruiter()
-            urls.extend(recruiter.recruit(1))
-        return urls
+        """For multi recruitment recruit and open_recruitment
+        have the same logic. We may need to open recruitment on any of our
+        sub-recruiters at any point in recruitment.
+        """
+        return self.open_recruitment(n)['items']
 
     def close_recruitment(self):
         for name in set(name for name, count in self.spec):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -248,7 +248,7 @@ class TestGitClient(object):
     def test_includes_details_in_exceptions(self, git):
         with pytest.raises(Exception) as ex_info:
             git.push('foo', 'bar')
-        assert ex_info.match('Not a git repository')
+        assert ex_info.match('[nN]ot a git repository')
 
     def test_can_use_alternate_output(self, git):
         import tempfile

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -406,8 +406,9 @@ class TestMTurkRecruiter(object):
         )
 
     def test_open_recruitment_raises_error_if_recruitment_in_progress(self, a, recruiter):
+        from dallinger.recruiters import MTurkRecruiterException
         a.participant(recruiter_id='mturk')
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment()
 
         recruiter.mturkservice.check_credentials.assert_not_called()
@@ -422,9 +423,11 @@ class TestMTurkRecruiter(object):
         assert recruiter.submitted_event() is None
 
     def test_current_hit_id_with_active_experiment(self, a, recruiter):
-        a.participant(hit_id=u'not the hit!', recruiter_id='hotair')
+        # Does not find hits associated with other recruiters
+        a.participant(hit_id=u'the hit!', recruiter_id='hotair')
         assert recruiter.current_hit_id() is None
 
+        # Finds its own hits
         a.participant(hit_id=u'the hit!', recruiter_id='mturk')
         assert recruiter.current_hit_id() == 'the hit!'
 
@@ -585,8 +588,9 @@ class TestMTurkLargeRecruiter(object):
             return r
 
     def test_open_recruitment_raises_error_if_experiment_in_progress(self, a, recruiter):
+        from dallinger.recruiters import MTurkRecruiterException
         a.participant(recruiter_id='mturklarge')
-        with pytest.raises(RuntimeError):
+        with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment()
 
         recruiter.mturkservice.check_credentials.assert_not_called()
@@ -684,16 +688,16 @@ class TestMultiRecruiter(object):
         ]
 
     def test_pick_recruiter(self, recruiter):
-        subrecruiter = recruiter.pick_recruiter()
-        assert subrecruiter.nickname == 'cli'
+        recruiters = list(recruiter.recruiters(3))
+        assert len(recruiters) == 2
 
-        subrecruiter = recruiter.pick_recruiter()
+        subrecruiter, count = recruiters[0]
         assert subrecruiter.nickname == 'cli'
+        assert count == 2
 
-        subrecruiter = recruiter.pick_recruiter()
+        subrecruiter, count = recruiters[1]
         assert subrecruiter.nickname == 'hotair'
-
-        assert recruiter.pick_recruiter() is None
+        assert count == 1
 
     def test_open_recruitment(self, recruiter):
         result = recruiter.open_recruitment(n=3)
@@ -702,12 +706,64 @@ class TestMultiRecruiter(object):
         assert result['items'][1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
         assert result['items'][2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
 
+    def test_open_recruitment_over_recruit(self, recruiter):
+        result = recruiter.open_recruitment(n=5)
+        assert len(result['items']) == 3
+        assert result['items'][0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result['items'][1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result['items'][2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+    def test_open_recruitment_twice(self, recruiter):
+        result = recruiter.open_recruitment(n=1)
+        assert len(result['items']) == 1
+        assert result['items'][0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+
+        result2 = recruiter.open_recruitment(n=3)
+        assert len(result2['items']) == 2
+        assert result2['items'][0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result2['items'][1].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
     def test_recruit(self, recruiter):
         result = recruiter.recruit(n=3)
         assert len(result) == 3
         assert result[0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
         assert result[1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
         assert result[2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+    def test_over_recruit(self, recruiter):
+        result = recruiter.recruit(n=5)
+        assert len(result) == 3
+        assert result[0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+    def test_recruit_partial(self, recruiter):
+        result = recruiter.open_recruitment(n=1)
+        assert len(result['items']) == 1
+        assert result['items'][0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+
+        result2 = recruiter.recruit(n=3)
+        assert len(result2) == 2
+        assert result2[0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result2[1].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+
+        result3 = recruiter.recruit(n=2)
+        assert len(result3) == 0
+
+    def test_recruit_batches(self, active_config):
+        from dallinger.recruiters import MultiRecruiter
+        active_config.extend({'recruiters': u'cli: 2, hotair: 1, cli: 3, hotair: 2'})
+        recruiter = MultiRecruiter()
+        result = recruiter.recruit(n=10)
+        assert len(result) == 8
+        assert result[0].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[1].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[2].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+        assert result[3].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[4].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[5].startswith('http://0.0.0.0:5000/ad?recruiter=cli')
+        assert result[6].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
+        assert result[7].startswith('http://0.0.0.0:5000/ad?recruiter=hotair')
 
     def test_close_recruitment(self, recruiter):
         patch1 = mock.patch('dallinger.recruiters.CLIRecruiter.close_recruitment')


### PR DESCRIPTION
## Description
This fixes a problem in serialising new participants that could cause high performance bots to get stuck in the waiting room. It also tidies some code around the questionnaire that was nonfunctional.

## Motivation and Context
This is part of a series on making bots work better.

## How Has This Been Tested?
This has been tested locally, @mmosleh is testing to see if it fixes https://github.com/Dallinger/Griduniverse/issues/196
