### PR TITLE
Improve reliability of bots

### DIFF
--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -246,24 +246,7 @@ class HighPerformanceBotBase(BotBase):
         This is done using a POST request to the /question/ endpoint.
         """
         self.log('Bot player signing off.')
-        while True:
-            question_responses = {"engagement": 4, "difficulty": 3}
-            data = {
-                'question': 'questionnaire',
-                'number': 1,
-                'response': json.dumps(question_responses),
-            }
-            url = (
-                "{host}/question/{self.participant_id}".format(
-                    host=self.host,
-                    self=self,
-                )
-            )
-            result = requests.post(url, data=data)
-            if result.status_code == 500:
-                self.stochastic_sleep()
-                continue
-            return True
+        return self.complete_questionnaire()
 
     def complete_experiment(self, status):
         """Record worker completion status to the experiment server.
@@ -301,3 +284,30 @@ class HighPerformanceBotBase(BotBase):
     def on_signup(self, data):
         """Take any needed action on response from /participant call."""
         self.participant_id = data['participant']['id']
+
+    @property
+    def question_responses(self):
+        return {"engagement": 4, "difficulty": 3}
+
+    def complete_questionnaire(self):
+        """Complete the standard debriefing form.
+
+        Answers the questions in the base questionnaire.
+        """
+        while True:
+            data = {
+                'question': 'questionnaire',
+                'number': 1,
+                'response': json.dumps(self.question_responses),
+            }
+            url = (
+                "{host}/question/{self.participant_id}".format(
+                    host=self.host,
+                    self=self,
+                )
+            )
+            result = requests.post(url, data=data)
+            if result.status_code == 500:
+                self.stochastic_sleep()
+                continue
+            return True

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -14,6 +14,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from six.moves import urllib
 import gevent
 import requests
+from requests.exceptions import RequestException
 
 logger = logging.getLogger(__file__)
 
@@ -232,8 +233,14 @@ class HighPerformanceBotBase(BotBase):
                     bot_name=self.__class__.__name__
                 )
             )
-            result = requests.post(url)
-            if result.status_code == 500 or result.json()['status'] == 'error':
+            try:
+                result = requests.post(url)
+                result.raise_for_status()
+            except RequestException:
+                self.stochastic_sleep()
+                continue
+
+            if result.json()['status'] == 'error':
                 self.stochastic_sleep()
                 continue
 
@@ -263,8 +270,10 @@ class HighPerformanceBotBase(BotBase):
                     status=status
                 )
             )
-            result = requests.get(url)
-            if result.status_code == 500:
+            try:
+                result = requests.get(url)
+                result.raise_for_status()
+            except RequestException:
                 self.stochastic_sleep()
                 continue
             return result
@@ -306,8 +315,10 @@ class HighPerformanceBotBase(BotBase):
                     self=self,
                 )
             )
-            result = requests.post(url, data=data)
-            if result.status_code == 500:
+            try:
+                result = requests.post(url, data=data)
+                result.raise_for_status()
+            except RequestException:
                 self.stochastic_sleep()
                 continue
             return True

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -6,6 +6,8 @@ import logging
 import os
 import psycopg2
 import sys
+import time
+import random
 
 from psycopg2.extensions import TransactionRollbackError
 from sqlalchemy import create_engine
@@ -147,6 +149,7 @@ def serialized(func):
                     raise
             finally:
                 session.remove()
+            time.sleep(random.expovariate(0.5))
     return wrapper
 
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -757,7 +757,7 @@ def assign_properties(thing):
 @app.route("/participant/<worker_id>/<hit_id>/<assignment_id>/<mode>",
            methods=["POST"])
 @db.serialized
-def create_participant(worker_id, hit_id, assignment_id, mode, session=None):
+def create_participant(worker_id, hit_id, assignment_id, mode):
     """Create a participant.
 
     This route is hit early on. Any nodes the participant creates will be

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -624,6 +624,24 @@ def summary():
     if state['completed'] is None:
         state['completed'] = False
 
+    # Regenerate a waiting room message when checking status
+    # to counter missed messages at the end of the waiting room
+    nonfailed_count = models.Participant.query.filter(
+        (models.Participant.status == "working") |
+        (models.Participant.status == "overrecruited") |
+        (models.Participant.status == "submitted") |
+        (models.Participant.status == "approved")
+    ).count()
+    exp = Experiment(session)
+    overrecruited = exp.is_overrecruited(nonfailed_count)
+    if exp.quorum:
+        quorum = {
+            'q': exp.quorum,
+            'n': nonfailed_count,
+            'overrecruited': overrecruited,
+        }
+        db.queue_message(WAITING_ROOM_CHANNEL, dumps(quorum))
+
     return Response(
         dumps(state),
         status=200,

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -26,6 +26,8 @@ from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 from sqlalchemy import exc
 from sqlalchemy import func
 from sqlalchemy.sql.expression import true
+from psycopg2.extensions import TransactionRollbackError
+
 
 from dallinger import db
 from dallinger import experiment
@@ -755,13 +757,20 @@ def assign_properties(thing):
 @app.route("/participant/<worker_id>/<hit_id>/<assignment_id>/<mode>",
            methods=["POST"])
 @db.serialized
-def create_participant(worker_id, hit_id, assignment_id, mode):
+def create_participant(worker_id, hit_id, assignment_id, mode, session=None):
     """Create a participant.
 
     This route is hit early on. Any nodes the participant creates will be
     defined in reference to the participant object. You must specify the
     worker_id, hit_id, assignment_id, and mode in the url.
     """
+    # Lock the table, triggering multiple simultaneous accesses to fail
+    try:
+        session.connection().execute("LOCK TABLE participant IN EXCLUSIVE MODE NOWAIT")
+    except exc.OperationalError as e:
+        e.orig = TransactionRollbackError()
+        raise e
+
     fingerprint_hash = request.args.get('fingerprint_hash')
     try:
         fingerprint_found = models.Participant.query.\

--- a/dallinger/heroku/worker.py
+++ b/dallinger/heroku/worker.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':  # pragma: nocover
     initialize_experiment_package(os.getcwd())
 
     import logging
-    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.INFO)
+    logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
 
     with Connection(conn):
         worker = Worker(list(map(Queue, listen)))


### PR DESCRIPTION
This is intended to replace #1385 as other things have been merged into there now.

## Description
This fixes a problem in serialising new participants that could cause high performance bots to get stuck in the waiting room. It also tidies some code around the questionnaire that was nonfunctional.

## Motivation and Context
This is part of a series on making bots work better.

## How Has This Been Tested?
This has been tested locally, @mmosleh is testing to see if it fixes https://github.com/Dallinger/Griduniverse/issues/196
