### PR TITLE
Remove demos from docs for v5 release

### DIFF
--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -6,7 +6,10 @@ First, make sure you have Dallinger installed:
 -  :doc:`installing_dallinger_for_users`
 -  :doc:`developing_dallinger_setup_guide`
 
-To test out Dallinger, we'll run a demo experiment in debug mode.
+To test out Dallinger, we'll run a demo experiment in "debug" mode.
+
+Note that running the demo in "sandbox" mode as opposed to "debug" mode, will require a Heroku account.
+More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
 
 You can read more about this experiment here:
 `Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__ and download the experiment files.

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -8,7 +8,7 @@ First, make sure you have Dallinger installed:
 
 To test out Dallinger, we'll run a demo experiment in "debug" mode.
 
-Note that running the demo in "sandbox" mode as opposed to "debug" mode, will require a Heroku account.
+Note that running the demo in "sandbox" mode as opposed to "debug" mode will require a Heroku account.
 More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
 
 You can read more about this experiment here:

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -65,7 +65,7 @@ directory.
 
 Change into your the new directory and make sure you are still in your
 virtual environment before installing the dependencies. If you want to
-be extra careful, run the command ``workon dallinger``, which will ensure
+be extra careful, run the command ``workon dlgr_env``, which will ensure
 that you are in the right virtual environment.
 
 **Note**: if you are using Anaconda – as of August 10, 2016 – you will need to

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -28,11 +28,6 @@ and setting up Dallinger, as well as use of the command line tools.
     registration_on_OSF
     troubleshooting
 
-Dallinger Demos
-^^^^^^^^^^^^^^^
-
-Several demos that demonstrate Dallinger in action can be found :doc:`here <demo_index>`.
-
 
 Experiment Author Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -67,7 +62,7 @@ in order to develop new experiments.
 
 .. toctree::
     :maxdepth: 1
-    
+
     developing_dallinger_setup_guide
     running_the_tests
     contributing_to_dallinger

--- a/docs/source/rewarding_participants.rst
+++ b/docs/source/rewarding_participants.rst
@@ -109,8 +109,6 @@ Sometimes experimenters may wish to convert an existing Javascript and HTML expe
 
 In order to integrate with Dallinger, the experiment must use the dallinger2.js function ``createInfo`` function to send its current state to the server. This is what allows analysis of the user's performance later, so it's important to send as much information as possible.
 
-The included :doc:`demos/twentyfortyeight/index` demo is an example of this type of experiment. It shows a popular javascript game with no interaction with the server or other players. Tiles in the grid have numbers associated with them, which can be combined to gain higher numbered tiles. If the experimenter wanted to give a bonus based on the highest tile the user reached there is a strong incentive for the player to try and cheat and therefore receive a much larger payout than expected.
-
 In this case, the data is sent to the server as:
 
 .. code-block:: javascript

--- a/docs/source/rewarding_participants.rst
+++ b/docs/source/rewarding_participants.rst
@@ -45,7 +45,7 @@ This pays the user based on how well they perform in the experiment. It is very 
 
 The ``bonus`` function should be kept as simple as possible, delegating to other functions for readability.
 
-For example, the :doc:`demos/bartlett1932/index` demo involves showing participants a piece of text and asking them to reproduce it from memory. A simple reward function could be as follows:
+A simple reward function could be as follows:
 
 .. code-block:: python
 

--- a/docs/source/rewarding_participants.rst
+++ b/docs/source/rewarding_participants.rst
@@ -45,7 +45,7 @@ This pays the user based on how well they perform in the experiment. It is very 
 
 The ``bonus`` function should be kept as simple as possible, delegating to other functions for readability.
 
-A simple reward function could be as follows:
+For example, the :doc:`demos/bartlett1932/index` demo involves showing participants a piece of text and asking them to reproduce it from memory. A simple reward function could be as follows:
 
 .. code-block:: python
 

--- a/docs/source/running_bots.rst
+++ b/docs/source/running_bots.rst
@@ -4,8 +4,8 @@ Running bots as participants
 Dallinger supports running simulated experiments using bots
 that participate in the experiment automatically.
 
-Not all experiments will have bots available; the :doc:`demos/bartlett1932/index`
-and :doc:`demos/chatroom/index` demos are the only built-in experiments that do.
+Note that not all experiments will have bots available.
+The :doc:`demos/bartlett1932/index` demo does have bots available.
 
 
 Running an experiment locally with bots

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -159,4 +159,4 @@ contents of your active virtual environment's site-packages folder. In
 The contents of this file will include the path to the working copy that's
 active. If you instead see a directory tree with actual dallinger files, you can
 restore "editable mode" by re-running the installation steps for dallinger from
-the "Developer Installation" documentation.
+the :doc:`developing_dallinger_setup_guide` documentation.

--- a/docs/source/waiting_rooms.rst
+++ b/docs/source/waiting_rooms.rst
@@ -13,7 +13,7 @@ Using the waiting room
 ^^^^^^^^^^^^^^^^^^^^^^
 
 To use the waiting room, users must first be directed into it rather than
-the experiment. The :doc:`demos/chatroom/index` demo shows an example of this.
+the experiment.
 
 Your ``instructions.html`` should call ``dallinger.goToPage('waiting')`` and should
 not call ``dallinger.createParticipant``.


### PR DESCRIPTION
The link to demos was removed from the main index. 
Only references to bartlett1932 were kept throughout the docs.
Added a link in the the **demoing Dallinger** section to the **running demos on Heroku** section, so that it exists somewhere for now. (Normally found in the demo index page).

References to chatroom and 2048 demos were removed from various sections. Besides bartlett which pops up frequently in our docs, chatroom was referenced twice and 2048 once.

I made a note: https://github.com/witekdev/dallinger_demos/blob/master/README.md and point to this PR so that we can know where to re-add those references once we make sure chatroom and 2048 are working properly. **Potentially these 2 demos should be prioritized for reinclusion in the docs?**


Additionally made a small fix to name of virtualenv in developer docs section. didn't make sense to make new branch and PR to me just for it.