### PR TITLE
Check experiment size before copying

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -30,7 +30,7 @@ from dallinger.deployment import _deploy_in_mode
 from dallinger.deployment import DebugDeployment
 from dallinger.deployment import LoaderDeployment
 from dallinger.deployment import setup_experiment
-from dallinger.deployment import experiment_directory_size
+from dallinger.deployment import size_on_copy
 from dallinger.notifications import get_messenger
 from dallinger.heroku.tools import HerokuApp
 from dallinger.heroku.tools import HerokuInfo
@@ -159,7 +159,7 @@ def verify_directory(verbose=True, max_size_mb=50):
             ok = False
 
     max_size = max_size_mb * mb_to_bytes
-    size = experiment_directory_size()
+    size = size_on_copy()
     if size > max_size:
         size_in_mb = round(size / mb_to_bytes)
         log(

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -145,8 +145,11 @@ def verify_id(ctx, param, app):
 
 
 def verify_directory(verbose=True, max_size_mb=50):
-    """Ensure that the current directory looks like a Dallinger experiment.
+    """Ensure that the current directory looks like a Dallinger experiment, and
+    does not appear to have unintended contents that will be copied on
+    deployment.
     """
+    # Check required files
     ok = True
     mb_to_bytes = 1000 * 1000
     expected_files = ["config.txt", "experiment.py"]
@@ -158,6 +161,7 @@ def verify_directory(verbose=True, max_size_mb=50):
             log("✗ {} is MISSING".format(f), chevrons=False, verbose=verbose)
             ok = False
 
+    # Check size
     max_size = max_size_mb * mb_to_bytes
     size = size_on_copy()
     if size > max_size:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -191,7 +191,7 @@ class Configuration(object):
             data.update(dict(parser.items(section)))
         self.extend(data, cast_types=True, strict=True)
 
-    def write(self, filter_sensitive=False):
+    def write(self, filter_sensitive=False, directory=None):
         parser = configparser.ConfigParser()
         parser.add_section("Parameters")
         for layer in reversed(self.data):
@@ -200,7 +200,9 @@ class Configuration(object):
                     continue
                 parser.set("Parameters", k, str(v))
 
-        with open(LOCAL_CONFIG, "w") as fp:
+        directory = directory or os.getcwd()
+        destination = os.path.join(directory, LOCAL_CONFIG)
+        with open(destination, "w") as fp:
             parser.write(fp)
 
     def load_from_environment(self):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -74,6 +74,7 @@ def new_webbrowser_profile():
 def _local_root_files():
     """Return an iterable of filenames which should be copied from the
     experiment root directory to the generated temp directory.
+
     Assumes the experiment root directory is the current working directory.
     """
     good_types = ("*.py", "*.txt")

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -116,12 +116,10 @@ def size_on_copy(root="."):
 def assemble_experiment_temp_dir(config):
     """Create a temp directory from which to run an experiment.
     The new directory will include:
-    - Copies of custom experiment files (.py and .txt only, but not config.txt,
-        which is exported separately)
-    - /templates and /static directories from local experiment directory
+    - Copies of custom experiment files which don't match the exclusion policy
     - Templates and static resources from Dallinger
     - An export of the loaded configuration
-    - Heroku-specific files (Procile, runtime.txt)
+    - Heroku-specific files (Procile, runtime.txt) from Dallinger
 
     Assumes the experiment root directory is the current working directory.
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -167,7 +167,7 @@ def assemble_experiment_temp_dir(config):
         src = os.path.join(dallinger_root, "heroku", filename)
         shutil.copy(src, os.path.join(dst, filename))
 
-    if not config.get("clock_on", False):
+    if not config.get("clock_on"):
         # If the clock process has been disabled, overwrite the Procfile:
         src = os.path.join(dallinger_root, "heroku", "Procfile_no_clock")
         shutil.copy(src, os.path.join(dst, "Procfile"))

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -95,7 +95,7 @@ def exclusion_policy():
     return shutil.ignore_patterns(*patterns)
 
 
-def experiment_directory_size(root="."):
+def size_on_copy(root="."):
     """Return the size of the experiment directory in bytes, excluding any
     files and directories which would be excluded on copy.
     """

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -93,7 +93,9 @@ def assemble_experiment_temp_dir(config):
     - Templates and static resources from Dallinger
     - An export of the loaded configuration
     - Heroku-specific files (Procile, runtime.txt)
+
     Assumes the experiment root directory is the current working directory.
+
     Returns the absolute path of the new directory.
     """
     app_id = config.get("id")

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -10,7 +10,6 @@ import tempfile
 import threading
 import time
 import webbrowser
-from glob import glob
 from six.moves import shlex_quote as quote
 
 from dallinger import data

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -7,6 +7,7 @@ import string
 import subprocess
 import sys
 import tempfile
+from pkg_resources import get_distribution
 
 from dallinger.config import get_config
 
@@ -28,6 +29,19 @@ def get_base_url():
         base_url = "http://{}:{}".format(host, port)
 
     return base_url
+
+
+def dallinger_package_path():
+    """Return the absolute path of the root directory of the installed
+    Dallinger package:
+
+    >>> utils.dallinger_package_location()
+    '/Users/janedoe/projects/Dallinger3/dallinger'
+    """
+    dist = get_distribution("dallinger")
+    src_base = os.path.join(dist.location, dist.project_name)
+
+    return src_base
 
 
 def generate_random_id(size=6, chars=string.ascii_uppercase + string.digits):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -67,11 +67,25 @@ def mturk():
         yield mock_mturk
 
 
-@pytest.mark.usefixtures("bartlett_dir")
 @pytest.mark.slow
+@pytest.mark.usefixtures("bartlett_dir", "reset_sys_modules")
 class TestVerify(object):
+    @pytest.fixture
+    def v_package(self):
+        from dallinger.command_line import verify_package
+
+        return verify_package
+
     def test_verify(self):
         subprocess.check_call(["dallinger", "verify"])
+
+    def test_large_float_payment(self, active_config, v_package):
+        active_config.extend({"base_payment": 1.2342})
+        assert v_package() is False
+
+    def test_negative_payment(self, active_config, v_package):
+        active_config.extend({"base_payment": -1.99})
+        assert v_package() is False
 
 
 @pytest.mark.slow

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -94,12 +94,12 @@ class TestVerify(object):
         assert v_package() is False
 
     def test_too_big_returns_false(self, v_directory):
-        with mock.patch("dallinger.command_line.experiment_directory_size") as size:
+        with mock.patch("dallinger.command_line.size_on_copy") as size:
             size.return_value = 6000000  # 6 MB, so over the limit
             assert v_directory(max_size_mb=5) is False
 
     def test_under_limit_returns_true(self, v_directory):
-        with mock.patch("dallinger.command_line.experiment_directory_size") as size:
+        with mock.patch("dallinger.command_line.size_on_copy") as size:
             size.return_value = 4000000  # 4 MB, so under the limit
             assert v_directory(max_size_mb=5) is True
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -268,3 +268,16 @@ worldwide = false
             contents = txt.read()
         assert "aws_region" in contents
         assert "aws_secret_access_key" in contents
+
+    def test_write_accepts_alternate_directory(self):
+        import tempfile
+
+        target = os.path.join(tempfile.mkdtemp(), "custom")
+        os.mkdir(target)
+        config = get_config()
+        config.set("aws_region", "some region")
+        config.ready = True
+        config.write(directory=target)
+        with open(os.path.join(target, LOCAL_CONFIG)) as txt:
+            contents = txt.read()
+        assert "aws_region" in contents

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -139,6 +139,41 @@ class TestIsolatedWebbrowser(object):
         assert isolated == webbrowser
 
 
+@pytest.mark.usefixtures("in_tempdir")
+class TestExperimentDirectorySizeCheck(object):
+    @pytest.fixture
+    def size_check(self):
+        from dallinger.deployment import experiment_directory_size
+
+        return experiment_directory_size
+
+    def test_includes_files_that_would_be_copied(self, size_check):
+        with open("legit.txt", "w") as f:
+            f.write("12345")
+
+        assert size_check(".") == 5
+
+    def test_excludes_files_that_would_not_be_copied(self, size_check):
+        with open("illegit.db", "w") as f:
+            f.write("12345")
+
+        assert size_check(".") == 0
+
+    def test_excludes_directories_that_would_not_be_copied(self, size_check):
+        os.mkdir("snapshots")
+        with open("snapshots/legit.txt", "w") as f:
+            f.write("12345")
+
+        assert size_check(".") == 0
+
+    def test_excludes_bad_files_when_in_subdirectories(self, size_check):
+        os.mkdir("legit_dir")
+        with open("legit_dir/illegit.db", "w") as f:
+            f.write("12345")
+
+        assert size_check(".") == 0
+
+
 @pytest.mark.usefixtures("bartlett_dir", "active_config", "reset_sys_modules")
 class TestSetupExperiment(object):
     @pytest.fixture

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -11,7 +11,6 @@ from pytest import raises
 from six.moves import configparser
 
 from dallinger.deployment import new_webbrowser_profile
-from dallinger.command_line import verify_package
 from dallinger.config import get_config
 from dallinger import recruiters
 
@@ -258,18 +257,6 @@ class TestSetupExperiment(object):
             with pytest.raises(Exception) as ex_info:
                 setup_experiment(log=mock.Mock())
                 assert ex_info.match("Boom!")
-
-    @pytest.mark.slow
-    def test_large_float_payment(self):
-        config = get_config()
-        config["base_payment"] = 1.2342
-        assert verify_package() is False
-
-    @pytest.mark.slow
-    def test_negative_payment(self):
-        config = get_config()
-        config["base_payment"] = -1.99
-        assert verify_package() is False
 
 
 @pytest.mark.usefixtures("active_config", "launch", "fake_git", "fake_redis", "faster")

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -143,9 +143,9 @@ class TestIsolatedWebbrowser(object):
 class TestExperimentDirectorySizeCheck(object):
     @pytest.fixture
     def size_check(self):
-        from dallinger.deployment import experiment_directory_size
+        from dallinger.deployment import size_on_copy
 
-        return experiment_directory_size
+        return size_on_copy
 
     def test_includes_files_that_would_be_copied(self, size_check):
         with open("legit.txt", "w") as f:


### PR DESCRIPTION
## Description
Cleans up experiment temp directory creation code, and checks the size of the proposed file set before copying them from the local experiment directory.

Code to remove temp directories on experiment completion will be implemented separately.

## Motivation and Context
Addresses #1710 

To avoid inadvertently copying large files or directories when running an experiment, check the total size of all the files that _would be copied_ before proceeding.

## How Has This Been Tested?
* Automated tests
* `dallinger debug`

## Screenshots

Dallinger verify:
```
 $ dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✗ 2309MB is TOO BIG (greater than 50MB)
✓ experiment.py defines 1 experiment
✓ no file conflicts

❯❯ ☹ Some problems were found.
```

Dallinger debug/sandbox/deploy:
```
$ dallinger debug --verbose
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✗ 2309MB is TOO BIG (greater than 50MB)
Usage: dallinger debug [OPTIONS]

Error: The current directory is not a valid Dallinger experiment.
```