### PR TITLE
Stories/448 missing fingerprint

### DIFF
--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -22,8 +22,8 @@
             <script src="/static/scripts/reconnecting-websocket.js"></script>
             <script src="/static/scripts/spin.min.js" type="text/javascript"></script>
             <script src="/static/scripts/store+json2.min.js" type="text/javascript"></script>
-            <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
             <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+            <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
         {% endblock %}
         {% block scripts %}
             <script type="text/javascript">


### PR DESCRIPTION
## Description
The fingerprint_hash value was in some cases not written to the Participant record.

## Motivation and Context
`Fingerprint2.get()` is an asynchronous function, so calling it inside `createParticipant()` is too late. Unless a fingerprint was already stored (often the case when debugging), the value would be undefined until after it was referenced. 

This PR moves the call to the time when the `dallinger` JS namespace module is loaded and other identifying values (HIT Id, worker Id, etc.) are stored.

## How Has This Been Tested?
Bartlett and GU demos.

