### PR TITLE
Include libpq-dev in installation instructions

### DIFF
--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -372,7 +372,7 @@ Postgres can be installed using the following instructions:
 **Ubuntu 18.04 LTS** or **Ubuntu 16.04 LTS:**
 ::
 
-    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib
+    sudo apt-get update && sudo apt-get install -y postgresql postgresql-contrib libpq-dev
 
 To run postgres, use the following command:
 ::


### PR DESCRIPTION
Fix an issue detected by Robin Watson on Ubuntu 18.04.2 with Python 3.6.7

When installing Dallinger the line ``` pip install dallinger[data] ``` fails with:
```
That error message you got says: `    Complete output from command python setup.py egg_info:
   running egg_info
   creating pip-egg-info/psycopg2.egg-info
   writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
   writing pip-egg-info/psycopg2.egg-info/PKG-INFO
   writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
   writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
   Error: b'You need to install postgresql-server-dev-NN for building a server-side extension or libpq-dev for building a client-side application.\n'
```

Installing the ```libpq-dev``` package fixes the issue.