### PR TITLE
Issues/1493 travis failing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,19 +33,19 @@ install:
 services:
   - redis-server
 before_install:
-- rm -rf ~/.local/share/heroku
-- rvm install 2.1.5
-- pip install --upgrade setuptools pip wheel
+  - rm -rf ~/.local/share/heroku
+  - rvm install 2.1.5
+  - pip install --upgrade setuptools pip wheel
 install:
-- pip install tox==3.1.2
-- gem install danger
-- gem install danger-commit_lint
-- gem install chandler
+  - pip install tox==3.1.2
+  - gem install danger
+  - gem install danger-commit_lint
+  - gem install chandler
 before_script:
-- bundle exec danger
-- createuser dallinger --createdb
-- createdb -O dallinger dallinger
-- createdb -O dallinger dallinger-import-bartlett-test
+  - bundle exec danger
+  - createuser dallinger --createdb
+  - createdb -O dallinger dallinger
+  - createdb -O dallinger dallinger-import-bartlett-test
 env:
   global:
   - DATABASE_URL=postgresql://dallinger@localhost/dallinger
@@ -57,14 +57,14 @@ env:
   - secure: fd4hFOH60UV8laBN4Mjva0w/EmVK3SVC5p/0O1oqPriPhUpoJ3eVVRvITbdvPctEJJgRR9t62rPk+Rv4EOXeRFfsjZK9gOfQqv/9VhJBebdQfOx2dwQLjDiGTrklkokDIDyfpyYOoJzZ/oP+6EneD403ilHnXC4fd/4EDQmaIRI=
   - secure: 3rnkGugv5Hp71gjwQMUj5tup7/xk94p5IXEh0VItSXTziKn0pBY+yrCzAuIzlylbrl0baLaZOFGEFn2K+Jf+tr9mmN23X+zOUNsIqC4swlLLJx6hzH5AZaRmqzGjURM2gLISUayXGT9flOXyOKzzCGFELJKG9KlVyEOJ4fk04wQ=
 script:
-- tox
+  - tox
 after_success:
-- bash <(curl -s https://codecov.io/bash)
-- if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
-    sh scripts/github_releases.sh;
-  fi
+  - bash <(curl -s https://codecov.io/bash)
+  - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+      sh scripts/github_releases.sh;
+    fi
 before_deploy:
-- pandoc --from=markdown --to=rst --output=README.rst README.md
+  - pandoc --from=markdown --to=rst --output=README.rst README.md
 deploy:
   - provider: pypi  # production pypi
     distributions: sdist

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ addons:
     - pandoc
     - enchant
     - heroku-toolbelt
-    - redis-server
 install:
   - sudo apt-get --yes install snapd
   - sudo snap install --classic heroku

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -661,7 +661,7 @@ class Experiment(object):
         # We need to fake dallinger_experiment to point at the current experiment
         module = sys.modules[type(self).__module__]
         if sys.modules.get('dallinger_experiment', module) != module:
-            logger.warn('dallinger_experiment is already set, updating')
+            logger.warning('dallinger_experiment is already set, updating')
         sys.modules['dallinger_experiment'] = module
 
         # Load the configuration system and globals

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -14,7 +14,7 @@ WORKER_CLASS = 'geventwebsocket.gunicorn.workers.GeventWebSocketWorker'
 
 def when_ready(arbiter):
     # Signal to parent process that server has started
-    logger.warn('Ready.')
+    logger.warning('Ready.')
 
 
 class StandaloneServer(Application):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -806,7 +806,7 @@ class BotRecruiter(Recruiter):
             urls.append(url)
             bot = factory(url, assignment_id=assignment, worker_id=worker, hit_id=hit)
             job = q.enqueue(bot.run_experiment, timeout=self._timeout)
-            logger.warn("Created job {} for url {}.".format(job.id, url))
+            logger.warning("Created job {} for url {}.".format(job.id, url))
 
         return urls
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,14 +53,14 @@ def cwd(root):
 def experiment_dir(root):
     os.chdir('tests/experiment')
     yield
-    cwd(root)
+    os.chdir(root)
 
 
 @pytest.fixture(scope="class")
 def bartlett_dir(root):
     os.chdir('demos/dlgr/demos/bartlett1932')
     yield
-    cwd(root)
+    os.chdir(root)
 
 
 @pytest.fixture(scope='class', autouse=True)

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,6 +1,11 @@
 import mock
 
 
+def test_redis():
+    from dallinger.db import redis_conn
+    assert redis_conn.ping()
+
+
 def test_serialized(db_session):
     from dallinger.db import serialized
     from dallinger.models import Participant

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -57,7 +57,7 @@ def test_serialized(db_session):
 
 
 def test_after_commit_hook(db_session):
-    with mock.patch('dallinger.heroku.worker.conn') as redis:
+    with mock.patch('dallinger.db.redis_conn') as redis:
         from dallinger.db import queue_message
         queue_message('test', 'test')
         db_session.commit()

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
     pip install -e demos
-    coverage run {envbindir}/pytest {posargs}
+    coverage run {envbindir}/pytest -v {posargs}
     coverage combine
     coverage report
     coverage xml

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r dev-requirements.txt
     pip install -e demos
-    coverage run {envbindir}/pytest -v {posargs}
+    coverage run {envbindir}/pytest {posargs}
     coverage combine
     coverage report
     coverage xml


### PR DESCRIPTION
## Description
Fix broken Travis builds.

## Motivation and Context
Something has changed within the Travis ecosystem such that all builds started failed because no `redis` connection was available to code depending on it. 

I found that we were unnecessarily double-installing redis-server, by including it both under `services:` in .travis.yml, and also under `addons: -> apt: -> packages:`. I removed the later.

This PR also:
- cleans up the YAML syntax of .travis.yml since this was cited as the source of redis startup problems a couple places on the web, though this wasn't the problem for us
- removes the dependence on redis in some deployment tests (some MTurkLargeRecruiter tests would also benefit from this, but I didn't include those changes here)
- updates instances of `logger.warn()` to `logger.warning()` to avoid deprecation warnings
- cleans up a couple pytest fixtures to avoid deprecation warnings

## How Has This Been Tested?
Local and Travis-based automated tests.

Over the course of working on this I learned that running pytest with the `-v` option breaks the `TestAppConfiguration` tests in `test_experiment_server`.

