### PR TITLE
Issues/1554 store undefined vals

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -101,7 +101,6 @@ var dallinger = (function () {
     dlgr.storage.set("hit_id", dlgr.identity.hitId);
     dlgr.storage.set("worker_id", dlgr.identity.workerId);
     dlgr.storage.set("assignment_id", dlgr.identity.assignmentId);
-    dlgr.storage.set("participant_id", dlgr.identity.participantId);
     dlgr.storage.set("mode", dlgr.identity.mode);
   }
 

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -48,6 +48,36 @@ var dallinger = (function () {
     }
   };
 
+  dlgr.storage = {
+    available: typeof store !== 'undefined',
+    _storage: store,
+    set: function (key, value) {
+      if (this._isUndefined(value)) {
+        return;
+      }
+      this._storage.set(key, value);
+    },
+    setMany: function (obj) {
+      var k, v;
+      for (k in obj) {
+        if (obj.hasOwnProperty(k)) {
+           this.set(k, obj[k]);
+        }
+      }
+    },
+    get: function (key) {
+      return this._storage.get(key);
+    },
+    all: function () {
+      return this._storage.getAll();
+    },
+    _isUndefined: function (value) {
+      return typeof value === 'undefined';
+    }
+
+
+  };
+
   /**
    * ``dallinger.identity`` provides information about the participant.
    * It has the following string properties:
@@ -74,13 +104,14 @@ var dallinger = (function () {
     mode: dlgr.getUrlParameter('mode'),
     participantId: dlgr.getUrlParameter('participant_id')
   };
-  if (typeof store !== "undefined") {
-    store.set("recruiter", dlgr.identity.recruiter);
-    store.set("hit_id", dlgr.identity.hitId);
-    store.set("worker_id", dlgr.identity.workerId);
-    store.set("assignment_id", dlgr.identity.assignmentId);
-    store.set("participant_id", dlgr.identity.participantId);
-    store.set("mode", dlgr.identity.mode);
+  if (dlgr.storage.available) {
+    // dlgr.storage.setMany(dlgr.identity);
+    dlgr.storage.set("recruiter", dlgr.identity.recruiter);
+    dlgr.storage.set("hit_id", dlgr.identity.hitId);
+    dlgr.storage.set("worker_id", dlgr.identity.workerId);
+    dlgr.storage.set("assignment_id", dlgr.identity.assignmentId);
+    dlgr.storage.set("participant_id", dlgr.identity.participantId);
+    dlgr.storage.set("mode", dlgr.identity.mode);
   }
 
   dlgr.BusyForm = (function () {
@@ -204,13 +235,13 @@ var dallinger = (function () {
   var get_hit_params = function() {
     // check if the local store is available, and if so, use it.
     var data = {};
-    if (typeof store !== "undefined") {
-      data.recruiter = store.get("recruiter");
-      data.worker_id = store.get("worker_id");
-      data.hit_id = store.get("hit_id");
-      data.assignment_id = store.get("assignment_id");
-      data.mode = store.get("mode");
-      data.fingerprint_hash = store.get("fingerprint_hash");
+    if (dlgr.storage.available) {
+      data.recruiter = dlgr.storage.get("recruiter");
+      data.worker_id = dlgr.storage.get("worker_id");
+      data.hit_id = dlgr.storage.get("hit_id");
+      data.assignment_id = dlgr.storage.get("assignment_id");
+      data.mode = dlgr.storage.get("mode");
+      data.fingerprint_hash = dlgr.storage.get("fingerprint_hash");
     } else {
       data.recruiter = dlgr.identity.recruiter;
       data.worker_id = dlgr.identity.worker_id;

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -57,14 +57,6 @@ var dallinger = (function () {
       }
       this._storage.set(key, value);
     },
-    setMany: function (obj) {
-      var k, v;
-      for (k in obj) {
-        if (obj.hasOwnProperty(k)) {
-           this.set(k, obj[k]);
-        }
-      }
-    },
     get: function (key) {
       return this._storage.get(key);
     },
@@ -105,7 +97,6 @@ var dallinger = (function () {
     participantId: dlgr.getUrlParameter('participant_id')
   };
   if (dlgr.storage.available) {
-    // dlgr.storage.setMany(dlgr.identity);
     dlgr.storage.set("recruiter", dlgr.identity.recruiter);
     dlgr.storage.set("hit_id", dlgr.identity.hitId);
     dlgr.storage.set("worker_id", dlgr.identity.workerId);


### PR DESCRIPTION
## Description
Minimal change to fix #1554 

A positive side effect of this change is that experiments will not need to explicitly store participant values in their own JS code. This routine becomes obsolete (from Bartlett's experiment.js):
```
  $("#consent").click(function() {
    store.set("recruiter", dallinger.getUrlParameter("recruiter"));
    store.set("hit_id", dallinger.getUrlParameter("hit_id"));
    store.set("worker_id", dallinger.getUrlParameter("worker_id"));
    store.set("assignment_id", dallinger.getUrlParameter("assignment_id"));
    store.set("mode", dallinger.getUrlParameter("mode"));
```
## How Has This Been Tested?
Griduniverse and memoryexp2 manual testing

