### PR TITLE
Release version 5.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,19 @@
 # Change Log
 
-## [v-master](https://github.com/dallinger/dallinger/master) (xxxx-xx-xx)
+## [v5.0.6](https://github.com/dallinger/dallinger/tree/v5.0.6) (2019-02-28)
 
-- Fixed: Add `details` JSON data to `__json__` methods for all models.
+- Heroku has deprecated the use of the --org parameter which previous versions of Dallinger used. This release fixes Dallinger to use the newer --team parameter instead, which has been available in Heroku for quite some time. The change was introduced in Heroku CLI 7.21. The --team parameter was introduced in Heroku a significant time ago, thus this version of Dallinger will work with many older versions of the Heroku CLI. If using an older version of the Heroku CLI, we recommend updating to the latest version.
+
 - Improve launch retry messaging when running in debug mode
 - `dallinger verify` now fails if you have more than one Experiment class
+
+- Fixed: Add `details` JSON data to `__json__` methods for all models.
+- Fixed bug related to running Dallinger with Redis 3.1.0 or higher.
+
+- Documentation improvements and additions:
+  + Postgres install instructions for Ubuntu have been simplified and tested
+  + Anaconda instructions have been removed
+  + Other minor documentation improvements/clarifications
 
 ## [v5.0.5](https://github.com/dallinger/dallinger/tree/v5.0.5) (2019-02-15)
 

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "5.0.5"
+__version__ = "5.0.6"

--- a/demos/dlgr/demos/bartlett1932/requirements.txt
+++ b/demos/dlgr/demos/bartlett1932/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/chatroom/requirements.txt
+++ b/demos/dlgr/demos/chatroom/requirements.txt
@@ -1,2 +1,2 @@
-dallinger==5.0.5
+dallinger==5.0.6
 nltk==3.3

--- a/demos/dlgr/demos/concentration/requirements.txt
+++ b/demos/dlgr/demos/concentration/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/function_learning/requirements.txt
+++ b/demos/dlgr/demos/function_learning/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/iterated_drawing/requirements.txt
+++ b/demos/dlgr/demos/iterated_drawing/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/mcmcp/requirements.txt
+++ b/demos/dlgr/demos/mcmcp/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/rogers/requirements.txt
+++ b/demos/dlgr/demos/rogers/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/sheep_market/requirements.txt
+++ b/demos/dlgr/demos/sheep_market/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/snake/requirements.txt
+++ b/demos/dlgr/demos/snake/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/twentyfortyeight/requirements.txt
+++ b/demos/dlgr/demos/twentyfortyeight/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/dlgr/demos/vox_populi/requirements.txt
+++ b/demos/dlgr/demos/vox_populi/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==5.0.5
+dallinger==5.0.6

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==5.0.5
+Dallinger==5.0.6

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == 'publish':
 
 setup_args = dict(
     name='dlgr.demos',
-    version="5.0.5",
+    version="5.0.6",
     description='Demonstration experiments for Dallinger',
     url='http://github.com/Dallinger/Dallinger',
     maintainer='Jordan Suchow',

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 5.0.5
+current_version = 5.0.6
 commit = False
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup_args = dict(
     name='dallinger',
     packages=['dallinger', 'dallinger_scripts'],
-    version="5.0.5",
+    version="5.0.6",
     description='Laboratory automation for the behavioral and social sciences',
     url='http://github.com/Dallinger/Dallinger',
     maintainer='Jordan Suchow',


### PR DESCRIPTION
- Heroku has deprecated the use of the --org parameter which previous versions of Dallinger used. This release fixes Dallinger to use the newer --team parameter instead, which has been available in Heroku for quite some time. The change was introduced in Heroku CLI 7.21. The --team parameter was introduced in Heroku a significant time ago, thus this version of Dallinger will work with many older versions of the Heroku CLI. If using an older version of the Heroku CLI, we recommend updating to the latest version.

- Improve launch retry messaging when running in debug mode
- `dallinger verify` now fails if you have more than one Experiment class

- Fixed: Add `details` JSON data to `__json__` methods for all models.
- Fixed bug related to running Dallinger with Redis 3.1.0 or higher.

- Documentation improvements and additions:
  + Postgres install instructions for Ubuntu have been simplified and tested
  + Anaconda instructions have been removed
  + Other minor documentation improvements/clarifications