### PR TITLE
Avoid Random Travis Errors By Running on Different Ports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ matrix:
   - python: 2.7
     env: TOXENV=py27
   - python: 3.6
-    env: TOXENV=py36
+    env:
+      - TOXENV=py36
+      - PORT=5001
+      - base_port=5001
   - python: 3.6
     env: TOXENV=style
   - python: 3.6
@@ -47,6 +50,7 @@ env:
   global:
   - DATABASE_URL=postgresql://dallinger@localhost/dallinger
   - PORT=5000
+  - base_port=5000
   - threads=1
   - secure: isabc6zJWlMBizW/5MbjmWJ9Q2shDj0rjTPmtQmq7QZrrmxczjWfgiQE0i6tcw3wPvBIOgsA4M806ddgM/oeUPWt892BlPHUESb7j96zHtig9B/P4kwH11EPK4pEPcvg90NfVeDCqYHVSNcMtsRTSf93Fg7aT081URb7vRUykxg=
   - secure: rWBAifHvKlQabe6gvz+edMEtjtDnpwI4RFHJB1ytYSNVKQ59s7fIk2q39IZc8K3Uix7ZtP3G7ws6ufQhOj44Pm4j1J+rbLnDjdMtmcDN5aiSnwb05JpltZXCNjUqAu/CBFZ44lnNenZp4uSLhU/kLVhB2Q+UPvyWNFgApEVoiHM=

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -486,7 +486,9 @@ class TestDebugServer(object):
     ):
         debugger_unpatched.proxy_port = '2222'
         debugger_unpatched.notify(
-            " {} some-fake-url:5000".format(recruiters.NEW_RECRUIT_LOG_PREFIX)
+            " {} some-fake-url:{}".format(
+                recruiters.NEW_RECRUIT_LOG_PREFIX,
+                active_config.get('base_port'))
         )
         browser.open.assert_called_once_with(
             'some-fake-url:2222', autoraise=True, new=1
@@ -573,7 +575,9 @@ class TestLoad(object):
         loader.out.log.assert_has_calls([
             mock.call('Starting up the server...'),
             mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
-            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
+            mock.call('Server is running on http://0.0.0.0:{}. Press Ctrl+C to exit.'.format(
+                os.environ.get('base_port', 5000)
+            )),
             mock.call('Terminating dataset load for experiment some_experiment_id'),
             mock.call('Cleaning up local Heroku process...'),
             mock.call('Local Heroku process terminated.')
@@ -591,7 +595,9 @@ class TestLoad(object):
         replay_loader.out.log.assert_has_calls([
             mock.call('Starting up the server...'),
             mock.call('Ingesting dataset from some_experiment_id-data.zip...'),
-            mock.call('Server is running on http://0.0.0.0:5000. Press Ctrl+C to exit.'),
+            mock.call('Server is running on http://0.0.0.0:{}. Press Ctrl+C to exit.'.format(
+                os.environ.get('base_port', 5000)
+            )),
             mock.call('Launching the experiment...'),
             mock.call('Launching replay browser...'),
             mock.call('Terminating dataset load for experiment some_experiment_id'),


### PR DESCRIPTION
## Description
Changes Travis config to use different server `base_port` for the py27 and py36 builds, and fixes tests to not assume a specific base port.

## Motivation and Context
During a couple test runs on my last PR I'd get errors randomly on one of the two builds indicating that port 5000 was already in use. This PR makes the two simultaneous test runs use different ports for the application server, avoiding the conflict.

## How Has This Been Tested?
Running the tests with `base_port` set differently.
