### PR TITLE
Event handler for client disconnect

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -327,6 +327,7 @@ def launch():
             from dallinger.experiment_server.sockets import chat_backend
 
             chat_backend.subscribe(exp, exp.channel)
+            chat_backend.subscribe(exp, "quorum")
         except Exception:
             return error_response(
                 error_text="Failed to subscribe to chat for channel on launch "

--- a/dallinger/experiment_server/sockets.py
+++ b/dallinger/experiment_server/sockets.py
@@ -112,7 +112,13 @@ class ChatBackend(object):
             if network_id:
                 redis_conn.publish(
                     channel_name,
-                    json.dumps({"type": "disconnect", "networkid": network_id}),
+                    json.dumps(
+                        {
+                            "type": "disconnect",
+                            "networkid": network_id,
+                            "participantid": participant_id,
+                        }
+                    ),
                 )
         if dropped and network_id:
             participant = Participant.query.filter_by(id=participant_id).one()

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -575,8 +575,7 @@ var dallinger = (function () {
     socket = new ReconnectingWebSocket(ws_scheme + location.host + "/chat?channel=quorum");
     socket.onopen = function(msg) {
       socket.send('quorum:' + JSON.stringify({type: 'connect', participantid: dlgr.identity.participantId}));
-    }
->>>>>>> cd82308e... Send connect message to quorum socket on open
+    };
     socket.onmessage = function (msg) {
       if (msg.data.indexOf('quorum:') !== 0) { return; }
       var data = JSON.parse(msg.data.substring(7));

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -129,6 +129,7 @@ class Participant(Base, SharedMixin):
     #:    - ``submitted`` - participant has submitted their work
     #:    - ``approved`` - their work has been approved and they have been paid
     #:    - ``rejected`` - their work has been rejected
+    #:    - ``dropped`` - their connection dropped before finishing
     #:    - ``returned`` - they returned the hit before finishing
     #:    - ``abandoned`` - they ran out of time
     #:    - ``did_not_attend`` - the participant finished, but failed the
@@ -146,6 +147,7 @@ class Participant(Base, SharedMixin):
             "submitted",
             "approved",
             "rejected",
+            "dropped",
             "returned",
             "abandoned",
             "did_not_attend",


### PR DESCRIPTION
## Motivation and Context

This is an initial attempt at a workaround for issue #1939 and #1947. 

## Description

Because the [`unsubscribe(client)`](https://github.com/Dallinger/Dallinger/blob/master/dallinger/experiment_server/sockets.py#L100-L103) function already essentially triggers on disconnection (i.e. on an exception thrown by an error during the socket heartbeat), my strategy was to provide the `Client` object with the information it would need to notify others on its channel of its own disconnection. 

This PR introduces the participantid as an attribute of the `Client` class so that the socket knows the identity of the participant it is associated with. These attributes are set upon the client's `connect' message.

Once this information is available in the socket class, we can broadcast a `disconnect` event to the newly disconnected client's network which experiment authors can handle however they choose in their custom `send` function. This change should only affect experiments that monitor for `connect` and `disconnect` socket events. 

In future work, this should be handled by the 'disconnect' event of a socket library (e.g. as socket.io provides). This is a temporary workaround relying on the 'heartbeat' to eventually trigger the disconnect event; exposing the real thing would require more significant changes toward integration of websockets. Importantly, while this workaround is ok in most cases, relying on the 'polling' of the heartbeat allows the possibility of race conditions because you don't notice they disconnect right when it happens. Other events happening before the heartbeat goes out may depend on the knowledge of whether they are disconnected, and will have the wrong information.

## How Has This Been Tested?

Making use of these events requires custom experiment logic. I'm using the experiment [here](https://github.com/hawkrobe/conventions_model/blob/master/reference_game/experiment.py#L312).

1. I launched two fully connected networks for reference games and after several rounds closed one of the tabs. I checked that participants in that player's network were referred to the questionnaire while participants in the other network were not affected. 

2. To specifically check for the bug in #1947, I disconnected one player in the waiting room and ensured that the waiting room count it properly decremented. 

## Concerns

I worried about several potential issues with the new participant `dropped` status I introduced where this status should be checked for; for instance in [`should_show_thanks_page_to()`](https://github.com/Dallinger/Dallinger/blob/b35e30ec169dfde473600ff35879d7a306868f9b/dallinger/experiment_server/experiment_server.py#L351). One possibility is to use the `abandoned` status for people who disconnect instead of introducing a new status, but I wasn't sure if that would have introduce other issues!