### PR TITLE
Black refinements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
   - id: black
     name: black
     entry: black
+    args: [--quiet]
     language: system
     types: [python]
     files: ^(tests|dallinger|dallinger_scripts|demos)/

--- a/tox.ini
+++ b/tox.ini
@@ -29,7 +29,9 @@ whitelist_externals =
 [testenv:style]
 commands =
     flake8
+    black --check dallinger dallinger_scripts demos tests
 deps =
+    black == 18.9b0
     flake8 == 3.4.1
 
 [testenv:docs]


### PR DESCRIPTION
## Description
- Only show error output from black inside the pre-commit output
- Run black on Travis and fail build if it finds formatting problems

## Motivation and Context
- Too much output from _black_ distracts from the important fact that your commit failed
- Failing Travis build if _black_ finds formatting problems will cover the case where someone pushes a commit on which _black_ hasn't already been applied.

## How Has This Been Tested?
Local failure:
```
$ git commit -a -m "Test output"
black....................................................................Failed
hookid: black

Files were modified by this hook.
```

Travis failure:
```
style runtests: commands[1] | black --check dallinger dallinger_scripts demos tests
would reformat /home/travis/build/Dallinger/Dallinger/dallinger/notifications.py
All done! 💥 💔 💥
1 file would be reformatted, 105 files would be left unchanged.
ERROR: InvocationError for command '/home/travis/build/Dallinger/Dallinger/.tox/style/bin/black --check dallinger dallinger_scripts demos tests' (exited with code 1)
___________________________________ summary ____________________________________
ERROR:   style: commands failed
The command "tox" exited with 1.
```