### PR TITLE
Add config variable for text length for questions

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -61,6 +61,7 @@ default_keys = (
     ("smtp_password", six.text_type, ["dallinger_email_password"], True),
     ("threads", six.text_type, []),
     ("title", six.text_type, []),
+    ("question_max_length", int, []),
     ("us_only", bool, []),
     ("webdriver_type", six.text_type, []),
     ("webdriver_url", six.text_type, []),

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -814,6 +814,12 @@ def create_question(participant_id):
             participant=ppt,
         )
 
+    config = get_config()
+    question_max_length = config.get("question_max_length", 1000)
+
+    if len(question) > question_max_length or len(response) > question_max_length:
+        return error_response(error_type="/question POST length too long", status=400)
+
     try:
         # execute the request
         models.Question(

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -297,10 +297,10 @@ class Question(Base, SharedMixin):
     number = Column(Integer, nullable=False)
 
     #: the text of the question
-    question = Column(String(250), nullable=False)
+    question = Column(Text, nullable=False)
 
     #: the participant's response. Stored as a string.
-    response = Column(String(1000), nullable=False)
+    response = Column(Text, nullable=False)
 
     def __init__(self, participant, question, response, number):
         """Create a question."""

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -267,7 +267,7 @@ class TestQuestion(object):
         assert resp.status_code == 200
 
         # This part of the test isn't working because of some weird use of the config object
-        ## Override the length to go shorter
+        # Override the length to go shorter
         # with config.override({"question_max_length": 99}):
         #    resp = webapp.post(
         #        "/question/{}?question=q&response={}&number=1".format(a.participant().id, 'x'*100)

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -250,7 +250,7 @@ class TestQuestion(object):
         )
         assert models.Question.query.all()
 
-    def test_excessive_question_text_is_blocked(self, a, webapp):
+    def test_excessive_question_text_is_blocked(self, a, webapp, active_config):
         # The normal max length is 1000
         resp = webapp.post(
             "/question/{}?question=q&response={}&number=1".format(
@@ -266,13 +266,14 @@ class TestQuestion(object):
         )
         assert resp.status_code == 200
 
-        # This part of the test isn't working because of some weird use of the config object
         # Override the length to go shorter
-        # with config.override({"question_max_length": 99}):
-        #    resp = webapp.post(
-        #        "/question/{}?question=q&response={}&number=1".format(a.participant().id, 'x'*100)
-        #    )
-        # assert resp.status_code == 400
+        with active_config.override({"question_max_length": 99}):
+            resp = webapp.post(
+                "/question/{}?question=q&response={}&number=1".format(
+                    a.participant().id, "x" * 100
+                )
+            )
+        assert resp.status_code == 400
 
     def test_nonworking_mturk_participants_accepted_if_debug(
         self, a, webapp, active_config

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -3,6 +3,9 @@ import mock
 import pytest
 from datetime import datetime
 from dallinger import models
+from dallinger.config import get_config
+
+config = get_config()
 
 
 @pytest.mark.usefixtures("experiment_dir")
@@ -246,6 +249,30 @@ class TestQuestion(object):
             "/question/{}?question=q&response=r&number=1".format(a.participant().id)
         )
         assert models.Question.query.all()
+
+    def test_excessive_question_text_is_blocked(self, a, webapp):
+        # The normal max length is 1000
+        resp = webapp.post(
+            "/question/{}?question=q&response={}&number=1".format(
+                a.participant().id, "x" * 1001
+            )
+        )
+        assert resp.status_code == 400
+
+        resp = webapp.post(
+            "/question/{}?question=q&response={}&number=1".format(
+                a.participant().id, "x" * 1000
+            )
+        )
+        assert resp.status_code == 200
+
+        # This part of the test isn't working because of some weird use of the config object
+        ## Override the length to go shorter
+        # with config.override({"question_max_length": 99}):
+        #    resp = webapp.post(
+        #        "/question/{}?question=q&response={}&number=1".format(a.participant().id, 'x'*100)
+        #    )
+        # assert resp.status_code == 400
 
     def test_nonworking_mturk_participants_accepted_if_debug(
         self, a, webapp, active_config


### PR DESCRIPTION
## Description
 This makes the question/response length configurable.

## Motivation and Context
Some experimenters want to have users write longer question responses.

## How Has This Been Tested?
Automated tests only