### PR TITLE
Fix Travis build by installing Heroku via Snap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 dist: trusty
-sudo: false
+sudo: required
 cache:
   - apt
   - bundler
@@ -19,13 +19,14 @@ matrix:
 addons:
   postgresql: "9.4"
   apt:
-    sources:
-    - heroku
     packages:
     - pandoc
     - enchant
     - heroku-toolbelt
     - redis-server
+install:
+  - sudo apt-get --yes install snapd
+  - sudo snap install --classic heroku
 services:
   - redis-server
 before_install:


### PR DESCRIPTION
## Description
As of around 9/28/18, all Travis builds started failing with the following error:
```
Installing APT Packages
8.33s$ travis_apt_get_update
3.93s$ sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install pandoc enchant heroku-toolbelt redis-server
Reading package lists...
Building dependency tree...
Reading state information...
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:
The following packages have unmet dependencies:
 heroku-toolbelt : Depends: heroku (= 3.99.4) but 7.16.0-1 is to be installed
E: Unable to correct problems, you have held broken packages.
apt-get.diagnostics
apt-get install failed
$ cat ${TRAVIS_HOME}/apt-get-update.log
Ign:2 http://toolbelt.heroku.com/ubuntu ./ InRelease
Get:4 http://apt.postgresql.org/pub/repos/apt trusty-pgdg InRelease [61.4 kB]
Get:3 http://toolbelt.heroku.com/ubuntu ./ Release [1,609 B]
Get:5 http://toolbelt.heroku.com/ubuntu ./ Release.gpg [473 B]
Get:6 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty InRelease [15.4 kB]
Ign:7 http://archive.ubuntu.com/ubuntu trusty InRelease
Get:1 http://dl.bintray.com/apache/cassandra 39x InRelease [3,168 B]
Get:8 http://toolbelt.heroku.com/ubuntu ./ Packages [636 B]
Ign:10 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 InRelease
Get:11 http://archive.ubuntu.com/ubuntu trusty-updates InRelease [65.9 kB]
Ign:12 http://dl.google.com/linux/chrome/deb stable InRelease
Get:13 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 Release [2,495 B]
Get:14 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4 Release.gpg [801 B]
Ign:15 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty InRelease
Get:18 http://dl.google.com/linux/chrome/deb stable Release [1,189 B]
Get:16 http://dl.bintray.com/apache/cassandra 39x/main amd64 Packages [682 B]
Get:19 http://apt.postgresql.org/pub/repos/apt trusty-pgdg/main amd64 Packages [190 kB]
Get:20 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty InRelease [15.4 kB]
Get:21 https://dl.hhvm.com/ubuntu trusty InRelease
Get:22 http://archive.ubuntu.com/ubuntu trusty-backports InRelease [65.9 kB]
Get:23 http://repo.mongodb.org/apt/ubuntu trusty/mongodb-org/3.4/multiverse amd64 Packages [12.4 kB]
Get:9 http://cli-assets.heroku.com/branches/stable/apt ./ InRelease
Get:24 http://dl.google.com/linux/chrome/deb stable Release.gpg [819 B]
Get:17 http://dl.bintray.com/apache/cassandra 39x/main i386 Packages [682 B]
Get:25 http://apt.postgresql.org/pub/repos/apt trusty-pgdg/main i386 Packages [189 kB]
Get:26 http://archive.ubuntu.com/ubuntu trusty-security InRelease [65.9 kB]
Get:27 http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty InRelease [15.4 kB]
Get:28 https://dl.hhvm.com/ubuntu trusty/main amd64 Packages [1,813 B]
Get:29 http://archive.ubuntu.com/ubuntu trusty Release [58.5 kB]
Get:30 http://archive.ubuntu.com/ubuntu trusty-updates/universe Sources [265 kB]
Get:31 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty InRelease [15.4 kB]
Get:32 http://cli-assets.heroku.com/branches/stable/apt ./ Packages [562 B]
Get:33 http://archive.ubuntu.com/ubuntu trusty-updates/main amd64 Packages [1,376 kB]
Get:34 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty InRelease [15.5 kB]
Get:35 http://dl.google.com/linux/chrome/deb stable/main amd64 Packages [1,122 B]
Get:36 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty/main amd64 Packages [1,710 B]
Get:37 http://archive.ubuntu.com/ubuntu trusty-updates/main i386 Packages [1,298 kB]
Get:38 http://archive.ubuntu.com/ubuntu trusty-updates/restricted amd64 Packages [21.4 kB]
Get:39 http://archive.ubuntu.com/ubuntu trusty-updates/restricted i386 Packages [21.1 kB]
Get:40 http://archive.ubuntu.com/ubuntu trusty-updates/universe amd64 Packages [620 kB]
Get:41 http://archive.ubuntu.com/ubuntu trusty-updates/universe i386 Packages [605 kB]
Get:42 http://archive.ubuntu.com/ubuntu trusty-updates/multiverse amd64 Packages [16.0 kB]
Get:43 http://archive.ubuntu.com/ubuntu trusty-updates/multiverse i386 Packages [16.5 kB]
Get:44 http://ppa.launchpad.net/chris-lea/redis-server/ubuntu trusty/main i386 Packages [1,702 B]
Get:45 http://archive.ubuntu.com/ubuntu trusty Release.gpg [933 B]
Get:46 http://archive.ubuntu.com/ubuntu trusty-backports/main amd64 Packages [14.7 kB]
Get:47 http://archive.ubuntu.com/ubuntu trusty-backports/main i386 Packages [14.7 kB]
Get:48 http://archive.ubuntu.com/ubuntu trusty-backports/restricted amd64 Packages [40 B]
Get:49 http://archive.ubuntu.com/ubuntu trusty-backports/restricted i386 Packages [40 B]
Get:50 http://archive.ubuntu.com/ubuntu trusty-backports/universe amd64 Packages [52.5 kB]
Get:51 http://archive.ubuntu.com/ubuntu trusty-backports/universe i386 Packages [52.4 kB]
Get:52 http://archive.ubuntu.com/ubuntu trusty-backports/multiverse amd64 Packages [1,392 B]
Get:53 http://archive.ubuntu.com/ubuntu trusty-backports/multiverse i386 Packages [1,376 B]
Get:54 http://archive.ubuntu.com/ubuntu trusty-security/universe Sources [101 kB]
Get:55 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty Release [15.1 kB]
Get:56 http://archive.ubuntu.com/ubuntu trusty-security/main amd64 Packages [954 kB]
Get:57 http://archive.ubuntu.com/ubuntu trusty-security/main i386 Packages [880 kB]
Get:58 http://archive.ubuntu.com/ubuntu trusty-security/restricted amd64 Packages [18.1 kB]
Get:59 http://archive.ubuntu.com/ubuntu trusty-security/restricted i386 Packages [17.8 kB]
Get:60 http://archive.ubuntu.com/ubuntu trusty-security/universe amd64 Packages [325 kB]
Get:61 http://archive.ubuntu.com/ubuntu trusty-security/universe i386 Packages [311 kB]
Get:62 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main amd64 Packages [3,483 B]
Get:63 http://archive.ubuntu.com/ubuntu trusty-security/multiverse amd64 Packages [4,726 B]
Get:64 http://archive.ubuntu.com/ubuntu trusty-security/multiverse i386 Packages [4,880 B]
Get:65 http://archive.ubuntu.com/ubuntu trusty/universe Sources [7,926 kB]
Get:66 http://ppa.launchpad.net/git-core/ppa/ubuntu trusty/main i386 Packages [3,484 B]
Get:67 http://archive.ubuntu.com/ubuntu trusty/main amd64 Packages [1,743 kB]
Get:68 http://archive.ubuntu.com/ubuntu trusty/main i386 Packages [1,739 kB]
Get:69 http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty/main amd64 Packages [7,494 B]
Get:70 http://archive.ubuntu.com/ubuntu trusty/restricted amd64 Packages [16.0 kB]
Get:71 http://archive.ubuntu.com/ubuntu trusty/restricted i386 Packages [16.4 kB]
Get:72 http://archive.ubuntu.com/ubuntu trusty/universe amd64 Packages [7,589 kB]
Get:73 http://ppa.launchpad.net/openjdk-r/ppa/ubuntu trusty/main i386 Packages [7,640 B]
Get:75 http://archive.ubuntu.com/ubuntu trusty/universe i386 Packages [7,597 kB]
Get:76 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty/main amd64 Packages [430 B]
Get:77 http://ppa.launchpad.net/pollinate/ppa/ubuntu trusty/main i386 Packages [430 B]
Get:78 http://archive.ubuntu.com/ubuntu trusty/multiverse amd64 Packages [169 kB]
Get:79 http://archive.ubuntu.com/ubuntu trusty/multiverse i386 Packages [172 kB]
Get:81 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty/main amd64 Packages [1,551 B]
Get:82 http://ppa.launchpad.net/webupd8team/java/ubuntu trusty/main i386 Packages [1,551 B]
Get:84 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty Release.gpg [316 B]
Get:86 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty/main amd64 Packages [985 B]
Get:87 http://ppa.launchpad.net/couchdb/stable/ubuntu trusty/main i386 Packages [985 B]
Fetched 34.8 MB in 4s (7,996 kB/s)
Reading package lists...
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install pandoc enchant heroku-toolbelt redis-server" failed and exited with 100 during .
Your build has been stopped.
```

Some internet research suggests that using "snap" to install on Ubuntu is the more current method, so I tried switching to this method in the Travis build, and it appears to work. This also required changing `sudo: false` to `sudo: required`.


## References
- https://devcenter.heroku.com/articles/heroku-cli#download-and-install
- https://docs.travis-ci.com/user/installing-dependencies/#installing-snap-packages

## How Has This Been Tested?
Made change and pushed to trigger a Travis build.

