### PR TITLE
Update docker documentation for v5.0.0 release 

### DIFF
--- a/docs/source/creating_an_experiment.rst
+++ b/docs/source/creating_an_experiment.rst
@@ -340,7 +340,7 @@ the spelling of your documentation. This can be very useful:
     $ make spelling
 
 The `docs` directory also includes `makefile.bat`, which does the same
-tasks on Windows systems.
+tasks on Microsoft Windows systems.
 
 myexperiments.pushbutton/docs/source/index.rst
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -1,10 +1,9 @@
 Developer Installation
 ======================
 
-We recommend installing Dallinger on Mac OS X. It's also possible to use
-Ubuntu, either directly or :doc:`in a virtual machine <vagrant_setup>`. Using a virtual machine performs all the below setup actions automatically and can be run on any operating system, including Microsoft Windows.
+We recommend installing Dallinger on Mac OS X. It's also possible to use Ubuntu, either directly or in a virtual machine. If you are attempting to use Dallinger on Microsoft Windows, running Ubuntu in a virtual machine is the recommend method.
 
-You can also install Dallinger using :doc:`Docker <docker_setup>`.
+If you are interested in using Dallinger with Docker, read more :doc:`here <docker_setup>`.
 
 Install Python
 --------------

--- a/docs/source/docker_setup.rst
+++ b/docs/source/docker_setup.rst
@@ -1,26 +1,9 @@
-Docker Setup
-============
+Dallinger with Docker
+=====================
 
-Docker support is newly added. Install Dallinger by pulling our image from Dockerhub. This installs Dallinger within an isolated Ubuntu 16.04 environment, running all the necessary services bridged to your local machine's ports.
+With the release of Dallinger version 5.0.0, we have created a Python script that uses `docker-compose <https://docs.docker.com/compose/>`__ to provide an automated installation and configuration of Dallinger to run experiments.
 
-Instructions
-------------
+The code and detailed instructions can be found in this `github repository <https://github.com/Dallinger/Dockerfiles/blob/master/README.md/>`__.
 
-Install Dallinger by pulling our image from Dockerhub.
-
-::
-
-    docker pull dallinger/dallinger
-
-Make sure your ports 5000, 5432, and 6379 are open, then run:
-
-::
-
-    docker run -p 5000:5000 -p 5432:5432 -p 6379:6379 -it dallinger/dallinger
-
-This command will attach you to the Ubuntu container and run the Bartlett (1932) experiment demo.
-You can visit the URL(s) at the end of the log using the command:
-
-::
-
-    python -m webbrowser <URL_IN_LOG>
+Please note that we consider this to be a working yet experimental method of running Dallinger. It adds an extra level of complexity which can potentially get in the way when trying to create and debug a new experiment as debugging is more diffcult than when using Dallinger natively or in a virtual machine.
+Having said that, there are can be certain advantages to this method, since Docker can install everything required to run Dallinger quickly in comparison to installing all the requirements yourself, and on platforms such as Microsoft Windows where a native installation is not possible.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -9,12 +9,11 @@ Installation Options
 --------------------
 
 Dallinger is tested with Ubuntu 14.04 LTS, 16.04 LTS, 18.04 LTS and Mac OS X locally.
-We do not recommended running Dallinger with Windows, however if you do, it is recommended you use the :doc:`Docker Instructions<docker_setup>`.
+We do not recommended running Dallinger with Microsoft Windows, however if you do, running Ubuntu in a virtual machine is the recommend method. You can also read about what is possible with using Dallinger with Docker :doc:`here<docker_setup>`.
 
-Installation via Docker
+Using Dallinger via Docker
 -----------------------
-Docker is a containerization tool used for developing isolated software environments. Follow these instructions for the
-:doc:`Docker setup<docker_setup>`.
+Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_setup>`.
 
 Install Python
 --------------


### PR DESCRIPTION
The Docker documentation has been updated to the docker-compose method. The older docker implementation has been removed. Mentions of the vagrant method have been removed from the installation instructions, although the vagrant_setup.rst is still present, just not linked into the main docs. The recommended method to run Dallinger is now either natively or via virtual machine, without specifying any VM specifics. Mentions of Windows have been prepended with Microsoft for consistency.

I have not been able to compile my docs locally due to a bad connection. I apologize if there are any compilation errors, although I hope there are none.
https://github.com/Dallinger/Dallinger/pull/1453