### PR TITLE
Issues/2013 exclude gitignore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 variable `heroku_python_version`. If not overriddent the default version of 3.6.10 will
 be used.
 
+- If files in the custom experiment directory are excluded by Git (by a local or global
+.gitignore file, $GIT_DIR/info/exclude, etc.), they will not be copied for use in deployment
+or ``dallinger debug`` runs. They will also be excluded from file size checks performed
+automatically during ``debug`` and deployment, and by ``dallinger verify``.
+
 ## [v-5.1.0](https://github.com/dallinger/dallinger/5.1.0) (2019-08-29)
 
 - As MTurk REST notifications are deprecated, the MTurk Recruiter creates an SNS Topic based on the experiment UID, subscribes to it, performs a subscription endpoint confirmation step, then associates the subscription with the HIT in order to receive notifications from MTurk about worker and HIT events

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -30,7 +30,7 @@ from dallinger.deployment import _deploy_in_mode
 from dallinger.deployment import DebugDeployment
 from dallinger.deployment import LoaderDeployment
 from dallinger.deployment import setup_experiment
-from dallinger.deployment import size_on_copy
+from dallinger.deployment import ExperimentFileSource
 from dallinger.notifications import get_messenger
 from dallinger.heroku.tools import HerokuApp
 from dallinger.heroku.tools import HerokuInfo
@@ -163,7 +163,7 @@ def verify_directory(verbose=True, max_size_mb=50):
 
     # Check size
     max_size = max_size_mb * mb_to_bytes
-    size = size_on_copy()
+    size = ExperimentFileSource().size
     if size > max_size:
         size_in_mb = round(size / mb_to_bytes)
         log(

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -163,11 +163,14 @@ def verify_directory(verbose=True, max_size_mb=50):
 
     # Check size
     max_size = max_size_mb * mb_to_bytes
-    size = ExperimentFileSource().size
+    file_source = ExperimentFileSource(os.getcwd())
+    size = file_source.size
     if size > max_size:
         size_in_mb = round(size / mb_to_bytes)
         log(
-            "✗ {}MB is TOO BIG (greater than {}MB)".format(size_in_mb, max_size_mb),
+            "✗ {}MB is TOO BIG (greater than {}MB)\n\tIncluded files:\n\t{}".format(
+                size_in_mb, max_size_mb, "\n\t".join(file_source.files)
+            ),
             chevrons=False,
             verbose=verbose,
         )

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -131,7 +131,7 @@ class ExperimentFileSource(object):
         for path in self.files:
             subpath = os.path.relpath(path, start=self.root)
             target_folder = os.path.join(destination, os.path.dirname(subpath))
-            os.makedirs(target_folder, exist_ok=True)
+            ensure_directory(target_folder)
             shutil.copy2(path, target_folder)
 
     def _walk(self):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -1,4 +1,3 @@
-import functools
 import os
 import pkg_resources
 import re
@@ -78,7 +77,6 @@ def exclusion_policy():
 
     See https://docs.python.org/3/library/shutil.html#shutil.ignore_patterns
     """
-
     patterns = set(
         [
             ".git",

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -126,7 +126,7 @@ class GitClient(object):
         return tempdir
 
     def files(self):
-        cmd = ["git", "ls-files"]
+        cmd = ["git", "ls-files", "--others", "--exclude-standard"]
         try:
             raw = check_output(cmd).decode()
         except Exception as e:

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -2,6 +2,7 @@ import functools
 import io
 import os
 import random
+import shlex
 import shutil
 import string
 import subprocess
@@ -123,6 +124,15 @@ class GitClient(object):
         cmd = ["git", "clone", repository, tempdir]
         self._run(cmd)
         return tempdir
+
+    def files(self):
+        cmd = ["git", "ls-files"]
+        try:
+            raw = check_output(cmd).decode()
+        except Exception as e:
+            return set()
+        result = set(shlex.split(raw))
+        return result
 
     def _run(self, cmd):
         self._log(cmd)

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -8,7 +8,15 @@ Dallinger is executed from the command line within the experiment directory with
 verify
 ^^^^^^
 
-Verify that a directory is a Dallinger-compatible app.
+Verify that a directory is a Dallinger-compatible app. A number of checks are run here:
+
+    * Required files are verified to exist
+    * The cumulative size of all experiment files is checked to make sure large files or
+      directories are not accidentally included (note that files excluded with a .gitignore
+      file are **not** included in this size total
+    * The experiment.py file is checked to make sure it includes a single Experiment subclass
+    * The configuration for ``base_payment`` from config.txt is validated
+    * Included files are checked for name conflicts with core Dallinger files
 
 .. _dallinger-bot:
 

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -13,7 +13,7 @@ Verify that a directory is a Dallinger-compatible app. A number of checks are ru
     * Required files are verified to exist
     * The cumulative size of all experiment files is checked to make sure large files or
       directories are not accidentally included (note that files excluded with a .gitignore
-      file are **not** included in this size total
+      file are **not** included in this size total)
     * The experiment.py file is checked to make sure it includes a single Experiment subclass
     * The configuration for ``base_payment`` from config.txt is validated
     * Included files are checked for name conflicts with core Dallinger files

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -211,7 +211,7 @@ Deployment Configuration
     API. Note that only the version number should be provided (eg: "2.7.14") and not the
     "python-" prefix included in the final `runtime.txt` format.
     See Dallinger's `global_config_defaults.txt` for the current default version.
-    See `Heroku's supported runtimes <https://devcenter.heroku.com/articles/python-support#supported-runtimes`__.
+    See `Heroku supported runtimes <https://devcenter.heroku.com/articles/python-support#supported-runtimes>`__.
 
 ``heroku_team`` *unicode*
     The name of the Heroku team to which all applications will be assigned.

--- a/docs/source/creating_an_experiment.rst
+++ b/docs/source/creating_an_experiment.rst
@@ -279,7 +279,9 @@ There are a few more files in the ``myexperiments.pushbutton`` directory.
 Here is a quick description of each:
 
 - ``.gitignore``. Used by `git` to keep track of which files to ignore
-  when looking for changes in your project.
+  when looking for changes in your project. Files ignored by `git` will
+  also be ignored both when deploying your experiment, and when testing it
+  in debug mode.
 - ``.travis.yml``. Travis is a continuous integration service, which can
   run your experiment's tests each time you push some changes. This is
   the configuration file where this is set up.

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -94,12 +94,18 @@ class TestVerify(object):
         assert v_package() is False
 
     def test_too_big_returns_false(self, v_directory):
-        with mock.patch("dallinger.command_line.size_on_copy") as size:
+        with mock.patch(
+            "dallinger.command_line.ExperimentFileSource.size",
+            new_callable=mock.PropertyMock,
+        ) as size:
             size.return_value = 6000000  # 6 MB, so over the limit
             assert v_directory(max_size_mb=5) is False
 
     def test_under_limit_returns_true(self, v_directory):
-        with mock.patch("dallinger.command_line.size_on_copy") as size:
+        with mock.patch(
+            "dallinger.command_line.ExperimentFileSource.size",
+            new_callable=mock.PropertyMock,
+        ) as size:
             size.return_value = 4000000  # 4 MB, so under the limit
             assert v_directory(max_size_mb=5) is True
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -142,6 +142,12 @@ class TestIsolatedWebbrowser(object):
 @pytest.mark.usefixtures("in_tempdir")
 class TestExperimentFilesSource(object):
     @pytest.fixture
+    def git(self):
+        from dallinger.utils import GitClient
+
+        return GitClient()
+
+    @pytest.fixture
     def subject(self):
         from dallinger.deployment import ExperimentFileSource
 
@@ -165,64 +171,93 @@ class TestExperimentFilesSource(object):
 
         assert len(source.files) == 0
 
-    def test_excludes_otherwise_valid_files_if_in_gitignore_simple(self, subject):
+    def test_excludes_otherwise_valid_files_if_in_gitignore_simple(self, subject, git):
         legit_file = "./some/subdir/legit.txt"
         os.makedirs(os.path.dirname(legit_file))
         with open(legit_file, "w") as f:
             f.write("12345")
         with open(".gitignore", "w") as f:
             f.write("*.txt")
+        git.init()
+        git.add("--all")
+        git.commit("Test Repo")
 
         source = subject()
 
         assert source.files == {"./.gitignore"}
 
-    def test_excludes_otherwise_valid_files_if_in_gitignore_complex(self, subject):
+    def test_excludes_otherwise_valid_files_if_in_gitignore_complex(self, subject, git):
         legit_file = "./some/subdir/legit.txt"
         os.makedirs(os.path.dirname(legit_file))
         with open(legit_file, "w") as f:
             f.write("12345")
         with open(".gitignore", "w") as f:
             f.write("**/subdir/*")
+        git.init()
+        git.add("--all")
+        git.commit("Test Repo")
 
         source = subject()
 
         assert source.files == {"./.gitignore"}
 
-
-@pytest.mark.usefixtures("in_tempdir")
-class TestExperimentDirectorySizeCheck(object):
-    @pytest.fixture
-    def size_check(self):
-        from dallinger.deployment import size_on_copy
-
-        return size_on_copy
-
-    def test_includes_files_that_would_be_copied(self, size_check):
+    def test_size_includes_files_that_would_be_copied(self, subject):
         with open("legit.txt", "w") as f:
             f.write("12345")
 
-        assert size_check(".") == 5
+        source = subject()
 
-    def test_excludes_files_that_would_not_be_copied(self, size_check):
+        assert source.size == 5
+
+    def test_size_excludes_files_that_would_not_be_copied(self, subject):
         with open("illegit.db", "w") as f:
             f.write("12345")
 
-        assert size_check(".") == 0
+        source = subject()
 
-    def test_excludes_directories_that_would_not_be_copied(self, size_check):
+        assert source.size == 0
+
+    def test_size_excludes_directories_that_would_not_be_copied(self, subject):
         os.mkdir("snapshots")
         with open("snapshots/legit.txt", "w") as f:
             f.write("12345")
 
-        assert size_check(".") == 0
+        source = subject()
 
-    def test_excludes_bad_files_when_in_subdirectories(self, size_check):
+        assert source.size == 0
+
+    def test_size_excludes_bad_files_when_in_subdirectories(self, subject):
         os.mkdir("legit_dir")
         with open("legit_dir/illegit.db", "w") as f:
             f.write("12345")
 
-        assert size_check(".") == 0
+        source = subject()
+
+        assert source.size == 0
+
+    def test_copy_to_copies_to_same_subdirectories(self, subject):
+        legit_file = "./some/subdir/legit.txt"
+        os.makedirs(os.path.dirname(legit_file))
+        with open(legit_file, "w") as f:
+            f.write("12345")
+        destination = tempfile.mkdtemp()
+        source = subject()
+
+        source.selective_copy_to(destination)
+
+        assert os.path.isfile(os.path.join(destination, "some/subdir/legit.txt"))
+
+    def test_copy_to_copies_with_explicit_root(self, subject):
+        legit_file = "./some/subdir/legit.txt"
+        os.makedirs(os.path.dirname(legit_file))
+        with open(legit_file, "w") as f:
+            f.write("12345")
+        destination = tempfile.mkdtemp()
+        source = subject(os.getcwd())
+
+        source.selective_copy_to(destination)
+
+        assert os.path.isfile(os.path.join(destination, "some/subdir/legit.txt"))
 
 
 @pytest.mark.usefixtures("bartlett_dir", "active_config", "reset_sys_modules")

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -179,7 +179,6 @@ class TestExperimentFilesSource(object):
         with open(".gitignore", "w") as f:
             f.write("*.txt")
         git.init()
-        git.add("--all")
 
         source = subject()
 
@@ -193,7 +192,6 @@ class TestExperimentFilesSource(object):
         with open(".gitignore", "w") as f:
             f.write("**/subdir/*")
         git.init()
-        git.add("--all")
 
         source = subject()
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -180,7 +180,6 @@ class TestExperimentFilesSource(object):
             f.write("*.txt")
         git.init()
         git.add("--all")
-        git.commit("Test Repo")
 
         source = subject()
 
@@ -195,7 +194,6 @@ class TestExperimentFilesSource(object):
             f.write("**/subdir/*")
         git.init()
         git.add("--all")
-        git.commit("Test Repo")
 
         source = subject()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -111,8 +111,6 @@ class TestGitClient(object):
         with open(".gitignore", "w") as ignore:
             ignore.write("two.*")
         git.init(config=config)
-        git.add("--all")
-        git.commit("Test Repo")
 
         assert set(git.files()) == {".gitignore", "one.txt"}
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -102,6 +102,23 @@ class TestGitClient(object):
         git.commit("Test Repo")
         assert b"Test Repo" in subprocess.check_output(["git", "log"])
 
+    def test_files_with_gitignore(self, git):
+        config = {"user.name": "Test User", "user.email": "test@example.com"}
+        with open("one.txt", "w") as one:
+            one.write("one")
+        with open("two.txt", "w") as two:
+            two.write("two")
+        with open(".gitignore", "w") as ignore:
+            ignore.write("two.*")
+        git.init(config=config)
+        git.add("--all")
+        git.commit("Test Repo")
+
+        assert set(git.files()) == {".gitignore", "one.txt"}
+
+    def test_files_on_non_git_repo(self, git):
+        assert git.files() == set()
+
     def test_includes_details_in_exceptions(self, git):
         with pytest.raises(Exception) as ex_info:
             git.push("foo", "bar")


### PR DESCRIPTION
## Description
If an experiment directory is a Git repository, skip copying, or including is size checks, any files that would be excluded by a .gitignore file, if present.

## Motivation and Context
Addresses #2031 
It makes no sense to copy, or size-check files that will never be deployed.

## How Has This Been Tested?
- [x] Automated tests
- [x] `dallinger debug`

## Screenshots

```
 dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✗ 72MB is TOO BIG (greater than 50MB)
	Included files:
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/tennis.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/templates/ad.html
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/Danaraja.mp3
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/outwit.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/scripts/experiment.js
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/templates/consent.html
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/scripts/markdown.min.js
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/css/bootstrap.min.css
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/species.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/__init__.py
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/demo.ipynb
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/cricket.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/moochi.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/experiment.py
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/ghosts.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/images/logo.png
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/models.py
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/README.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/templates/experiment.html
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/raid.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/requirements.txt
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/stimuli/vagabond.md
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/templates/layout.html
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/templates/instructions/instruct-ready.html
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/Danaraja2.mp3
	/Users/jesses/py_dev/Dallinger3/demos/dlgr/demos/bartlett1932/static/favicon.ico
✓ experiment.py defines 1 experiment
✓ no file conflicts

❯❯ ☹ Some problems were found.
```