### PR TITLE
Minor adjustments to docs and demo configurations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ install:
   - pip install tox==3.1.2
   - gem install danger
   - gem install danger-commit_lint
-  - gem install chandler
+  - gem install chandler -v 0.7.0
   - npm install
 before_script:
   - bundle exec danger

--- a/demos/dlgr/demos/bartlett1932/config.txt
+++ b/demos/dlgr/demos/bartlett1932/config.txt
@@ -19,7 +19,7 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = standard-0
+database_size = hobby-dev
 
 [Server]
 dyno_type = hobby

--- a/demos/dlgr/demos/rogers/config.txt
+++ b/demos/dlgr/demos/rogers/config.txt
@@ -18,11 +18,11 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = standard-2
+database_size = hobby-dev
 
 [Server]
-dyno_type = performance-m
-num_dynos_web = 2
+dyno_type = hobby
+num_dynos_web = 1
 num_dynos_worker = 1
 host = 0.0.0.0
 notification_url = None

--- a/demos/dlgr/demos/rogers/experiment.py
+++ b/demos/dlgr/demos/rogers/experiment.py
@@ -72,8 +72,8 @@ class RogersExperiment(Experiment):
         self.min_acceptable_performance = config.get(
             'min_acceptable_performance', 10 / float(12)
         )
-        self.generation_size = config.get('generation_size', 4)
-        self.generations = config.get('generations', 4)
+        self.generation_size = config.get('generation_size', 2)
+        self.generations = config.get('generations', 3)
         self.bonus_payment = config.get('bonus_payment', 1.0)
         self.initial_recruitment_size = self.generation_size
 

--- a/demos/dlgr/demos/twentyfortyeight/config.txt
+++ b/demos/dlgr/demos/twentyfortyeight/config.txt
@@ -19,7 +19,7 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = standard-0
+database_size = hobby-dev
 
 [Server]
 dyno_type = hobby

--- a/demos/dlgr/demos/vox_populi/config.txt
+++ b/demos/dlgr/demos/vox_populi/config.txt
@@ -18,7 +18,7 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = standard-0
+database_size = hobby-dev
 
 [Server]
 dyno_type = hobby

--- a/docs/source/demo_index.rst
+++ b/docs/source/demo_index.rst
@@ -12,6 +12,7 @@ More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
     :glob:
 
     demos/bartlett1932/*
+    demos/chatroom/*
     demos/concentration/*
     demos/function_learning/*
     demos/mcmcp/*


### PR DESCRIPTION
Added the chatroom demo link in the demos documentation page.

Adjusted the settings of the following demos to function in hobby-dev (free) mode:
```
Bartlett 
2048
Vox Populi
Rogers experiment
```

These were tested to be working in debug and sandbox modes.
I reduced the number of participants and generations in the Rogers demo mostly for ease of testing, however that should hopefully keep the load lower with only 1 dyno available in hobby-dev mode.