### PR TITLE
Fix indentation in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [v5.0.4](https://github.com/dallinger/dallinger/tree/v5.0.4) (2019-01-31)
 
-Documentation improvements and additions:
+- Documentation improvements and additions:
   + New documentation section on Networks added
   + Reintroduce working Chatroom demo
 


### PR DESCRIPTION
The indentation in the CHANGELOG for release 5.0.4 made it seem like all changes/updates were related to documentation. Fixed.