### PR TITLE
Start monitoring JS code coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ cache:
   - bundler
   - pip
   - yarn
+  - npm
 matrix:
   include:
   - python: 2.7
@@ -42,6 +43,7 @@ install:
   - gem install danger
   - gem install danger-commit_lint
   - gem install chandler
+  - npm install
 before_script:
   - bundle exec danger
   - createuser dallinger --createdb
@@ -59,6 +61,7 @@ env:
   - secure: 3rnkGugv5Hp71gjwQMUj5tup7/xk94p5IXEh0VItSXTziKn0pBY+yrCzAuIzlylbrl0baLaZOFGEFn2K+Jf+tr9mmN23X+zOUNsIqC4swlLLJx6hzH5AZaRmqzGjURM2gLISUayXGT9flOXyOKzzCGFELJKG9KlVyEOJ4fk04wQ=
 script:
   - tox
+  - npm run test --coverage
 after_success:
   - bash <(curl -s https://codecov.io/bash)
   - if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -647,3 +647,4 @@ var dallinger = (function () {
   return dlgr;
 }());
 
+module.exports.dallinger = dallinger;

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -1,0 +1,29 @@
+const store = require('./store+json2.min');
+global.store = store;
+
+// Mock out alert to the command line, so we can see errors
+global.window.alert = console.log;
+
+function Fingerprint2() {
+    // This mocks out Fingerprint2 
+    function get() {
+      return "testing";
+    };
+    return {"get": get};
+  }
+global.window.Fingerprint2 = Fingerprint2;
+
+const dlgr = require('./dallinger2').dallinger;
+
+
+
+test('Passes adblock check', () => {
+    expect(dlgr.missingFingerprint()).toBe(false);
+});
+
+test('Storage is available', () => {
+  expect(dlgr.storage.available).toBe(true);
+  expect(dlgr.storage.get('foo')).toBe(undefined);
+  dlgr.storage.set('foo', 'bar');
+  expect(dlgr.storage.get('foo')).toBe('bar');
+});

--- a/package.json
+++ b/package.json
@@ -6,13 +6,30 @@
   "devDependencies": {
     "browser-sync": "^2.18.8",
     "browser-sync-webpack-plugin": "^1.1.4",
+    "fingerprintjs2": "^1.5.1",
+    "jest": "^23.6.0",
     "jsdoc": "^3.5.5",
     "uglify-es": "^3.0.28",
     "webpack": "^2.4.1"
   },
   "scripts": {
     "build": "webpack",
-    "dev": "webpack --watch"
+    "dev": "webpack --watch",
+    "test": "jest"
+  },
+  "jest": {
+    "collectCoverage": true,
+    "coverageDirectory": "coverage",
+    "roots": [
+      "<rootDir>/dallinger/"
+    ],
+    "testPathIgnorePatterns": [
+      "<rootDir>/node_modules"
+    ],
+    "coveragePathIgnorePatterns": [
+      "<rootDir>/node_modules",
+      ".min.js"
+    ]
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description
This enables the Jest JS testing framework and integrates it into CI.

## Motivation and Context
I noticed that PR #1556 has no tests but makes lots of changes I don't understand. This made me nervous, but I couldn't fail the PR as there is no testing framework for JavaScript in Dallinger. To that end, I've added a basic one and a first test, in the hope that it will shame us into starting to test the JS library.

## How Has This Been Tested?
I wrote two basic tests and verified that they pass and are run by Travis.
