### PR TITLE
Update rq to 0.13.0

### DIFF
--- a/constraints-deps.txt
+++ b/constraints-deps.txt
@@ -74,7 +74,7 @@ pyzmq==17.1.2
 qtconsole==4.4.1
 redis==3.0.1
 requests==2.20.1
-rq==0.12.0
+rq==0.13.0
 s3transfer==0.1.13
 scandir==1.9.0
 send2trash==1.5.0

--- a/constraints.txt
+++ b/constraints.txt
@@ -15,7 +15,7 @@ psutil==5.4.8
 psycopg2-binary==2.7.6.1
 redis==3.0.1
 requests==2.20.1
-rq==0.12.0
+rq==0.13.0
 selenium==3.141.0
 six==1.11.0
 sqlalchemy-postgres-copy==0.5.0


### PR DESCRIPTION
With rq version 0.12.0, this bug was found in Dallinger by @suchow :
```
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1: Traceback (most recent call last): 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "src/gevent/greenlet.py", line 716, in gevent._greenlet.Greenlet.run 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "/app/.heroku/python/lib/python3.6/site-packages/rq/worker.py", line 781, in perform_job 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:     self.prepare_job_execution(job) 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "/app/.heroku/python/lib/python3.6/site-packages/rq/worker.py", line 706, in prepare_job_execution 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:     registry.add(job, timeout, pipeline=pipeline) 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "/app/.heroku/python/lib/python3.6/site-packages/rq/registry.py", line 47, in add 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:     return pipeline.zadd(self.key, score, job.id) 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "/app/.heroku/python/lib/python3.6/site-packages/redis/client.py", line 2263, in zadd 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:     for pair in iteritems(mapping): 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:   File "/app/.heroku/python/lib/python3.6/site-packages/redis/_compat.py", line 123, in iteritems 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:      for pair in iteritems(mapping): 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:    File "/app/.heroku/python/lib/python3.6/site-packages/redis/_compat.py", line 123, in iteritems 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:      return iter(x.items()) 
Dec 13 07:55:17 dlgr-8372b4ee app/worker.1:  AttributeError: 'int' object has no attribute 'items'
 ```

Updating rq to 0.13.0 solves this problem.