### PR TITLE
Support rolling waiting room

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -168,15 +168,15 @@ class Experiment(object):
         """
         return recruiters.from_config(get_config())
 
-    def is_overrecruited(self, waiting_count):
-        """Returns True if the number of people waiting is in excess of the
-        total number expected, indicating that this and subsequent users should
+    def is_overrecruited(self, total_needed):
+        """Returns True if the number of people recruited is in excess of the
+        total number requested, indicating that this and subsequent users should
         skip the experiment. A quorum value of 0 means we don't limit
         recruitment, and always return False.
         """
         if not self.quorum:
             return False
-        return waiting_count > self.quorum
+        return total_needed > self.quorum * self.experiment_repeats
 
     def send(self, raw_message):
         """socket interface implementation, and point of entry for incoming

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -126,6 +126,7 @@ class Participant(Base, SharedMixin):
 
     #: String representing the current status of the participant, can be:
     #:    - ``working`` - participant is working
+    #:    - ``waiting`` - participant is in waiting room
     #:    - ``submitted`` - participant has submitted their work
     #:    - ``approved`` - their work has been approved and they have been paid
     #:    - ``rejected`` - their work has been rejected
@@ -142,6 +143,7 @@ class Participant(Base, SharedMixin):
     status = Column(
         Enum(
             "working",
+            "waiting",
             "overrecruited",
             "submitted",
             "approved",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This PR adds an additional Participant status ("waiting") that tracks participants currently in the waiting room. When the number of participants waiting reaches the specified `quorum` (typically, the number needed for a single interactive network to perform the task), they are allowed to proceed. Critically, though, if `experiment_repeats` is set to a value greater than 1, this PR then allows additional participants to enter the waiting room for further "batches" until the specified number has been recruited. 

This is equivalent to the previous implementation when `experiment_repeats=1`, i.e. when the entire sample must to enter the waiting room before starting.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

The current waiting room implementation hard-codes the assumption that the quorum is equivalent to the overall number of participants the experimenter wants to recruit. If you wanted to run 10 interactive dyadic games, you either (a) set a quorum of 2, which allowed the first 2 participants to begin their game but rejected subsequent participants as over-recruited, or (b) set a quorum of 20, forcing everyone to wait for the entire sample size to join the waiting room before starting a single game. This PR fixes this problem, allowing games to start on a rolling basis as participants trickle in.

In addition, this resolves a confusing feature of the `chatroom` demo which suggested that `repeats` could be set higher to recruit for multiple networks simultaneously:

```
# Recruit for all networks at once
self.experiment_repeats = repeats = config.get("repeats")
self.initial_recruitment_size = repeats * self.quorum
```

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

I ran the chatroom demo with `experiment_repeats=2` and `quorum=2` and tested whether the first 2 participants were able to immediately begin chatting and that the second two were not rejected as over-recruited (and entered the chat room as a pair as soon as the 4th joined)

<!--- see how your change affects other areas of the code, etc. -->

I followed a comment in the `chatroom` demo suggesting that `experiment_repeats` could be overloaded for this purpose, but this should be documented (the documentation suggests that it has to do with how many times a single participant can repeat the experiment). 

## Screenshots (if appropriate):
