### PR TITLE
Add tests and refactor MTurkLargeRecruiter

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -754,7 +754,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         to_recruit = 0
         if self.pool_is_exhausted:
             # Once we've exhausted the initial pool we don't really care
-            # about the total, but keeep it up to date anyway:
+            # about the total, but keep it up to date anyway:
             self._increment_recruitment_count_by(n)
             to_recruit = n
         else:

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -11,7 +11,7 @@ class TestAgents(object):
 
     def test_create_agent_generic(self, a):
         agent = a.agent()
-        assert agent
+        assert isinstance(agent, nodes.Agent)
 
     def test_create_agent_with_participant(self, a):
         participant = a.participant()
@@ -30,10 +30,10 @@ class TestAgents(object):
         assert len(results) == 1
         assert results[0] is agent
 
-    def test_fitness_expression_search_fail(self, a):
+    def test_fitness_expression_search_requires_exact_match(self, a):
         agent = a.agent()
         agent.fitness = 1.99999
-        results = nodes.Agent.query.filter_by(fitness=1.9).all()
+        results = nodes.Agent.query.filter_by(fitness=1.9999).all()
         assert len(results) == 0
 
     def test_create_agent_generic_transmit_to_all(self, a):
@@ -46,7 +46,7 @@ class TestAgents(object):
         agent1.connect(direction="to", whom=agent3)
         assert agent1.transmit(to_whom=models.Node) == []
 
-    def test_fail_agent(self, a):
+    def test_fail_agent_assigns_time_of_death(self, a):
         agent = a.agent()
         assert agent.failed is False and agent.time_of_death is None
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -745,6 +745,7 @@ class TestMTurkLargeRecruiter(object):
             r.mturkservice = mockservice('fake key', 'fake secret', 'fake_region')
             r.mturkservice.check_credentials.return_value = True
             r.mturkservice.create_hit.return_value = {'type_id': 'fake type id'}
+            r.current_hit_id = mock.Mock(return_value='fake HIT id')
             return r
 
     def test_open_recruitment_raises_error_if_experiment_in_progress(self, a, recruiter):
@@ -761,7 +762,7 @@ class TestMTurkLargeRecruiter(object):
         assert len(result['items']) == 1
         recruiter.mturkservice.check_credentials.assert_called_once()
 
-    def test_open_recruitment_single_recruitee(self, recruiter):
+    def test_open_recruitment_single_recruitee_actually_overrecruits(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
             ad_url='http://fake-domain/ad?recruiter=mturklarge',
@@ -779,8 +780,9 @@ class TestMTurkLargeRecruiter(object):
             annotation='some experiment uid',
         )
 
-    def test_more_than_ten_can_be_recruited_on_open(self, recruiter):
-        recruiter.open_recruitment(n=20)
+    def test_open_recruitment_with_more_than_pool_size_uses_requested_count(self, recruiter):
+        num_recruits = recruiter.pool_size + 1
+        recruiter.open_recruitment(n=num_recruits)
         recruiter.mturkservice.create_hit.assert_called_once_with(
             ad_url='http://fake-domain/ad?recruiter=mturklarge',
             approve_requirement=95,
@@ -788,7 +790,7 @@ class TestMTurkLargeRecruiter(object):
             duration_hours=1.0,
             keywords=['kw1', 'kw2', 'kw3'],
             lifetime_days=1,
-            max_assignments=20,
+            max_assignments=num_recruits,
             notification_url='https://url-of-notification-route',
             reward=0.01,
             title='fake experiment title',
@@ -798,35 +800,55 @@ class TestMTurkLargeRecruiter(object):
         )
 
     def test_recruit_participants_auto_recruit_on_recruits_for_current_hit(self, recruiter):
-        fake_hit_id = 'fake HIT id'
-        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
         recruiter.open_recruitment(n=1)
-        recruiter.recruit(n=9)
+        recruiter.recruit(n=recruiter.pool_size - 1)
+
         recruiter.mturkservice.extend_hit.assert_not_called()
+
         recruiter.recruit(n=1)
+
         recruiter.mturkservice.extend_hit.assert_called_once_with(
             'fake HIT id',
             duration_hours=1.0,
             number=1
         )
 
-    def test_recruiting_partially_from_preallocated_pool(self, recruiter):
-        fake_hit_id = 'fake HIT id'
-        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+    def test_recruit_draws_partially_from_preallocated_pool(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.recruit(n=5)
+
         recruiter.mturkservice.extend_hit.assert_not_called()
         recruiter.recruit(n=10)
+
         recruiter.mturkservice.extend_hit.assert_called_once_with(
             'fake HIT id',
             duration_hours=1.0,
             number=6
         )
 
+    def test_recruit_right_at_cutoff(self, recruiter):
+        recruiter.open_recruitment(n=recruiter.pool_size)
+        recruiter.recruit()
+
+        recruiter.mturkservice.extend_hit.assert_called_once_with(
+            'fake HIT id',
+            duration_hours=1.0,
+            number=1
+        )
+
+    def test_recruit_more_after_initial_recruitment_exceeding_pool_size(self, recruiter):
+        recruiter.open_recruitment(n=recruiter.pool_size + 1)
+        recruiter.recruit(n=5)
+
+        recruiter.mturkservice.extend_hit.assert_called_once_with(
+            'fake HIT id',
+            duration_hours=1.0,
+            number=5
+        )
+
     def test_recruit_auto_recruit_off_does_not_extend_hit(self, recruiter):
         recruiter.config['auto_recruit'] = False
-        fake_hit_id = 'fake HIT id'
-        recruiter.current_hit_id = mock.Mock(return_value=fake_hit_id)
+
         recruiter.recruit()
 
         assert not recruiter.mturkservice.extend_hit.called


### PR DESCRIPTION
## Description
I thought I'd found a subtle bug in the MTurkLargeRecruiter, because the logic of the recruit() method was hard to follow. This PR just adds or clarifies some tests, and then refactors that method.

## Motivation and Context
1. Clarity
2. Avoid depending on the real redis connection in these tests. We have other tests for the redis connection.

## How Has This Been Tested?
Full automated test coverage.
