### PR TITLE
Log assignment status on failure

### DIFF
--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -525,9 +525,12 @@ class MTurkService(object):
                 self.mturk.approve_assignment(AssignmentId=assignment_id)
             )
         except ClientError as ex:
+            assignment = self.get_assignment(assignment_id)
             raise MTurkServiceException(
-                "Failed to approve assignment {}: {}".format(
-                    assignment_id, str(ex))
+                "Failed to approve assignment {}, {}: {}".format(
+                    assignment_id,
+                    str(assignment),
+                    str(ex))
             )
 
     def _calc_old_api_signature(self, params, *args):

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1020,6 +1020,8 @@ class TestMTurkServiceWithFakeConnection(object):
         )
 
     def test_approve_assignment_wraps_exception_helpfully(self, with_mock):
+        fake_response = fake_get_assignment_response()
+        with_mock.mturk.get_assignment = mock.Mock(return_value=fake_response)
         with_mock.mturk.configure_mock(**{
             'approve_assignment.side_effect': ClientError({}, "Boom!")
         })


### PR DESCRIPTION
## Description
When `approve_assignment` calls fail on MTurk, query for current assignment state, so it can be included in our own error message.

## Motivation and Context
Since we call MTurk to approve assignments based on messages from MTurk that the assignment has been submitted by the worker, it's a bit of mystery why MTurk then says they're in the wrong state when we attempt to approve them. More information may shed light on the matter.

## How Has This Been Tested?
- Automated tests
- Large-scale (120 participant) heroku/MTurk deployment run by @a-paxton.
