### PR TITLE
Fix base url function

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -40,7 +40,7 @@ default_keys = (
     ("heroku_auth_token", six.text_type, [], True),
     ("heroku_python_version", six.text_type, []),
     ("heroku_team", six.text_type, ["team"]),
-    ("host", six.text_type, []),
+    ("host", six.text_type, ["HOST"]),
     ("id", six.text_type, []),
     ("keywords", six.text_type, []),
     ("lifetime", int, []),

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -15,7 +15,7 @@ from dallinger.config import get_config
 
 def get_base_url():
     config = get_config()
-    host = os.getenv("HOST", config.get("host"))
+    host = config.get("host")
     if "herokuapp.com" in host:
         if host.startswith("https://"):
             base_url = host

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -219,34 +219,6 @@ worldwide = false
             config.register_extra_parameters()
             assert sys.modules["dallinger_experiment"] is exp_module
 
-    def test_local_base_url(self):
-        from dallinger.utils import get_base_url
-
-        config = get_config()
-        config.ready = True
-        config.set("host", "localhost")
-        config.set("base_port", 5000)
-        config.set("num_dynos_web", 1)
-        assert get_base_url() == "http://localhost:5000"
-
-    def test_remote_base_url(self):
-        from dallinger.utils import get_base_url
-
-        config = get_config()
-        config.ready = True
-        config.set("host", "https://dlgr-bogus.herokuapp.com")
-        config.set("num_dynos_web", 1)
-        assert get_base_url() == "https://dlgr-bogus.herokuapp.com"
-
-    def test_remote_base_url_always_ssl(self):
-        from dallinger.utils import get_base_url
-
-        config = get_config()
-        config.ready = True
-        config.set("host", "http://dlgr-bogus.herokuapp.com")
-        config.set("num_dynos_web", 1)
-        assert get_base_url() == "https://dlgr-bogus.herokuapp.com"
-
     def test_write_omits_sensitive_keys_if_filter_sensitive(self, in_tempdir):
         config = get_config()
         config.set("aws_region", "some region")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import io
-import os
 import mock
 import pytest
 from datetime import datetime

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -213,21 +213,21 @@ class TestBaseURL(object):
         config.config = None
 
     def test_local_base_url(self, subject, config):
-        config.set("host", "localhost")
+        config.set("host", u"localhost")
         config.set("base_port", 5000)
         config.set("num_dynos_web", 1)
-        assert subject() == "http://localhost:5000"
+        assert subject() == u"http://localhost:5000"
 
     def test_remote_base_url_always_ssl(self, subject, config):
-        config.set("host", "http://dlgr-bogus.herokuapp.com")
+        config.set("host", u"http://dlgr-bogus.herokuapp.com")
         config.set("base_port", 80)
         config.set("num_dynos_web", 1)
-        assert subject() == "https://dlgr-bogus.herokuapp.com"
+        assert subject() == u"https://dlgr-bogus.herokuapp.com"
 
     def test_os_HOST_environ_used_as_host(self, subject, config):
         old_host = os.environ.get("HOST")
-        with mock.patch("os.environ", {"HOST": "dlgr-bogus-2.herokuapp.com"}):
+        with mock.patch("os.environ", {"HOST": u"dlgr-bogus-2.herokuapp.com"}):
             config.load_from_environment()
         config.set("base_port", 80)
         config.set("num_dynos_web", 1)
-        assert subject() == "https://dlgr-bogus-2.herokuapp.com"
+        assert subject() == u"https://dlgr-bogus-2.herokuapp.com"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -225,7 +225,6 @@ class TestBaseURL(object):
         assert subject() == u"https://dlgr-bogus.herokuapp.com"
 
     def test_os_HOST_environ_used_as_host(self, subject, config):
-        old_host = os.environ.get("HOST")
         with mock.patch("os.environ", {"HOST": u"dlgr-bogus-2.herokuapp.com"}):
             config.load_from_environment()
         config.set("base_port", 80)


### PR DESCRIPTION
This fixes the tests for a base url function, which were poor and in the incorrect place. It also fixes a bug where a HOST environment variable could not be overriden in tests.