### PR TITLE
Increase bot timeout to accommodate slow MTurk recruits

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -480,6 +480,7 @@ class BotRecruiter(Recruiter):
     """Recruit bot participants using a queue"""
 
     nickname = 'bots'
+    _timeout = '1h'
 
     def __init__(self):
         super(BotRecruiter, self).__init__()
@@ -497,6 +498,9 @@ class BotRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n new participant bots to the queue"""
+        logger.info("Recruiting {} Bot participants".format(
+            n
+        ))
         factory = self._get_bot_factory()
         urls = []
         q = _get_queue()
@@ -510,7 +514,7 @@ class BotRecruiter(Recruiter):
             url = '{}/ad?{}'.format(base_url, ad_parameters)
             urls.append(url)
             bot = factory(url, assignment_id=assignment, worker_id=worker, hit_id=hit)
-            job = q.enqueue(bot.run_experiment, timeout=60 * 20)
+            job = q.enqueue(bot.run_experiment, timeout=self._timeout)
             logger.warn("Created job {} for url {}.".format(job.id, url))
 
         return urls


### PR DESCRIPTION

## Description
It has sometimes been challenging to get human participants (MTurk workers in particular) to start an experiment promptly enough so that bot participants can complete the experiment before timing out. This PR is a simple extension of the bot worker timeout from 20' to 60'. 

Moving this value to a config variable would be a further refinement, but may not be worth it.

## How Has This Been Tested?
* Started Griduniverse experiment with 29 bots and one human and let all bots join waiting room
* Waited 30 minutes to join an complete quorum
* Played successfully to experiment completion

