### PR TITLE
Updates to `verify_package`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v-master](https://github.com/dallinger/dallinger/master) (xxxx-xx-xx)
 
 - Improve launch retry messaging when running in debug mode
+- `dallinger verify` now fails if you have more than one Experiment class
 
 
 ## [v5.0.5](https://github.com/dallinger/dallinger/tree/v5.0.5) (2019-02-15)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -197,6 +197,7 @@ def verify_experiment_module(verbose):
     else:
         log("✗ experiment.py defines more than one experiment class.",
             delay=0, chevrons=False, verbose=verbose)
+        ok = False
 
     return ok
 
@@ -245,6 +246,7 @@ def verify_no_conflicts(verbose=True):
         os.path.join("static", "css", "dallinger.css"),
         os.path.join("static", "scripts", "dallinger2.js"),
         os.path.join("static", "scripts", "reqwest.min.js"),
+        os.path.join("static", "scripts", "store+json2.min.js"),
         os.path.join("static", "scripts", "tracker.js"),
         os.path.join("static", "robots.txt")
     ]


### PR DESCRIPTION
## Description
A couple problems spotted while working on the demos:
1. A core Dallinger JS file is not checked in the existing duplicate file check
2. If an experiment module defines more than one experiment, that should probably be an error(?)
