### PR TITLE
Tweak styling of network docs

### DIFF
--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -11,7 +11,7 @@ require participants to interact among themselves in various ways.
 In Dallinger, these interactions among participants and stimuli are
 represented using networks. Each participant and each stimulus represent a
 node in a network. The way these nodes are connected to each other is known
-as a `network topology`. For brevity, we will use the term `network` from now
+as a ``network topology``. For brevity, we will use the term ``network`` from now
 on when discussing Dallinger network topologies.
 
 Dallinger comes with a variety of networks that can be used by experimenters,
@@ -33,18 +33,18 @@ Nodes and Sources
 -----------------
 
 In these networks, each participant is considered as a node. There is also a
-special kind of node, known as a `source`, which transmits information to
+special kind of node, known as a ``source``, which transmits information to
 other nodes. Sources are used in Dallinger as a means to send the stimuli to
 the participants. Not all experiments have sources, though. A chatroom
 experiment, for example, could just rely on user interactions and not
 require any other stimuli.
 
-All nodes have methods named `transmit` and `receive`, for sending and
+All nodes have methods named ``transmit`` and ``receive``, for sending and
 receiving information to or from other nodes. These methods can be used when
 adding a node to allow any specialized communication between nodes that an
 experiment may require.
 
-Nodes can have a `fitness` property, which is a number that can be used in
+Nodes can have a ``fitness`` property, which is a number that can be used in
 some network models. The basic networks do not use this property.
 
 Some networks require that nodes have other properties, so for properly using
@@ -60,11 +60,11 @@ A node can be connected to another node in three ways:
 2. a single direction connection from another node ("from")
 3. a bidirectional connection to another node ("both")
 
-A node can transmit information when connected `to` another node. It can
-receive information when connected `from` another node. If it is connected to
-another node in `both` directions, it can both receive and transmit.
+A node can transmit information when connected ``to`` another node. It can
+receive information when connected ``from`` another node. If it is connected to
+another node in ``both`` directions, it can both receive and transmit.
 
-Nodes have a `connect` method that is used to connect them to other nodes.
+Nodes have a ``connect`` method that is used to connect them to other nodes.
 This method can specify the direction of a connection:
 
 ::
@@ -72,7 +72,7 @@ This method can specify the direction of a connection:
     my_node.connect(some_node, direction='both')
     my_node.connect(another_node, direction='from')
 
-The default direction is `to`. The following example will make a `to`
+The default direction is ``to``. The following example will make a ``to``
 connection:
 
 ::
@@ -80,7 +80,7 @@ connection:
     my_node.connect(another_node)
     
 Note that sources can only transmit information, so the only connection type
-allowed for a source node is `to` another node:
+allowed for a source node is ``to`` another node:
 
 ::
 
@@ -89,8 +89,8 @@ allowed for a source node is `to` another node:
 Using a network
 ---------------
 
-To use a specific network, an experiment needs to define a `create_network`
-method in its code. For example, to use a `Chain` network:
+To use a specific network, an experiment needs to define a ``create_network``
+method in its code. For example, to use a ``Chain`` network:
 
 ::
 
@@ -103,25 +103,25 @@ method in its code. For example, to use a `Chain` network:
 			return Chain(max_size=5)
 
 Like the example shows, to use a network it's necessary to import it from
-`dallinger.networks` using the network class name (the name from the list
+``dallinger.networks`` using the network class name (the name from the list
 given above). Once imported, it needs to be initialized as part of the
-experiment, which is done using the `create_network` method.
+experiment, which is done using the ``create_network`` method.
 
-All networks accept the `max_size` parameter, which is illustrated above. It
+All networks accept the ``max_size`` parameter, which is illustrated above. It
 represents the maximum number of nodes that a network can have. In the
-example above, maximum size is 5 nodes. The `full` method of the network can
+example above, maximum size is 5 nodes. The ``full`` method of the network can
 be used to check if a network is full.
 
 Multiple networks
 ^^^^^^^^^^^^^^^^^
 
-In experiments configured for a number of `practice_repeats` or
-`experiment_repeats` higher than one, the `create_network` method is called
+In experiments configured for a number of ``practice_repeats`` or
+``experiment_repeats`` higher than one, the ``create_network`` method is called
 multiple times, once for every repeat. This means that an experiment can have
 multiple networks at the same time.
 
-The experiment setup code assigns each network a role of `practice` or
-`experiment`, depending on how it was created. The experiment class allows
+The experiment setup code assigns each network a role of ``practice`` or
+``experiment``, depending on how it was created. The experiment class allows
 experiment developers to query networks by role (practice, experiment), or by
 state (full, not full). For example:
 
@@ -164,7 +164,7 @@ send a stimulus to all network nodes, regardless of their isolation.
 Chain
 ^^^^^
 
-A Chain network, also known as `line` network, connects each new node to the
+A Chain network, also known as ``line`` network, connects each new node to the
 previous one, so that nodes can receive information from their parent, but
 cannot send information back. In other words, it's a one way transmission
 chain. In general, it's useful to have a source as the first node, so that
@@ -206,7 +206,7 @@ Star
 ^^^^
 
 A Star network uses its first node as a central node, and nodes created
-after that have a bidirectional connection (`both`) with that node. This
+after that have a bidirectional connection (``both``) with that node. This
 means the central node can send and receive information from/to all nodes,
 but every other node in the network can only communicate with the central
 node.
@@ -228,7 +228,7 @@ Burst
 ^^^^^
 
 A Burst network is very similar to a Star network, except the central node is
-connected to the other nodes using a `to` connection. In this case, a source
+connected to the other nodes using a ``to`` connection. In this case, a source
 can be used as a central node.
 
 This type of network can be used for experiments where participants do not
@@ -248,7 +248,7 @@ other in both directions, thus allowing any node to transmit and receive from
 any other node. This can be very useful for cooperation experiments or
 chatrooms.
 
-A source is allowed as a node in this network. However, it will use a `to`
+A source is allowed as a node in this network. However, it will use a ``to``
 connection to the other nodes, so transmitting to it will not be allowed.
 
 .. figure:: _static/full.png
@@ -267,21 +267,21 @@ DiscreteGenerational
 ^^^^^^^^^^^^^^^^^^^^
 
 In this network, nodes are arranged into "generations". This network accepts
-some new parameters: `generations` (number of generations), `generation_size`
-(how many nodes in a generation) and `initial_source`. If there is an initial
+some new parameters: ``generations`` (number of generations), ``generation_size``
+(how many nodes in a generation) and ``initial_source``. If there is an initial
 source, it will be used as the parent for all first generation nodes. After
 the first generation, the parent from each new node will be selected from the
-previous generation, using the `fitness` attribute of the nodes to select it.
+previous generation, using the ``fitness`` attribute of the nodes to select it.
 The higher the fitness, the higher the probability that a node will be a
 parent.
 
 Note that for this network to function correctly, the experiment nodes need
-to have a `generation` property defined.
+to have a ``generation`` property defined.
 
 ScaleFree
 ^^^^^^^^^
 
-This network takes two parameters: `m0` and `m`. The first (m0) is the
+This network takes two parameters: ``m0`` and ``m``. The first (m0) is the
 number of initial nodes. These initial nodes will be connected in a fully
 connected network among each other. The second parameter (m) is the number of
 connections that every subsequent node will have. The nodes for this limited
@@ -291,7 +291,7 @@ connections will have a higher probability of being selected.
 SequentialMicrosociety
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A network in which each new node will be connected using a `to` connection to
+A network in which each new node will be connected using a ``to`` connection to
 a limited set of its most recent predecessors. The number of recent
 predecessors is passed in as an argument (n) at network creation.
 
@@ -299,7 +299,7 @@ SplitSampleNetwork
 ^^^^^^^^^^^^^^^^^^
 
 This network helps when implementing split sample experiment designs. It
-assigns a random boolean value to a property named `exploratory`. When this
+assigns a random boolean value to a property named ``exploratory``. When this
 property is True, it means that the current network is part of the
 exploratory data subset.
 
@@ -336,24 +336,24 @@ interconnections. To create one, we can subclass from the Network model:
                     parent = min(other_nodes, key=attrgetter('creation_time'))
                     node.connect(whom=parent)
                    
-In the above example, we create a simple `ring` network, where each node is
+In the above example, we create a simple ``ring`` network, where each node is
 connected in chain to the next one, until we get to the last one, which is
 connected back to the first, making a full circle (thus, the ring name).
 
-Ring is a subclass of `dallinger.models.Network`, which contains the basic
-network model and implementation. The `__mapper_args__` assignment at the
+Ring is a subclass of ``dallinger.models.Network``, which contains the basic
+network model and implementation. The ``__mapper_args__`` assignment at the
 top is for differentiating this network from others, so that data exports
 don't give incorrect results. Usually the safe thing is to use the same name
 as the subclass, to avoid confusion.
 
-Most simple networks will only need to override the `add_node` method. This
+Most simple networks will only need to override the ``add_node`` method. This
 method is called after a node is added, with the added node as a parameter.
 This method then can decide how and when to connect this node to other nodes
 in the network.
 
 In our code, we first get all nodes in the network (except the new one). If
 the new node is a source, we raise an exception, because due to the circular
-nature of our network, there can be no sources (they don't accept `from`
+nature of our network, there can be no sources (they don't accept ``from``
 connections and can only transmit).
 
 After that, we take the most recent node and connect it to the new node. At
@@ -361,10 +361,10 @@ this point, this is almost the same as a chain network, but when we get to
 the last node, we connect the new node to the first node, in addition to its
 connection to the previous node.
 
-The code in the `add_node` method can be as complex as needed, so very
+The code in the ``add_node`` method can be as complex as needed, so very
 complex networks are possible. In most cases, to create a more advanced
 network it will be necessary to add custom properties to it. This is done by
-overriding the `__init__` method of the network to add the properties. The
+overriding the ``__init__`` method of the network to add the properties. The
 following example shows how to do that:
 
 ::
@@ -378,9 +378,9 @@ property need not be persistent, but in general it's better to save it as
 part of the network using the persistent custom properties available in all
 Dallinger models. If they are not stored, any calculations that rely on them
 have to be performed at initialization time. Once they are stored, they can
-be used in any part of the network code, like in the `add_node` method.
+be used in any part of the network code, like in the ``add_node`` method.
 
-In the code above, we use `repr` when storing the property value. This is
+In the code above, we use ``repr`` when storing the property value. This is
 because Dallinger custom properties are all of the text type, so even if a
 custom property represents a number, it has to be stored as a string. If the
 property is a string to begin with, it's not necessary to convert it.

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -56,9 +56,9 @@ Node connections
 
 A node can be connected to another node in three ways:
 
-1. a single direction connection to another node ("to")
-2. a single direction connection from another node ("from")
-3. a bidirectional connection to another node ("both")
+1. "to" - a single direction connection to another node
+2. "from" - a single direction connection from another node
+3. "both" - a bidirectional connection to another node
 
 A node can transmit information when connected `to` another node. It can
 receive information when connected `from` another node. If it is connected to
@@ -72,7 +72,7 @@ This method can specify the direction of a connection:
     my_node.connect(some_node, direction='both')
     my_node.connect(another_node, direction='from')
 
-The default direction is ``to``. The following example will make a ``to``
+The default direction is "to". The following example will make a `to`
 connection:
 
 ::
@@ -80,7 +80,7 @@ connection:
     my_node.connect(another_node)
     
 Note that sources can only transmit information, so the only connection type
-allowed for a source node is ``to`` another node:
+allowed for a source node is `to` another node:
 
 ::
 
@@ -94,13 +94,13 @@ method in its code. For example, to use a ``Chain`` network:
 
 ::
 
-	from dallinger.experiment import Experiment
-	from dallinger.networks import Chain
+    from dallinger.experiment import Experiment
+    from dallinger.networks import Chain
 
-	class MyExperiment(Experiment):
+    class MyExperiment(Experiment):
 
-		def create_network(self):
-			return Chain(max_size=5)
+        def create_network(self):
+            return Chain(max_size=5)
 
 Like the example shows, to use a network it's necessary to import it from
 ``dallinger.networks`` using the network class name (the name from the list

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -72,7 +72,7 @@ This method can specify the direction of a connection:
     my_node.connect(some_node, direction='both')
     my_node.connect(another_node, direction='from')
 
-The default direction is ```to```. The following example will make a ```to```
+The default direction is ``to``. The following example will make a ``to``
 connection:
 
 ::

--- a/docs/source/networks.rst
+++ b/docs/source/networks.rst
@@ -11,7 +11,7 @@ require participants to interact among themselves in various ways.
 In Dallinger, these interactions among participants and stimuli are
 represented using networks. Each participant and each stimulus represent a
 node in a network. The way these nodes are connected to each other is known
-as a ``network topology``. For brevity, we will use the term ``network`` from now
+as a `network topology`. For brevity, we will use the term `network` from now
 on when discussing Dallinger network topologies.
 
 Dallinger comes with a variety of networks that can be used by experimenters,
@@ -33,7 +33,7 @@ Nodes and Sources
 -----------------
 
 In these networks, each participant is considered as a node. There is also a
-special kind of node, known as a ``source``, which transmits information to
+special kind of node, known as a `source`, which transmits information to
 other nodes. Sources are used in Dallinger as a means to send the stimuli to
 the participants. Not all experiments have sources, though. A chatroom
 experiment, for example, could just rely on user interactions and not
@@ -60,9 +60,9 @@ A node can be connected to another node in three ways:
 2. a single direction connection from another node ("from")
 3. a bidirectional connection to another node ("both")
 
-A node can transmit information when connected ``to`` another node. It can
-receive information when connected ``from`` another node. If it is connected to
-another node in ``both`` directions, it can both receive and transmit.
+A node can transmit information when connected `to` another node. It can
+receive information when connected `from` another node. If it is connected to
+another node in `both` directions, it can both receive and transmit.
 
 Nodes have a ``connect`` method that is used to connect them to other nodes.
 This method can specify the direction of a connection:
@@ -72,7 +72,7 @@ This method can specify the direction of a connection:
     my_node.connect(some_node, direction='both')
     my_node.connect(another_node, direction='from')
 
-The default direction is ``to``. The following example will make a ``to``
+The default direction is ```to```. The following example will make a ```to```
 connection:
 
 ::
@@ -120,8 +120,8 @@ In experiments configured for a number of ``practice_repeats`` or
 multiple times, once for every repeat. This means that an experiment can have
 multiple networks at the same time.
 
-The experiment setup code assigns each network a role of ``practice`` or
-``experiment``, depending on how it was created. The experiment class allows
+The experiment setup code assigns each network a role of `practice` or
+`experiment`, depending on how it was created. The experiment class allows
 experiment developers to query networks by role (practice, experiment), or by
 state (full, not full). For example:
 
@@ -164,7 +164,7 @@ send a stimulus to all network nodes, regardless of their isolation.
 Chain
 ^^^^^
 
-A Chain network, also known as ``line`` network, connects each new node to the
+A Chain network, also known as `line` network, connects each new node to the
 previous one, so that nodes can receive information from their parent, but
 cannot send information back. In other words, it's a one way transmission
 chain. In general, it's useful to have a source as the first node, so that
@@ -206,7 +206,7 @@ Star
 ^^^^
 
 A Star network uses its first node as a central node, and nodes created
-after that have a bidirectional connection (``both``) with that node. This
+after that have a bidirectional connection (`both`) with that node. This
 means the central node can send and receive information from/to all nodes,
 but every other node in the network can only communicate with the central
 node.
@@ -228,7 +228,7 @@ Burst
 ^^^^^
 
 A Burst network is very similar to a Star network, except the central node is
-connected to the other nodes using a ``to`` connection. In this case, a source
+connected to the other nodes using a `to` connection. In this case, a source
 can be used as a central node.
 
 This type of network can be used for experiments where participants do not
@@ -248,7 +248,7 @@ other in both directions, thus allowing any node to transmit and receive from
 any other node. This can be very useful for cooperation experiments or
 chatrooms.
 
-A source is allowed as a node in this network. However, it will use a ``to``
+A source is allowed as a node in this network. However, it will use a `to`
 connection to the other nodes, so transmitting to it will not be allowed.
 
 .. figure:: _static/full.png
@@ -291,7 +291,7 @@ connections will have a higher probability of being selected.
 SequentialMicrosociety
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A network in which each new node will be connected using a ``to`` connection to
+A network in which each new node will be connected using a `to` connection to
 a limited set of its most recent predecessors. The number of recent
 predecessors is passed in as an argument (n) at network creation.
 
@@ -336,11 +336,11 @@ interconnections. To create one, we can subclass from the Network model:
                     parent = min(other_nodes, key=attrgetter('creation_time'))
                     node.connect(whom=parent)
                    
-In the above example, we create a simple ``ring`` network, where each node is
+In the above example, we create a simple ring network, where each node is
 connected in chain to the next one, until we get to the last one, which is
-connected back to the first, making a full circle (thus, the ring name).
+connected back to the first, making a full circle (thus, the 'ring' name).
 
-Ring is a subclass of ``dallinger.models.Network``, which contains the basic
+Our ``Ring`` network is a subclass of ``dallinger.models.Network``, which contains the basic
 network model and implementation. The ``__mapper_args__`` assignment at the
 top is for differentiating this network from others, so that data exports
 don't give incorrect results. Usually the safe thing is to use the same name
@@ -353,7 +353,7 @@ in the network.
 
 In our code, we first get all nodes in the network (except the new one). If
 the new node is a source, we raise an exception, because due to the circular
-nature of our network, there can be no sources (they don't accept ``from``
+nature of our network, there can be no sources (they don't accept `from`
 connections and can only transmit).
 
 After that, we take the most recent node and connect it to the new node. At


### PR DESCRIPTION
Following up on https://github.com/Dallinger/Dallinger/pull/1627

> I hadn't read through these before, so I did so, and made a couple small edits, unrelated to the question of linking them in the docs (the topic of this PR). One question I had (again, on the docs, not their linking) was whether references to source code values should be styled as literals, using double back-ticks, rather than italics (single back-ticks) as they are now.

@jessesnyder I have changed them to double back-ticks as the visibility is improved IMO. If somebody feels differently, please comment. Thanks!