### PR TITLE
Prevent chrome from showing default browser popup on debug runs

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -31,7 +31,8 @@ def new_webbrowser_profile():
         new_chrome.name = 'google-chrome'
         profile_directory = tempfile.mkdtemp()
         new_chrome.remote_args = webbrowser.Chrome.remote_args + [
-            '--user-data-dir="{}"'.format(profile_directory)
+            '--user-data-dir="{}"'.format(profile_directory),
+            '--no-first-run',
         ]
         return new_chrome
     elif is_command('firefox'):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -103,9 +103,10 @@ class TestIsolatedWebbrowser(object):
             isolated = new_webbrowser_profile()
         assert isinstance(isolated, webbrowser.Chrome)
         assert isolated.remote_args[:2] == [r'%action', r'%s']
-        assert isolated.remote_args[-1].startswith(
+        assert isolated.remote_args[-2].startswith(
             '--user-data-dir="{}'.format(tempfile.gettempdir())
         )
+        assert isolated.remote_args[-1] == r'--no-first-run'
 
     def test_firefox_isolation(self):
         import webbrowser


### PR DESCRIPTION
Change deployment script to add command line option for preventing chrome to ask to be default browser when running in debug mode.

## Motivation and Context
It is annoying to have to click through this popup for every recruitment request in an experiment debug run.

