### PR TITLE
Unlink Required Experiment files section for v5 release

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -47,7 +47,6 @@ designing new experiments for others to use.
     creating_an_experiment
     docker_setup
     running_the_tests
-    required_experiment_files
     the_experiment_class
     classes
     web_api


### PR DESCRIPTION
This section has been removed the main index.