### PR TITLE
store identity data from start

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -74,6 +74,14 @@ var dallinger = (function () {
     mode: dlgr.getUrlParameter('mode'),
     participantId: dlgr.getUrlParameter('participant_id')
   };
+  if (typeof store !== "undefined") {
+    store.set("recruiter", dlgr.identity.recruiter);
+    store.set("hit_id", dlgr.identity.hitId);
+    store.set("worker_id", dlgr.identity.workerId);
+    store.set("assignment_id", dlgr.identity.assignmentId);
+    store.set("participant_id", dlgr.identity.participantId);
+    store.set("mode", dlgr.identity.mode);
+  }
 
   dlgr.BusyForm = (function () {
     /* Loads a spinner as a visual cue that something is happening


### PR DESCRIPTION
Save identity data taken from the ad URL at experiment start.

## Description
Check for the js store, and if available save dlgr.identity data.

## Motivation and Context
Currently, experiments require explicitly setting identity parameters in experiment js. This is usually done after consent. This is prone to errors and requires repeating the same lines of code in every experiment. This PR sets the store data right after taking it from the experiment URL. This allows users to focus on the experiment and not having to deal with required boilerplate that can crash their experiment if missing.

## How Has This Been Tested?
Tested in debug and sandbox modes.

