### PR TITLE
Add `details` column to json serializations of data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/master) (xxxx-xx-xx)
 
+- Fixed: Add `details` JSON data to `__json__` methods for all models.
 - Improve launch retry messaging when running in debug mode
 - `dallinger verify` now fails if you have more than one Experiment class
-
 
 ## [v5.0.5](https://github.com/dallinger/dallinger/tree/v5.0.5) (2019-02-15)
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1315,11 +1315,10 @@ def info_post(node_id):
     """
     # get the parameters and validate them
     contents = request_parameter(parameter="contents")
-    details = request_parameter(parameter="details", optional=True)
     info_type = request_parameter(parameter="info_type",
                                   parameter_type="known_class",
                                   default=models.Info)
-    for x in [contents, details, info_type]:
+    for x in [contents, info_type]:
         if type(x) == Response:
             return x
     # check the node exists
@@ -1327,13 +1326,10 @@ def info_post(node_id):
     if node is None:
         return error_response(error_type="/info POST, node does not exist")
 
-    if details:
-        details = loads(details)
-
     exp = Experiment(session)
     try:
         # execute the request
-        info = info_type(origin=node, contents=contents, details=details)
+        info = info_type(origin=node, contents=contents)
         assign_properties(info)
 
         # ping the experiment

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -782,6 +782,10 @@ def assign_properties(thing):
     properties of the object in the request. This function gets those values
     from the request and fills in the relevant columns of the table.
     """
+    details = request_parameter(parameter='details', optional=True)
+    if details:
+        setattr(thing, 'details', loads(details))
+
     for p in range(5):
         property_name = "property" + str(p + 1)
         property = request_parameter(parameter=property_name, optional=True)
@@ -1396,20 +1400,20 @@ def node_transmit(node_id):
 
     The sender's node id must be specified in the url.
 
-    As with node.transmit() the key parameters are what and to_whom.
-    However, the values these accept are more limited than for the back end
-    due to the necessity of serialization.
+    As with node.transmit() the key parameters are what and to_whom. However,
+    the values these accept are more limited than for the back end due to the
+    necessity of serialization.
 
     If what and to_whom are not specified they will default to None.
-    Alternatively you can pass an int (e.g. '5') or a class name (e.g.
-    'Info' or 'Agent'). Passing an int will get that info/node, passing
-    a class name will pass the class. Note that if the class you are specifying
-    is a custom class it will need to be added to the dictionary of
-    known_classes in your experiment code.
+    Alternatively you can pass an int (e.g. '5') or a class name (e.g. 'Info' or
+    'Agent'). Passing an int will get that info/node, passing a class name will
+    pass the class. Note that if the class you are specifying is a custom class
+    it will need to be added to the dictionary of known_classes in your
+    experiment code.
 
-    You may also pass the values property1, property2, property3, property4
-    and property5. If passed this will fill in the relevant values of the
-    transmissions created with the values you specified.
+    You may also pass the values property1, property2, property3, property4,
+    property5 and details. If passed this will fill in the relevant values of
+    the transmissions created with the values you specified.
 
     For example, to transmit all infos of type Meme to the node with id 10:
     dallinger.post(

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -68,6 +68,21 @@ class SharedMixin(object):
     #: a generic column for storing structured JSON data
     details = Column(JSONB, nullable=False, server_default="{}", default=lambda: {})
 
+    def __json__(self):
+        """Return json description of a participant."""
+        return {
+            "id": self.id,
+            "creation_time": self.creation_time,
+            "failed": self.failed,
+            "time_of_death": self.time_of_death,
+            "property1": self.property1,
+            "property2": self.property2,
+            "property3": self.property3,
+            "property4": self.property4,
+            "property5": self.property5,
+            "details": self.details,
+        }
+
 
 class Participant(Base, SharedMixin):
     """An ex silico participant."""
@@ -179,7 +194,8 @@ class Participant(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     def nodes(self, type=None, failed=False):
@@ -348,7 +364,8 @@ class Question(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
 
@@ -404,7 +421,8 @@ class Network(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     """ ###################################
@@ -690,7 +708,8 @@ class Node(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     """ ###################################
@@ -1393,7 +1412,8 @@ class Vector(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     """#######################################
@@ -1713,7 +1733,8 @@ class Transmission(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     def fail(self):
@@ -1811,7 +1832,8 @@ class Transformation(Base, SharedMixin):
             "property2": self.property2,
             "property3": self.property3,
             "property4": self.property4,
-            "property5": self.property5
+            "property5": self.property5,
+            "details": self.details,
         }
 
     def fail(self):

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -68,9 +68,12 @@ class SharedMixin(object):
     #: a generic column for storing structured JSON data
     details = Column(JSONB, nullable=False, server_default="{}", default=lambda: {})
 
+    def json_data(self):
+        return {}
+
     def __json__(self):
         """Return json description of a participant."""
-        return {
+        model_data = {
             "id": self.id,
             "creation_time": self.creation_time,
             "failed": self.failed,
@@ -82,6 +85,9 @@ class SharedMixin(object):
             "property5": self.property5,
             "details": self.details,
         }
+        # Add any model specific data to the base data
+        model_data.update(self.json_data())
+        return model_data
 
 
 class Participant(Base, SharedMixin):
@@ -174,10 +180,9 @@ class Participant(Base, SharedMixin):
         self.mode = mode
         self.fingerprint_hash = fingerprint_hash
 
-    def __json__(self):
+    def json_data(self):
         """Return json description of a participant."""
         return {
-            "id": self.id,
             "type": self.type,
             "recruiter": self.recruiter_id,
             "assignment_id": self.assignment_id,
@@ -187,15 +192,6 @@ class Participant(Base, SharedMixin):
             "base_pay": self.base_pay,
             "bonus": self.bonus,
             "status": self.status,
-            "creation_time": self.creation_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     def nodes(self, type=None, failed=False):
@@ -348,24 +344,14 @@ class Question(Base, SharedMixin):
             self.failed = True
             self.time_of_death = timenow()
 
-    def __json__(self):
+    def json_data(self):
         """Return json description of a question."""
         return {
-            "id": self.id,
             "number": self.number,
             "type": self.type,
             "participant_id": self.participant_id,
             "question": self.question,
             "response": self.response,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
-            "creation_time": self.creation_time,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
 
@@ -406,23 +392,13 @@ class Network(Base, SharedMixin):
             len(self.transmissions()),
             len(self.transformations()))
 
-    def __json__(self):
+    def json_data(self):
         """Return json description of a participant."""
         return {
-            "id": self.id,
             "type": self.type,
             "max_size": self.max_size,
             "full": self.full,
             "role": self.role,
-            "creation_time": self.creation_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     """ ###################################
@@ -694,22 +670,12 @@ class Node(Base, SharedMixin):
         """The string representation of a node."""
         return "Node-{}-{}".format(self.id, self.type)
 
-    def __json__(self):
+    def json_data(self):
         """The json of a node."""
         return {
-            "id": self.id,
             "type": self.type,
             "network_id": self.network_id,
-            "creation_time": self.creation_time,
-            "time_of_death": self.time_of_death,
-            "failed": self.failed,
             "participant_id": self.participant_id,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     """ ###################################
@@ -1398,22 +1364,12 @@ class Vector(Base, SharedMixin):
         return "Vector-{}-{}".format(
             self.origin_id, self.destination_id)
 
-    def __json__(self):
+    def json_data(self):
         """The json representation of a vector."""
         return {
-            "id": self.id,
             "origin_id": self.origin_id,
             "destination_id": self.destination_id,
             "network_id": self.network_id,
-            "creation_time": self.creation_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     """#######################################
@@ -1516,23 +1472,13 @@ class Info(Base, SharedMixin):
         """The string representation of an info."""
         return "Info-{}-{}".format(self.id, self.type)
 
-    def __json__(self):
+    def json_data(self):
         """The json representation of an info."""
         return {
-            "id": self.id,
             "type": self.type,
             "origin_id": self.origin_id,
             "network_id": self.network_id,
-            "creation_time": self.creation_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
             "contents": self.contents,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     def fail(self):
@@ -1715,26 +1661,16 @@ class Transmission(Base, SharedMixin):
         """The string representation of a transmission."""
         return "Transmission-{}".format(self.id)
 
-    def __json__(self):
+    def json_data(self):
         """The json representation of a transmissions."""
         return {
-            "id": self.id,
             "vector_id": self.vector_id,
             "origin_id": self.origin_id,
             "destination_id": self.destination_id,
             "info_id": self.info_id,
             "network_id": self.network_id,
-            "creation_time": self.creation_time,
             "receive_time": self.receive_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
             "status": self.status,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     def fail(self):
@@ -1817,23 +1753,13 @@ class Transformation(Base, SharedMixin):
         self.node_id = info_out.origin_id
         self.network_id = info_out.network_id
 
-    def __json__(self):
+    def json_data(self):
         """The json representation of a transformation."""
         return {
-            "id": self.id,
             "info_in_id": self.info_in_id,
             "info_out_id": self.info_out_id,
             "node_id": self.node_id,
             "network_id": self.network_id,
-            "creation_time": self.creation_time,
-            "failed": self.failed,
-            "time_of_death": self.time_of_death,
-            "property1": self.property1,
-            "property2": self.property2,
-            "property3": self.property3,
-            "property4": self.property4,
-            "property5": self.property5,
-            "details": self.details,
         }
 
     def fail(self):

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -53,6 +53,10 @@ columns that are common across tables:
 
 .. autoattribute:: dallinger.models.SharedMixin.property5
     :annotation:
+    :annotation:
+
+.. autoattribute:: dallinger.models.SharedMixin.details
+    :annotation:
 
 .. autoattribute:: dallinger.models.SharedMixin.failed
     :annotation:
@@ -312,6 +316,9 @@ Columns
     :annotation:
 
 .. autoattribute:: dallinger.models.Info.property5
+    :annotation:
+
+.. autoattribute:: dallinger.models.Info.details
     :annotation:
 
 .. autoattribute:: dallinger.models.Info.failed

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -160,9 +160,9 @@ passing a class name will pass the class. Note that if the class you
 are specifying is a custom class it will need to be added to the
 dictionary of known\_classes in your experiment code.
 
-You may also pass the values property1, property2, property3,
-property4 and property5. If passed this will fill in the relevant
-values of the transmissions created with the values you specified.
+You may also pass the values property1, property2, property3, property4,
+property5 and details. If passed this will fill in the relevant values of the
+transmissions created with the values you specified.
 
 The transmitting node and a list of created transmissions are sent to
 experiment method ``transmission_post_request(node, transmissions)``.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -69,6 +69,7 @@ class TestModels(object):
         assert net.property3 is None
         assert net.property4 is None
         assert net.property5 is None
+        assert net.details == {}
         assert net.failed is False
         assert net.time_of_death is None
         assert net.type == "network"
@@ -99,7 +100,8 @@ class TestModels(object):
             "property2": None,
             "property3": None,
             "property4": None,
-            "property5": None
+            "property5": None,
+            "details": {},
         }
 
         # test nodes()
@@ -662,6 +664,14 @@ class TestModels(object):
         self.add(db_session, node)
         assert node.creation_time is not None
 
+    def test_details(self, db_session):
+        net = models.Network()
+        db_session.add(net)
+        node = models.Node(network=net)
+        node.details = {"my_data": [1, 2, 3]}
+        self.add(db_session, node)
+        assert tuple(node.details["my_data"]) == (1, 2, 3)
+
     ##################################################################
     # Participant
     ##################################################################
@@ -706,9 +716,14 @@ class TestModels(object):
         participant = models.Participant(
             recruiter_id='hotair', worker_id=str(1), hit_id=str(1),
             assignment_id=str(1), mode="test")
+        participant.details = {"data": "something"}
         db_session.add(participant)
         db_session.commit()
 
+        participant_json = participant.__json__()
+        assert 'details' in participant_json
+        assert participant_json["details"].get("data") == "something"
+
         # make sure private data is not in there
-        assert 'unique_id' not in participant.__json__()
-        assert 'worker_id' not in participant.__json__()
+        assert 'unique_id' not in participant_json
+        assert 'worker_id' not in participant_json


### PR DESCRIPTION
## Description
Adds a `__json__` method to the `SharedMixin` model base class that includes details for any types that don't already provide `__json__`. Adds `details` to existing model `__json__` methods.

## Motivation and Context
This allows JSONB data stored on various models to be made available via the experiment server API. This should resolve #1645.

## How Has This Been Tested?
Automated tests now include tests for presence of details JSON data.
