### PR TITLE
Restructure user and developer installations + misc doc fixes

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -9,7 +9,7 @@ div.wy-nav-content {
 }
 
 .wy-nav-side {
-    color: #dadada;
+    color: #678be0;
 }
 
 /* Hide toctree captions in the content */

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -152,7 +152,7 @@ html_theme_path = ["_themes", ]
 # documentation.
 #
 html_theme_options = {
-    'logo_name': True,
+#    'logo_name': True,
     'canonical_url': '',
     'analytics_id': '',
     'display_version': True,

--- a/docs/source/dallinger_with_anaconda.rst
+++ b/docs/source/dallinger_with_anaconda.rst
@@ -3,8 +3,13 @@ Installing Dallinger with Anaconda
 
 If you are interested in Dallinger and use
 `Anaconda <https://www.continuum.io/downloads>`__, you'll need to adapt
-the standard instructions slightly.
+the standard installation instructions slightly.
 
+Install python
+--------------
+::
+
+    conda install python
 
 Install psycopg2
 ----------------
@@ -19,6 +24,12 @@ installing Dallinger.
 
 The `[data]` optional extra makes sure that all the data analysis dependencies
 are installed.
+
+Set up a virtual environment
+----------------------------
+
+If you are using Anaconda, ignore this virtualenv section; use ``conda`` to create your virtual environment. Or, see the
+special :doc:`Anaconda installation instructions <dallinger_with_anaconda>`.
 
 Confirm Dallinger works
 -----------------------
@@ -52,3 +63,7 @@ Finally, you'll need to re-link ``openssl``. Run the following:
 
     brew install --upgrade openssl
     brew unlink openssl && brew link openssl --force
+
+
+Next, you'll need :doc:`access keys for AWS, Heroku,
+etc. <aws_etc_keys>`.

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -14,16 +14,16 @@ To test out Dallinger, we'll run a demo experiment in "debug" mode.
     More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
 
 You can read more about this experiment here:
-`Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__ and download the experiment files.
+`Bartlett (1932) demo <http://dallinger.readthedocs.io/en/latest/demos/bartlett1932/index.html>`__.
 
-Navigate to the bartlett1932 directory and run
+The experiment files can be found `here <https://dallinger.readthedocs.io/en/latest/_static/bartlett1932.zip>`__. Extract them to a location of your choice, then from there, navigate to the `bartlett1932` directory and run:
 
 ::
 
     dallinger debug
 
 
-If applicable, make sure that your virtualenv is enabled so that the ``dallinger`` command is available to you. 
+If applicable, make sure that your virtualenv is enabled so that the ``dallinger`` command is available to you.
 All Dallinger command options are explained in the :doc:`Command-line Utility" <command_line_utility>` section.
 
 You will see some output as Dallinger loads. When it is finished, you will

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -256,8 +256,22 @@ To check which version of the Heroku CLI you have installed, run:
 
     heroku --version
 
-The Heroku CLI is available for download from
-`heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
+To install:
+
+Mac OS X
+~~~~~~~~
+::
+
+    brew install heroku/brew/heroku
+
+Ubuntu
+~~~~~~
+::
+
+    curl https://cli-assets.heroku.com/install.sh | sh
+
+
+More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
 
 Install Redis
 -------------

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -450,7 +450,7 @@ If using Python 3.x and pip3:
     sudo pip3 install virtualenvwrapper
     export WORKON_HOME=$HOME/.virtualenvs
     mkdir -p $WORKON_HOME
-	export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+    export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
     source /usr/local/bin/virtualenvwrapper.sh
 
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -6,20 +6,27 @@ If you are attempting to use Dallinger on Microsoft Windows, running Ubuntu in a
 
 If you are interested in using Dallinger with Docker, read more :doc:`here <docker_setup>`.
 
+
+Mac OS X
+--------
+
 Install Python
---------------
+~~~~~~~~~~~~~~
 
-It recommended that you run Dallinger on Python 3. Dallinger has been tested to work on Python 3.6 and up.
-Dallinger also supports Python 2.7
-
+Dallinger is written in the language Python. For it to work, you will need
+to have Python 2.7 installed, or alternatively Python 3.6 or higher. Python 3 is the preferred option.
 You can check what version of Python you have by running:
 ::
 
     python --version
 
 
-Mac OS X
-~~~~~~~~
+.. note::
+
+    You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed.
+    It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
+    If you are using Python 3, you may find that you may need to use the ``pip3`` command instead of ``pip`` where applicable in the instructions that follow.
+
 
 Using Homebrew will install the latest version of Python and pip by default.
 
@@ -45,12 +52,320 @@ With the preinstalled Python in Mac OS X, you will need to install pip yourself.
 Should that not work for whatever reason, you can search `here <https://docs.python-guide.org/>`__ for more clues.
 
 
+Install Postgresql
+~~~~~~~~~~~~~~~~~~
+
+On Mac OS X, we recommend installing using Homebrew:
+::
+
+    brew install postgresql
+
+
+Postgresql can then be started and stopped using:
+::
+
+    brew services start postgresql
+    brew services stop postgresql
+
+
+Create the databases
+~~~~~~~~~~~~~~~~~~~~
+
+After installing Postgres, you will need to create two databases:
+one for your experiments to use, and a second to support importing saved
+experiments. It is recommended that you also create a database user.
+
+Naviagate to a terminal and type:
+::
+
+    createuser -P dallinger --createdb
+    (Password: dallinger)
+    createdb -O dallinger dallinger
+    createdb -O dallinger dallinger-import
+
+
+The first command will create a user named ``dallinger`` and prompt you for a
+password. The second and third command will create the ``dallinger`` and 
+``dallinger-import`` databases, setting the newly created user as the owner.
+
+You can optionally inspect your databases by entering ``psql dallinger``. 
+Inside psql you can use commands to see the roles and database tables:
+::
+
+    \du
+    \l
+
+To quit:
+::
+
+    \q
+
+
+If you get an error like the following:
+::
+
+    createuser: could not connect to database postgres: could not connect to server:
+        Is the server running locally and accepting
+        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
+
+then postgres is not running. Start postgres as described in the Install Postgresql section above.
+
+Install Heroku
+~~~~~~~~~~~~~~
+
+To run experiments locally or on the internet, you will need the Heroku Command
+Line Interface installed, version 3.28.0 or better. If you want to launch experiments on the internet, then
+you will also need a Heroku.com account, however this is not needed for local debugging.
+
+To check which version of the Heroku CLI you have installed, run:
+::
+
+    heroku --version
+
+
+To install:
+::
+
+    brew install heroku/brew/heroku
+
+More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
+
+
+Install Redis
+~~~~~~~~~~~~~
+
+Debugging experiments requires you to have Redis installed and the Redis
+server running.
+::
+
+    brew install redis
+
+Start Redis on Mac OS X with:
+::
+
+    brew services start redis
+
+You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
+
+Install Git
+~~~~~~~~~~~
+
+Dallinger uses Git, a distributed version control system, for version control of its code.
+If you do not have it installed, you can install it as follows:
+
+::
+
+    brew install git
+
+
+Set up a virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Why use virtualenv?
+
+Virtualenv solves a very specific problem: it allows multiple Python projects
+that have different (and often conflicting) requirements, to coexist on the same computer.
+If you want to understand this in detail, you can read more about it `here <https://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`__.
+
+Now let's set up a virtual environment by running the following commands:
+
+If using Python 2.7 and pip:
+::
+
+
+    pip install virtualenv
+    pip install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    export VIRTUALENVWRAPPER_PYTHON=$(which python)
+    source $(which virtualenvwrapper.sh)
+
+If using Python 3.x and pip3 (Python 3.7 in this example):
+::
+
+
+    pip3 install virtualenv
+    pip3 install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
+    source $(which virtualenvwrapper.sh)
+
+
+Now create the virtual environment using:
+::
+
+
+    mkvirtualenv dlgr_env --python <specify_your_python_path_here>
+
+
+Examples:
+
+Using homebrew installed Python 3.7:
+::
+
+
+    mkvirtualenv dlgr_env --python /usr/local/bin/python3.7
+
+Using Python 2.7:
+::
+
+
+    mkvirtualenv dlgr_env --python /usr/bin/python
+
+
+Virtualenvwrapper provides an easy way to switch between virtual environments
+by simply typing: ``workon [virtual environment name]``.
+
+The technical details:
+
+These commands use ``pip/pip3``, the Python package manager, to install two
+packages ``virtualenv`` and ``virtualenvwrapper``. They set up an
+environmental variable named ``WORKON_HOME`` with a string that gives a
+path to a subfolder of your home directory (``~``) called ``Envs``,
+which the next command (``mkdir``) then makes according to the path
+described in ``$WORKON_HOME`` (recursively, due to the ``-p`` flag).
+That is where your environments will be stored. The ``source`` command
+will run the command that follows, which in this case locates the
+``virtualenvwrapper.sh`` shell script, the contents of which are beyond
+the scope of this setup tutorial. If you want to know what it does, a
+more in depth description can be found on the `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
+
+Finally, the ``mkvirtualenv`` makes your first virtual environment which
+you've named ``dlgr_env``. We have explicitly passed it the location of the Python
+that the virtualenv should use. This Python has been mapped to the ``python``
+command inside the virtual environment.
+
+The how-to:
+
+In the future, you can work on your virtual environment by running:
+Python 2.7
+::
+
+    export VIRTUALENVWRAPPER_PYTHON=$(which python)
+    source $(which virtualenvwrapper.sh)
+    workon dlgr_env
+
+Python 3.x
+::
+
+    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
+    source $(which virtualenvwrapper.sh)
+    workon dlgr_env
+
+
+NB: To stop working in the virtual environment, run ``deactivate``. To
+list all available virtual environments, run ``workon`` with no
+arguments.
+
+If you plan to do a lot of work with Dallinger, you can make your shell
+execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
+do that type:
+
+Python 2.7
+::
+
+    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python)" >> ~/.bash_profile
+    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
+
+Python 3.x
+::
+
+    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)" >> ~/.bash_profile
+    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
+
+
+From then on, you only need to use the ``workon`` command before starting.
+
+Install prerequisites for building documentation
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To be able to build the documentation, you will need yarn.
+
+Please follow the instructions `here <https://yarnpkg.com/lang/en/docs/install>`__  to install it.
+
+Install Dallinger
+~~~~~~~~~~~~~~~~~
+
+Next, navigate to the directory where you want to house your development
+work on Dallinger. Once there, clone the Git repository using:
+::
+
+    git clone https://github.com/Dallinger/Dallinger
+
+This will create a directory called ``Dallinger`` in your current
+directory.
+
+Change into your the new directory and make sure you are still in your
+virtual environment before installing the dependencies. If you want to
+be extra careful, run the command ``workon dlgr_env``, which will ensure
+that you are in the right virtual environment.
+
+::
+
+    cd Dallinger
+
+Now we need to install the dependencies using pip:
+
+::
+
+    pip install -r dev-requirements.txt
+
+Next run ``setup.py`` with the argument ``develop``:
+
+::
+
+    pip install -e .[data]
+
+Test that your installation works by running:
+
+::
+
+    dallinger --version
+
+
+Install the dlgr.demos sub-package
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Both the test suite and the included demo experiments require installing the
+``dlgr.demos`` sub-package in order to run. Install this in "develop mode"
+with the ``-e`` option, so that any changes you make to a demo will be
+immediately reflected on your next test or debug session.
+
+From the root ``Dallinger`` directory you created in the previous step, run the
+installation command:
+
+::
+
+    pip install -e demos
+
+Next, you'll need :doc:`access keys for AWS, Heroku,
+etc. <aws_etc_keys>`.
+
 Ubuntu
-~~~~~~
+------
+
+Install Python
+~~~~~~~~~~~~~~
+
+Dallinger is written in the language Python. For it to work, you will need
+to have Python 2.7 installed, or alternatively Python 3.6 or higher. Python 3 is the preferred option.
+You can check what version of Python you have by running:
+::
+
+    python --version
+
+
+.. note::
+
+    You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed.
+    It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
+    If you are using Python 3, you may find that you may need to use the ``pip3`` command instead of ``pip`` where applicable in the instructions that follow.
+
 
 Ubuntu 18.04 LTS ships with Python 3.6.
 
-Ubuntu 16.04 LTS ships with Python 3.5, while Ubuntu 14.04 LTS ships with Python 3.4. In case you are using these distribution of Ubuntu, you can use
+Ubuntu 16.04 LTS ships with Python 3.5, while Ubuntu 14.04 LTS ships with Python 3.4. In case you are using one of these distributions of Ubuntu, you can use
 dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
 
 (All three of these Ubuntu versions also provide a version of Python 2.7)
@@ -75,34 +390,9 @@ If using Python 3.x:
     sudo apt install -y python3-pip
 
 
-Anaconda
-~~~~~~~~
-::
-
-    conda install python
-
 
 Install Postgresql
-------------------
-
-Mac OS X
-~~~~~~~~
-
-On Mac OS X, we recommend installing using Homebrew:
-::
-
-    brew install postgresql
-
-
-Postgresql can then be started and stopped using:
-::
-
-    brew services start postgresql
-    brew services stop postgresql
-
-
-Ubuntu
-~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 The lowest version of Postgresql that Dallinger v5 supports is 9.4.
 
@@ -171,53 +461,8 @@ After that you'll need to run the following commands
     sudo service postgresql reload
 
 
-Create the Databases
---------------------
-
-Mac OS X
-~~~~~~~~
-
-After installing Postgres, you will need to create two databases:
-one for your experiments to use, and a second to support importing saved
-experiments. It is recommended that you also create a database user.
-
-Naviagate to a terminal and type:
-::
-
-    createuser -P dallinger --createdb
-    (Password: dallinger)
-    createdb -O dallinger dallinger
-    createdb -O dallinger dallinger-import
-
-
-The first command will create a user named ``dallinger`` and prompt you for a
-password. The second and third command will create the ``dallinger`` and 
-``dallinger-import`` databases, setting the newly created user as the owner.
-
-You can optionally inspect your databases by entering ``psql dallinger``. 
-Inside psql you can use commands to see the roles and database tables:
-::
-
-    \du
-    \l
-
-To quit:
-::
-
-    \q
-
-
-If you get an error like the following:
-::
-
-    createuser: could not connect to database postgres: could not connect to server:
-        Is the server running locally and accepting
-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
-
-then postgres is not running. Start postgres as described in the Install Postgresql section above.
-
-Ubuntu
-~~~~~~
+Create the databases
+~~~~~~~~~~~~~~~~~~~~
 
 Make sure that postgres is running. Switch to the postgres user:
 
@@ -244,9 +489,8 @@ Finally restart postgresql:
 
     sudo service postgresql reload
 
-
 Install Heroku
---------------
+~~~~~~~~~~~~~~
 
 To run experiments locally or on the internet, you will need the Heroku Command
 Line Interface installed, version 3.28.0 or better. If you want to launch experiments on the internet, then
@@ -257,16 +501,8 @@ To check which version of the Heroku CLI you have installed, run:
 
     heroku --version
 
+
 To install:
-
-Mac OS X
-~~~~~~~~
-::
-
-    brew install heroku/brew/heroku
-
-Ubuntu
-~~~~~~
 ::
 
     sudo apt-get install curl
@@ -276,24 +512,11 @@ Ubuntu
 More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
 
 Install Redis
--------------
+~~~~~~~~~~~~~
 
 Debugging experiments requires you to have Redis installed and the Redis
 server running.
 
-Mac OS X
-~~~~~~~~
-::
-
-    brew install redis
-
-Start Redis on Mac OS X with:
-::
-
-    brew services start redis
-
-Ubuntu
-~~~~~~
 ::
 
     sudo apt-get install -y redis-server
@@ -305,13 +528,19 @@ Start Redis on Ubuntu with:
 
 You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
 
+Install Git
+~~~~~~~~~~~
+
+Dallinger uses Git, a distributed version control system, for version control of its code.
+If you do not have it installed, you can install it as follows:
+
+::
+
+    sudo apt install git
+
 
 Set up a virtual environment
-----------------------------
-
-**Note**: if you are using Anaconda, ignore this ``virtualenv``
-section; use ``conda`` to create your virtual environment. Or, see the
-special :doc:`Anaconda installation instructions <dallinger_with_anaconda>`.
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Why use virtualenv?
 
@@ -320,120 +549,6 @@ that have different (and often conflicting) requirements, to coexist on the same
 If you want to understand this in detail, you can read more about it `here <https://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`__.
 
 Now let's set up a virtual environment by running the following commands:
-
-Mac OS X
-~~~~~~~~
-
-If using Python 2.7 and pip:
-::
-
-
-    pip install virtualenv
-    pip install virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    export VIRTUALENVWRAPPER_PYTHON=$(which python)
-    source $(which virtualenvwrapper.sh)
-
-If using Python 3.x and pip3 (Python 3.7 in this example):
-::
-
-
-    pip3 install virtualenv
-    pip3 install virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
-    source $(which virtualenvwrapper.sh)
-
-
-Now create the virtual environment using:
-::
-
-
-    mkvirtualenv dlgr_env --python <specify_your_python_path_here>
-
-
-Examples:
-
-Using homebrew installed Python 3.7:
-::
-
-
-    mkvirtualenv dlgr_env --python /usr/local/bin/python3.7
-
-Using Python 2.7:
-::
-
-
-    mkvirtualenv dlgr_env --python /usr/bin/python
-
-
-Virtualenvwrapper provides an easy way to switch between virtual environments 
-by simply typing: ``workon [virtual environment name]``.
-
-The technical details:
-
-These commands use ``pip/pip3``, the Python package manager, to install two
-packages ``virtualenv`` and ``virtualenvwrapper``. They set up an
-environmental variable named ``WORKON_HOME`` with a string that gives a
-path to a subfolder of your home directory (``~``) called ``Envs``,
-which the next command (``mkdir``) then makes according to the path
-described in ``$WORKON_HOME`` (recursively, due to the ``-p`` flag).
-That is where your environments will be stored. The ``source`` command
-will run the command that follows, which in this case locates the
-``virtualenvwrapper.sh`` shell script, the contents of which are beyond
-the scope of this setup tutorial. If you want to know what it does, a
-more in depth description can be found on the `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
-
-Finally, the ``mkvirtualenv`` makes your first virtual environment which
-you've named ``dlgr_env``. We have explicitly passed it the location of the Python
-that the virtualenv should use. This Python has been mapped to the ``python``
-command inside the virtual environment.
-
-The how-to:
-
-In the future, you can work on your virtual environment by running:
-Python 2.7
-::
-
-    export VIRTUALENVWRAPPER_PYTHON=$(which python)
-    source $(which virtualenvwrapper.sh)
-    workon dlgr_env
-
-Python 3.x
-::
-
-    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
-    source $(which virtualenvwrapper.sh)
-    workon dlgr_env
-
-
-NB: To stop working in the virtual environment, run ``deactivate``. To
-list all available virtual environments, run ``workon`` with no
-arguments.
-
-If you plan to do a lot of work with Dallinger, you can make your shell
-execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
-do that type:
-
-Python 2.7
-::
-
-    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python)" >> ~/.bash_profile
-    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
-
-Python 3.x
-::
-
-    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)" >> ~/.bash_profile
-    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
-
-
-From then on, you only need to use the ``workon`` command before starting.
-
-Ubuntu
-~~~~~~
 
 If using Python 2.7 and pip:
 ::
@@ -468,14 +583,14 @@ If you are using Python 2 that is part of your Ubuntu installation:
 
     mkvirtualenv dlgr_env --python /usr/bin/python
 
-If you are using another Python version 
+If you are using another Python version
 (eg. custom installed Python 3.x on Ubuntu 14.04):
 ::
 
     mkvirtualenv dlgr_env --python <specify_your_python_path_here>
 
 
-Virtualenvwrapper provides an easy way to switch between virtual environments 
+Virtualenvwrapper provides an easy way to switch between virtual environments
 by simply typing: ``workon [virtual environment name]``.
 
 The technical details:
@@ -518,16 +633,15 @@ do that:
 
 From then on, you only need to use the ``workon`` command before starting.
 
-
 Install prerequisites for building documentation
-------------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To be able to build the documentation, you will need yarn.
 
 Please follow the instructions `here <https://yarnpkg.com/lang/en/docs/install>`__  to install it.
 
 Install Dallinger
------------------
+~~~~~~~~~~~~~~~~~
 
 Next, navigate to the directory where you want to house your development
 work on Dallinger. Once there, clone the Git repository using:
@@ -542,12 +656,6 @@ Change into your the new directory and make sure you are still in your
 virtual environment before installing the dependencies. If you want to
 be extra careful, run the command ``workon dlgr_env``, which will ensure
 that you are in the right virtual environment.
-
-.. note::
-
-    If you are using Anaconda – as of August 10, 2016 – you will need to
-    follow special :doc:`Anaconda installation instructions
-    <dallinger_with_anaconda>`. This should be fixed in future versions.
 
 ::
 
@@ -571,13 +679,9 @@ Test that your installation works by running:
 
     dallinger --version
 
-.. note::
-
-    If you are using Anaconda and get a long traceback here,
-    please see the special :doc:`dallinger_with_anaconda`.
 
 Install the dlgr.demos sub-package
-----------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Both the test suite and the included demo experiments require installing the
 ``dlgr.demos`` sub-package in order to run. Install this in "develop mode"

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -418,6 +418,8 @@ From then on, you only need to use the ``workon`` command before starting.
 
 Ubuntu
 ~~~~~~
+
+If using Python 2.7 and pip:
 ::
 
     sudo pip install virtualenv
@@ -425,6 +427,18 @@ Ubuntu
     export WORKON_HOME=$HOME/.virtualenvs
     mkdir -p $WORKON_HOME
     source /usr/local/bin/virtualenvwrapper.sh
+
+
+If using Python 3.x and pip3:
+::
+
+    sudo pip3 install virtualenv
+    sudo pip3 install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+	export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+    source /usr/local/bin/virtualenvwrapper.sh
+
 
 Now create the virtualenv using the ``mkvirtualenv`` command as follows:
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -1,7 +1,8 @@
 Developer Installation
 ======================
 
-We recommend installing Dallinger on Mac OS X. It's also possible to use Ubuntu, either directly or in a virtual machine. If you are attempting to use Dallinger on Microsoft Windows, running Ubuntu in a virtual machine is the recommend method.
+Dallinger is tested with Ubuntu 18.04 LTS, 16.04 LTS, 14.04 LTS and Mac OS X locally.
+If you are attempting to use Dallinger on Microsoft Windows, running Ubuntu in a virtual machine is the recommend method.
 
 If you are interested in using Dallinger with Docker, read more :doc:`here <docker_setup>`.
 
@@ -268,6 +269,7 @@ Ubuntu
 ~~~~~~
 ::
 
+    sudo apt-get install curl
     curl https://cli-assets.heroku.com/install.sh | sh
 
 

--- a/docs/source/gsoc.rst
+++ b/docs/source/gsoc.rst
@@ -81,12 +81,8 @@ to the core platform, independent of any particular kind of experiment run on
 it. Here are a few discrete pieces of functionality that could make good summer
 projects:
 
-+ Browser fingerprinting. Use the `valve2 <https://github.com/Valve/fingerprintjs2>`__
-browser fingerprinting library to detect when a person participates twice in an
-experiment, without exposing personally identifiable information.
-+ Speed testing. One way that an experiment can go wrong is if the participant's
-internet connection cannot keep up. Integrate a speed-testing mechanism that
-excludes participants whose internet connections are too slow for the experiment.
++ Browser fingerprinting. Use the `valve2 <https://github.com/Valve/fingerprintjs2>`__ browser fingerprinting library to detect when a person participates twice in an experiment, without exposing personally identifiable information.
++ Speed testing. One way that an experiment can go wrong is if the participant's internet connection cannot keep up. Integrate a speed-testing mechanism that excludes participants whose internet connections are too slow for the experiment.
 
 3
 ~

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -26,7 +26,12 @@ You can check what version of Python you have by running:
     python --version
 
 
-You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed. It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
+.. note::
+
+    You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed.
+    It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
+    If you are using Python 3, you may find that you may need to use ``pip3`` instead of ``pip`` where applicable in the instructions that follow.
+
 
 Mac OS X
 ~~~~~~~~
@@ -451,6 +456,8 @@ From then on, you only need to use the ``workon`` command before starting.
 
 Ubuntu
 ~~~~~~
+
+If using Python 2.7 and pip:
 ::
 
     sudo pip install virtualenv
@@ -458,6 +465,18 @@ Ubuntu
     export WORKON_HOME=$HOME/.virtualenvs
     mkdir -p $WORKON_HOME
     source /usr/local/bin/virtualenvwrapper.sh
+
+
+If using Python 3.x and pip3:
+::
+
+    sudo pip3 install virtualenv
+    sudo pip3 install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+	export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+    source /usr/local/bin/virtualenvwrapper.sh
+
 
 Now create the virtualenv using the ``mkvirtualenv`` command as follows:
 
@@ -471,14 +490,14 @@ If you are using Python 2 that is part of your Ubuntu installation:
 
     mkvirtualenv dlgr_env --python /usr/bin/python
 
-If you are using another Python version 
+If you are using another Python version
 (eg. custom installed Python 3.x on Ubuntu 14.04):
 ::
 
     mkvirtualenv dlgr_env --python <specify_your_python_path_here>
 
 
-Virtualenvwrapper provides an easy way to switch between virtual environments 
+Virtualenvwrapper provides an easy way to switch between virtual environments
 by simply typing: ``workon [virtual environment name]``.
 
 The technical details:

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -271,8 +271,23 @@ To check which version of the Heroku CLI you have installed, run:
 
     heroku --version
 
-The Heroku CLI is available for download from
-`heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__.
+
+To install:
+
+Mac OS X
+~~~~~~~~
+::
+
+    brew install heroku/brew/heroku
+
+Ubuntu
+~~~~~~
+::
+
+    curl https://cli-assets.heroku.com/install.sh | sh
+
+
+More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
 
 Install Redis
 -------------

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -8,19 +8,19 @@ instructions <developing_dallinger_setup_guide>`.
 Installation Options
 --------------------
 
-Dallinger is tested with Ubuntu 14.04 LTS, 16.04 LTS, 18.04 LTS and Mac OS X locally.
-We do not recommended running Dallinger with Microsoft Windows, however if you do, running Ubuntu in a virtual machine is the recommend method. You can also read about what is possible with using Dallinger with Docker :doc:`here<docker_setup>`.
+Dallinger is tested with Ubuntu 18.04 LTS, 16.04 LTS, 14.04 LTS and Mac OS X locally.
+We do not recommended running Dallinger with Microsoft Windows, however if you do, running Ubuntu in a virtual machine is the recommend method.
 
 Using Dallinger with Docker
 ---------------------------
 Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_setup>`.
 
 
-
-
+Mac OS X
+--------
 
 Install Python
---------------
+~~~~~~~~~~~~~~
 
 Dallinger is written in the language Python. For it to work, you will need
 to have Python 2.7 installed, or alternatively Python 3.6 or higher. Python 3 is the preferred option.
@@ -34,11 +34,8 @@ You can check what version of Python you have by running:
 
     You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed.
     It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
-    If you are using Python 3, you may find that you may need to use ``pip3`` instead of ``pip`` where applicable in the instructions that follow.
+    If you are using Python 3, you may find that you may need to use the ``pip3`` command instead of ``pip`` where applicable in the instructions that follow.
 
-
-Mac OS X
-~~~~~~~~
 
 Using Homebrew will install the latest version of Python and pip by default.
 
@@ -64,12 +61,273 @@ With the preinstalled Python in Mac OS X, you will need to install pip yourself.
 Should that not work for whatever reason, you can search `here <https://docs.python-guide.org/>`__ for more clues.
 
 
+Install Postgresql
+~~~~~~~~~~~~~~~~~~
+
+On Mac OS X, we recommend installing using Homebrew:
+::
+
+    brew install postgresql
+
+
+Postgresql can then be started and stopped using:
+::
+
+    brew services start postgresql
+    brew services stop postgresql
+
+
+Create the databases
+~~~~~~~~~~~~~~~~~~~~
+
+After installing Postgres, you will need to create two databases:
+one for your experiments to use, and a second to support importing saved
+experiments. It is recommended that you also create a database user.
+
+Naviagate to a terminal and type:
+::
+
+    createuser -P dallinger --createdb
+    (Password: dallinger)
+    createdb -O dallinger dallinger
+    createdb -O dallinger dallinger-import
+
+
+The first command will create a user named ``dallinger`` and prompt you for a
+password. The second and third command will create the ``dallinger`` and 
+``dallinger-import`` databases, setting the newly created user as the owner.
+
+You can optionally inspect your databases by entering ``psql dallinger``. 
+Inside psql you can use commands to see the roles and database tables:
+::
+
+    \du
+    \l
+
+To quit:
+::
+
+    \q
+
+
+If you get an error like the following:
+::
+
+    createuser: could not connect to database postgres: could not connect to server:
+        Is the server running locally and accepting
+        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
+
+then postgres is not running. Start postgres as described in the Install Postgresql section above.
+
+Install Heroku
+~~~~~~~~~~~~~~
+
+To run experiments locally or on the internet, you will need the Heroku Command
+Line Interface installed, version 3.28.0 or better. If you want to launch experiments on the internet, then
+you will also need a Heroku.com account, however this is not needed for local debugging.
+
+To check which version of the Heroku CLI you have installed, run:
+::
+
+    heroku --version
+
+
+To install:
+::
+
+    brew install heroku/brew/heroku
+
+More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
+
+
+Install Redis
+~~~~~~~~~~~~~
+
+Debugging experiments requires you to have Redis installed and the Redis
+server running.
+::
+
+    brew install redis
+
+Start Redis on Mac OS X with:
+::
+
+    brew services start redis
+
+You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
+
+Install Git
+~~~~~~~~~~~
+
+Dallinger uses Git, a distributed version control system, for version control of its code.
+If you do not have it installed, you can install it as follows:
+
+::
+
+    brew install git
+
+
+Set up a virtual environment
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Why use virtualenv?
+
+Virtualenv solves a very specific problem: it allows multiple Python projects
+that have different (and often conflicting) requirements, to coexist on the same computer.
+If you want to understand this in detail, you can read more about it `here <https://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`__.
+
+Now let's set up a virtual environment by running the following commands:
+
+If using Python 2.7 and pip:
+::
+
+
+    pip install virtualenv
+    pip install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    export VIRTUALENVWRAPPER_PYTHON=$(which python)
+    source $(which virtualenvwrapper.sh)
+
+If using Python 3.x and pip3 (Python 3.7 in this example):
+::
+
+
+    pip3 install virtualenv
+    pip3 install virtualenvwrapper
+    export WORKON_HOME=$HOME/.virtualenvs
+    mkdir -p $WORKON_HOME
+    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
+    source $(which virtualenvwrapper.sh)
+
+
+Now create the virtual environment using:
+::
+
+
+    mkvirtualenv dlgr_env --python <specify_your_python_path_here>
+
+
+Examples:
+
+Using homebrew installed Python 3.7:
+::
+
+
+    mkvirtualenv dlgr_env --python /usr/local/bin/python3.7
+
+Using Python 2.7:
+::
+
+
+    mkvirtualenv dlgr_env --python /usr/bin/python
+
+
+Virtualenvwrapper provides an easy way to switch between virtual environments
+by simply typing: ``workon [virtual environment name]``.
+
+The technical details:
+
+These commands use ``pip/pip3``, the Python package manager, to install two
+packages ``virtualenv`` and ``virtualenvwrapper``. They set up an
+environmental variable named ``WORKON_HOME`` with a string that gives a
+path to a subfolder of your home directory (``~``) called ``Envs``,
+which the next command (``mkdir``) then makes according to the path
+described in ``$WORKON_HOME`` (recursively, due to the ``-p`` flag).
+That is where your environments will be stored. The ``source`` command
+will run the command that follows, which in this case locates the
+``virtualenvwrapper.sh`` shell script, the contents of which are beyond
+the scope of this setup tutorial. If you want to know what it does, a
+more in depth description can be found on the `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
+
+Finally, the ``mkvirtualenv`` makes your first virtual environment which
+you've named ``dlgr_env``. We have explicitly passed it the location of the Python
+that the virtualenv should use. This Python has been mapped to the ``python``
+command inside the virtual environment.
+
+The how-to:
+
+In the future, you can work on your virtual environment by running:
+Python 2.7
+::
+
+    export VIRTUALENVWRAPPER_PYTHON=$(which python)
+    source $(which virtualenvwrapper.sh)
+    workon dlgr_env
+
+Python 3.x
+::
+
+    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
+    source $(which virtualenvwrapper.sh)
+    workon dlgr_env
+
+
+NB: To stop working in the virtual environment, run ``deactivate``. To
+list all available virtual environments, run ``workon`` with no
+arguments.
+
+If you plan to do a lot of work with Dallinger, you can make your shell
+execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
+do that type:
+
+Python 2.7
+::
+
+    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python)" >> ~/.bash_profile
+    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
+
+Python 3.x
+::
+
+    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)" >> ~/.bash_profile
+    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
+
+
+From then on, you only need to use the ``workon`` command before starting.
+
+Install Dallinger
+~~~~~~~~~~~~~~~~~
+
+Install Dallinger from the terminal by running
+::
+
+    pip install dallinger[data]
+
+Test that your installation works by running:
+::
+
+    dallinger --version
+
+
+Next, you'll need :doc:`access keys for AWS, Heroku,
+etc. <aws_etc_keys>`.
+
+
 Ubuntu
-~~~~~~
+------
+
+Install Python
+~~~~~~~~~~~~~~
+
+Dallinger is written in the language Python. For it to work, you will need
+to have Python 2.7 installed, or alternatively Python 3.6 or higher. Python 3 is the preferred option.
+You can check what version of Python you have by running:
+::
+
+    python --version
+
+
+.. note::
+
+    You will also need to have `pip <https://pip.pypa.io/en/stable>`__ installed.
+    It is included in some of the later versions of Python 3, but not all. (pip is a package manager for Python packages, or modules if you like.)
+    If you are using Python 3, you may find that you may need to use the ``pip3`` command instead of ``pip`` where applicable in the instructions that follow.
+
 
 Ubuntu 18.04 LTS ships with Python 3.6.
 
-Ubuntu 16.04 LTS ships with Python 3.5, while Ubuntu 14.04 LTS ships with Python 3.4. In case you are using these distribution of Ubuntu, you can use
+Ubuntu 16.04 LTS ships with Python 3.5, while Ubuntu 14.04 LTS ships with Python 3.4. In case you are using one of these distributions of Ubuntu, you can use
 dallinger with Python 2.7 or upgrade to the latest Python 3.x on your own.
 
 (All three of these Ubuntu versions also provide a version of Python 2.7)
@@ -94,33 +352,9 @@ If using Python 3.x:
     sudo apt install -y python3-pip
 
 
-Anaconda
-~~~~~~~~
-::
-
-    conda install python
 
 Install Postgresql
-------------------
-
-Mac OS X
-~~~~~~~~
-
-On Mac OS X, we recommend installing using Homebrew:
-::
-
-    brew install postgresql
-
-
-Postgresql can then be started and stopped using:
-::
-
-    brew services start postgresql
-    brew services stop postgresql
-
-
-Ubuntu
-~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 The lowest version of Postgresql that Dallinger v5 supports is 9.4.
 
@@ -190,52 +424,7 @@ After that you'll need to run the following commands
 
 
 Create the databases
---------------------
-
-Mac OS X
-~~~~~~~~
-
-After installing Postgres, you will need to create two databases:
-one for your experiments to use, and a second to support importing saved
-experiments. It is recommended that you also create a database user.
-
-Naviagate to a terminal and type:
-::
-
-    createuser -P dallinger --createdb
-    (Password: dallinger)
-    createdb -O dallinger dallinger
-    createdb -O dallinger dallinger-import
-
-
-The first command will create a user named ``dallinger`` and prompt you for a
-password. The second and third command will create the ``dallinger`` and 
-``dallinger-import`` databases, setting the newly created user as the owner.
-
-You can optionally inspect your databases by entering ``psql dallinger``. 
-Inside psql you can use commands to see the roles and database tables:
-::
-
-    \du
-    \l
-
-To quit:
-::
-
-    \q
-
-
-If you get an error like the following:
-::
-
-    createuser: could not connect to database postgres: could not connect to server:
-        Is the server running locally and accepting
-        connections on Unix domain socket "/tmp/.s.PGSQL.5432"?
-
-then postgres is not running. Start postgres as described in the Install Postgresql section above.
-
-Ubuntu
-~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 Make sure that postgres is running. Switch to the postgres user:
 
@@ -262,9 +451,8 @@ Finally restart postgresql:
 
     sudo service postgresql reload
 
-
 Install Heroku
---------------
+~~~~~~~~~~~~~~
 
 To run experiments locally or on the internet, you will need the Heroku Command
 Line Interface installed, version 3.28.0 or better. If you want to launch experiments on the internet, then
@@ -277,15 +465,6 @@ To check which version of the Heroku CLI you have installed, run:
 
 
 To install:
-
-Mac OS X
-~~~~~~~~
-::
-
-    brew install heroku/brew/heroku
-
-Ubuntu
-~~~~~~
 ::
 
     curl https://cli-assets.heroku.com/install.sh | sh
@@ -294,24 +473,11 @@ Ubuntu
 More information on the Heroku CLI is available at `heroku.com <https://devcenter.heroku.com/articles/heroku-cli>`__ along with alternative installation instructions, if needed.
 
 Install Redis
--------------
+~~~~~~~~~~~~~
 
 Debugging experiments requires you to have Redis installed and the Redis
 server running.
 
-Mac OS X
-~~~~~~~~
-::
-
-    brew install redis
-
-Start Redis on Mac OS X with:
-::
-
-    brew services start redis
-
-Ubuntu
-~~~~~~
 ::
 
     sudo apt-get install -y redis-server
@@ -323,36 +489,19 @@ Start Redis on Ubuntu with:
 
 You can find more details and other installation instructions at `redis.com <https://redis.io/topics/quickstart>`__.
 
-
-
 Install Git
------------
+~~~~~~~~~~~
 
 Dallinger uses Git, a distributed version control system, for version control of its code.
 If you do not have it installed, you can install it as follows:
 
-Mac OS X
-~~~~~~~~
-::
-
-    brew install git
-
-Ubuntu
-~~~~~~
 ::
 
     sudo apt install git
 
 
 Set up a virtual environment
-----------------------------
-
-.. note::
-
-    If you are using Anaconda, ignore this virtualenv
-    section; use ``conda`` to create your virtual environment. Or, see the
-    special :doc:`Anaconda installation instructions <dallinger_with_anaconda>`.
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Why use virtualenv?
 
@@ -361,120 +510,6 @@ that have different (and often conflicting) requirements, to coexist on the same
 If you want to understand this in detail, you can read more about it `here <https://www.dabapps.com/blog/introduction-to-pip-and-virtualenv-python/>`__.
 
 Now let's set up a virtual environment by running the following commands:
-
-Mac OS X
-~~~~~~~~
-
-If using Python 2.7 and pip:
-::
-
-
-    pip install virtualenv
-    pip install virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    export VIRTUALENVWRAPPER_PYTHON=$(which python)
-    source $(which virtualenvwrapper.sh)
-
-If using Python 3.x and pip3 (Python 3.7 in this example):
-::
-
-
-    pip3 install virtualenv
-    pip3 install virtualenvwrapper
-    export WORKON_HOME=$HOME/.virtualenvs
-    mkdir -p $WORKON_HOME
-    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
-    source $(which virtualenvwrapper.sh)
-
-
-Now create the virtual environment using:
-::
-
-
-    mkvirtualenv dlgr_env --python <specify_your_python_path_here>
-
-
-Examples:
-
-Using homebrew installed Python 3.7:
-::
-
-
-    mkvirtualenv dlgr_env --python /usr/local/bin/python3.7
-
-Using Python 2.7:
-::
-
-
-    mkvirtualenv dlgr_env --python /usr/bin/python
-
-
-Virtualenvwrapper provides an easy way to switch between virtual environments 
-by simply typing: ``workon [virtual environment name]``.
-
-The technical details:
-
-These commands use ``pip/pip3``, the Python package manager, to install two
-packages ``virtualenv`` and ``virtualenvwrapper``. They set up an
-environmental variable named ``WORKON_HOME`` with a string that gives a
-path to a subfolder of your home directory (``~``) called ``Envs``,
-which the next command (``mkdir``) then makes according to the path
-described in ``$WORKON_HOME`` (recursively, due to the ``-p`` flag).
-That is where your environments will be stored. The ``source`` command
-will run the command that follows, which in this case locates the
-``virtualenvwrapper.sh`` shell script, the contents of which are beyond
-the scope of this setup tutorial. If you want to know what it does, a
-more in depth description can be found on the `documentation site for virtualenvwrapper <http://virtualenvwrapper.readthedocs.io/en/latest/install.html#python-interpreter-virtualenv-and-path>`__.
-
-Finally, the ``mkvirtualenv`` makes your first virtual environment which
-you've named ``dlgr_env``. We have explicitly passed it the location of the Python
-that the virtualenv should use. This Python has been mapped to the ``python``
-command inside the virtual environment.
-
-The how-to:
-
-In the future, you can work on your virtual environment by running:
-Python 2.7
-::
-
-    export VIRTUALENVWRAPPER_PYTHON=$(which python)
-    source $(which virtualenvwrapper.sh)
-    workon dlgr_env
-
-Python 3.x
-::
-
-    export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)
-    source $(which virtualenvwrapper.sh)
-    workon dlgr_env
-
-
-NB: To stop working in the virtual environment, run ``deactivate``. To
-list all available virtual environments, run ``workon`` with no
-arguments.
-
-If you plan to do a lot of work with Dallinger, you can make your shell
-execute the ``virtualenvwrapper.sh`` script everytime you open a terminal. To
-do that type:
-
-Python 2.7
-::
-
-    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python)" >> ~/.bash_profile
-    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
-
-Python 3.x
-::
-
-    echo "export VIRTUALENVWRAPPER_PYTHON=$(which python3.7)" >> ~/.bash_profile
-    echo "source $(which virtualenvwrapper.sh)" >> ~/.bash_profile
-
-
-From then on, you only need to use the ``workon`` command before starting.
-
-Ubuntu
-~~~~~~
 
 If using Python 2.7 and pip:
 ::
@@ -560,9 +595,8 @@ do that:
 From then on, you only need to use the ``workon`` command before starting.
 
 
-
 Install Dallinger
------------------
+~~~~~~~~~~~~~~~~~
 
 Install Dallinger from the terminal by running
 ::
@@ -573,17 +607,6 @@ Test that your installation works by running:
 ::
 
     dallinger --version
-
-If you use Anaconda, installing Dallinger probably failed. The problem is
-that you need to install bindings for the ``psycopg2`` package (it helps
-Python play nicely with Postgres) and you must use conda for conda to
-know where to look for the links. You do this with:
-::
-
-    conda install psycopg2
-
-Then, try the above installation commands. They should work now, meaning
-you can move on.
 
 
 Next, you'll need :doc:`access keys for AWS, Heroku,

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -467,6 +467,7 @@ To check which version of the Heroku CLI you have installed, run:
 To install:
 ::
 
+    sudo apt-get install curl
     curl https://cli-assets.heroku.com/install.sh | sh
 
 

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -15,6 +15,10 @@ Using Dallinger with Docker
 ---------------------------
 Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_setup>`.
 
+
+
+
+
 Install Python
 --------------
 
@@ -489,7 +493,7 @@ If using Python 3.x and pip3:
     sudo pip3 install virtualenvwrapper
     export WORKON_HOME=$HOME/.virtualenvs
     mkdir -p $WORKON_HOME
-	export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
+    export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
     source /usr/local/bin/virtualenvwrapper.sh
 
 


### PR DESCRIPTION
The user and developer installations have been reordered and the OS sections have been grouped logically together. The side menus now look much cleaner: :muscle: 

**User instructions**

![screenshot from 2019-02-09 03-34-52](https://user-images.githubusercontent.com/883619/52518744-cde6bc00-2c4f-11e9-8257-a134dc4fc365.png)

**Developer instructions**

![screenshot from 2019-02-09 03-34-40](https://user-images.githubusercontent.com/883619/52518743-cd4e2580-2c4f-11e9-99c4-5333dee947cf.png)

The instructions for using pip3 in certain cases have been made more explicit. Likewise the Demoing Dallinger section has been made more explicit as where to find the demo files.

References to Anaconda have been removed from the user and developer installation and where appropriate those comments have been placed in the Anaconda installation instructions themselves.

**NB**  **If we chose to continue supporting Anaconda, we should think about whether we want to provide an entire installation path (and test it) and link that in appropriately, or drop Anaconda entirely?**

@vlall 's Heroku related documentation improvements from https://github.com/Dallinger/Dallinger/pull/1593 have been integrated and adapted in this PR. (This is because I feel they are helpful and it seems that https://github.com/Dallinger/Dallinger/pull/1593 has other blockers to merge, and if/once merged will need to be rebased/adapted anyway since this documentation change moves a lot of content around)

As an experiment, for better visibility in the left side menu, I changed the color of the main level headings from white/gray to light blue. If there is protest, we can easily revert back :smiley: 

Two existing sphinx warnings have been fixed as part of this PR.