### PR TITLE
Suppress module is undefined error in dallinger2.js in the browser

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -635,4 +635,9 @@ var dallinger = (function () {
   return dlgr;
 }());
 
-module.exports.dallinger = dallinger;
+
+try {
+  module.exports.dallinger = dallinger;
+} catch (err) {
+  // We aren't being loaded from a node context, no need to export
+}


### PR DESCRIPTION
## Description
An extraneous error about module being undefined is present when using dallinger2.js in the browser. This change guards the setting of module.exports.dallinger (which is required for node-based unittesting) to suppress that error.

## Motivation and Context
It annoys users.

## How Has This Been Tested?
Through the web testing and running of jest tests.