### PR TITLE
Optimize redis connection in worker

### DIFF
--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -525,9 +525,12 @@ class MTurkService(object):
                 self.mturk.approve_assignment(AssignmentId=assignment_id)
             )
         except ClientError as ex:
+            assignment = self.get_assignment(assignment_id)
             raise MTurkServiceException(
-                "Failed to approve assignment {}: {}".format(
-                    assignment_id, str(ex))
+                "Failed to approve assignment {}, {}: {}".format(
+                    assignment_id,
+                    str(assignment),
+                    str(ex))
             )
 
     def _calc_old_api_signature(self, params, *args):

--- a/dallinger_scripts/worker.py
+++ b/dallinger_scripts/worker.py
@@ -1,24 +1,23 @@
 """Heroku web worker."""
-# Make sure gevent patches are applied early.
-import os
-
 listen = ['high', 'default', 'low']
 
 
 def main():
     import gevent.monkey
     gevent.monkey.patch_all()
+    from gevent.queue import LifoQueue
 
     # These imports are inside the __main__ block
     # to make sure that we only import from rq_gevent_worker
     # (which has the side effect of applying gevent monkey patches)
     # in the worker process. This way other processes can import the
     # redis connection without that side effect.
+    import os
+    from redis import BlockingConnectionPool, StrictRedis
     from rq import (
         Queue,
         Connection
     )
-    from dallinger.db import redis_conn
     from dallinger.heroku.rq_gevent_worker import GeventWorker as Worker
 
     from dallinger.config import initialize_experiment_package
@@ -26,6 +25,10 @@ def main():
 
     import logging
     logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
+    redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
+    redis_pool = BlockingConnectionPool.from_url(redis_url,
+                                                 queue_class=LifoQueue)
+    redis_conn = StrictRedis(connection_pool=redis_pool)
 
     with Connection(redis_conn):
         worker = Worker(list(map(Queue, listen)))

--- a/dallinger_scripts/worker.py
+++ b/dallinger_scripts/worker.py
@@ -26,6 +26,8 @@ def main():
     import logging
     logging.basicConfig(format='%(asctime)s %(message)s', level=logging.DEBUG)
     redis_url = os.getenv('REDIS_URL', 'redis://localhost:6379')
+    # Specify queue class for improved performance with gevent.
+    # see http://carsonip.me/posts/10x-faster-python-gevent-redis-connection-pool/
     redis_pool = BlockingConnectionPool.from_url(redis_url,
                                                  queue_class=LifoQueue)
     redis_conn = StrictRedis(connection_pool=redis_pool)

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1020,6 +1020,8 @@ class TestMTurkServiceWithFakeConnection(object):
         )
 
     def test_approve_assignment_wraps_exception_helpfully(self, with_mock):
+        fake_response = fake_get_assignment_response()
+        with_mock.mturk.get_assignment = mock.Mock(return_value=fake_response)
         with_mock.mturk.configure_mock(**{
             'approve_assignment.side_effect': ClientError({}, "Boom!")
         })


### PR DESCRIPTION
## Description
1. Moves creation of the redis connection for the heroku worker into the new `worker` script, and applies `gevent.monkey.patch_all()` beforehand
2. Improves performance of redis in conjunction with gevent in the context of the heroku worker process
3. Logs details of MTurk assignment when an ApproveAssignment request fails

## Motivation and Context
Consistent timing problems in the worker process following the move of the worker, web, and and clock into entry_point scripts suggested a problem with the order and manner of gevent patching. This work was an somewhat of an experiment, but seems to have been successful.

## How Has This Been Tested?
Large-scale (120 participant) heroku/MTurk deployment run by @a-paxton.

## Note
This PR includes all the commits from https://github.com/Dallinger/Dallinger/pull/1491, and so supersedes it if merged first.
