### PR TITLE
Pin chandler ruby gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - pip install tox==3.1.2
   - gem install danger
   - gem install danger-commit_lint
-  - gem install chandler
+  - gem install chandler -v 0.7.0
   - npm install
 before_script:
   - bundle exec danger


### PR DESCRIPTION


## Description
Pin version of chandler gem used by `danger` on Travis CI

## Motivation and Context
Our version of Ruby only supports versions of chandler <= 0.7.0
```
3.08s$ gem install danger
Successfully installed claide-1.0.2
Successfully installed nap-1.1.0
Successfully installed colored2-3.1.2
Successfully installed cork-0.3.0
Successfully installed open4-1.3.4
Successfully installed claide-plugins-0.9.2
Successfully installed git-1.5.0
Successfully installed multipart-post-2.0.0
Successfully installed faraday-0.15.4
Successfully installed faraday-http-cache-1.3.1
Successfully installed public_suffix-3.0.3
Successfully installed addressable-2.5.2
Successfully installed sawyer-0.8.1
Successfully installed octokit-4.13.0
Successfully installed kramdown-1.17.0
Successfully installed unicode-display_width-1.4.1
Successfully installed terminal-table-1.8.0
Successfully installed no_proxy_fix-0.1.2
Successfully installed danger-5.12.0
19 gems installed
install.3
0.61s$ gem install danger-commit_lint
Successfully installed danger-commit_lint-0.0.6
1 gem installed
0.57s$ gem install chandler
ERROR:  Error installing chandler:
	The last version of chandler (>= 0) to support your Ruby & RubyGems was 0.7.0. Try installing it with `gem install chandler -v 0.7.0`
	chandler requires Ruby version >= 2.3.0. The current ruby version is 2.1.0.
Successfully installed netrc-0.11.0
The command "gem install chandler" failed and exited with 1 during .
Your build has been stopped.
```

## How Has This Been Tested?
Travis build with no other changes.
