### PR TITLE
Remove insecure Ubuntu postgres instructions

### DIFF
--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -401,7 +401,7 @@ ship with Postgresql 10.4 and 9.5 respectively, however Ubuntu 14.04 LTS ships w
 
 Postgres can be installed using the following instructions:
 
-**Ubuntu 18.04 LTS:**
+**Ubuntu 18.04 LTS** or **Ubuntu 16.04 LTS:**
 ::
 
     sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
@@ -411,29 +411,6 @@ To run postgres, use the following command:
 
     sudo service postgresql start
 
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
-
-**Ubuntu 16.04 LTS:**
-::
-
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
-
-To run postgres, use the following command:
-::
-
-    service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
-    sudo service postgresql reload
 
 **Ubuntu 14.04 LTS:**
 
@@ -452,13 +429,6 @@ To run postgres, use the following command:
 ::
 
     sudo service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
 
 
 Create the databases

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -363,7 +363,7 @@ ship with Postgresql 10.4 and 9.5 respectively, however Ubuntu 14.04 LTS ships w
 
 Postgres can be installed using the following instructions:
 
-**Ubuntu 18.04 LTS:**
+**Ubuntu 18.04 LTS** or **Ubuntu 16.04 LTS:**
 ::
 
     sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
@@ -373,29 +373,6 @@ To run postgres, use the following command:
 
     sudo service postgresql start
 
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
-
-**Ubuntu 16.04 LTS:**
-::
-
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
-
-To run postgres, use the following command:
-::
-
-    service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/9.5/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/9.5/main/postgresql.conf'
-    sudo service postgresql reload
 
 **Ubuntu 14.04 LTS:**
 
@@ -414,13 +391,6 @@ To run postgres, use the following command:
 ::
 
     sudo service postgresql start
-
-After that you'll need to run the following commands
-::
-
-    sudo sed /etc/postgresql/10/main/pg_hba.conf -e 's/md5/trust/g' --in-place
-    sudo sed -e "s/[#]\?listen_addresses = .*/listen_addresses = '*'/g" -i '/etc/postgresql/10/main/postgresql.conf'
-    sudo service postgresql reload
 
 
 Create the databases


### PR DESCRIPTION
This PR addresses https://github.com/Dallinger/Dallinger/issues/1636

It was found that these insecure postgres configuration instructions are not necessary to run experiments.

Tested with a fresh Ubuntu 18.04 installation that deliberately omitted these postgres configuration/installation steps, therefore using postgres defaults which are set to:
```
# Database administrative login by Unix domain socket
local   all             postgres                                peer

# TYPE  DATABASE        USER            ADDRESS                 METHOD

# "local" is for Unix domain socket connections only
local   all             all                                     peer
# IPv4 local connections:
host    all             all             127.0.0.1/32            md5
# IPv6 local connections:
host    all             all             ::1/128                 md5
# Allow replication connections from localhost, by a user with the
# replication privilege.
local   replication     all                                     peer
host    replication     all             127.0.0.1/32            md5
host    replication     all             ::1/128                 md5
```

Experiments could still be run in debug and sandbox mode. Experiment data was succesfully exported using ``` dallinger export ``` and ``` dallinger export --local ```. 

Bartlett was also run in debug mode programatically as per:
https://dallinger.readthedocs.io/en/latest/python_module.html