### PR TITLE
Profiles on osx

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -35,6 +35,7 @@ default_keys = (
     ('browser_exclude_rule', six.text_type, []),
     ('clock_on', bool, []),
     ('contact_email_on_error', six.text_type, []),
+    ('chrome-path', six.binary_type, []),
     ('dallinger_email_address', six.text_type, []),
     ('database_size', six.text_type, []),
     ('database_url', six.text_type, [], True),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -39,7 +39,8 @@ def _make_chrome(path):
             # the default
             firstrun.flush()
     new_chrome.remote_args = webbrowser.Chrome.remote_args + [
-        '--user-data-dir="{}"'.format(profile_directory)
+        '--user-data-dir="{}"'.format(profile_directory),
+        '--no-first-run',
     ]
     return new_chrome
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -27,7 +27,7 @@ from dallinger.utils import GitClient
 
 
 config = get_config()
-OSX_CHROME_PATH = 'Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+OSX_CHROME_PATH = '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
 
 
 def _make_chrome(path):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -120,8 +120,11 @@ class TestIsolatedWebbrowser(object):
 
     def test_fallback_isolation(self):
         import webbrowser
-        with mock.patch('dallinger.deployment.is_command') as is_command:
-            is_command.return_value = False
+        with mock.patch.multiple(
+            'dallinger.deployment', is_command=mock.DEFAULT, sys=mock.DEFAULT
+        ) as patches:
+            patches['is_command'].return_value = False
+            patches['sys'].platform = 'anything but "darwin"'
             isolated = new_webbrowser_profile()
         assert isolated == webbrowser
 


### PR DESCRIPTION
## Description
This adds a special case to `new_webbrowser_profile` which attempts to cover the most common codepath on OSX, which was previously unsupported.

## Motivation and Context
This is an attempt to fix the issue in #1361, which is that #816 doesn't work on Apple Macs.

## How Has This Been Tested?
This has not been tested. I don't have an apple device anymore. Could you take a look perhaps, @vlall?