### PR TITLE
Allow failed infos to be created on failed nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ be used.
 or ``dallinger debug`` runs. They will also be excluded from file size checks performed
 automatically during ``debug`` and deployment, and by ``dallinger verify``.
 
+- Add `failed` parameter to the add info route. This requires that all custom `Info` classes respect
+a `failed` keyword argument. 
+
 ## [v-5.1.0](https://github.com/dallinger/dallinger/5.1.0) (2019-08-29)
 
 - As MTurk REST notifications are deprecated, the MTurk Recruiter creates an SNS Topic based on the experiment UID, subscribes to it, performs a subscription endpoint confirmation step, then associates the subscription with the HIT in order to receive notifications from MTurk about worker and HIT events

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1175,6 +1175,8 @@ def info_post(node_id):
     info_type = request_parameter(
         parameter="info_type", parameter_type="known_class", default=models.Info
     )
+    failed = request_parameter(parameter="failed", parameter_type="bool", default=False)
+
     for x in [contents, info_type]:
         if type(x) == Response:
             return x
@@ -1186,7 +1188,10 @@ def info_post(node_id):
     exp = Experiment(session)
     try:
         # execute the request
-        info = info_type(origin=node, contents=contents)
+        additional_params = {}
+        if failed:
+            additional_params["failed"] = failed
+        info = info_type(origin=node, contents=contents, **additional_params)
         assign_properties(info)
 
         # ping the experiment

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1449,11 +1449,13 @@ class Info(Base, SharedMixin):
     #: the contents of the info. Must be stored as a String.
     contents = Column(Text(), default=None)
 
-    def __init__(self, origin, contents=None, details=None):
+    def __init__(self, origin, contents=None, details=None, failed=False):
         """Create an info."""
         # check the origin hasn't failed
-        if origin.failed:
-            raise ValueError("{} cannot create an info as it has failed".format(origin))
+        if origin.failed and not failed:
+            raise ValueError(
+                "Only failed Infos can be added to {}, as it has failed".format(origin)
+            )
 
         self.origin = origin
         self.origin_id = origin.id
@@ -1462,6 +1464,8 @@ class Info(Base, SharedMixin):
         self.network = origin.network
         if details:
             self.details = details
+        if failed is not None:
+            self.failed = failed
 
     @validates("contents")
     def _write_once(self, key, value):

--- a/demos/dlgr/demos/mcmcp/models.py
+++ b/demos/dlgr/demos/mcmcp/models.py
@@ -73,23 +73,14 @@ class AnimalInfo(Info):
         "head_angle": [5, 80],
     }
 
-    def __init__(self, origin, contents=None):
-        # check the origin hasn't failed
-        if origin.failed:
-            raise ValueError("{} cannot create an info as it has failed".format(origin))
-
-        self.origin = origin
-        self.origin_id = origin.id
-        self.network_id = origin.network_id
-        self.network = origin.network
-
-        if contents is not None:
-            self.contents = contents
-        else:
+    def __init__(self, origin, contents=None, **kwargs):
+        if contents is None:
             data = {}
             for prop, prop_range in self.properties.items():
                 data[prop] = random.uniform(prop_range[0], prop_range[1])
-            self.contents = json.dumps(data)
+            contents = json.dumps(data)
+
+        super(AnimalInfo, self).__init__(origin, contents, **kwargs)
 
     def perturbed_contents(self):
         """Perturb the given animal."""

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -69,6 +69,9 @@ must be passed as data. ``info_type`` can be passed as data and will
 cause the info to be of the specified type. Also calls experiment method
 ``info_post_request(node, info)``.
 
+If the specified node is failed then this will fail unless ``failed`` is
+also passed with the value True. This will create a failed Info on the node.
+
 ::
 
     POST /launch

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -58,6 +58,17 @@ class TestAgents(object):
         info = a.info(origin=agent, contents="foo")
         assert agent.infos()[0] == info
 
+    def test_can_only_connect_failed_infos_to_failed_node(self, a):
+        net = a.network()
+        agent = a.agent(network=net)
+        agent.fail()
+
+        with raises(ValueError):
+            info = a.info(origin=agent, contents="foo")
+        info = a.info(origin=agent, contents="foo", failed=True)
+        assert agent.infos() == []
+        assert agent.infos(failed=True) == [info]
+
     def test_agent_transmit(self, a):
         net = a.network()
         agent1 = a.replicator(network=net)


### PR DESCRIPTION
## Description
Currently, it is not possible to add an Info to a Node that is failed. This change alters the check to make it so it's not possible to add an Info to a node that's failed unless the Info is also failed. This keeps the guarantee that Infos on a failed node are all failed and allows developers to explicitly add info to failed nodes.

The `/info/nodeid` route has been changed so it allows a failed parameter to mark JS-originated infos as failed. The `Info` base class's `__init __` also has a failed kwarg for these purposes.

This should be a major version change, as it changes the Info `__init__` signature, albeit in a way that would be backwards compatible for careful users.

## Motivation and Context
See issue #2037 

## How Has This Been Tested?
Extensive unit testing, manual testing of existing (non-failed) case.