### PR TITLE
Provide Dallinger scripts for heroku processes

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -126,9 +126,6 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
 
     heroku_files = [
         "Procfile",
-        "launch.py",
-        "worker.py",
-        "clock.py",
         "runtime.txt",
     ]
 

--- a/dallinger/heroku/Procfile
+++ b/dallinger/heroku/Procfile
@@ -1,3 +1,3 @@
-web: python launch.py
-worker: python worker.py
-clock: python clock.py
+web: dallinger_heroku_web
+worker: dallinger_heroku_worker
+clock: dallinger_heroku_clock

--- a/dallinger/heroku/Procfile_no_clock
+++ b/dallinger/heroku/Procfile_no_clock
@@ -1,2 +1,2 @@
-web: python launch.py
-worker: python worker.py
+web: dallinger_heroku_web
+worker: dallinger_heroku_worker

--- a/dallinger/heroku/launch.py
+++ b/dallinger/heroku/launch.py
@@ -1,9 +1,14 @@
 """Launch the experiment server."""
 
-if __name__ == '__main__':
+
+def main():
     # Make sure gevent patches are applied early.
     import gevent.monkey
     gevent.monkey.patch_all()
 
     from dallinger.experiment_server.gunicorn import launch
     launch()
+
+
+if __name__ == '__main__':
+    main()

--- a/dallinger/heroku/runtime.txt
+++ b/dallinger/heroku/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.4
+python-3.6.6

--- a/dallinger/heroku/worker.py
+++ b/dallinger/heroku/worker.py
@@ -8,8 +8,8 @@ listen = ['high', 'default', 'low']
 redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
 conn = redis.from_url(redis_url)
 
-if __name__ == '__main__':  # pragma: nocover
 
+def main():
     # Make sure gevent patches are applied early.
     import gevent.monkey
     gevent.monkey.patch_all()
@@ -34,3 +34,7 @@ if __name__ == '__main__':  # pragma: nocover
     with Connection(conn):
         worker = Worker(list(map(Queue, listen)))
         worker.work()
+
+
+if __name__ == '__main__':  # pragma: nocover
+    main()

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup_args = dict(
     entry_points={
         'console_scripts': [
             'dallinger = dallinger.command_line:dallinger',
+            'dallinger_heroku_web = dallinger.heroku.launch:main',
+            'dallinger_heroku_worker = dallinger.heroku.worker:main',
+            'dallinger_heroku_clock = dallinger.heroku.clock:launch',
         ],
         'dallinger.experiments': [],
     },

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -132,9 +132,6 @@ class TestSetupExperiment(object):
         assert found_in('experiment.py', exp_dir)
         assert not found_in('experiment_id.txt', exp_dir)
         assert not found_in('Procfile', exp_dir)
-        assert not found_in('launch.py', exp_dir)
-        assert not found_in('worker.py', exp_dir)
-        assert not found_in('clock.py', exp_dir)
 
         exp_id, dst = setup_experiment(log=mock.Mock())
 
@@ -146,9 +143,6 @@ class TestSetupExperiment(object):
         assert found_in('experiment.py', dst)
         assert found_in('models.py', dst)
         assert found_in('Procfile', dst)
-        assert found_in('launch.py', dst)
-        assert found_in('worker.py', dst)
-        assert found_in('clock.py', dst)
 
         assert found_in(os.path.join("static", "css", "dallinger.css"), dst)
         assert found_in(os.path.join("static", "scripts", "dallinger2.js"), dst)
@@ -161,6 +155,36 @@ class TestSetupExperiment(object):
         assert found_in(os.path.join("templates", "error-complete.html"), dst)
         assert found_in(os.path.join("templates", "launch.html"), dst)
         assert found_in(os.path.join("templates", "complete.html"), dst)
+
+    def test_setup_procfile_no_clock(self, setup_experiment):
+        config = get_config()
+        config.set('clock_on', False)
+        assert config.get('clock_on') is False
+        exp_dir = os.getcwd()
+        assert not found_in('Procfile', exp_dir)
+
+        exp_id, dst = setup_experiment(log=mock.Mock())
+
+        assert found_in('Procfile', dst)
+        with open(os.path.join(dst, 'Procfile')) as proc:
+            assert 'clock: dallinger_heroku_clock' not in [
+                l.strip() for l in proc
+            ]
+
+    def test_setup_procfile_with_clock(self, setup_experiment):
+        config = get_config()
+        config.set('clock_on', True)
+        assert config.get('clock_on') is True
+        exp_dir = os.getcwd()
+        assert not found_in('Procfile', exp_dir)
+
+        exp_id, dst = setup_experiment(log=mock.Mock())
+
+        assert found_in('Procfile', dst)
+        with open(os.path.join(dst, 'Procfile')) as proc:
+            assert 'clock: dallinger_heroku_clock' in [
+                l.strip() for l in proc
+            ]
 
     def test_setup_with_custom_dict_config(self, setup_experiment):
         config = get_config()


### PR DESCRIPTION
## Description
This PR implements new setuptools entrypoint scripts for the Heroku processes: `launch.py`, `worker.py`, and `clock.py`. These scripts are now installed along with the `dallinger` script as `dallinger_heroku_web`, `dallinger_heroku_worker`, and `dallinger_heroku_clock`. Instead of copying these scripts from the machine launching the experiment, the heroku dynos will run the scripts installed on the instance when Dallinger was installed. The `Procfile` and `runtime.txt` files are still copied from the machine starting the experiment, which should provide some additional flexibility in deployment while minimizing backwards compatibility issues. Additionally, this PR updates the default python runtime from 3.6.4 to 3.6.6.

## Motivation and Context
This PR relates to [ScrumDo Story 413](https://app.scrumdo.com/projects/story_permalink/1694947), and attempts to address issues that occur when running different versions of Dallinger locally than on the Heroku dynos.

## How Has This Been Tested?
The changes are fairly limited and result in a reduction in LOC. Additional automated tests were added for Procfile config changes based on clock settings. In addition to automated tests, I ran experiments locally and in sandbox using this branch.

