### PR TITLE
Check valid experiment dir

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -143,75 +143,100 @@ def verify_id(ctx, param, app):
     return app
 
 
-def verify_package(verbose=True):
-    """Ensure the package has a config file and a valid experiment file."""
-    is_passing = True
-
-    # Check for existence of required files.
-    required_files = [
+def verify_directory(verbose=True):
+    """Ensure that the current directory looks like a Dallinger experiment.
+    """
+    ok = True
+    expected_files = [
         "config.txt",
         "experiment.py",
     ]
 
-    for f in required_files:
+    for f in expected_files:
         if os.path.exists(f):
             log("✓ {} is PRESENT".format(f), chevrons=False, verbose=verbose)
         else:
             log("✗ {} is MISSING".format(f), chevrons=False, verbose=verbose)
-            is_passing = False
+            ok = False
 
-    # Check the experiment file.
-    if os.path.exists("experiment.py"):
+    return ok
 
-        # Check if the experiment file has exactly one Experiment class.
-        tmp = tempfile.mkdtemp()
-        clone_dir = os.path.join(tmp, 'temp_exp_package')
-        to_ignore = shutil.ignore_patterns(
-            os.path.join(".git", "*"),
-            "*.db",
-            "snapshots",
-            "data",
-            "server.log"
-        )
-        shutil.copytree(os.getcwd(), clone_dir, ignore=to_ignore)
 
-        initialize_experiment_package(clone_dir)
-        from dallinger_experiment import experiment
-        classes = inspect.getmembers(experiment, inspect.isclass)
-        exps = [c for c in classes
-                if (c[1].__bases__[0].__name__ in "Experiment")]
+def verify_experiment_module(verbose):
+    """Perform basic sanity checks on experiment.py.
+    """
+    ok = True
+    if not os.path.exists("experiment.py"):
+        return False
 
-        if len(exps) == 0:
-            log("✗ experiment.py does not define an experiment class.",
-                delay=0, chevrons=False, verbose=verbose)
-            is_passing = False
-        elif len(exps) == 1:
-            log("✓ experiment.py defines 1 experiment",
-                delay=0, chevrons=False, verbose=verbose)
-        else:
-            log("✗ experiment.py defines more than one experiment class.",
-                delay=0, chevrons=False, verbose=verbose)
+    # Check if the experiment file has exactly one Experiment class.
+    tmp = tempfile.mkdtemp()
+    clone_dir = os.path.join(tmp, 'temp_exp_package')
+    to_ignore = shutil.ignore_patterns(
+        os.path.join(".git", "*"),
+        "*.db",
+        "snapshots",
+        "data",
+        "server.log"
+    )
+    shutil.copytree(os.getcwd(), clone_dir, ignore=to_ignore)
 
+    initialize_experiment_package(clone_dir)
+    from dallinger_experiment import experiment
+    classes = inspect.getmembers(experiment, inspect.isclass)
+    exps = [c for c in classes
+            if (c[1].__bases__[0].__name__ in "Experiment")]
+
+    if len(exps) == 0:
+        log("✗ experiment.py does not define an experiment class.",
+            delay=0, chevrons=False, verbose=verbose)
+        ok = False
+    elif len(exps) == 1:
+        log("✓ experiment.py defines 1 experiment",
+            delay=0, chevrons=False, verbose=verbose)
+    else:
+        log("✗ experiment.py defines more than one experiment class.",
+            delay=0, chevrons=False, verbose=verbose)
+
+    return ok
+
+
+def verify_config(verbose=True):
+    """Check for common or costly errors in experiment configuration.
+    """
+    ok = True
     config = get_config()
     if not config.ready:
         config.load()
-
     # Check base_payment is correct
-    base_pay = config.get('base_payment')
-    dollarFormat = "{:.2f}".format(base_pay)
+    try:
+        base_pay = config.get('base_payment')
+    except KeyError:
+        log("✗ No value for base_pay.", delay=0, chevrons=False, verbose=verbose)
+    else:
+        dollarFormat = "{:.2f}".format(base_pay)
 
-    if base_pay <= 0:
-        log("✗ base_payment must be positive value in config.txt.",
-            delay=0, chevrons=False, verbose=verbose)
-        is_passing = False
+        if base_pay <= 0:
+            log("✗ base_payment must be positive value in config.txt.",
+                delay=0, chevrons=False, verbose=verbose)
+            ok = False
 
-    if float(dollarFormat) != float(base_pay):
-        log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
-            "{0} to {1}.".format(base_pay, dollarFormat), delay=0, chevrons=False, verbose=verbose)
-        is_passing = False
+        if float(dollarFormat) != float(base_pay):
+            log("✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
+                "{0} to {1}.".format(base_pay, dollarFormat),
+                delay=0, chevrons=False, verbose=verbose)
+            ok = False
 
-    # Check front-end files do not exist
-    files = [
+    return ok
+
+
+def verify_no_conflicts(verbose=True):
+    """Warn if there are filenames which conflict with those deployed by
+    Dallinger, but always returns True (meaning "OK").
+    """
+    conflicts = False
+
+    reserved_files = [
         os.path.join("templates", "complete.html"),
         os.path.join("templates", "error.html"),
         os.path.join("templates", "error-complete.html"),
@@ -224,14 +249,32 @@ def verify_package(verbose=True):
         os.path.join("static", "robots.txt")
     ]
 
-    for f in files:
+    for f in reserved_files:
         if os.path.exists(f):
             log("✗ {} OVERWRITES shared frontend files inserted at run-time".format(f),
                 delay=0, chevrons=False, verbose=verbose)
+            conflicts = True
 
-    log("✓ no file conflicts", delay=0, chevrons=False, verbose=verbose)
+    if not conflicts:
+        log("✓ no file conflicts", delay=0, chevrons=False, verbose=verbose)
 
-    return is_passing
+    return True
+
+
+def verify_package(verbose=True):
+    """Perform a series of checks on the current directory to verify that
+    it's a valid Dallinger experiment.
+    """
+    results = (
+        verify_directory(verbose),
+        verify_experiment_module(verbose),
+        verify_config(verbose),
+        verify_no_conflicts(verbose)
+    )
+
+    ok = all(results)
+
+    return ok
 
 
 click.disable_unicode_literals_warning = True

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -11,7 +11,6 @@ from dallinger.bots import BotBase
 from dallinger.networks import Chain
 from dallinger.experiment import Experiment
 
-from . import models
 
 logger = logging.getLogger(__file__)
 
@@ -27,6 +26,7 @@ class Bartlett1932(Experiment):
         Finally, setup() is called.
         """
         super(Bartlett1932, self).__init__(session)
+        from . import models  # Import at runtime to avoid SQLAlchemy warnings
         self.models = models
         self.experiment_repeats = 1
         self.initial_recruitment_size = 1


### PR DESCRIPTION
## Description
Fail early with an explicit error message when running a command that requires being in a Dallinger experiment directory if you are not.

## Motivation and Context
Currently if you run `debug`, `sandbox`, or `deploy` outside of an experiment directory, you get a very confusing traceback, and risk unpleasant accidental side-effects. This PR introduces a sanity check for these commands, so the problem is detected early and reported clearly.

```
$ dallinger debug --verbose
✗ config.txt is MISSING
✗ experiment.py is MISSING
Usage: dallinger debug [OPTIONS]

Error: The current directory is not a Dallinger experiment.
```

The changes also include a breaking down of the `verify_package()` function so that it delegates to smaller, single-purpose functions, so that the basic directory check can be run separately. This was done largely to simplify test setup.

A summary has also been added to the output of `dallinger verify`:
```
$  dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✗ config.txt is MISSING
✗ experiment.py is MISSING
✗ No value for base_pay.
✓ no file conflicts

❯❯ ☹ Some problems were found.
```
 or
```
$  dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✓ experiment.py defines 1 experiment
✓ no file conflicts

❯❯ ✓ Everything looks good!
```

## How Has This Been Tested?
* Automated tests
* Manual testing with Bartlett demo and Griduniverse

