### PR TITLE
Update process termination in tests to work with entry point commands

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,8 +23,7 @@ def clear_workers():
 
     def _zap():
         kills = [
-            ['pkill', '-f', 'python launch.py'],
-            ['pkill', '-f', 'python worker.py'],
+            ['pkill', '-f', 'heroku'],
         ]
         for kill in kills:
             try:


### PR DESCRIPTION
## Description
Fixes tests which run `heroku local` to work with the new way of starting web and worker dynos via entry point commands.
