### PR TITLE
Expand command line documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [v-master](https://github.com/dallinger/dallinger/master) (xxxx-xx-xx)
+
+- Documentation improvements and additions:
+  + Command Line Utility section: Added previously undocumented commands and expanded on optional parameters
+
 ## [v5.0.6](https://github.com/dallinger/dallinger/tree/v5.0.6) (2019-02-28)
 
 - Heroku has deprecated the use of the --org parameter which previous versions of Dallinger used. This release fixes Dallinger to use the newer --team parameter instead, which has been available in Heroku for quite some time. The change was introduced in Heroku CLI 7.21. The --team parameter was introduced in Heroku a significant time ago, thus this version of Dallinger will work with many older versions of the Heroku CLI. If using an older version of the Heroku CLI, we recommend updating to the latest version.

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -135,10 +135,10 @@ def report_idle_after(seconds):
 def verify_id(ctx, param, app):
     """Verify the experiment id."""
     if app is None:
-        raise TypeError("Select an experiment using the --app flag.")
+        raise TypeError("Select an experiment using the --app parameter.")
     elif app[0:5] == "dlgr-":
         raise ValueError(
-            "The --app flag requires the full "
+            "The --app parameter requires the full "
             "UUID beginning with {}-...".format(app[5:13])
         )
     return app
@@ -730,7 +730,7 @@ def load(app, verbose, replay, exp_config=None):
 def logs(app):
     """Show the logs."""
     if app is None:
-        raise TypeError("Select an experiment using the --app flag.")
+        raise TypeError("Select an experiment using the --app parameter.")
 
     HerokuApp(dallinger_uid=app).open_logs()
 

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -15,21 +15,25 @@ Verify that a directory is a Dallinger-compatible app.
 bot
 ^^^
 
-Spawn a bot and attach it to the specified application. The ``--debug`` flag
+Spawn a bot and attach it to the specified application. The ``--debug`` parameter
 connects the bot to the locally running instance of Dallinger. Alternatively,
-the ``--app <app>`` flag specifies a live experiment by its id.
+the ``--app <app>`` parameter specifies a live experiment by its id.
 
 debug
 ^^^^^
 
 Run the experiment locally. An optional ``--verbose`` flag prints more detailed
-logs to the command line.
+logs to the command line. Use the optional ``--bot`` flag to use a bot to
+complete the experiment and the optional ``--proxy`` parameter can be used to
+specify an alternative port when opening browser windows.
 
 sandbox
 ^^^^^^^
 
 Runs the experiment on MTurk's sandbox using Heroku as a server. An optional
-``--verbose`` flag prints more detailed logs to the command line.
+``--verbose`` flag prints more detailed logs to the command line. An optional
+``--app <app>`` parameter specifies the experiment id, if not specified, a new
+unique experiment experiment id is automatically generated.
 
 deploy
 ^^^^^^
@@ -37,49 +41,55 @@ deploy
 Runs the experiment live on MTurk using Heroku as a server. An optional
 ``--verbose`` flag prints more detailed logs to the command line. An optional
 ``--bot`` flag forces the bot recruiter to be used, rather than the configured
-recruiter.
+recruiter. An optional ``--app <app>`` parameter specifies the experiment id,
+if not specified, a new unique experiment id is automatically generated.
 
 logs
 ^^^^
 
-Open the app's logs in Papertrail. A required ``--app <app>`` flag specifies
-the experiment by its id.
+Open the app's logs in Papertrail. A required ``--app <app>`` parameter
+specifies the experiment by its id.
 
 summary
 ^^^^^^^
 
-Return a summary of an experiment. A required ``--app <app>`` flag specifies
-the experiment by its id.
+Return a summary of an experiment. A required ``--app <app>`` parameter
+specifies the experiment by its id.
 
 export
 ^^^^^^
 
 Download the database and partial server logs to a zipped folder within
 the data directory of the experimental folder. Databases are stored in
-CSV format. A required ``--app <app>`` flag specifies
-the experiment by its id.
+CSV format. A required ``--app <app>`` parameter specifies the experiment by its
+id. Use the optional ``--local`` flag if exporting a local experiment data.
+An optional ``--no-scrub`` flag will stop the scrubbing of personally
+identifiable information in the export. The scrubbing of PII is enabled by
+default.
 
 qualify
 ^^^^^^^
 
 Assign a Mechanical Turk qualification to one or more workers.
-Requires a ``qualification``, which is a qualification ID, (or, if
-the ``--by_name`` is used, a qualification name), value ``value``,
-and a list of one or more worker IDs, passed at the end of the command.
 This is useful when compensating workers if something goes wrong with
-the experiment.
+the experiment. Requires a ``--qualification`` parameter, which is a
+qualification ID, (or, if the ``--by_name`` is used, a qualification name),
+value ``--value`` parameter, and a list of one or more worker IDs, passed at
+the end of the command. The optional ``--notify`` flag can be used to notify
+workers via email. You can also optionally specify the ``--sandbox`` flag to use
+ the MTurk sandbox.
 
 revoke
 ^^^^^^
 
 Revoke a Mechanical Turk qualification for one or more workers.
-Requires a ``qualification``, which is a qualification ID, (or, if
-the ``--by_name`` is used, a qualification name), an optional ``reason``
-string, and a list of one or more MTurk worker IDs.
 This is useful when developing an experiment with "insider" participants,
 who would otherwise be prevented from accepting a HIT for an experiment
 they've already participated in.
-
+Requires a ``--qualification``, which is a qualification ID, (or, if
+the ``--by_name`` is used, a qualification name), an optional ``--reason``
+string, and a list of one or more MTurk worker IDs. You can also optionally
+specify the ``--sandbox`` flag to use the MTurk sandbox.
 
 hibernate
 ^^^^^^^^^
@@ -88,12 +98,12 @@ Temporarily scales down the specified app to save money. All dynos are
 removed and so are many of the add-ons. Hibernating apps are
 non-functional. It is likely that the app will not be entirely free
 while hibernating. To restore the app use ``awaken``. A required
-``--app <app>`` flag specifies the experiment by its id.
+``--app <app>`` parameter specifies the experiment by its id.
 
 awaken
 ^^^^^^
 
-Restore a hibernating app. A required ``--app <app>`` flag specifies the
+Restore a hibernating app. A required ``--app <app>`` parameter specifies the
 experiment by its id.
 
 destroy
@@ -126,3 +136,35 @@ apps
 List all running heroku apps associated with the currently logged in
 heroku account. Returns the Dallinger app UID, app launch timestamp,
 and heroku app url for each running app.
+
+monitor
+^^^^^^^
+
+Monitor a live Dallinger experiment. A required ``--app <app>`` parameter
+specifies the experiment by its id.
+
+load
+^^^^
+
+Import database state from an exported zip file and leave the server
+running until stopping the process with <control>-c.
+A required ``--app <app>`` parameter specifies the experiment by its id.
+An optional ``--verbose`` flag prints more detailed logs to the command line.
+Use the optional ``--replay`` flag to start the experiment locally in replay
+mode after loading the data into the local database.
+
+setup
+^^^^^
+
+Create the Dallinger config file if it does not already exist.
+
+uuid
+^^^^
+
+Generate a new unique identifier.
+
+rq_worker
+^^^^^^^^^
+
+Start an rq worker in the context of Dallinger.
+This command can potentially be useful during the development/debugging process.

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -77,7 +77,7 @@ qualification ID, (or, if the ``--by_name`` is used, a qualification name),
 value ``--value`` parameter, and a list of one or more worker IDs, passed at
 the end of the command. The optional ``--notify`` flag can be used to notify
 workers via email. You can also optionally specify the ``--sandbox`` flag to use
- the MTurk sandbox.
+the MTurk sandbox.
 
 revoke
 ^^^^^^

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -254,7 +254,7 @@ class TestSandboxAndDeploy(object):
         result = CliRunner().invoke(sandbox, ["--verbose", "--app", "dlgr-some app id"])
         deploy_in_mode.assert_not_called()
         assert result.exit_code == -1
-        assert "The --app flag requires the full UUID" in str(result.exception)
+        assert "The --app parameter requires the full UUID" in str(result.exception)
 
     def test_deploy_with_app_id(self, deploy, deploy_in_mode):
         CliRunner().invoke(deploy, ["--verbose", "--app", "some app id"])
@@ -830,7 +830,9 @@ class TestMonitor(object):
     ):
         heroku.db_uri = "fake-db-uri"
         result = CliRunner().invoke(monitor, ["--app", None])
-        assert str(result.exception) == "Select an experiment using the --app flag."
+        assert (
+            str(result.exception) == "Select an experiment using the --app parameter."
+        )
 
 
 class TestHits(object):


### PR DESCRIPTION
Expand the command line documentation section & fix some small errors.
Call the ``--app`` flag a parameter and any other parameter that requires some value following a flag a ```parameter```, everything else remains a ```flag``` if it has no parameter following it.
Add a few undocumented commands.

This addresses https://github.com/Dallinger/Dallinger/issues/1672