### PR TITLE
Release version 5.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v5.0.2](https://github.com/dallinger/dallinger/tree/v5.0.2) (2018-12-18)
+
+- Documentation improvements and additions:
+  + Update Creating an Experiment documentation to use dallinger.goToPage() standard
+  + Reintroduce seven working demos into the documentation
+
+- Legacy `dallinger.js` has been removed
+- Fixed: AttributeError: 'int' object has no attribute 'items' (rq has been updated to 0.13.0 to fix this)
+- Fixed: dallinger2.js: valid store values are overwritten with 'undefined'
+
 ## [v5.0.1](https://github.com/dallinger/dallinger/tree/v5.0.1) (2018-11-30)
 
 - Documentation improvements and additions:

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "5.0.1"
+__version__ = "5.0.2"

--- a/demos/dlgr/demos/bartlett1932/requirements.txt
+++ b/demos/dlgr/demos/bartlett1932/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/chatroom/requirements.txt
+++ b/demos/dlgr/demos/chatroom/requirements.txt
@@ -1,2 +1,2 @@
 nltk==3.3
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/concentration/requirements.txt
+++ b/demos/dlgr/demos/concentration/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/function_learning/requirements.txt
+++ b/demos/dlgr/demos/function_learning/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/iterated_drawing/requirements.txt
+++ b/demos/dlgr/demos/iterated_drawing/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/mcmcp/requirements.txt
+++ b/demos/dlgr/demos/mcmcp/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/rogers/requirements.txt
+++ b/demos/dlgr/demos/rogers/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/sheep_market/requirements.txt
+++ b/demos/dlgr/demos/sheep_market/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/snake/requirements.txt
+++ b/demos/dlgr/demos/snake/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/twentyfortyeight/requirements.txt
+++ b/demos/dlgr/demos/twentyfortyeight/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/demos/dlgr/demos/vox_populi/requirements.txt
+++ b/demos/dlgr/demos/vox_populi/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.1
+dallinger==5.0.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.1
+current_version = 5.0.2
 commit = False
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup_args = dict(
     name='dallinger',
     packages=['dallinger', 'dallinger_scripts'],
-    version="5.0.1",
+    version="5.0.2",
     description='Laboratory automation for the behavioral and social sciences',
     url='http://github.com/Dallinger/Dallinger',
     maintainer='Jordan Suchow',


### PR DESCRIPTION
- Documentation improvements and additions:
  + Update Creating an Experiment documentation to use dallinger.goToPage() standard
  + Reintroduce seven working demos into the documentation


- Legacy `dallinger.js` has been removed
- Fixed: AttributeError: 'int' object has no attribute 'items' (rq has been updated to 0.13.0 to fix this)
- Fixed: dallinger2.js: valid store values are overwritten with 'undefined'