### PR TITLE
Add end user Vagrantfile to demos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/master) (xxxx-xx-xx)
 
+- Add user vagrant setup for running demos
+
 - Improve launch retry messaging when running in debug mode
 
 

--- a/demos/Vagrantfile
+++ b/demos/Vagrantfile
@@ -89,6 +89,9 @@ Vagrant.configure("2") do |config|
       echo "dallinger_email_address = $EMAIL" >> ~/.dallingerconfig
       echo "contact_email_on_error = $EMAIL" >> ~/.dallingerconfig
     fi
+    if [ ! $(grep -q "^base_port" ~/.dallingerconfig) ]; then
+      echo 'base_port = 5000' >> ~/.dallingerconfig
+    fi
     pip install -U dallinger[data]
 
     # Git configuration

--- a/demos/Vagrantfile
+++ b/demos/Vagrantfile
@@ -1,0 +1,124 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+
+  class Name
+      def to_s
+          print "Dallinger needs a name and email for making git commits and running experiments\n"
+          print "Full Name: "
+          STDIN.gets.chomp
+      end
+  end
+
+  class Email
+      def to_s
+          print "Email: "
+          STDIN.gets.chomp
+      end
+  end
+
+  config.vm.box = "ubuntu/bionic64"
+
+  config.vm.provider "virtualbox" do |vb|
+      vb.customize ["modifyvm", :id, "--natdnsproxy1", "on"]
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+      vb.cpus = 2
+      vb.memory = 4096
+  end
+
+  config.vm.network "public_network",
+    use_dhcp_assigned_default_route: true
+
+  config_env = {}
+  ['~/.dallingerconfig', '~/.gitconfig'].each do |f|
+    full_f = File.expand_path(f)
+    if File.exist?(full_f) then
+      config.vm.provision "file", source: full_f, destination: f
+
+      config_env[File.basename(f).sub(/^./,'')] = 'TRUE'
+    end
+  end
+
+  # Only ask for name and email if we didn't find a .gitconfig and/or .dallingerconfig
+  if config_env.empty? then
+    config_env = {"NAME" => Name.new, "EMAIL" => Email.new}
+  end
+
+  config.vm.provision "shell", env: config_env, privileged: false, inline: <<-SHELL
+    if [ -n $dallingerconfig ]; then
+      echo 'Copied ~/.dallingerconfig from host machine'
+    fi
+    if [ -n $gitconfig ]; then
+      echo 'Copied ~/.gitconfig from host machine'
+    fi
+    export DEBIAN_FRONTEND=noninteractive
+    export LANG=en_US.UTF-8
+    sudo -E apt-get update
+
+    # Python, git and dev dependencies
+    sudo -E apt-get install -y python3-dev python3-pip python3-virtualenv python-pip python-virtualenv enchant pandoc git
+
+    # Postgres setup
+    sudo -E apt-get install -y postgresql-10 postgresql-server-dev-all
+    sudo -u postgres createuser -ds vagrant
+    sudo -u postgres createuser -ds dallinger
+    createdb dallinger
+    # trust all connections
+    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
+    sudo service postgresql reload
+
+    # Redis server
+    sudo -E apt-get install redis-server -y
+
+    # Virtual environment
+    if [ ! $(grep -q 'heroku login' ~/.bashrc) ]; then
+      echo 'source ~/venv/bin/activate' >> ~/.bashrc
+      echo 'cd /vagrant' >> ~/.bashrc
+      echo "export HOST=$(ifconfig | grep 'inet\s' | head -n1 | awk '{print $2;}')" >> ~/.bashrc
+      echo 'if [ ! -f ~/.cache/heroku/lastrun ]; then heroku login -i; fi' >> ~/.bashrc
+    fi
+    virtualenv --no-site-packages ~/venv -p $(which python3)
+    source ~/venv/bin/activate
+    cd /vagrant
+
+    # Dallinger install
+    if [ ! -f ~/.dallingerconfig ]; then
+      echo '[Dallinger Config]' > ~/.dallingerconfig
+      echo 'base_port = 5000' >> ~/.dallingerconfig
+      echo "dallinger_email_address = $EMAIL" >> ~/.dallingerconfig
+      echo "contact_email_on_error = $EMAIL" >> ~/.dallingerconfig
+    fi
+    pip install -U dallinger[data]
+
+    # Git configuration
+    if [ ! -f ~/.gitconfig ]; then
+      echo '[user]' > ~/.gitconfig
+      echo "name = $NAME" >> ~/.gitconfig
+      echo "email = $EMAIL" >> ~/.gitconfig
+    fi
+
+    # Try to install the current package and deps
+    if [ -f dev-requirements.txt ]; then
+      pip install -U -r dev-requirements.txt || echo "Failed to install dev-requirements.txt"
+    elif [ -f requirements.txt ]; then
+      pip install -U -r requirements.txt || echo "Failed to install requirements.txt"
+    fi
+
+    if [ -f setup.py ]; then
+      pip install -e . || echo "Failed to install experiment"
+    fi
+
+    # Heroku CLI installation
+    sudo -E apt-get install software-properties-common
+    sudo add-apt-repository "deb https://cli-assets.heroku.com/branches/stable/apt ./"
+    curl -L https://cli-assets.heroku.com/apt/release.key | sudo apt-key add -
+    sudo -E apt-get update
+    sudo -E apt-get install heroku
+
+    if [ ! -n $dallingerconfig ]; then
+      echo "Don't forget to customize your ~/.dallingerconfig to include AWS keys, etc."
+    fi
+
+  SHELL
+end

--- a/demos/Vagrantfile
+++ b/demos/Vagrantfile
@@ -40,16 +40,17 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  # Only ask for name and email if we didn't find a .gitconfig and/or .dallingerconfig
-  if config_env.empty? then
-    config_env = {"NAME" => Name.new, "EMAIL" => Email.new}
+  # Only ask for name and email if we didn't find a .gitconfig
+  if !config_env.has_key?('gitconfig') then
+    config_env["NAME"] = Name.new
+    config_env["EMAIL"] = Email.new
   end
 
   config.vm.provision "shell", env: config_env, privileged: false, inline: <<-SHELL
-    if [ -n $dallingerconfig ]; then
+    if [ $dallingerconfig ]; then
       echo 'Copied ~/.dallingerconfig from host machine'
     fi
-    if [ -n $gitconfig ]; then
+    if [ $gitconfig ]; then
       echo 'Copied ~/.gitconfig from host machine'
     fi
     export DEBIAN_FRONTEND=noninteractive

--- a/docs/source/creating_an_experiment.rst
+++ b/docs/source/creating_an_experiment.rst
@@ -141,6 +141,10 @@ like this:
 Make sure you run this command from the initial directory created by
 Cookiecutter. In this case the directory is ``myexperiments.pushbutton``.
 
+Your new experiment directory also includes a `Vagrantfile` which will allow
+you to easily create and run a virtual machine preconfigured to run your
+experiment. See :doc:`Vagrant Installation <vagrant_setup>` for details.
+
 The Experiment Package
 ----------------------
 

--- a/docs/source/vagrant_setup.rst
+++ b/docs/source/vagrant_setup.rst
@@ -1,4 +1,4 @@
-Vagrant installation
+Vagrant Installation
 ====================
 
 Install the Vagrant virtual machine management system from `Hashicorp <https://www.vagrantup.com/docs/installation/>`__ and the `VirtualBox <https://www.virtualbox.org/>`__ virtualization software.
@@ -28,3 +28,8 @@ When you're finished, shut the Vagrant machine down by running:
 
     vagrant halt
 
+New experiments created using the `cookiecutter` template described in
+:doc:`Creating an Experiment <creating_an_experiment>`
+include a `Vagrantfile` which will setup a virtual machine configured to run
+your new Dallinger experiment. The Dallinger demos package also includes a
+`Vagrantfile`.


### PR DESCRIPTION
## Description
The enduser `Vagrantfile` for [ScrumDo Story 486](https://app.scrumdo.com/projects/story_permalink/1816192) lives in the [cookiecutter repository](https://github.com/Dallinger/cookiecutter-dallinger), since it will be most useful for people working with their own experiments. This pull request places a copy of that `Vagrantfile` in the demos package, and updates the Dallinger documentation to provide some additional information about enduser vagrant usage.

## Motivation and Context
The new `Vagrantfile` provides a quick way for someone creating or running an experiment to setup
a fully configured Dallinger virtual machine able to run their experiment(s) in debug, sandbox or deploy modes. It is based on the existing Dallinger `Vagrantfile` intended for developer use with a few changes:

* It uses Ubuntu Bionic (18.04) instead of Xenial (16.04)
* It installs PostgreSQL 10 instead of 9.5
* If the user already has a `~/.dallingerconfig` and/or `~/.gitconfig` on the host machine those
files will be copied to the VM.
* If the user does not have either of the above files, the user will be prompted to enter a name and
email address which will be used to generate barebones git and dallinger configurations in the VM.
* Small configuration and logging changes.

It would probably make sense to incorporate at least some of these changes into the development `Vagrantfile` at the root of the Dallinger repo.

## How Has This Been Tested?
I created VMs using the `Vagrantfile` and successfully ran demos in debug mode using them.
