### PR TITLE
Move Config Defaults Out of Python

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -807,7 +807,7 @@ def apps():
     config = get_config()
     if not config.ready:
         config.load()
-    team = config.get("heroku_team", "").strip() or None
+    team = config.get("heroku_team", None)
     command_runner = HerokuInfo(team=team)
     my_apps = command_runner.my_apps()
     my_user = command_runner.login_name()

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -669,7 +669,7 @@ def awaken(app, databaseurl):
     heroku_app.pg_wait()
     time.sleep(10)
 
-    heroku_app.addon("heroku-redis:{}".format(config.get("redis_size", "premium-0")))
+    heroku_app.addon("heroku-redis:{}".format(config.get("redis_size")))
     heroku_app.restore(url)
 
     # Scale up the dynos.

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -29,7 +29,7 @@ default_keys = (
     ("browser_exclude_rule", six.text_type, []),
     ("clock_on", bool, []),
     ("contact_email_on_error", six.text_type, []),
-    ("chrome-path", six.binary_type, []),
+    ("chrome-path", six.text_type, []),
     ("dallinger_email_address", six.text_type, []),
     ("database_size", six.text_type, []),
     ("database_url", six.text_type, [], True),
@@ -131,7 +131,10 @@ class Configuration(object):
             raise RuntimeError("Config not loaded")
         for layer in self.data:
             try:
-                return layer[key]
+                value = layer[key]
+                if isinstance(value, six.text_type):
+                    value = value.strip()
+                return value
             except KeyError:
                 continue
         if default is marker:
@@ -181,7 +184,7 @@ class Configuration(object):
             self.sensitive.add(key)
 
     def load_from_file(self, filename):
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.read(filename)
         data = {}
         for section in parser.sections():
@@ -189,7 +192,7 @@ class Configuration(object):
         self.extend(data, cast_types=True, strict=True)
 
     def write(self, filter_sensitive=False):
-        parser = configparser.SafeConfigParser()
+        parser = configparser.ConfigParser()
         parser.add_section("Parameters")
         for layer in reversed(self.data):
             for k, v in layer.items():

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -11,3 +11,22 @@ smtp_password = ???
 [Error Notifications]
 contact_email_on_error = ???
 dallinger_email_address = dallinger@mailinator.com
+
+[Experiment]
+replay = False
+
+[Recruiter]
+auto_recruit = False
+assign_qualifications = False
+
+[Bots]
+webdriver_type = phantomjs
+chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
+
+[Heroku]
+clock_on = False
+sentry = False
+redis_size = premium-0
+worker_multiplier = 1.5
+num_dynos_web = 1
+num_dynos_worker = 1

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -14,6 +14,7 @@ dallinger_email_address = dallinger@mailinator.com
 
 [Experiment]
 replay = False
+mode = debug
 
 [Recruiter]
 auto_recruit = False

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -274,7 +274,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
 
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
-    team = config.get("heroku_team", "").strip() or None
+    team = config.get("heroku_team", None)
     heroku_app = HerokuApp(dallinger_uid=id, output=out, team=team)
     heroku_app.bootstrap()
     heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -25,9 +25,7 @@ from dallinger.utils import ensure_directory
 from dallinger.utils import get_base_url
 from dallinger.utils import GitClient
 
-
 config = get_config()
-OSX_CHROME_PATH = "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 
 
 def _make_chrome(path):
@@ -62,7 +60,7 @@ def new_webbrowser_profile():
         ]
         return new_firefox
     elif sys.platform == "darwin":
-        chrome_path = config.get("chrome-path", OSX_CHROME_PATH)
+        chrome_path = config.get("chrome-path")
         if os.path.exists(chrome_path):
             return _make_chrome(chrome_path)
         else:
@@ -154,7 +152,7 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
         src = os.path.join(src_base, "heroku", filename)
         shutil.copy(src, os.path.join(dst, filename))
 
-    clock_on = config.get("clock_on", False)
+    clock_on = config.get("clock_on")
 
     # If the clock process has been disabled, overwrite the Procfile.
     if not clock_on:
@@ -281,13 +279,13 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
 
     # Set up add-ons and AWS environment variables.
     database_size = config.get("database_size")
-    redis_size = config.get("redis_size", "premium-0")
+    redis_size = config.get("redis_size")
     addons = [
         "heroku-postgresql:{}".format(quote(database_size)),
         "heroku-redis:{}".format(quote(redis_size)),
         "papertrail",
     ]
-    if config.get("sentry", False):
+    if config.get("sentry"):
         addons.append("sentry")
 
     for name in addons:
@@ -573,7 +571,7 @@ class LoaderDeployment(HerokuLocalDeployment):
         base_url = get_base_url()
         self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
 
-        if self.exp_config.get("replay", False):
+        if self.exp_config.get("replay"):
             self.out.log("Launching the experiment...")
             time.sleep(4)
             _handle_launch_data("{}/launch".format(base_url), error=self.out.error)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -564,7 +564,6 @@ def advertisement():
     """
     if not ("hitId" in request.args and "assignmentId" in request.args):
         raise ExperimentError("hit_assign_worker_id_not_set_in_mturk")
-
     config = _config()
 
     # Browser rule validation, if configured:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -236,7 +236,7 @@ def error_page(
             "error.html",
             error_text=error_text,
             compensate=compensate,
-            contact_address=config.get("contact_email_on_error", ""),
+            contact_address=config.get("contact_email_on_error"),
             error_type=error_type,
             hit_id=hit_id,
             assignment_id=assignment_id,
@@ -440,7 +440,7 @@ def handle_error():
     return render_template(
         "error-complete.html",
         completed=completed,
-        contact_address=config.get("contact_email_on_error", ""),
+        contact_address=config.get("contact_email_on_error"),
         hit_id=hit_id,
     )
 

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -60,7 +60,7 @@ class StandaloneServer(Application):
         config = get_config()
         workers = config.get("threads")
         if workers == "auto":
-            multiplier = config.get("worker_multiplier", 1.5)
+            multiplier = config.get("worker_multiplier")
             workers = str(int(round(multiprocessing.cpu_count() * multiplier)) + 1)
 
         host = config.get("host")

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -469,8 +469,8 @@ class HerokuLocalWrapper(object):
             raise HerokuStartupError('"HOME" environment not set... aborting.')
 
         port = self.config.get("base_port")
-        web_dynos = self.config.get("num_dynos_web", 1)
-        worker_dynos = self.config.get("num_dynos_worker", 1)
+        web_dynos = self.config.get("num_dynos_web")
+        worker_dynos = self.config.get("num_dynos_worker")
         commands = [
             self.shell_command,
             "local",

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -537,8 +537,8 @@ class HerokuLocalWrapper(object):
 
 def sanity_check(config):
     # check if dyno size is compatible with team configuration.
-    size = config.get("dyno_type", "").strip()
-    team = config.get("heroku_team", "").strip()
+    size = config.get("dyno_type")
+    team = config.get("heroku_team", None)
     if team and size == "free":
         raise RuntimeError(
             'Heroku "free" dyno type not compatible '

--- a/dallinger/notifications.py
+++ b/dallinger/notifications.py
@@ -33,11 +33,11 @@ class EmailConfig(object):
     }
 
     def __init__(self, config):
-        self.host = config.get("smtp_host", "")
-        self.username = config.get("smtp_username", "")
-        self.toaddr = config.get("contact_email_on_error", "")
-        self.password = config.get("smtp_password", "")
-        self.fromaddr = config.get("dallinger_email_address", "")
+        self.host = config.get("smtp_host")
+        self.username = config.get("smtp_username", None)
+        self.toaddr = config.get("contact_email_on_error")
+        self.password = config.get("smtp_password", None)
+        self.fromaddr = config.get("dallinger_email_address")
 
     def validate(self):
         """Could this config be used to send a real email?"""

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -484,7 +484,7 @@ class MTurkRecruiter(Recruiter):
     def recruit(self, n=1):
         """Recruit n new participants to an existing HIT"""
         logger.info("Recruiting {} MTurk participants".format(n))
-        if not self.config.get("auto_recruit", False):
+        if not self.config.get("auto_recruit"):
             logger.info("auto_recruit is False: recruitment suppressed")
             return
 
@@ -594,7 +594,7 @@ class MTurkRecruiter(Recruiter):
 
     @property
     def qualification_active(self):
-        return bool(self.config.get("assign_qualifications", False))
+        return bool(self.config.get("assign_qualifications"))
 
     def current_hit_id(self):
         any_participant_record = (
@@ -662,7 +662,9 @@ class MTurkRecruiter(Recruiter):
     def _config_to_list(self, key):
         # At some point we'll support lists, so all service code supports them,
         # but the config system only supports strings for now, so we convert:
-        as_string = self.config.get(key, "")
+        as_string = self.config.get(key, None)
+        if as_string is None:
+            return []
         return [item.strip() for item in as_string.split(",") if item.strip()]
 
     def _create_mturk_qualifications(self):
@@ -727,7 +729,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
 
     def recruit(self, n=1):
         logger.info("Recruiting {} MTurkLarge participants".format(n))
-        if not self.config.get("auto_recruit", False):
+        if not self.config.get("auto_recruit"):
             logger.info("auto_recruit is False: recruitment suppressed")
             return
 
@@ -938,12 +940,12 @@ def from_config(config):
     the bot recruiter, which can be used in debug mode)
     and the MTurkRecruiter in other modes.
     """
-    debug_mode = config.get("mode", None) == "debug"
+    debug_mode = config.get("mode") == "debug"
     name = config.get("recruiter", None)
     recruiter = None
 
     # Special case 1: Don't use a configured recruiter in replay mode
-    if config.get("replay", None):
+    if config.get("replay"):
         return HotAirRecruiter()
 
     if name is not None:

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -24,7 +24,7 @@ def get_base_url():
     else:
         # debug mode
         base_port = config.get("base_port")
-        port = random.randrange(base_port, base_port + config.get("num_dynos_web", 1))
+        port = random.randrange(base_port, base_port + config.get("num_dynos_web"))
         base_url = "http://{}:{}".format(host, port)
 
     return base_url

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -42,7 +42,7 @@ class Bartlett1932(Experiment):
 
     def configure(self):
         config = get_config()
-        self.num_participants = config.get("num_participants", 1)
+        self.num_participants = config.get("num_participants")
 
     def setup(self):
         """Setup the networks.

--- a/demos/dlgr/demos/rogers/config.txt
+++ b/demos/dlgr/demos/rogers/config.txt
@@ -1,6 +1,16 @@
 [Experiment]
 mode = sandbox
 auto_recruit = true
+experiment_repeats = 10
+practice_repeats = 0
+catch_repeats = 0
+practice_difficulty = 0.80
+difficulties = 0.525, 0.5625, 0.65
+catch_difficulty = 0.80
+min_acceptable_performance = 0.833333333333333
+generation_size = 2
+generations = 3
+bonus_payment = 1.0
 
 [MTurk]
 title = Judge the dots

--- a/demos/dlgr/demos/rogers/experiment.py
+++ b/demos/dlgr/demos/rogers/experiment.py
@@ -54,25 +54,22 @@ class RogersExperiment(Experiment):
 
     def configure(self):
         config = get_config()
-        self.experiment_repeats = config.get("experiment_repeats", 10)
-        self.practice_repeats = config.get("practice_repeats", 0)
+        self.experiment_repeats = config.get("experiment_repeats")
+        self.practice_repeats = config.get("practice_repeats")
         self.catch_repeats = config.get(
             "catch_repeats", 0
         )  # a subset of experiment repeats
-        self.practice_difficulty = config.get("practice_difficulty", 0.80)
+        self.practice_difficulty = config.get("practice_difficulty")
 
         self.difficulties = [
-            float(f.strip())
-            for f in config.get("difficulties", "0.525, 0.5625, 0.65").split(",")
+            float(f.strip()) for f in config.get("difficulties").split(",")
         ] * self.experiment_repeats
 
-        self.catch_difficulty = config.get("catch_difficulty", 0.80)
-        self.min_acceptable_performance = config.get(
-            "min_acceptable_performance", 10 / float(12)
-        )
-        self.generation_size = config.get("generation_size", 2)
-        self.generations = config.get("generations", 3)
-        self.bonus_payment = config.get("bonus_payment", 1.0)
+        self.catch_difficulty = config.get("catch_difficulty")
+        self.min_acceptable_performance = config.get("min_acceptable_performance")
+        self.generation_size = config.get("generation_size")
+        self.generations = config.get("generations")
+        self.bonus_payment = config.get("bonus_payment")
         self.initial_recruitment_size = self.generation_size
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -273,7 +273,7 @@ def stub_config():
         u"base_payment": 0.01,
         u"base_port": 5000,
         u"browser_exclude_rule": u"MSIE, mobile, tablet",
-        u"clock_on": True,
+        u"clock_on": False,
         u"contact_email_on_error": u"error_contact@test.com",
         u"dallinger_email_address": u"test@example.com",
         u"database_size": u"standard-0",
@@ -304,6 +304,8 @@ def stub_config():
         u"us_only": True,
         u"webdriver_type": u"phantomjs",
         u"whimsical": True,
+        u"replay": False,
+        u"worker_multiplier": 1.5,
     }
     from dallinger.config import default_keys
     from dallinger.config import Configuration
@@ -327,6 +329,9 @@ def active_config(stub_config):
     config = get_config()
     config.data = stub_config.data
     config.ready = True
+
+    # Ignore calls to config.load when using active_config
+    config.load = mock.Mock(side_effect=lambda: setattr(config, "ready", True))
     return config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,6 +314,8 @@ def stub_config():
     for key in default_keys:
         config.register(*key)
     config.extend(defaults.copy())
+    # Patch load() so we don't update any key/value pairs from actual files:
+    config.load = mock.Mock(side_effect=lambda: setattr(config, "ready", True))
     config.ready = True
 
     return config
@@ -327,7 +329,6 @@ def active_config(stub_config):
     from dallinger import config as c
 
     c.config = stub_config
-    c.config.load = mock.Mock(side_effect=lambda: setattr(c.config, "ready", True))
     return c.config
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -325,6 +325,7 @@ def active_config(stub_config):
     dallinger.config.get_config() and returns it.
     """
     from dallinger import config as c
+
     c.config = stub_config
     c.config.load = mock.Mock(side_effect=lambda: setattr(c.config, "ready", True))
     return c.config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -324,15 +324,10 @@ def active_config(stub_config):
     """Loads the standard config as the active configuration returned by
     dallinger.config.get_config() and returns it.
     """
-    from dallinger.config import get_config
-
-    config = get_config()
-    config.data = stub_config.data
-    config.ready = True
-
-    # Ignore calls to config.load when using active_config
-    config.load = mock.Mock(side_effect=lambda: setattr(config, "ready", True))
-    return config
+    from dallinger import config as c
+    c.config = stub_config
+    c.config.load = mock.Mock(side_effect=lambda: setattr(c.config, "ready", True))
+    return c.config
 
 
 @pytest.fixture

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -655,7 +655,7 @@ class TestAwaken(object):
         assert expected == heroku.addon.call_args_list[0]
 
     def test_adds_redis(self, awaken, heroku, data, active_config):
-        active_config["redis_size"] = u"premium-2"
+        active_config.set("redis_size", u"premium-2")
         CliRunner().invoke(awaken, ["--app", "some-app-uid"])
         assert mock.call("heroku-redis:premium-2") == heroku.addon.call_args_list[1]
 
@@ -664,10 +664,11 @@ class TestAwaken(object):
         heroku.restore.assert_called_once_with("fake restore url")
 
     def test_scales_up_dynos(self, awaken, heroku, data, active_config):
-        CliRunner().invoke(awaken, ["--app", "some-app-uid"])
         web_count = active_config.get("num_dynos_web")
         worker_count = active_config.get("num_dynos_worker")
         size = active_config.get("dyno_type")
+        active_config.set("clock_on", True)
+        CliRunner().invoke(awaken, ["--app", "some-app-uid"])
         heroku.scale_up_dyno.assert_has_calls(
             [
                 mock.call("web", web_count, size),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -103,6 +103,13 @@ class TestConfiguration(object):
         config.ready = True
         assert config.get("num_participants", 10) == 10
 
+    def test_get_strips_strings(self):
+        config = Configuration()
+        config.register("test_string", str)
+        config.ready = True
+        config.extend({"test_string": " something "})
+        assert config.get("test_string") == "something"
+
     def test_dict_access(self):
         config = Configuration()
         config.register("num_participants", int)
@@ -219,6 +226,7 @@ worldwide = false
         config.ready = True
         config.set("host", "localhost")
         config.set("base_port", 5000)
+        config.set("num_dynos_web", 1)
         assert get_base_url() == "http://localhost:5000"
 
     def test_remote_base_url(self):
@@ -227,6 +235,7 @@ worldwide = false
         config = get_config()
         config.ready = True
         config.set("host", "https://dlgr-bogus.herokuapp.com")
+        config.set("num_dynos_web", 1)
         assert get_base_url() == "https://dlgr-bogus.herokuapp.com"
 
     def test_remote_base_url_always_ssl(self):
@@ -235,6 +244,7 @@ worldwide = false
         config = get_config()
         config.ready = True
         config.set("host", "http://dlgr-bogus.herokuapp.com")
+        config.set("num_dynos_web", 1)
         assert get_base_url() == "https://dlgr-bogus.herokuapp.com"
 
     def test_write_omits_sensitive_keys_if_filter_sensitive(self, in_tempdir):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -154,7 +154,7 @@ worldwide = false
         )
 
         with NamedTemporaryFile() as configfile:
-            configfile.write(bytes(contents, encoding="utf-8"))
+            configfile.write(contents.encode("utf-8"))
             configfile.flush()
             config.load_from_file(configfile.name)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -140,19 +140,26 @@ class TestConfiguration(object):
 
     def test_loading_keys_from_config_file(self):
         config = Configuration()
+        config.register("mode", six.text_type)
         config.register("num_participants", int, synonyms={"n"})
         config.register("deploy_worldwide", bool, synonyms={"worldwide"})
-        with NamedTemporaryFile() as configfile:
-            configfile.write(
-                b"""
+        mode_with_trailing_whitespace = "live    "
+        contents = """
 [Example Section]
+mode = {}
 num_participants = 10
 worldwide = false
-"""
-            )
+""".format(
+            mode_with_trailing_whitespace
+        )
+
+        with NamedTemporaryFile() as configfile:
+            configfile.write(bytes(contents, encoding="utf-8"))
             configfile.flush()
             config.load_from_file(configfile.name)
+
         config.ready = True
+        assert config.get("mode") == "live"  # whitespace stripped
         assert config.get("num_participants") == 10
         assert config.get("deploy_worldwide") is False
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -105,7 +105,7 @@ class TestConfiguration(object):
 
     def test_get_strips_strings(self):
         config = Configuration()
-        config.register("test_string", str)
+        config.register("test_string", six.text_type)
         config.ready = True
         config.extend({"test_string": " something "})
         assert config.get("test_string") == "something"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -218,7 +218,7 @@ class TestSetupExperiment(object):
         os.path.exists(os.path.join("snapshots", exp_id + "-code.zip"))
 
         # There should be a modified configuration in the temp dir
-        deploy_config = configparser.SafeConfigParser()
+        deploy_config = configparser.ConfigParser()
         deploy_config.read(os.path.join(dst, "config.txt"))
         assert int(deploy_config.get("Parameters", "num_dynos_web")) == 2
 
@@ -242,7 +242,7 @@ class TestSetupExperiment(object):
         exp_id, dst = setup_experiment(log=mock.Mock())
 
         # The temp dir should have a config with the sensitive variables missing
-        deploy_config = configparser.SafeConfigParser()
+        deploy_config = configparser.ConfigParser()
         deploy_config.read(os.path.join(dst, "config.txt"))
         assert deploy_config.get("Parameters", "something_normal") == "show this"
         with raises(configparser.NoOptionError):
@@ -326,7 +326,8 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=mock.Mock())
         fake_redis.set.assert_called_once_with("foo", "bar")
 
-    def test_scales_dynos(self, dsss, heroku_mock):
+    def test_scales_dynos(self, dsss, heroku_mock, active_config):
+        active_config.set("clock_on", True)
         dsss(log=mock.Mock())
         heroku_mock.scale_up_dyno.assert_has_calls(
             [

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -8,13 +8,11 @@ from dallinger import models
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestAppConfiguration(object):
-    def test_config_gets_loaded_before_first_request(self, webapp):
-        from dallinger.config import get_config
-
-        conf = get_config()
-        conf.clear()
+    def test_config_gets_loaded_before_first_request(self, webapp, active_config):
+        active_config.clear()
         webapp.get("/")
-        assert conf.ready
+        active_config.load.assert_called_once()
+        assert active_config.ready
 
     def test_debug_mode_puts_flask_in_debug_mode(self, webapp, active_config):
         webapp.application.debug = False


### PR DESCRIPTION
## Description
This PR implements [ScrumDo Story 494](https://app.scrumdo.com/projects/story_permalink/1829486). It moves default config values from calls like `config.get(key, default)` to the `global_config_defaults.txt`. It also implements automatic whitespace stripping of strings in `config.get` and fixes some issues with how config was being manipulated in tests. Custom configuration in demo experiments has also been adapted to set default values in `config.txt` instead of in the experiment code.

## Motivation and Context
See [ScrumDo Story 494](https://app.scrumdo.com/projects/story_permalink/1829486). The primary motivation is to centralize the location of all configuration default values and avoid repeating them or accidentally setting defaults to different values in different parts of the codebase.

## How Has This Been Tested?
I added an automated test for the new `config.get` behavior, and ensured that all tests continue to pass. Some tests and fixtures needed adjustment as they were implicitly relying on the in-code config defaults while not yet having loaded a default config.
