### PR TITLE
If a HIT is already deleted, don't raise from disable_hit()

### DIFF
--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -430,7 +430,14 @@ class MTurkService(object):
 
     def disable_hit(self, hit_id):
         self.expire_hit(hit_id)
-        return self._is_ok(self.mturk.delete_hit(HITId=hit_id))
+        try:
+            result = self.mturk.delete_hit(HITId=hit_id)
+        except Exception as ex:
+            if "currently in the state 'Disposed'" in str(ex):
+                # this means "already deleted"...
+                return True
+            raise
+        return self._is_ok(result)
 
     def expire_hit(self, hit_id):
         """Expire a HIT, which will change its status to "Reviewable",


### PR DESCRIPTION
## Description
Addresses #1637 

## Motivation and Context
Timing issues in tests can result in trying to clean up an already deleted HIT. We should just ignore these errors.

## How Has This Been Tested?
Hard to reproduce the error context, and not possible to write an automated test. I did run tests with the `--mturkfull` flag to verify HIT deletion still works, but can't be sure the Except block was executed.

