### PR TITLE
Have beginner docs show up in lefthand menu of documentation

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -38,10 +38,14 @@ Beginner Documentation
 Many Dallinger users may not have lots of programming experience, and might
 want a bit more information about the inner workings of Dallinger in a
 beginner-friendly format. Thomas Morgan has started such a project:
-`"Dallinger for Programming Novices"
-<https://github.com/thomasmorgan/dallinger-for-novices>`__.
-Every Dallinger user is encouraged to take a look at this guide, which is a
+"Dallinger for Programming Novices". Every Dallinger user is encouraged to take a look at this guide, which is a
 nice complement to the documentation presented here.
+
+.. toctree::
+    :caption: Beginner Documentation
+    :maxdepth: 1
+
+    Dallinger for Programming Novices <https://github.com/thomasmorgan/dallinger-for-novices>
 
 Dallinger Demos
 ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This is an optional enchancement. TBD if it is desirable or not. See screenshot:

**Before:**

![before](https://user-images.githubusercontent.com/883619/54727389-80f6df00-4b45-11e9-897e-4a41540b60dd.jpg)


**After**

![Screenshot from 2019-03-20 18-18-29 - Copy](https://user-images.githubusercontent.com/883619/54727405-953adc00-4b45-11e9-83c3-bd7964efca61.png)


![Screenshot from 2019-03-20 18-18-29 - Copy copy](https://user-images.githubusercontent.com/883619/54727411-9a982680-4b45-11e9-9e20-2b9bc345b81a.jpg)





