### PR TITLE
Clock check: HIT does not exist

### DIFF
--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -118,9 +118,7 @@ def run_check(config, mturk, participants, session, reference_time):
                 try:
                     mturk.expire_hit(hit_id)
                 except MTurkServiceException as ex:
-                    print(
-                        "Could not expire MTurk HIT w/ ID '{}': {}".format(hit_id, ex)
-                    )
+                    print(ex)
 
                 # message the researcher
                 messenger.send_hit_cancelled_msg()

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -112,7 +112,9 @@ def run_check(config, mturk, participants, session, reference_time):
                     headers=headers,
                 )
 
-                # then attempt to force-expire the hit via boto:
+                # Attempt to force-expire the hit via boto. It's possible
+                # that the HIT won't exist, either because we didn't use the
+                # MTurkRecruiter, or because the HIT has been deleted manually.
                 try:
                     mturk.expire_hit(hit_id)
                 except MTurkServiceException as ex:

--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -10,6 +10,7 @@ import dallinger
 from dallinger import db
 from dallinger.models import Participant
 from dallinger.mturk import MTurkService
+from dallinger.mturk import MTurkServiceException
 from dallinger.heroku.messages import HITSummary
 from dallinger.heroku.messages import get_messenger
 from dallinger.recruiters import BotRecruiter
@@ -111,8 +112,13 @@ def run_check(config, mturk, participants, session, reference_time):
                     headers=headers,
                 )
 
-                # then force expire the hit via boto
-                mturk.expire_hit(hit_id)
+                # then attempt to force-expire the hit via boto:
+                try:
+                    mturk.expire_hit(hit_id)
+                except MTurkServiceException as ex:
+                    print(
+                        "Could not expire MTurk HIT w/ ID '{}': {}".format(hit_id, ex)
+                    )
 
                 # message the researcher
                 messenger.send_hit_cancelled_msg()

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -181,7 +181,6 @@ class TestHerokuClockTasks(object):
             mock_messenger.send_resubmitted_msg.assert_called()
 
     def test_no_assignment_on_mturk_shuts_down_recruitment(self, a, stub_config, run_check):
-        # Include whimsical set to True to avoid error in the False code branch:
         stub_config.extend({'host': u'fakehost.herokuapp.com'})
         mturk = mock.Mock(**{'get_assignment.return_value': None})
         participants = [a.participant()]
@@ -210,7 +209,6 @@ class TestHerokuClockTasks(object):
             )
 
     def test_no_assignment_on_mturk_expires_hit(self, a, stub_config, run_check):
-        # Include whimsical set to True to avoid error in the False code branch:
         stub_config.extend({'host': u'fakehost.herokuapp.com'})
         mturk = mock.Mock(**{'get_assignment.return_value': None})
         participants = [a.participant()]
@@ -226,7 +224,6 @@ class TestHerokuClockTasks(object):
         self, a, stub_config, run_check
     ):
         from dallinger.mturk import MTurkServiceException
-        # Include whimsical set to True to avoid error in the False code branch:
         stub_config.extend({'host': u'fakehost.herokuapp.com'})
         mturk = mock.Mock(**{
             'get_assignment.return_value': None,


### PR DESCRIPTION
## Description
Encountered while investigating problems with @mongates's memoryexp2. 

## Motivation and Context
The check for participants who have been working on an experiment for too long attempts to expire HITs, but sometimes the HIT has already been removed from MTurk, or never existed in the first place (no MTurkRecruiter is in use).

This timed check function now handles exceptions in the call the MTurkService and logs them, but continues processing so the worker's assignment can be resolved.

## How Has This Been Tested?
Automated tests

## Traceback of problem
```
dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	During handling of the above exception, another exception occurred: 
982119572721897478	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	Traceback (most recent call last): 
982119572721897479	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	  File "/app/.heroku/python/lib/python3.6/site-packages/apscheduler/executors/base.py", line 125, in run_job 
982119572721897480	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	    retval = job.func(*job.args, **job.kwargs) 
982119572721897481	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	  File "clock.py", line 149, in check_db_for_missing_notifications 
982119572721897482	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	    run_check(config, mturk, participants, session, reference_time) 
982119572835143684	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	  File "clock.py", line 115, in run_check 
982119572835143685	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	    mturk.expire_hit(hit_id) 
982119572835143686	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	  File "/app/.heroku/src/dallinger/dallinger/mturk.py", line 452, in expire_hit 
982119572835143687	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	    "Failed to expire HIT {}: {}".format(hit_id, str(ex))) 
982119572835143688	2018-09-27T23:59:35	2018-09-27T23:59:35Z	2356746171	dlgr-e2a139c1	54.91.70.18	Local7	Info	app/clock.1	dallinger.mturk.MTurkServiceException: Failed to expire HIT 0ZP25P: An error occurred (RequestError) when calling the UpdateExpirationForHIT operation: Hit 0ZP25P does not exist. (1538092775279) 
```
