### PR TITLE
Wait for redis URL on heroku before connecting

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -310,11 +310,11 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     log("Waiting for Redis...")
     ready = False
     while not ready:
-        r = redis.from_url(heroku_app.redis_url)
         try:
+            r = redis.from_url(heroku_app.redis_url)
             r.set("foo", "bar")
             ready = True
-        except redis.exceptions.ConnectionError:
+        except (ValueError, redis.exceptions.ConnectionError):
             time.sleep(2)
 
     log("Saving the URL of the postgres database...")


### PR DESCRIPTION

## Description
Fix for #1671 

## Motivation and Context
After creating the remote Heroku app, there may be a delay before a valid value is returned for `REDIS_URL`. This change moves the attempt to connect into the existing try/except/loop construct.

## How Has This Been Tested?
`dallinger sandbox` on Bartlett.

