### PR TITLE
Update Ruby to fix Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ services:
   - redis-server
 before_install:
   - rm -rf ~/.local/share/heroku
-  - rvm install 2.1.5
+  - rvm install 2.6.2
   - pip install --upgrade setuptools pip wheel
 install:
   - pip install tox==3.1.2


### PR DESCRIPTION
## Description
All Travis builds are failing due to a problem with Ruby gem versions. Updating to the latest Ruby (2.6.2) fixes the problem and seems like a better option than pinning back specific gems.