### PR TITLE
Handle case where HIT has no keywords

### DIFF
--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -631,6 +631,10 @@ class MTurkService(object):
         return translated
 
     def _translate_hit(self, hit):
+        if "Keywords" in hit:
+            keywords = [w.strip() for w in hit["Keywords"].split(",") if w.strip()]
+        else:
+            keywords = []
         translated = {
             "id": hit["HITId"],
             "type_id": hit["HITTypeId"],
@@ -639,9 +643,7 @@ class MTurkService(object):
             "max_assignments": hit["MaxAssignments"],
             "title": hit["Title"],
             "description": hit["Description"],
-            "keywords": [
-                w.strip() for w in hit.get("Keywords", "").split(",") if w.strip()
-            ],
+            "keywords": keywords,
             "qualification_type_ids": [
                 q["QualificationTypeId"] for q in hit["QualificationRequirements"]
             ],

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -639,7 +639,9 @@ class MTurkService(object):
             "max_assignments": hit["MaxAssignments"],
             "title": hit["Title"],
             "description": hit["Description"],
-            "keywords": [w.strip() for w in hit["Keywords"].split(",")],
+            "keywords": [
+                w.strip() for w in hit.get("Keywords", "").split(",") if w.strip()
+            ],
             "qualification_type_ids": [
                 q["QualificationTypeId"] for q in hit["QualificationRequirements"]
             ],

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1086,6 +1086,9 @@ class TestMTurkServiceWithFakeConnection(object):
         assert hits[0]["title"] == "HIT Two"
 
     def test_get_hits_copes_with_no_keywords(self, with_mock):
+        # HITs created directly through the MTurk web UI
+        # may have no Keywords at all, so we need to account for this when
+        # parsing HITs.
         hr1 = fake_hit_response(Title="One")
         del hr1["HIT"]["Keywords"]
         responses = fake_list_hits_responses([hr1])

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1085,6 +1085,17 @@ class TestMTurkServiceWithFakeConnection(object):
         assert len(hits) == 1
         assert hits[0]["title"] == "HIT Two"
 
+    def test_get_hits_copes_with_no_keywords(self, with_mock):
+        hr1 = fake_hit_response(Title="One")
+        del hr1["HIT"]["Keywords"]
+        responses = fake_list_hits_responses([hr1])
+        with_mock.mturk.configure_mock(**{"list_hits.side_effect": responses})
+
+        hits = list(with_mock.get_hits())
+
+        assert len(hits) == 1
+        assert hits[0]["keywords"] == []
+
     def test_grant_bonus_translates_values_and_calls_wrapped_mturk(self, with_mock):
         with_mock.mturk.configure_mock(
             **{


### PR DESCRIPTION

## Description
Bugfix: sometimes HITs have no keywords

## Motivation and Context
HITs created through the MTurk web UI may have no keywords. This can cause problems for the Dallinger MTurk API, which assumes they're always present.  This PR checks to see if there are keywords defined before trying to parse them into the internal Dallinger HIT format.

## How Has This Been Tested?
Automated tests
