### PR TITLE
Non-asciii filename support

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import unicode_literals
 import os
 import pkg_resources
@@ -148,9 +149,9 @@ class ExperimentFileSource(object):
             # topdown = True
             dirnames[:] = [d for d in dirnames if d not in current_exclusions]
             legit_files = {
-                os.path.join(dirpath, normalize("NFC", f))
+                os.path.join(dirpath, normalize("NFC", six.text_type(f)))
                 for f in filenames
-                if f not in current_exclusions and os.path.join(dirpath, f)
+                if f not in current_exclusions
             }
             if git_files:
                 legit_files = legit_files.intersection(git_files)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -149,12 +149,15 @@ class ExperimentFileSource(object):
             # topdown = True
             dirnames[:] = [d for d in dirnames if d not in current_exclusions]
             legit_files = {
-                os.path.join(dirpath, normalize("NFC", six.text_type(f)))
+                os.path.join(dirpath, f)
                 for f in filenames
                 if f not in current_exclusions
             }
             if git_files:
-                legit_files = legit_files.intersection(git_files)
+                normalized = {
+                    normalize("NFC", six.text_type(f)): f for f in legit_files
+                }
+                legit_files = {v for k, v in normalized.items() if k in git_files}
             for legit in legit_files:
                 yield legit
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -129,7 +129,7 @@ class ExperimentFileSource(object):
 
     def _walk(self):
         exclusions = exclusion_policy()
-        git_files = set([os.path.join(self.root, f) for f in self.git.files()])
+        git_files = {os.path.join(self.root, f) for f in self.git.files()}
         for dirpath, dirnames, filenames in os.walk(self.root, topdown=True):
             current_exclusions = exclusions(dirpath, os.listdir(dirpath))
             # Modifying dirnames in-place will prune the subsequent files and

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -1,5 +1,6 @@
 import functools
 import io
+import locale
 import os
 import random
 import shutil
@@ -127,7 +128,7 @@ class GitClient(object):
     def files(self):
         cmd = ["git", "ls-files", "--cached", "--others", "--exclude-standard"]
         try:
-            raw = check_output(cmd).decode()
+            raw = check_output(cmd).decode(locale.getpreferredencoding())
         except Exception:
             return set()
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -2,7 +2,6 @@ import functools
 import io
 import os
 import random
-import shlex
 import shutil
 import string
 import subprocess
@@ -129,9 +128,10 @@ class GitClient(object):
         cmd = ["git", "ls-files", "--cached", "--others", "--exclude-standard"]
         try:
             raw = check_output(cmd).decode()
-        except Exception as e:
+        except Exception:
             return set()
-        result = set(shlex.split(raw))
+
+        result = {item for item in raw.split("\n") if item}
         return result
 
     def _run(self, cmd):

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -1,3 +1,4 @@
+from __future__ import unicode_literals
 import functools
 import io
 import locale
@@ -126,13 +127,13 @@ class GitClient(object):
         return tempdir
 
     def files(self):
-        cmd = ["git", "ls-files", "--cached", "--others", "--exclude-standard"]
+        cmd = ["git", "ls-files", "-z", "--cached", "--others", "--exclude-standard"]
         try:
             raw = check_output(cmd).decode(locale.getpreferredencoding())
         except Exception:
             return set()
 
-        result = {item for item in raw.split("\n") if item}
+        result = {item for item in raw.split("\0") if item}
         return result
 
     def _run(self, cmd):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -154,7 +154,7 @@ class TestExperimentFilesSource(object):
         return ExperimentFileSource
 
     def test_lists_files_valid_for_copying(self, subject):
-        legit_file = "./some/subdir/legit.txt"
+        legit_file = "./some/subdir/John Doe's file.txt"
         os.makedirs(os.path.dirname(legit_file))
         with open(legit_file, "w") as f:
             f.write("12345")
@@ -232,7 +232,7 @@ class TestExperimentFilesSource(object):
         assert source.size == 0
 
     def test_copy_to_copies_to_same_subdirectories(self, subject):
-        legit_file = "./some/subdir/legit.txt"
+        legit_file = "./some/subdir/John Doe's file.txt"
         os.makedirs(os.path.dirname(legit_file))
         with open(legit_file, "w") as f:
             f.write("12345")
@@ -241,7 +241,9 @@ class TestExperimentFilesSource(object):
 
         source.selective_copy_to(destination)
 
-        assert os.path.isfile(os.path.join(destination, "some/subdir/legit.txt"))
+        assert os.path.isfile(
+            os.path.join(destination, "some/subdir/John Doe's file.txt")
+        )
 
     def test_copy_to_copies_with_explicit_root(self, subject):
         legit_file = "./some/subdir/legit.txt"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 from pytest import raises
 from six.moves import configparser
-from unicodedata import normalize
 
 from dallinger.deployment import new_webbrowser_profile
 from dallinger.config import get_config
@@ -209,7 +208,7 @@ class TestExperimentFilesSource(object):
 
         source = subject()
 
-        assert source.files == {normalize("NFC", legit_file)}
+        assert source.files == {legit_file}
 
     def test_size_includes_files_that_would_be_copied(self, subject):
         with open("legit.txt", "w") as f:

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1,5 +1,6 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 import mock
 import os
 import pexpect
@@ -88,11 +89,11 @@ def heroku_mock():
 
     instance = mock.Mock(spec=HerokuApp)
     instance.redis_url = "\n"
-    instance.name = u"dlgr-fake-uid"
-    instance.url = u"fake-web-url"
-    instance.db_url = u"fake-db-url"
+    instance.name = "dlgr-fake-uid"
+    instance.url = "fake-web-url"
+    instance.db_url = "fake-db-url"
     with mock.patch("dallinger.deployment.heroku") as heroku_module:
-        heroku_module.auth_token.return_value = u"fake token"
+        heroku_module.auth_token.return_value = "fake token"
         with mock.patch("dallinger.deployment.HerokuApp") as mock_app_class:
             mock_app_class.return_value = instance
             yield instance
@@ -336,7 +337,7 @@ class TestSetupExperiment(object):
         assert found_in(os.path.join("templates", "complete.html"), dst)
 
     def test_setup_uses_specified_python_version(self, active_config, setup_experiment):
-        active_config.extend({"heroku_python_version": u"2.7.14"})
+        active_config.extend({"heroku_python_version": "2.7.14"})
 
         exp_id, dst = setup_experiment(log=mock.Mock())
 
@@ -398,9 +399,9 @@ class TestSetupExperiment(object):
 
         config.extend(
             {
-                "a_password": u"secret thing",
-                "something_sensitive": u"hide this",
-                "something_normal": u"show this",
+                "a_password": "secret thing",
+                "something_sensitive": "hide this",
+                "something_normal": "show this",
             }
         )
 
@@ -437,8 +438,8 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         log = mock.Mock()
         result = dsss(log=log)
         assert result == {
-            "app_home": u"fake-web-url",
-            "app_name": u"dlgr-fake-uid",
+            "app_home": "fake-web-url",
+            "app_name": "dlgr-fake-uid",
             "recruitment_msg": "fake\nrecruitment\nlist",
         }
 
@@ -467,11 +468,11 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=mock.Mock())
         heroku_mock.set_multiple.assert_called_once_with(
             auto_recruit=True,
-            aws_access_key_id=u"fake aws key",
-            aws_region=u"us-east-1",
-            aws_secret_access_key=u"fake aws secret",
-            smtp_password=u"fake email password",
-            smtp_username=u"fake email username",
+            aws_access_key_id="fake aws key",
+            aws_region="us-east-1",
+            aws_secret_access_key="fake aws secret",
+            smtp_password="fake email password",
+            smtp_username="fake email username",
             whimsical=True,
         )
 
@@ -488,9 +489,9 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         dsss(log=mock.Mock())
         heroku_mock.scale_up_dyno.assert_has_calls(
             [
-                mock.call("web", 1, u"free"),
-                mock.call("worker", 1, u"free"),
-                mock.call("clock", 1, u"free"),
+                mock.call("web", 1, "free"),
+                mock.call("worker", 1, "free"),
+                mock.call("clock", 1, "free"),
             ]
         )
 
@@ -544,13 +545,13 @@ class Test_deploy_in_mode(object):
             yield mock_dsss
 
     def test_sets_mode_in_config(self, active_config, dim, dsss):
-        dim(u"live", "some app id", verbose=True, log=mock.Mock())
+        dim("live", "some app id", verbose=True, log=mock.Mock())
         dsss.assert_called_once()
-        assert active_config.get("mode") == u"live"
+        assert active_config.get("mode") == "live"
 
     def test_sets_logfile_to_dash_for_some_reason(self, active_config, dim, dsss):
-        dim(u"live", "some app id", verbose=True, log=mock.Mock())
-        assert active_config.get("logfile") == u"-"
+        dim("live", "some app id", verbose=True, log=mock.Mock())
+        assert active_config.get("logfile") == "-"
 
 
 @pytest.mark.usefixtures("bartlett_dir")
@@ -566,10 +567,10 @@ class Test_handle_launch_data(object):
         log = mock.Mock()
         with mock.patch("dallinger.deployment.requests.post") as mock_post:
             result = mock.Mock(
-                ok=True, json=mock.Mock(return_value={"message": u"msg!"})
+                ok=True, json=mock.Mock(return_value={"message": "msg!"})
             )
             mock_post.return_value = result
-            assert handler("/some-launch-url", error=log) == {"message": u"msg!"}
+            assert handler("/some-launch-url", error=log) == {"message": "msg!"}
 
     def test_failure(self, handler):
         from requests.exceptions import HTTPError
@@ -578,7 +579,7 @@ class Test_handle_launch_data(object):
         with mock.patch("dallinger.deployment.requests.post") as mock_post:
             mock_post.return_value = mock.Mock(
                 ok=False,
-                json=mock.Mock(return_value={"message": u"msg!"}),
+                json=mock.Mock(return_value={"message": "msg!"}),
                 raise_for_status=mock.Mock(side_effect=HTTPError),
             )
             with pytest.raises(HTTPError):
@@ -593,7 +594,7 @@ class Test_handle_launch_data(object):
                     "Experiment launch failed. Trying again (attempt 3 of 3) in 0.2 seconds ..."
                 ),
                 mock.call("Experiment launch failed, check web dyno logs for details."),
-                mock.call(u"msg!"),
+                mock.call("msg!"),
             ]
         )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -125,7 +125,7 @@ class TestGitClient(object):
         with open("John Doe's (wow!) file.txt", "w") as two:
             two.write("two")
 
-        assert set(git.files()) == {"one.txt", "John Doe's (wow!) file.txt"}
+        assert git.files() == {"one.txt", "John Doe's (wow!) file.txt"}
 
     def test_files_on_non_git_repo(self, git):
         assert git.files() == set()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,6 @@
+# -*- coding: utf-8 -*-
 import io
+import locale
 import mock
 import pytest
 from datetime import datetime
@@ -122,10 +124,20 @@ class TestGitClient(object):
             one.write("one")
         git.add("--all")
 
-        with open("Jøhn Døé's – fîlé.txt", "w") as two:
+        with open("two.txt", "w") as two:
             two.write("two")
 
-        assert git.files() == {"one.txt", "Jøhn Døé's – fîlé.txt"}
+        assert git.files() == {"one.txt", "two.txt"}
+
+    def test_files_handles_nonascii_filenames(self, git):
+        config = {"user.name": "Test User", "user.email": "test@example.com"}
+        git.init(config=config)
+        filename = b"J\xc3\xb8hn D\xc3\xb8\xc3\xa9's \xe2\x80\x93.txt"
+
+        with open(filename, "w") as two:
+            two.write("blah")
+
+        assert git.files() == {filename.decode(locale.getpreferredencoding())}
 
     def test_files_on_non_git_repo(self, git):
         assert git.files() == set()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,10 +122,10 @@ class TestGitClient(object):
             one.write("one")
         git.add("--all")
 
-        with open("John Doe's (wow!) file.txt", "w") as two:
+        with open("Jøhn Døé's – fîlé.txt", "w") as two:
             two.write("two")
 
-        assert git.files() == {"one.txt", "John Doe's (wow!) file.txt"}
+        assert git.files() == {"one.txt", "Jøhn Døé's – fîlé.txt"}
 
     def test_files_on_non_git_repo(self, git):
         assert git.files() == set()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -122,10 +122,10 @@ class TestGitClient(object):
             one.write("one")
         git.add("--all")
 
-        with open("two.txt", "w") as two:
+        with open("John Doe's (wow!) file.txt", "w") as two:
             two.write("two")
 
-        assert set(git.files()) == {"one.txt", "two.txt"}
+        assert set(git.files()) == {"one.txt", "John Doe's (wow!) file.txt"}
 
     def test_files_on_non_git_repo(self, git):
         assert git.files() == set()


### PR DESCRIPTION
## Description
Bug fix for #2092 

## How Has This Been Tested?
- [x] Automated tests
- [x] Test repo on Mac OS
- [x] Test repo on Ubuntu

## Demo

```
>>> os.listdir('.')
['.DS_Store', 'foo\nbar', 'ånøthér file.txt', '.git', 'fîlé.txt']
>>> from dallinger.deployment import ExperimentFileSource
>>> src = ExperimentFileSource()
>>> src.files
{'./fîlé.txt', './foo\nbar', './ånøthér file.txt'}
``` 
