### PR TITLE
Fixes for MultiRecruiter

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -393,7 +393,7 @@ class MTurkRecruiter(Recruiter):
         # Has this recruiter resulted in any participants?
         return bool(Participant.query.filter_by(
             recruiter_id=self.nickname
-        ).count())
+        ).first())
 
     @property
     def qualification_active(self):
@@ -401,7 +401,7 @@ class MTurkRecruiter(Recruiter):
 
     def current_hit_id(self):
         any_participant_record = Participant.query.with_entities(
-            Participant.hit_id).first()
+            Participant.hit_id).filter_by(recruiter_id=self.nickname).first()
 
         if any_participant_record is not None:
             return str(any_participant_record.hit_id)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -280,9 +280,11 @@ class MTurkRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Open a connection to AWS MTurk and create a HIT."""
+        logger.info("Opening MTurk recruitment.")
         if self.is_in_progress:
-            # Already started... do nothing.
-            return None
+            raise RuntimeError(
+                "Tried to open_recruitment on already open recruiter."
+            )
 
         if self.hit_domain is None:
             raise MTurkRecruiterException("Can't run a HIT from localhost")
@@ -388,7 +390,10 @@ class MTurkRecruiter(Recruiter):
 
     @property
     def is_in_progress(self):
-        return bool(Participant.query.first())
+        # Has this recruiter resulted in any participants?
+        return bool(Participant.query.filter_by(
+            recruiter_id=self.nickname
+        ).count())
 
     @property
     def qualification_active(self):
@@ -451,9 +456,11 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         super(MTurkLargeRecruiter, self).__init__(*args, **kwargs)
 
     def open_recruitment(self, n=1):
+        logger.info("Opening MTurkLarge recruitment.")
         if self.is_in_progress:
-            # Already started... do nothing.
-            return None
+            raise RuntimeError(
+                "Tried to open_recruitment on already open recruiter."
+            )
         conn.incr('num_recruited', n)
         to_recruit = max(n, 10)
         return super(MTurkLargeRecruiter, self).open_recruitment(to_recruit)
@@ -616,6 +623,7 @@ class MultiRecruiter(Recruiter):
                 result = recruiter.open_recruitment(1)
                 recruitments.extend(result['items'])
                 messages[recruiter.nickname] = result['message']
+
         return {
             'items': recruitments,
             'message': '\n'.join(messages.values())

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -248,7 +248,7 @@ class TestGitClient(object):
     def test_includes_details_in_exceptions(self, git):
         with pytest.raises(Exception) as ex_info:
             git.push('foo', 'bar')
-        assert ex_info.match('Not a git repository')
+        assert ex_info.match('[nN]ot a git repository')
 
     def test_can_use_alternate_output(self, git):
         import tempfile

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -693,8 +693,7 @@ class TestMultiRecruiter(object):
         subrecruiter = recruiter.pick_recruiter()
         assert subrecruiter.nickname == 'hotair'
 
-        with pytest.raises(Exception):
-            recruiter.pick_recruiter()
+        assert recruiter.pick_recruiter() is None
 
     def test_open_recruitment(self, recruiter):
         result = recruiter.open_recruitment(n=3)

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -422,8 +422,10 @@ class TestMTurkRecruiter(object):
         assert recruiter.submitted_event() is None
 
     def test_current_hit_id_with_active_experiment(self, a, recruiter):
-        a.participant(hit_id=u'the hit!')
+        a.participant(hit_id=u'not the hit!', recruiter_id='hotair')
+        assert recruiter.current_hit_id() is None
 
+        a.participant(hit_id=u'the hit!', recruiter_id='mturk')
         assert recruiter.current_hit_id() == 'the hit!'
 
     def test_current_hit_id_with_no_active_experiment(self, recruiter):


### PR DESCRIPTION
## Description
These changes fix a number of issues with the MultiRecruiter, particularly when used in combination with the MTurkRecruiter and/or with multiple heroku web dynos running experiment servers.

The `pick_recruiter()` method now makes DB commits when adding Recruitment records to ensure information about the number of existing recruitments is visible. Before the Recruitment records were never recorded to the database because `pick_recruiter()` was called outside of a transaction wrapper.

The `open_recruitment()` method checks `pick_recruiter()` for each intended recruit and stops when it's run out of either configured recruiters or the intended recruit count.

The MTurk recruiters now look only at their own recruits when trying to determine if they have active participants/hits.

More logging in each recruiter.

## Motivation and Context
`MultiRecruiter` recruitment was not being limited by the number of people already recruited because the `Recruitment` records were not being committed. MTurk recruiters used with the `MultiRecruiter` were throwing errors because they treating non-MTurk participants as if they were MTurk participants. Debugging information about how and when recruiters were called was limited.

## How Has This Been Tested?
Additional automated tests have been added to test modified functionality. I ran a few sandbox and debug GridUniverse experiments with the MultiRecruiter.
