### PR TITLE
Add fast tox environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,8 @@ matrix:
     env: TOXENV=style
   - python: 3.6
     env: TOXENV=docs
+  - python: 3.6
+    env: TOXENV=fast
   - python: 3.7
     env:
       - TOXENV=py37

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -409,6 +409,9 @@ def pytest_addoption(parser):
     parser.addoption("--chrome", action="store_true", help="Run chrome bot tests")
     parser.addoption("--phantomjs", action="store_true", help="Run phantomjs bot tests")
     parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+    parser.addoption(
         "--webdriver",
         nargs="?",
         action="store",
@@ -438,3 +441,13 @@ def pytest_addoption(parser):
         action="store_true",
         help="Run griduinverse tests and fail if not all pass",
     )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -7,6 +7,7 @@ import pytest
 import dallinger
 
 
+@pytest.mark.slow
 class TestAPI(object):
     def test_uuid(self):
         from dallinger.experiment import Experiment

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -68,11 +68,13 @@ def mturk():
 
 
 @pytest.mark.usefixtures("bartlett_dir")
+@pytest.mark.slow
 class TestVerify(object):
     def test_verify(self):
         subprocess.check_call(["dallinger", "verify"])
 
 
+@pytest.mark.slow
 class TestCommandLine(object):
     def test_dallinger_no_args(self):
         output = subprocess.check_output(["dallinger"])
@@ -113,6 +115,7 @@ class TestCommandLine(object):
         subprocess.check_call(["dallinger", "setup"])
 
 
+@pytest.mark.slow
 class TestReportAfterIdleDecorator(object):
     def test_reports_timeout(self, active_config):
         @report_idle_after(1)
@@ -126,6 +129,7 @@ class TestReportAfterIdleDecorator(object):
             mock_messenger.send.assert_called_once()
 
 
+@pytest.mark.slow
 class TestOutput(object):
     @pytest.fixture
     def output(self):
@@ -175,6 +179,7 @@ class TestDebugCommand(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir")
+@pytest.mark.slow
 class TestSandboxAndDeploy(object):
     @pytest.fixture
     def sandbox(self):
@@ -285,6 +290,7 @@ class TestSummary(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir")
+@pytest.mark.slow
 class TestBot(object):
     @pytest.fixture
     def bot_command(self):
@@ -678,6 +684,7 @@ class TestDestroy(object):
 
         return destroy
 
+    @pytest.mark.slow
     def test_calls_destroy(self, destroy, heroku):
         CliRunner().invoke(destroy, ["--app", "some-app-uid", "--yes"])
         heroku.destroy.assert_called_once()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -167,6 +167,7 @@ worldwide = false
         config.ready = True
         assert config.get("num_participants") == 1
 
+    @pytest.mark.slow
     def test_experiment_defined_parameters(self):
         try:
             python = pexpect.spawn("python", encoding="utf-8")

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -26,6 +26,7 @@ def zip_path():
     return os.path.join("tests", "datasets", "test_export.zip")
 
 
+@pytest.mark.slow
 class TestData(object):
     @pytest.fixture
     def cleanup(self):

--- a/tests/test_demos.py
+++ b/tests/test_demos.py
@@ -7,6 +7,7 @@ from dallinger.command_line import verify_package
 from dallinger.config import get_config
 
 
+@pytest.mark.slow
 class TestDemos(object):
     """Verify all the built-in demos."""
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -259,11 +259,13 @@ class TestSetupExperiment(object):
                 setup_experiment(log=mock.Mock())
                 assert ex_info.match("Boom!")
 
+    @pytest.mark.slow
     def test_large_float_payment(self):
         config = get_config()
         config["base_payment"] = 1.2342
         assert verify_package() is False
 
+    @pytest.mark.slow
     def test_negative_payment(self):
         config = get_config()
         config["base_payment"] = -1.99
@@ -394,6 +396,7 @@ class Test_deploy_in_mode(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir")
+@pytest.mark.slow
 class Test_handle_launch_data(object):
     @pytest.fixture
     def handler(self):
@@ -452,6 +455,7 @@ class Test_handle_launch_data(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir", "clear_workers", "env")
+@pytest.mark.slow
 class TestDebugServer(object):
     @pytest.fixture
     def debugger_unpatched(self, output):
@@ -562,6 +566,7 @@ class TestDebugServer(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir", "clear_workers", "env")
+@pytest.mark.slow
 class TestLoad(object):
 
     exp_id = "some_experiment_id"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -20,7 +20,8 @@ class TestAppConfiguration(object):
         webapp.application.debug = False
         from dallinger.experiment_server.gunicorn import StandaloneServer
 
-        StandaloneServer().load()
+        with mock.patch("sys.argv", ["gunicorn"]):
+            StandaloneServer().load()
         assert webapp.application.debug
 
     def test_production_mode_leaves_flask_in_production_mode(
@@ -30,7 +31,8 @@ class TestAppConfiguration(object):
         webapp.application.debug = False
         from dallinger.experiment_server.gunicorn import StandaloneServer
 
-        StandaloneServer().load()
+        with mock.patch("sys.argv", ["gunicorn"]):
+            StandaloneServer().load()
         assert not webapp.application.debug
 
     def test_gunicorn_worker_config(self, webapp, active_config):
@@ -39,17 +41,18 @@ class TestAppConfiguration(object):
             cpu_count.return_value = 2
             from dallinger.experiment_server.gunicorn import StandaloneServer
 
-            server = StandaloneServer()
-            assert server.options["workers"] == u"4"
-            cpu_count.return_value = 4
-            server.load_user_config()
-            assert server.options["workers"] == u"7"
-            active_config.extend({"worker_multiplier": 1.0})
-            server.load_user_config()
-            assert server.options["workers"] == u"5"
-            active_config.extend({"threads": u"2"})
-            server.load_user_config()
-            assert server.options["workers"] == u"2"
+            with mock.patch("sys.argv", ["gunicorn"]):
+                server = StandaloneServer()
+                assert server.options["workers"] == u"4"
+                cpu_count.return_value = 4
+                server.load_user_config()
+                assert server.options["workers"] == u"7"
+                active_config.extend({"worker_multiplier": 1.0})
+                server.load_user_config()
+                assert server.options["workers"] == u"5"
+                active_config.extend({"threads": u"2"})
+                server.load_user_config()
+                assert server.options["workers"] == u"2"
 
 
 @pytest.mark.usefixtures("experiment_dir")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -6,6 +6,7 @@ from dallinger import models
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestAppConfiguration(object):
     def test_config_gets_loaded_before_first_request(self, webapp):
         from dallinger.config import get_config
@@ -52,6 +53,7 @@ class TestAppConfiguration(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestAdvertisement(object):
     def test_returns_error_without_hitId_and_assignmentId(self, webapp):
         resp = webapp.get("/ad")
@@ -227,6 +229,7 @@ class TestAdvertisement(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestQuestion(object):
     def test_with_no_participant_id_fails_to_match_route_returns_405(self, webapp):
         # I found this surprising, so leaving the test here.
@@ -284,6 +287,7 @@ class TestQuestion(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestWorkerComplete(object):
     def test_with_no_participant_id_returns_error(self, webapp):
         resp = webapp.get("/worker_complete")
@@ -371,6 +375,7 @@ def mock_messenger():
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestHandleError(object):
     def test_completes_assignment(self, a, webapp):
         resp = webapp.post("/handle-error", data={"participant_id": a.participant().id})
@@ -491,6 +496,7 @@ class TestHandleError(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestWorkerFailed(object):
     def test_with_no_participant_id_returns_error(self, webapp):
         resp = webapp.get("/worker_failed")
@@ -530,6 +536,7 @@ class TestWorkerFailed(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestSimpleGETRoutes(object):
     def test_success_response(self):
         from dallinger.experiment_server.experiment_server import success_response
@@ -580,6 +587,7 @@ class TestSimpleGETRoutes(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestAdRoute(object):
     def test_ad(self, webapp):
         resp = webapp.get(
@@ -610,6 +618,7 @@ class TestAdRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestParticipantGetRoute(object):
     def test_participant_info(self, a, webapp):
         p = a.participant()
@@ -627,6 +636,7 @@ class TestParticipantGetRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestParticipantCreateRoute(object):
     @pytest.fixture
     def overrecruited(self):
@@ -697,6 +707,7 @@ class TestParticipantCreateRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestAPINotificationRoute(object):
     @pytest.fixture
     def queue(self):
@@ -723,6 +734,7 @@ class TestAPINotificationRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestSummaryRoute(object):
     def test_summary_no_participants(self, a, webapp):
         resp = webapp.get("/summary")
@@ -812,6 +824,7 @@ class TestSummaryRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestNetworkRoute(object):
     def test_get_network(self, a, webapp):
         network = a.network()
@@ -833,6 +846,7 @@ class TestNetworkRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestNodeRouteGET(object):
     def test_node_vectors(self, a, webapp):
         node = a.node()
@@ -850,6 +864,7 @@ class TestNodeRouteGET(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestParticipantNodeCreationRoute(object):
     def test_with_invalid_participant_id_returns_error(self, webapp):
         resp = webapp.post("/node/123")
@@ -948,6 +963,7 @@ class TestRequestParameter(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestNodeRoutePOST(object):
     def test_node_transmit_info_creates_transmission(self, a, webapp, db_session):
         network = a.star()
@@ -1026,6 +1042,7 @@ class TestNodeRoutePOST(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestInfoRoutePOST(object):
     def test_invalid_node_id_returns_error(self, webapp):
         nonexistent_node_id = 999
@@ -1074,6 +1091,7 @@ class TestInfoRoutePOST(object):
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
+@pytest.mark.slow
 class TestTrackingEventRoutePOST(object):
     def test_invalid_node_id_returns_error(self, webapp):
         nonexistent_node_id = 999
@@ -1093,6 +1111,7 @@ class TestTrackingEventRoutePOST(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestNodeNeighbors(object):
     def test_returns_error_on_invalid_paramter(self, webapp):
         resp = webapp.get("/node/123/neighbors?node_type=BadClass")
@@ -1141,6 +1160,7 @@ class TestNodeNeighbors(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestNodeReceivedInfos(object):
     def test_returns_error_on_invalid_paramter(self, webapp):
         resp = webapp.get("/node/123/received_infos?info_type=BadClass")
@@ -1198,6 +1218,7 @@ class TestNodeReceivedInfos(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestTransformationGet(object):
     def test_returns_error_on_invalid_paramter(self, webapp):
         resp = webapp.get("/node/123/transformations?transformation_type=BadClass")
@@ -1243,6 +1264,7 @@ class TestTransformationGet(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestTransformationPost(object):
     def test_returns_error_on_invalid_paramter(self, webapp):
         resp = webapp.post("/transformation/123/123/123?transformation_type=BadClass")
@@ -1305,6 +1327,7 @@ class TestTransformationPost(object):
 
 
 @pytest.mark.usefixtures("experiment_dir")
+@pytest.mark.slow
 class TestLaunchRoute(object):
     def test_launch(self, webapp):
         resp = webapp.post("/launch", data={})

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -453,6 +453,7 @@ class TestHerokuApp(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir")
+@pytest.mark.slow
 class TestHerokuLocalWrapper(object):
     @pytest.fixture
     def config(self):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -6,12 +6,13 @@ import six
 import sys
 from datetime import datetime
 from dallinger import models, nodes
-from pytest import raises
+from pytest import raises, mark
 from dallinger.nodes import Agent, Source
 from dallinger.information import Gene
 from dallinger.transformations import Mutation
 
 
+@mark.slow
 class TestModels(object):
     def add(self, session, *args):
         session.add_all(args)

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -321,6 +321,7 @@ def qtype(mturk):
 
 @pytest.mark.mturk
 @pytest.mark.mturkworker
+@pytest.mark.slow
 class TestMTurkServiceIntegrationSmokeTest(object):
     """Hits about 75% of the MTurkService class with actual boto.mturk network
     calls. For comprehensive system tests, run with the --mturkfull option.
@@ -560,6 +561,7 @@ class TestMTurkService(object):
 @pytest.mark.skipif(
     not pytest.config.getvalue("mturkfull"), reason="--mturkfull was not specified"
 )
+@pytest.mark.slow
 class TestMTurkServiceWithRequesterAndWorker(object):
     def test_can_assign_new_qualification(self, with_cleanup, worker_id, qtype):
         assert with_cleanup.assign_qualification(qtype["id"], worker_id, score=2)
@@ -681,6 +683,7 @@ class TestMTurkServiceWithRequesterAndWorker(object):
 @pytest.mark.skipif(
     not pytest.config.getvalue("manual"), reason="--manual was not specified"
 )
+@pytest.mark.slow
 class TestInteractive(object):
     def test_worker_can_see_hit_when_blacklist_not_in_qualifications(
         self, with_cleanup, worker_id, qtype

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -460,6 +460,7 @@ class TestStar(object):
             assert exc_info.match("cannot connect to itself")
 
 
+@pytest.mark.slow
 class TestScaleFree(object):
     def test_create_scale_free(self, a):
         m0 = 4
@@ -517,6 +518,7 @@ class GenerationalAgent(nodes.Agent):
         return cast(self.property2, Integer)
 
 
+@pytest.mark.slow
 class TestDiscreteGenerational(TestNetworks):
 
     n_gens = 4

--- a/tests/test_processes.py
+++ b/tests/test_processes.py
@@ -1,6 +1,8 @@
 from dallinger import processes, networks, nodes, models
 from dallinger.nodes import Agent
 
+import pytest
+
 
 class TestProcesses(object):
     def test_random_walk_from_source(self, db_session):
@@ -38,6 +40,7 @@ class TestProcesses(object):
 
         assert msg == agent3.infos()[0].contents
 
+    @pytest.mark.slow
     def test_moran_process_cultural(self, db_session):
 
         # Create a fully-connected network.
@@ -86,6 +89,7 @@ class TestProcesses(object):
             == max(agent1.infos(), key=attrgetter("creation_time")).contents
         )
 
+    @pytest.mark.slow
     def test_moran_process_sexual(self, db_session):
 
         # Create a fully-connected network.

--- a/tests/test_replay.py
+++ b/tests/test_replay.py
@@ -2,6 +2,8 @@ from datetime import datetime
 import gevent
 import random
 
+import pytest
+
 
 class DummyEvent(object):
     creation_time = None
@@ -43,6 +45,7 @@ class DummyExperiment(object):
         self.finished = True
 
 
+@pytest.mark.slow
 class TestReplayBackend:
 
     allowed_jitter = 0.05

--- a/tests/test_replay_state.py
+++ b/tests/test_replay_state.py
@@ -13,6 +13,7 @@ def zip_path():
     return os.path.join("tests", "datasets", "test_export.zip")
 
 
+@pytest.mark.slow
 class TestReplayState(object):
     @pytest.fixture
     def cleanup(self):

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -114,6 +114,7 @@ class TestChatBackend:
         assert client not in chat.channels["quorum"].clients
 
 
+@pytest.mark.slow
 class TestClient:
     def test_send(self, client):
         client.send("message")

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-     docs,py27,py36,style
+     docs,py27,py36,style,fast
 
 [testenv]
 extras =
@@ -10,7 +10,7 @@ commands =
     find . -type f -name "*.py[c|o]" -delete
     pip install -r build-requirements.txt
     pip install -e demos
-    coverage run {envbindir}/pytest {posargs}
+    coverage run {envbindir}/pytest {posargs} --runslow
     coverage combine
     coverage report
     coverage xml
@@ -25,6 +25,25 @@ passenv =
     threads
 whitelist_externals =
     find
+
+[testenv:fast]
+extras =
+    data
+    jupyter
+deps =
+    -r build-requirements.txt
+    -e demos
+commands =
+    {envbindir}/pytest {posargs}
+passenv =
+    CI
+    DATABASE_URL
+    PORT
+    HOME
+    aws_access_key_id
+    aws_secret_access_key
+    mturk_worker_id
+    threads
 
 [testenv:style]
 commands =


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
The fast tox environment runs a subset of the tests under Python 3.6
that exclude the slowest of the current set. This is intended to be
used to make the development process more usable.

## Motivation and Context
Tests are too slow

## How Has This Been Tested?
I've run the tests locally. Testing on travis now.