### PR TITLE
Issues/gu 223 undef participant

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -189,24 +189,14 @@ var dallinger = (function () {
   };
 
   var get_hit_params = function() {
-    // check if the local store is available, and if so, use it.
-    // TODO: Do we really want to have fallback behavior here? It's hard
-    // to verify that it actually works.
     var data = {};
-    if (dlgr.storage.available) {
-      data.recruiter = dlgr.storage.get("recruiter");
-      data.worker_id = dlgr.storage.get("worker_id");
-      data.hit_id = dlgr.storage.get("hit_id");
-      data.assignment_id = dlgr.storage.get("assignment_id");
-      data.mode = dlgr.storage.get("mode");
-      data.fingerprint_hash = dlgr.storage.get("fingerprint_hash");
-    } else {
-      data.recruiter = dlgr.identity.recruiter;
-      data.worker_id = dlgr.identity.worker_id;
-      data.hit_id = dlgr.identity.hit_id;
-      data.assignment_id = dlgr.identity.assignment_id;
-      data.mode = dlgr.identity.mode;
-    }
+    data.recruiter = dlgr.storage.get("recruiter");
+    data.worker_id = dlgr.storage.get("worker_id");
+    data.hit_id = dlgr.storage.get("hit_id");
+    data.assignment_id = dlgr.storage.get("assignment_id");
+    data.mode = dlgr.storage.get("mode");
+    data.fingerprint_hash = dlgr.storage.get("fingerprint_hash");
+
     return data;
   };
 
@@ -381,7 +371,7 @@ var dallinger = (function () {
         dlgr.post(url).done(function (resp) {
           console.log(resp);
           $('.btn-success').prop('disabled', false);
-          dlgr.identity.participantId = resp.participant.id;
+          dlgr.storage.set('participant_id', resp.participant.id);
           if (resp.quorum && resp.quorum.n !== resp.quorum.q) {
             if (resp.quorum.overrecruited) {
               dlgr.skip_experiment = true;
@@ -604,6 +594,16 @@ var dallinger = (function () {
       );
       return;
     }
+
+    dlgr.storage.set("recruiter", dlgr.getUrlParameter('recruiter'));
+    dlgr.storage.set("hit_id", dlgr.getUrlParameter('hit_id'));
+    dlgr.storage.set("worker_id", dlgr.getUrlParameter('worker_id'));
+    dlgr.storage.set("assignment_id", dlgr.getUrlParameter('assignment_id'));
+    dlgr.storage.set("mode", dlgr.getUrlParameter('mode'));
+    new Fingerprint2().get(function(result){
+      dlgr.storage.set("fingerprint_hash", result);
+    });
+
     /**
      * ``dallinger.identity`` provides information about the participant.
      * It has the following string properties:
@@ -623,23 +623,15 @@ var dallinger = (function () {
      * @namespace
      */
     dlgr.identity = {
-      recruiter: dlgr.getUrlParameter('recruiter'),
-      hitId: dlgr.getUrlParameter('hit_id'),
-      workerId: dlgr.getUrlParameter('worker_id'),
-      assignmentId: dlgr.getUrlParameter('assignment_id'),
-      mode: dlgr.getUrlParameter('mode'),
-      participantId: dlgr.getUrlParameter('participant_id')
+      recruiter: dlgr.storage.get("recruiter"),
+      hitId: dlgr.storage.get("hit_id"),
+      workerId: dlgr.storage.get('worker_id'),
+      assignmentId: dlgr.storage.get('assignment_id'),
+      mode: dlgr.storage.get('mode'),
+      participantId: dlgr.storage.get('participant_id'),
     };
-    if (dlgr.storage.available) {  // TODO: just raise an error rather than check?
-      dlgr.storage.set("recruiter", dlgr.identity.recruiter);
-      dlgr.storage.set("hit_id", dlgr.identity.hitId);
-      dlgr.storage.set("worker_id", dlgr.identity.workerId);
-      dlgr.storage.set("assignment_id", dlgr.identity.assignmentId);
-      dlgr.storage.set("mode", dlgr.identity.mode);
-      new Fingerprint2().get(function(result){
-        dlgr.storage.set("fingerprint_hash", result);
-      });
-    }
+
+
   };
 
   _initialize();

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -102,17 +102,6 @@ var dallinger = (function () {
     get fingerprintHash() { return dlgr.storage.get('fingerprint_hash'); },
     set fingerprintHash(value) { dlgr.storage.set('fingerprint_hash', value);},
 
-    serverFormat: function () {
-      return {
-        'recruiter': this.recruiter,
-        'mode': this.mode,
-        'hit_id': this.hitId,
-        'worker_id': this.workerId,
-        'assignment_id': this.assignmentId,
-        'fingerprint_hash': this.fingerprintHash,
-      };
-    },
-
     initialize: function () {
       this.recruiter = dlgr.getUrlParameter('recruiter');
       this.hitId = dlgr.getUrlParameter('hit_id');
@@ -124,7 +113,6 @@ var dallinger = (function () {
         _self.fingerprintHash = result;
       });
     }
-
   };
 
   dlgr.BusyForm = (function () {
@@ -328,7 +316,16 @@ var dallinger = (function () {
    */
   dlgr.error = function (rejection) {
     // Render an error form for a rejected deferred returned by an ajax() call.
-    var $form, hit_params;
+    var hit_params = {
+          'recruiter': dlgr.identity.recruiter,
+          'mode': dlgr.identity.mode,
+          'hit_id': dlgr.identity.hitId,
+          'worker_id': dlgr.identity.workerId,
+          'assignment_id': dlgr.identity.assignmentId,
+          'fingerprint_hash': dlgr.identity.fingerprintHash,
+        },
+        $form;
+
     console.log("Calling dallinger.error()");
 
     if (rejection.html) {
@@ -342,7 +339,6 @@ var dallinger = (function () {
       add_hidden_input($form, 'participant_id', rejection.data.participant_id);
     }
     add_hidden_input($form, 'request_data', rejection.requestJSON);
-    hit_params = dlgr.identity.serverFormat();
     for (var prop in hit_params) {
       if (hit_params.hasOwnProperty(prop)) add_hidden_input($form, prop, hit_params[prop]);
     }

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -101,7 +101,7 @@ describe('identity', function () {
 
   beforeEach(function () {
     window.history.pushState({}, 'Test Title',
-      'test.html?recruiter=hotair&hit_id=VV8OTJ&assignment_id=RW4Z3G&worker_id=KMEAPX&workerId=KMEAPX&mode=debug'
+      'test.html?recruiter=hotair&hit_id=HHH&assignment_id=AAA&worker_id=WWW&mode=debug'
     );
 
     dlgr = require('./dallinger2').dallinger;
@@ -109,9 +109,9 @@ describe('identity', function () {
 
   test('identity object is initialized from query string', () => {
     expect(dlgr.identity.recruiter).toBe('hotair');
-    expect(dlgr.identity.assignmentId).toBe('RW4Z3G');
-    expect(dlgr.identity.hitId).toBe('VV8OTJ');
-    expect(dlgr.identity.workerId).toBe('KMEAPX');
+    expect(dlgr.identity.assignmentId).toBe('AAA');
+    expect(dlgr.identity.hitId).toBe('HHH');
+    expect(dlgr.identity.workerId).toBe('WWW');
     expect(dlgr.identity.mode).toBe('debug');
   });
 
@@ -128,12 +128,12 @@ describe('identity', function () {
     dlgr.identity.fingerprintHash = 'some fingerprint';
     expect(dlgr.identity.serverFormat()).toEqual(
       {
-        "assignment_id": "RW4Z3G",
+        "assignment_id": "AAA",
         "fingerprint_hash": "some fingerprint",
-        "hit_id": "VV8OTJ",
+        "hit_id": "HHH",
         "mode": "debug",
         "recruiter": "hotair",
-        "worker_id": "KMEAPX"
+        "worker_id": "WWW"
       }
     );
   });

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -15,7 +15,7 @@ function StubFingerprint2() {
   }
 
   return {"get": get};
-  }
+}
 
 // Setup run before other beforeEach blocks
 beforeEach(() => {
@@ -122,20 +122,6 @@ describe('identity', function () {
   test('values can be set', () => {
     dlgr.identity.recruiter = 'other recruiter';
     expect(dlgr.identity.recruiter).toBe('other recruiter');
-  });
-
-  test('serverFormat uses server-side key names', () => {
-    dlgr.identity.fingerprintHash = 'some fingerprint';
-    expect(dlgr.identity.serverFormat()).toEqual(
-      {
-        "assignment_id": "AAA",
-        "fingerprint_hash": "some fingerprint",
-        "hit_id": "HHH",
-        "mode": "debug",
-        "recruiter": "hotair",
-        "worker_id": "WWW"
-      }
-    );
   });
 
 });

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -1,29 +1,141 @@
+/*globals expect, describe, jest, test, beforeEach */
+
 const store = require('./store+json2.min');
 global.store = store;
-
 // Mock out alert to the command line, so we can see errors
 global.window.alert = console.log;
 
-function Fingerprint2() {
-    // This mocks out Fingerprint2 
-    function get() {
-      return "testing";
-    };
-    return {"get": get};
+
+function StubFingerprint2() {
+  // A fake Fingerprint function that always returns the same value.
+  function get(callback) {
+    window.setTimeout(function() {
+        callback("testing");
+    }, 0);
   }
-global.window.Fingerprint2 = Fingerprint2;
 
-const dlgr = require('./dallinger2').dallinger;
+  return {"get": get};
+  }
 
-
-
-test('Passes adblock check', () => {
-    expect(dlgr.missingFingerprint()).toBe(false);
+// Setup run before other beforeEach blocks
+beforeEach(() => {
+  // Stub out Fingerprint2 with a deterministic replacement.
+  global.window.Fingerprint2 = StubFingerprint2;
+  // re-load dallinger2 in each test to avoid interactions between tests:
+  jest.resetModules();
 });
 
-test('Storage is available', () => {
-  expect(dlgr.storage.available).toBe(true);
-  expect(dlgr.storage.get('foo')).toBe(undefined);
-  dlgr.storage.set('foo', 'bar');
-  expect(dlgr.storage.get('foo')).toBe('bar');
+
+describe('getUrlParameter', function () {
+
+  var dlgr;
+
+  beforeEach(function () {
+    window.history.pushState({}, 'Test Title', '/test.html?key1=val1&key2=val2');
+    dlgr = require('./dallinger2').dallinger;
+  });
+
+  test('getUrlParameter returns values for params', () => {
+    expect(dlgr.getUrlParameter('key1')).toBe('val1');
+    expect(dlgr.getUrlParameter('key2')).toBe('val2');
+  });
+
+  test('getUrlParameter returns undefined for missing params', () => {
+    expect(dlgr.getUrlParameter('nonexistent')).toBe(undefined);
+  });
+
+});
+
+describe('AD block functions', function () {
+
+  var dlgr;
+
+  beforeEach(function () {
+    dlgr = require('./dallinger2').dallinger;
+  });
+
+
+  test('Passes basic adblock check', () => {
+    expect(dlgr.missingFingerprint()).toBe(false);
+  });
+
+  /* Marked this test to be skipped, since it does fail and I don't know
+     how to test this effectively. */
+  test.skip('hasAdBlocker should be not call callback', done => {
+    function callback() {
+      throw new Error("hasAdBlocker() found a blocker!");
+      done();
+    }
+
+    dlgr.hasAdBlocker(callback);
+  });
+
+});
+
+
+describe('storage', function () {
+
+  var dlgr;
+
+  beforeEach(function () {
+    dlgr = require('./dallinger2').dallinger;
+  });
+
+  test('Storage is available', () => {
+    expect(dlgr.storage.available).toBe(true);
+  });
+
+  test('Unstored values return undefined', () => {
+    expect(dlgr.storage.get('foo')).toBe(undefined);
+  });
+
+  test('Values are storable', () => {
+    dlgr.storage.set('foo', 'bar');
+    expect(dlgr.storage.get('foo')).toBe('bar');
+  });
+
+});
+
+describe('identity', function () {
+  var dlgr;
+
+  beforeEach(function () {
+    window.history.pushState({}, 'Test Title',
+      'test.html?recruiter=hotair&hit_id=VV8OTJ&assignment_id=RW4Z3G&worker_id=KMEAPX&workerId=KMEAPX&mode=debug'
+    );
+
+    dlgr = require('./dallinger2').dallinger;
+  });
+
+  test('identity object is initialized from query string', () => {
+    expect(dlgr.identity.recruiter).toBe('hotair');
+    expect(dlgr.identity.assignmentId).toBe('RW4Z3G');
+    expect(dlgr.identity.hitId).toBe('VV8OTJ');
+    expect(dlgr.identity.workerId).toBe('KMEAPX');
+    expect(dlgr.identity.mode).toBe('debug');
+  });
+
+  test('participantId is initially undefined', () => {
+    expect(dlgr.identity.participantId).toBe(undefined);
+  });
+
+  test('values can be set', () => {
+    dlgr.identity.recruiter = 'other recruiter';
+    expect(dlgr.identity.recruiter).toBe('other recruiter');
+  });
+
+  test('serverFormat uses server-side key names', () => {
+    dlgr.identity.fingerprintHash = 'some fingerprint';
+    expect(dlgr.identity.serverFormat()).toEqual(
+      {
+        "assignment_id": "RW4Z3G",
+        "fingerprint_hash": "some fingerprint",
+        "hit_id": "VV8OTJ",
+        "mode": "debug",
+        "recruiter": "hotair",
+        "worker_id": "KMEAPX"
+      }
+    );
+  });
+
 });

--- a/dallinger/frontend/templates/base/ad.html
+++ b/dallinger/frontend/templates/base/ad.html
@@ -33,7 +33,7 @@
 {% block scripts %}
 <script>
     function openwindow(event) {
-        popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&workerId={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+        popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
         event.target.setAttribute("disabled", "");
     }
 


### PR DESCRIPTION
## Description
Simplify management of participant values in Javascript.

## Motivation and Context
* Spun off from https://github.com/Dallinger/Griduniverse/issues/223
* Replaces https://github.com/Dallinger/Dallinger/pull/1556, which potentially broke existing code (this PR should not)

Although dallinger2.js was already storing participant values in localstorage via `dallinger.storage`, `dallinger.identity` was still using URL parameters instead of reading from the storage. This led to some unpredictable results, and burdened custom experiments with passing values in URL parameters when moving between pages in order to access participant values.

This PR makes `dallinger.identity` a client of `dallinger.storage` instead of the other way around. Benefits:
* values are stored early on (by the time the consent form is loaded, all values except the `participantId` will be stored in `dallinger.identity`) by the Dallinger framework, and remain available (and immune from overwriting with `undefined`) for the remainder of the experiment
* custom experiments can simply access `dallinger.identity` if they need a participant value, and it will return the correct value without URL parameter passing
* The `participantId` is stored as a side-effect of the call to `createParticipant()` since this is when the value becomes available, and is subsequently available as `dallinger.identity.participantId`

Since `dalllinger.identity` is now responsible for initializing itself from URL parameters, other code in dallinger2.js needs to do less translation between the keys used on the server (`assignment_id`, for example) and the properties of `dallinger.identity` (`assignmentId` for the same value).

## How Has This Been Tested?
* Improved Jest JS tests
* Bartlett1932 debug
