### PR TITLE
Fix encoding of source image to work on Python3

### DIFF
--- a/demos/dlgr/demos/iterated_drawing/models.py
+++ b/demos/dlgr/demos/iterated_drawing/models.py
@@ -23,8 +23,8 @@ class DrawingSource(Source):
 
         image_path = os.path.join("static", "stimuli", image)
 
-        uri_encoded_image = "data:image/png;base64," + base64.b64encode(
+        uri_encoded_image = u"data:image/png;base64," + base64.b64encode(
             open(image_path, "rb").read()
-        )
+        ).decode("ascii")
 
         return json.dumps({"image": uri_encoded_image, "sketch": ""})


### PR DESCRIPTION
## Description
The iterated drawing demo loads an image from the filesystem and creates a base64 encoded data url of it. This changes the loading mechanism to work on Python 3.

## Motivation and Context
Iterated Drawing was not functional on any supported version of Python without this, amazingly.

## How Has This Been Tested?
Manual testing. 