### PR TITLE
Don't error when looking up environment state

### DIFF
--- a/dallinger/nodes.py
+++ b/dallinger/nodes.py
@@ -101,6 +101,9 @@ class Environment(Node):
 
         If time is None then it returns the most recent state as of now.
         """
+        if not len(self.infos(type=State)):
+            return None
+
         if time is None:
             return max(self.infos(type=State), key=attrgetter('creation_time'))
         else:

--- a/tests/test_environments.py
+++ b/tests/test_environments.py
@@ -8,12 +8,15 @@ class TestEnvironments(object):
         net = models.Network()
         db_session.add(net)
         environment = nodes.Environment(network=net)
-        information.State(origin=environment, contents="foo")
         db_session.commit()
-
         assert isinstance(environment.id, int)
         assert environment.type == "environment"
         assert environment.creation_time
+        assert environment.state() is None
+
+        information.State(origin=environment, contents="foo")
+        db_session.commit()
+
         assert environment.state().contents == "foo"
 
     def test_create_environment_get_observed(self, db_session):


### PR DESCRIPTION
## Description
The environment node's `state()` method will now return `None` when no state infos are available instead of raising an exception.

## Motivation and Context
This addresses [ScrumDo Story 417](https://app.scrumdo.com/projects/story_permalink/1695114) and issue #1399.

## How Has This Been Tested?
A new automated test is in place. In addition, I've added a related test to GridUniverse.
