### PR TITLE
Don't show database passwords to end users

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -37,7 +37,7 @@ default_keys = (
     ('contact_email_on_error', six.text_type, []),
     ('dallinger_email_address', six.text_type, []),
     ('database_size', six.text_type, []),
-    ('database_url', six.text_type, []),
+    ('database_url', six.text_type, [], True),
     ('description', six.text_type, []),
     ('duration', float, []),
     ('dyno_type', six.text_type, []),


### PR DESCRIPTION
## Description
This marks the database uri as sensitive.

## Motivation and Context
For some reason that I do not understand or support, the root of an experiment shows a huge amount of config data. This correctly excludes parameters marked as sensitive but there hasn't been an audit of which are actually sensitive.

I'd also recommend removing this feature.