### PR TITLE
"compensate" Command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 ## [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
 - Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
-<<<<<<< HEAD
 - Regression fix: experiment files with apostrophes and non-ascii characters in file names are again supported
 - Documentation for including dependencies on private repositories
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
-
+- New `dallinger compensate` command: compensate a worker a specific amount in US dollars. This is useful if something goes wrong with the experiment and you need to pay workers for their wasted time.
+- 
 ## [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
 - Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 - New `dallinger compensate` command: compensate a worker a specific amount in US dollars. This is useful if something goes wrong with the experiment and you need to pay workers for their wasted time.
-- 
+- New `dallinger email_test` command: validate and test your email settings quickly and easily.
+
 ## [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
 - Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
+<<<<<<< HEAD
 - Regression fix: experiment files with apostrophes and non-ascii characters in file names are again supported
 - Documentation for including dependencies on private repositories
 

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -541,9 +541,19 @@ def compensate(recruiter, worker_id, dollars, no_email, sandbox):
             out.log("Aborting...")
             return
 
-        result = rec.compensate_worker(
-            worker_id=worker_id, dollars=dollars, notify=do_notify
-        )
+        try:
+            result = rec.compensate_worker(
+                worker_id=worker_id, dollars=dollars, notify=do_notify
+            )
+        except Exception as ex:
+            out.error(
+                "Compensation failed. The recruiter reports the following error:\n{}".format(
+                    ex
+                ),
+                delay=0,
+            )
+            return
+
     out.log("HIT Details", delay=0)
     out.log(tabulate.tabulate(result["hit"].items()), chevrons=False, delay=0)
     out.log("Qualification Details", delay=0)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -514,6 +514,20 @@ def qualify(workers, qualification, value, by_name, notify, sandbox):
 
 
 @dallinger.command()
+@click.option("--worker", required=True)
+@click.option("--dollars", required=True, type=int)
+@click.option("--notify", is_flag=True, flag_value=True, help="Notify worker by email")
+@click.option("--sandbox", is_flag=True, flag_value=True, help="Use the MTurk sandbox")
+def credit_turker(worker, dollars, notify, sandbox):
+    """Credit a specific MTurk worker by ID."""
+    where = "MTurk sandbox" if sandbox else "MTurk production"
+    email = " and email them" if notify else ""
+    click.echo(
+        "Would credit worker ID {} ${} in {}{}.".format(worker, dollars, where, email)
+    )
+
+
+@dallinger.command()
 @click.option("--qualification")
 @click.option(
     "--by_name",

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -529,7 +529,7 @@ def email_test():
     problems = settings.validate()
     if problems:
         out.error(
-            "There are mail configuration problems. Fix these first:\n{}".format(
+            "✗ There are mail configuration problems. Fix these first:\n{}".format(
                 problems
             )
         )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -534,7 +534,7 @@ def compensate(recruiter, worker_id, dollars, no_email, sandbox):
     with config.override({"mode": mode}):
         rec = by_name(recruiter)
         if not click.confirm(
-            '\n\nYou are about to pay worker "{}" ${} in "{}"" mode using the "{}" recruiter.\n'
+            '\n\nYou are about to pay worker "{}" ${} in "{}" mode using the "{}" recruiter.\n'
             "This will{} send an email to them from Amazon MTurk. "
             "Continue?".format(worker_id, dollars, mode, recruiter, no_email_str)
         ):

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -535,7 +535,7 @@ def compensate(recruiter, worker_id, dollars, no_email, sandbox):
         rec = by_name(recruiter)
         if not click.confirm(
             '\n\nYou are about to pay worker "{}" ${} in "{}"" mode using the "{}" recruiter.\n'
-            "This will{} send an email to each of them from Amazon MTurk. "
+            "This will{} send an email to them from Amazon MTurk. "
             "Continue?".format(worker_id, dollars, mode, recruiter, no_email_str)
         ):
             out.log("Aborting...")

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -502,7 +502,7 @@ def qualify(workers, qualification, value, by_name, notify, sandbox):
         )
     )
     for worker in workers:
-        if mturk.set_qualification_score(qid, worker, int(value), notify=notify):
+        if mturk.assign_qualification(qid, worker, int(value), notify=notify):
             click.echo("{} OK".format(worker))
 
     # print out the current set of workers with the qualification

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -19,6 +19,7 @@ mode = debug
 [Recruiter]
 auto_recruit = False
 assign_qualifications = False
+us_only = False
 
 [Bots]
 webdriver_type = phantomjs

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -21,7 +21,7 @@ from dallinger import experiment
 from dallinger import models
 from dallinger.config import get_config
 from dallinger import recruiters
-from dallinger.notifications import get_messenger
+from dallinger.notifications import admin_notifier
 from dallinger.notifications import MessengerError
 
 from .replay import ReplayBackend
@@ -247,9 +247,9 @@ def handle_error():
         ),
     }
     db.logger.debug("Reporting HIT error...")
-    messenger = get_messenger(config)
+    messenger = admin_notifier(config)
     try:
-        messenger.send(message)
+        messenger.send(**message)
     except MessengerError as ex:
         db.logger.exception(ex)
 

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -707,9 +707,9 @@ class MTurkService(object):
 
     def _worker_hit_url(self, type_id):
         if self.is_sandbox:
-            url = "https://workersandbox.mturk.com/mturk/preview?groupId={}"
+            url = "https://workersandbox.mturk.com/projects/{}/tasks"
         else:
-            url = "https://worker.mturk.com/mturk/preview?groupId={}"
+            url = "https://worker.mturk.com/projects/{}/tasks"
 
         return url.format(type_id)
 

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -116,6 +116,22 @@ class SNSService(object):
         return experiment_topics[0]
 
 
+class MTurkQuestions(object):
+    """Creates MTurk HIT Question definitions:
+    https://docs.aws.amazon.com/AWSMechTurk/latest/AWSMturkAPI/ApiReference_QuestionAnswerDataArticle.html
+    """
+
+    @staticmethod
+    def external(ad_url, frame_height=600):
+        q = (
+            '<ExternalQuestion xmlns="http://mechanicalturk.amazonaws.com/'
+            'AWSMechanicalTurkDataSchemas/2006-07-14/ExternalQuestion.xsd">'
+            "<ExternalURL>{}</ExternalURL>"
+            "<FrameHeight>{}</FrameHeight></ExternalQuestion>"
+        )
+        return q.format(ad_url, frame_height)
+
+
 class MTurkQualificationRequirements(object):
     """Syntactic correctness for MTurk QualificationRequirements
     """
@@ -404,15 +420,15 @@ class MTurkService(object):
         reward,
         duration_hours,
         lifetime_days,
-        ad_url,
+        question,
         notification_url,
         max_assignments,
         annotation=None,
         qualifications=(),
     ):
-        """Create the actual HIT and return a dict with its useful properties."""
-        frame_height = 600
-        mturk_question = self._external_question(ad_url, frame_height)
+        """Create the actual HIT and return a dict with its useful properties.
+        """
+
         # We need a HIT_Type in order to register for notifications
         hit_type_id = self.register_hit_type(
             title, description, reward, duration_hours, keywords, qualifications
@@ -423,7 +439,7 @@ class MTurkService(object):
             )
         params = {
             "HITTypeId": hit_type_id,
-            "Question": mturk_question,
+            "Question": question,
             "LifetimeInSeconds": int(
                 datetime.timedelta(days=lifetime_days).total_seconds()
             ),
@@ -603,15 +619,6 @@ class MTurkService(object):
             },
             Active=True,
         )
-
-    def _external_question(self, url, frame_height):
-        q = (
-            '<ExternalQuestion xmlns="http://mechanicalturk.amazonaws.com/'
-            'AWSMechanicalTurkDataSchemas/2006-07-14/ExternalQuestion.xsd">'
-            "<ExternalURL>{}</ExternalURL>"
-            "<FrameHeight>{}</FrameHeight></ExternalQuestion>"
-        )
-        return q.format(url, frame_height)
 
     def _request_token(self):
         return str(time.time())

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -276,26 +276,6 @@ class MTurkService(object):
         """Called by the MTurkRecruiter Flask route"""
         self.sns.confirm_subscription(token=token, topic=topic)
 
-    def register_hit_type(
-        self, title, description, reward, duration_hours, keywords, qualifications
-    ):
-        """Register HIT Type for this HIT and return the type's ID, which
-        is required for creating a HIT.
-        """
-        reward = str(reward)
-        duration_secs = int(datetime.timedelta(hours=duration_hours).total_seconds())
-        hit_type = self.mturk.create_hit_type(
-            Title=title,
-            Description=description,
-            Reward=reward,
-            AssignmentDurationInSeconds=duration_secs,
-            Keywords=",".join(keywords),
-            AutoApprovalDelayInSeconds=0,
-            QualificationRequirements=qualifications,
-        )
-
-        return hit_type["HITTypeId"]
-
     def create_qualification_type(self, name, description, status="Active"):
         """Create a new qualification Workers can be scored for.
         """
@@ -354,10 +334,6 @@ class MTurkService(object):
                 SendNotification=notify,
             )
         )
-
-    # BBB:
-    set_qualification_score = assign_qualification
-    update_qualification_score = assign_qualification
 
     def increment_qualification_score(self, name, worker_id, notify=False):
         """Increment the current qualification score for a worker, on a
@@ -471,7 +447,7 @@ class MTurkService(object):
         """
 
         # We need a HIT_Type in order to register for notifications
-        hit_type_id = self.register_hit_type(
+        hit_type_id = self._register_hit_type(
             title, description, reward, duration_hours, keywords, qualifications
         )
         if do_subscribe:
@@ -663,6 +639,26 @@ class MTurkService(object):
             },
             Active=True,
         )
+
+    def _register_hit_type(
+        self, title, description, reward, duration_hours, keywords, qualifications
+    ):
+        """Register HIT Type for this HIT and return the type's ID, which
+        is required for creating a HIT.
+        """
+        reward = str(reward)
+        duration_secs = int(datetime.timedelta(hours=duration_hours).total_seconds())
+        hit_type = self.mturk.create_hit_type(
+            Title=title,
+            Description=description,
+            Reward=reward,
+            AssignmentDurationInSeconds=duration_secs,
+            Keywords=",".join(keywords),
+            AutoApprovalDelayInSeconds=0,
+            QualificationRequirements=qualifications,
+        )
+
+        return hit_type["HITTypeId"]
 
     def _request_token(self):
         return str(time.time())

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -461,8 +461,8 @@ class MTurkService(object):
         duration_hours,
         lifetime_days,
         question,
-        notification_url,
         max_assignments,
+        notification_url=None,
         annotation=None,
         qualifications=(),
         do_subscribe=True,
@@ -700,9 +700,18 @@ class MTurkService(object):
             "review_status": hit["HITReviewStatus"],
             "status": hit["HITStatus"],
             "annotation": hit.get("RequesterAnnotation"),
+            "worker_url": self._worker_hit_url(hit["HITTypeId"]),
         }
 
         return translated
+
+    def _worker_hit_url(self, type_id):
+        if self.is_sandbox:
+            url = "https://workersandbox.mturk.com/mturk/preview?groupId={}"
+        else:
+            url = "https://worker.mturk.com/mturk/preview?groupId={}"
+
+        return url.format(type_id)
 
     def _translate_qtype(self, qtype):
         return {

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -142,6 +142,37 @@ class MTurkQuestions(object):
         )
         return q.format(ad_url, frame_height)
 
+    @staticmethod
+    def compensation(title="Compensation HIT", sandbox=False, frame_height=600):
+        if sandbox:
+            action = "https://workersandbox.mturk.com/mturk/externalSubmit"
+        else:
+            action = "https://www.mturk.com/mturk/externalSubmit"
+
+        q = (
+            '<HTMLQuestion xmlns="http://mechanicalturk.amazonaws.com/AWSMechanicalTurkDataSchemas/2011-11-11/HTMLQuestion.xsd">'
+            "<HTMLContent><![CDATA[<!DOCTYPE html><html>"
+            "<head>"
+            '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>'
+            '<script type="text/javascript" src="https://s3.amazonaws.com/mturk-public/externalHIT_v1.js"></script>'
+            "</head>"
+            "<body>"
+            '<form name="mturk_form" method="post" id="mturk_form" action="{}">'
+            '<input type="hidden" value="" name="assignmentId" id="assignmentId"/>'
+            "<h1>{}</h1>"
+            "<p>We are sorry that you encountered difficulties with our experiment. "
+            "We will compensate you immediately upon submission of this HIT.</p>"
+            '<input type="hidden" name="some-input-required" value="anything" ></input>'
+            '<input type="submit" id="submitButton" value="Submit" /></p></form>'
+            '<script language="Javascript">turkSetAssignmentID();</script>'
+            "</body></html>]]>"
+            "</HTMLContent>"
+            "<FrameHeight>{}</FrameHeight>"
+            "</HTMLQuestion>"
+        )
+
+        return q.format(action, title, frame_height)
+
 
 class MTurkQualificationRequirements(object):
     """Syntactic correctness for MTurk QualificationRequirements

--- a/dallinger/notifications.py
+++ b/dallinger/notifications.py
@@ -127,19 +127,25 @@ class EmailConfig(object):
     }
 
     def __init__(self, config):
-        # self.config = config
         self.smtp_host = config.get("smtp_host")
         self.smtp_username = config.get("smtp_username", None)
         self.contact_email_on_error = config.get("contact_email_on_error")
         self.smtp_password = config.get("smtp_password", None)
         self.dallinger_email_address = config.get("dallinger_email_address")
 
+    def as_dict(self):
+        cleaned = self.__dict__.copy()
+        password = self.smtp_password
+        if password and password != CONFIG_PLACEHOLDER:
+            cleaned["smtp_password"] = password[:3] + "......" + password[-1]
+
+        return cleaned
+
     def validate(self):
         """Could this config be used to send a real email?"""
         missing = []
         for k in self.mail_config_keys:
             attr = getattr(self, k, False)
-            # attr = self.config.get(k)
             if not attr or attr == CONFIG_PLACEHOLDER:
                 missing.append(k)
         if missing:

--- a/dallinger/notifications.py
+++ b/dallinger/notifications.py
@@ -18,19 +18,6 @@ class InvalidEmailConfig(ValueError):
     """
 
 
-def EmailMessage(subject, sender, recipients, text):
-    """Factory for making email.message.EmailMessage objects, which have a
-    stupid API.
-    """
-    _message = EmailMessage_()
-    _message["Subject"] = subject
-    _message["To"] = recipients
-    _message["From"] = sender
-    _message.set_content(text)
-
-    return _message
-
-
 class SMTPMailer(object):
     def __init__(self, host, username, password):
         self.host = host

--- a/dallinger/notifications.py
+++ b/dallinger/notifications.py
@@ -2,11 +2,7 @@ import logging
 import six
 import smtplib
 from cached_property import cached_property
-
-try:
-    from email.message import EmailMessage as EmailMessage_
-except ImportError:
-    from email.message import Message as EmailMessage_
+from email.mime.text import MIMEText
 
 
 logger = logging.getLogger(__file__)
@@ -34,7 +30,7 @@ class SMTPMailer(object):
         try:
             self.server.starttls()
             self.server.login(self.username, self.password)
-            self.server.send_message(msg)
+            self.server.sendmail(sender, recipients, msg.as_string())
             self.server.quit()
         except smtplib.SMTPException as ex:
             six.raise_from(MessengerError("SMTP error sending HIT error email."), ex)
@@ -44,11 +40,10 @@ class SMTPMailer(object):
         self._sent.append(msg)
 
     def _make_email(self, subject, sender, recipients, body):
-        msg = EmailMessage_()
+        msg = MIMEText(body)
         msg["Subject"] = subject
-        msg["To"] = recipients
+        msg["To"] = ",".join(recipients)
         msg["From"] = sender
-        msg.set_content(body)
 
         return msg
 

--- a/dallinger/notifications.py
+++ b/dallinger/notifications.py
@@ -2,11 +2,104 @@ import logging
 import six
 import smtplib
 from cached_property import cached_property
-from email.mime.text import MIMEText
+
+try:
+    from email.message import EmailMessage as EmailMessage_
+except ImportError:
+    from email.message import Message as EmailMessage_
 
 
 logger = logging.getLogger(__file__)
 CONFIG_PLACEHOLDER = u"???"
+
+
+class InvalidEmailConfig(ValueError):
+    """The configuration contained missing or invalid email-related values.
+    """
+
+
+def EmailMessage(subject, sender, recipients, text):
+    """Factory for making email.message.EmailMessage objects, which have a
+    stupid API.
+    """
+    _message = EmailMessage_()
+    _message["Subject"] = subject
+    _message["To"] = recipients
+    _message["From"] = sender
+    _message.set_content(text)
+
+    return _message
+
+
+class SMTPMailer(object):
+    def __init__(self, host, username, password):
+        self.host = host
+        self.username = username
+        self.password = password
+        self._sent = []
+
+    @cached_property
+    def server(self):
+        return get_email_server(self.host)
+
+    def send(self, subject, sender, recipients, body):
+        msg = self._make_email(subject, sender, recipients, body)
+        try:
+            self.server.starttls()
+            self.server.login(self.username, self.password)
+            self.server.send_message(msg)
+            self.server.quit()
+        except smtplib.SMTPException as ex:
+            six.raise_from(MessengerError("SMTP error sending HIT error email."), ex)
+        except Exception as ex:
+            six.raise_from(MessengerError("Unknown error sending HIT error email."), ex)
+
+        self._sent.append(msg)
+
+    def _make_email(self, subject, sender, recipients, body):
+        msg = EmailMessage_()
+        msg["Subject"] = subject
+        msg["To"] = recipients
+        msg["From"] = sender
+        msg.set_content(body)
+
+        return msg
+
+
+class LoggingMailer(object):
+    def __init__(self):
+        self._sent = []
+
+    def send(self, subject, sender, recipients, text):
+        msg = "{}:\nSubject: {}\nSender: {}\nRecipients: {}\nBody:\n".format(
+            self.__class__.__name__, subject, sender, ", ".join(recipients), text
+        )
+
+        logger.info(msg)
+        self._sent.append(msg)
+
+
+def get_mailer(config, strict=False):
+    """Return an appropriate Messenger.
+
+    If we're in debug mode, or email settings aren't set, return a debug
+    version which logs the message instead of attempting to send a real
+    email.
+    """
+    settings = EmailConfig(config)
+    if config.get("mode") == "debug":
+        return LoggingMailer()
+    problems = settings.validate()
+    if problems:
+        if strict:
+            raise InvalidEmailConfig(problems)
+
+        logger.info(problems + " Will log errors instead of emailing them.")
+        return LoggingMailer()
+
+    return SMTPMailer(
+        settings.smtp_host, settings.smtp_username, settings.smtp_password
+    )
 
 
 def get_email_server(host):
@@ -25,80 +118,76 @@ class EmailConfig(object):
     """Extracts and validates email-related values from a Configuration
     """
 
-    _map = {
-        "username": "smtp_username",
-        "toaddr": "contact_email_on_error",
-        "fromaddr": "dallinger_email_address",
-        "password": "smtp_password",
+    mail_config_keys = {
+        "smtp_host",
+        "smtp_username",
+        "smtp_password",
+        "contact_email_on_error",
+        "dallinger_email_address",
     }
 
     def __init__(self, config):
-        self.host = config.get("smtp_host")
-        self.username = config.get("smtp_username", None)
-        self.toaddr = config.get("contact_email_on_error")
-        self.password = config.get("smtp_password", None)
-        self.fromaddr = config.get("dallinger_email_address")
+        # self.config = config
+        self.smtp_host = config.get("smtp_host")
+        self.smtp_username = config.get("smtp_username", None)
+        self.contact_email_on_error = config.get("contact_email_on_error")
+        self.smtp_password = config.get("smtp_password", None)
+        self.dallinger_email_address = config.get("dallinger_email_address")
 
     def validate(self):
         """Could this config be used to send a real email?"""
         missing = []
-        for k, v in self._map.items():
+        for k in self.mail_config_keys:
             attr = getattr(self, k, False)
+            # attr = self.config.get(k)
             if not attr or attr == CONFIG_PLACEHOLDER:
-                missing.append(v)
+                missing.append(k)
         if missing:
             return "Missing or invalid config values: {}".format(
                 ", ".join(sorted(missing))
             )
 
 
-class BaseMessenger(object):
-    def __init__(self, email_settings):
-        self.host = email_settings.host
-        self.username = email_settings.username
-        self.fromaddr = email_settings.fromaddr
-        self.toaddr = email_settings.toaddr
-        self.password = email_settings.password
+class NotifiesAdmin(object):
+    """Quickly email the experiment admin/author with to/from addresses
+    taken from configuration.
+    """
+
+    def __init__(self, email_settings, mailer):
+        self.fromaddr = email_settings.dallinger_email_address
+        self.toaddr = email_settings.contact_email_on_error
+        self.mailer = mailer
 
 
-class EmailingMessenger(BaseMessenger):
+class NotifiesAdminByEmail(NotifiesAdmin):
     """Actually sends an email message to the experiment owner.
     """
 
-    @cached_property
-    def server(self):
-        return get_email_server(self.host)
+    def __init__(self, email_settings, mailer):
+        super(NotifiesAdminByEmail, self).__init__(email_settings, mailer)
+        self.mailer = mailer
 
-    def send(self, message):
-        msg = MIMEText(message["body"])
-        msg["Subject"] = message["subject"]
-        try:
-            self.server.starttls()
-            self.server.login(self.username, self.password)
-            self.server.sendmail(self.fromaddr, self.toaddr, msg.as_string())
-            self.server.quit()
-        except smtplib.SMTPException as ex:
-            six.raise_from(MessengerError("SMTP error sending HIT error email."), ex)
-        except Exception as ex:
-            six.raise_from(MessengerError("Unknown error sending HIT error email."), ex)
+    def send(self, subject, body):
+        self.mailer.send(subject, self.fromaddr, [self.toaddr], body)
 
 
-class DebugMessenger(BaseMessenger):
+class NotifiesAdminViaLogs(NotifiesAdmin):
     """Used in debug mode.
 
     Prints the message contents to the log instead of sending an email.
     """
 
-    def send(self, message):
-        logger.info(
-            "{}:\n{}\n{}".format(
-                self.__class__.__name__, message["subject"], message["body"]
-            )
-        )
+    def __init__(self, email_settings, mailer):
+        super(NotifiesAdminViaLogs, self).__init__(email_settings, mailer)
+        self._sent = []
+
+    def send(self, subject, body):
+        self._sent.append(": ".join([subject, body]))
+        self.mailer.send(subject, self.fromaddr, [self.toaddr], body)
 
 
-def get_messenger(config):
-    """Return an appropriate Messenger.
+def admin_notifier(config):
+    """Return an appropriate NotifiesAdmin implementation.
 
     If we're in debug mode, or email settings aren't set, return a debug
     version which logs the message instead of attempting to send a real
@@ -106,9 +195,16 @@ def get_messenger(config):
     """
     email_settings = EmailConfig(config)
     if config.get("mode") == "debug":
-        return DebugMessenger(email_settings)
+        return NotifiesAdminViaLogs(email_settings, LoggingMailer())
     problems = email_settings.validate()
     if problems:
         logger.info(problems + " Will log errors instead of emailing them.")
-        return DebugMessenger(email_settings)
-    return EmailingMessenger(email_settings)
+        return NotifiesAdminViaLogs(email_settings, LoggingMailer())
+    return NotifiesAdminByEmail(
+        email_settings,
+        SMTPMailer(
+            email_settings.smtp_host,
+            email_settings.smtp_username,
+            email_settings.smtp_password,
+        ),
+    )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -22,6 +22,7 @@ from dallinger.notifications import MessengerError
 from dallinger.models import Participant
 from dallinger.models import Recruitment
 from dallinger.mturk import MTurkQualificationRequirements
+from dallinger.mturk import MTurkQuestions
 from dallinger.mturk import MTurkService
 from dallinger.mturk import DuplicateQualificationNameError
 from dallinger.mturk import MTurkServiceException
@@ -505,7 +506,7 @@ class MTurkRecruiter(Recruiter):
             "reward": self.config.get("base_payment"),
             "duration_hours": self.config.get("duration"),
             "lifetime_days": self.config.get("lifetime"),
-            "ad_url": self.ad_url,
+            "question": MTurkQuestions.external(self.ad_url),
             "notification_url": self.notification_url,
             "annotation": self.config.get("id"),
             "qualifications": self._build_hit_qualifications(),

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -512,15 +512,10 @@ class MTurkRecruiter(Recruiter):
             "qualifications": self._build_hit_qualifications(),
         }
         hit_info = self.mturkservice.create_hit(**hit_request)
-        if self.config.get("mode") == "sandbox":
-            lookup_url = (
-                "https://workersandbox.mturk.com/mturk/preview?groupId={type_id}"
-            )
-        else:
-            lookup_url = "https://worker.mturk.com/mturk/preview?groupId={type_id}"
+        url = hit_info["worker_url"]
 
         return {
-            "items": [lookup_url.format(**hit_info)],
+            "items": [url],
             "message": "HIT now published to Amazon Mechanical Turk",
         }
 
@@ -671,6 +666,10 @@ class MTurkRecruiter(Recruiter):
         #     )
         # except MTurkServiceException as ex:
         #     logger.exception(str(ex))
+
+    @property
+    def _is_sandbox(self):
+        return self.config.get("mode") == "sandbox"
 
     def _build_hit_qualifications(self):
         quals = []

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -75,6 +75,31 @@ An optional ``--no-scrub`` flag will stop the scrubbing of personally
 identifiable information in the export. The scrubbing of PII is enabled by
 default.
 
+compensate
+~~~~~~~~~~
+
+Compensate a worker a specific amount in US dollars. This is useful if something
+goes wrong with the experiment and you need to pay workers for their wasted
+time. Currently only the ``mturk`` recruiter is supported, and is the default,
+so doesn't need to be specified.
+
+For Mechanical Turk, compensation is acheived by:
+    1. Creating a unique qualification and assigning it to the worker
+    2. Creating a very simple HIT which is only visible to workers with this
+       qualification, using the dollar amount specified in the command as the
+       base payment
+    3. Automatically approving (and this granting base payment) when the HIT
+       is submitted.
+
+Usage:
+    * ``--worker_id`` (required) - The worker's identifier
+    * ``--dollars`` (required) - The amount to pay, in US dollars
+    * ``--sandbox`` (optional flag) - If present, the compensation will be made
+      via the test platform (the MTurk Sandbox)
+    * ``--no_email`` (optional flag) - If present, no email notification will be
+      sent to the worker.
+
+
 qualify
 ^^^^^^^
 

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -75,6 +75,16 @@ An optional ``--no-scrub`` flag will stop the scrubbing of personally
 identifiable information in the export. The scrubbing of PII is enabled by
 default.
 
+email_test
+~~~~~~~~~~
+
+Validate email settings derived from Dallinger Configuration and send a test
+email if the configuration appears valid.
+
+The test email will use ``dallinger_email_address`` as the sender and
+``contact_email_on_error`` as the recipient.
+
+
 compensate
 ~~~~~~~~~~
 

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -88,7 +88,7 @@ For Mechanical Turk, compensation is acheived by:
     2. Creating a very simple HIT which is only visible to workers with this
        qualification, using the dollar amount specified in the command as the
        base payment
-    3. Automatically approving (and this granting base payment) when the HIT
+    3. Automatically approving (and thus granting base payment) when the HIT
        is submitted.
 
 Usage:

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -499,6 +499,34 @@ class TestQualify(object):
         assert 'No qualification with name "some qual name" exists.' in result.output
 
 
+class TestEmailTest(object):
+    @pytest.fixture
+    def email_test(self):
+        from dallinger.command_line import email_test
+
+        return email_test
+
+    @pytest.fixture
+    def mailer(self):
+        from dallinger.notifications import SMTPMailer
+
+        mock_mailer = mock.Mock(spec=SMTPMailer)
+        with mock.patch("dallinger.command_line.SMTPMailer") as klass:
+            klass.return_value = mock_mailer
+            yield mock_mailer
+
+    def test_check_with_good_config(self, email_test, mailer, active_config):
+        result = CliRunner().invoke(email_test,)
+        mailer.send.assert_called_once()
+        assert result.exit_code == 0
+
+    def test_check_with_missing_value(self, email_test, mailer, active_config):
+        active_config.extend({"smtp_username": u"???"})
+        result = CliRunner().invoke(email_test,)
+        mailer.send.assert_not_called()
+        assert result.exit_code == 0
+
+
 class TestCompensate(object):
 
     DO_IT = "Y\n"

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -499,7 +499,7 @@ class TestQualify(object):
         assert 'No qualification with name "some qual name" exists.' in result.output
 
 
-class TestCompensateWorker(object):
+class TestCompensate(object):
 
     DO_IT = "Y\n"
     DO_NOT_DO_IT = "N\n"
@@ -557,6 +557,19 @@ class TestCompensateWorker(object):
         )
         assert result.exit_code == 0
         mturkrecruiter.compensate_worker.assert_not_called()
+
+    def test_traps_errors_and_forwards_message_portion(
+        self, compensate, mturkrecruiter
+    ):
+        with mock.patch("dallinger.command_line.by_name") as by_name:
+            by_name.return_value = mturkrecruiter
+            mturkrecruiter.compensate_worker.side_effect = Exception("Boom!")
+            result = CliRunner().invoke(
+                compensate,
+                ["--worker_id", "some worker ID", "--dollars", "5", "--no_email"],
+                input=self.DO_IT,
+            )
+        assert result.exit_code == 0
 
 
 class TestRevoke(object):

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -391,7 +391,7 @@ class TestQualify(object):
             ],
         )
         assert result.exit_code == 0
-        mturk.set_qualification_score.assert_called_once_with(
+        mturk.assign_qualification.assert_called_once_with(
             "some qid", "some worker id", qual_value, notify=False
         )
         mturk.get_workers_with_qualification.assert_called_once_with("some qid")
@@ -436,7 +436,7 @@ class TestQualify(object):
             ],
         )
         assert result.exit_code == 0
-        mturk.set_qualification_score.assert_called_once_with(
+        mturk.assign_qualification.assert_called_once_with(
             "some qid", "some worker id", qual_value, notify=True
         )
 
@@ -454,7 +454,7 @@ class TestQualify(object):
             ],
         )
         assert result.exit_code == 0
-        mturk.set_qualification_score.assert_has_calls(
+        mturk.assign_qualification.assert_has_calls(
             [
                 mock.call(u"some qid", u"worker1", 1, notify=False),
                 mock.call(u"some qid", u"worker2", 1, notify=False),
@@ -476,7 +476,7 @@ class TestQualify(object):
             ],
         )
         assert result.exit_code == 0
-        mturk.set_qualification_score.assert_called_once_with(
+        mturk.assign_qualification.assert_called_once_with(
             "some qid", "some worker id", qual_value, notify=False
         )
         mturk.get_workers_with_qualification.assert_called_once_with("some qid")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -393,9 +393,9 @@ class TestWorkerComplete(object):
 
 @pytest.fixture
 def mock_messenger():
-    from dallinger.notifications import NotifiesAdminByEmail
+    from dallinger.notifications import NotifiesAdmin
 
-    messenger = mock.Mock(spec=NotifiesAdminByEmail)
+    messenger = mock.Mock(spec=NotifiesAdmin)
     with mock.patch(
         "dallinger.experiment_server.experiment_server.admin_notifier"
     ) as get:

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -393,11 +393,11 @@ class TestWorkerComplete(object):
 
 @pytest.fixture
 def mock_messenger():
-    from dallinger.notifications import EmailingMessenger
+    from dallinger.notifications import NotifiesAdminByEmail
 
-    messenger = mock.Mock(spec=EmailingMessenger)
+    messenger = mock.Mock(spec=NotifiesAdminByEmail)
     with mock.patch(
-        "dallinger.experiment_server.experiment_server.get_messenger"
+        "dallinger.experiment_server.experiment_server.admin_notifier"
     ) as get:
         get.return_value = messenger
         yield messenger

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -14,6 +14,7 @@ from dallinger.mturk import MTurkServiceException
 from dallinger.mturk import SNSService
 from dallinger.mturk import WorkerLacksQualification
 from dallinger.mturk import MTurkQualificationRequirements
+from dallinger.mturk import MTurkQuestions
 from dallinger.mturk import RevokedQualification
 from dallinger.mturk import QualificationNotFoundException
 from dallinger.utils import generate_random_id
@@ -231,13 +232,13 @@ def fake_get_assignment_response():
 def standard_hit_config(**kwargs):
     defaults = {
         "experiment_id": "some-experiment-id",
-        "ad_url": "https://url-of-ad-route",
         "lifetime_days": 0.0004,  # 34 seconds (30 is minimum)
         "max_assignments": 1,
         "notification_url": "https://url-of-notification-route",
         "title": "Test Title",
         "keywords": ["testkw1", "testkw2"],
         "reward": 0.01,
+        "question": MTurkQuestions.external(ad_url="https://url-of-ad-route"),
         "duration_hours": 0.25,
         "qualifications": [
             MTurkQualificationRequirements.min_approval(95),

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -978,11 +978,22 @@ class TestMTurkServiceWithFakeConnection(object):
 
         hit = with_mock.create_hit(**standard_hit_config())
 
-        assert hit["max_assignments"] == 1
-        assert hit["reward"] == 0.01
-        assert hit["keywords"] == ["testkw1", "testkw2"]
-        assert isinstance(hit["created"], datetime.datetime)
-        assert isinstance(hit["expiration"], datetime.datetime)
+        assert hit == {
+            "annotation": None,
+            "created": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000),
+            "description": "***TEST SUITE HIT***43683",
+            "expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000),
+            "id": "3X7837UUADRXYCA1K7JAJLKC66DJ60",
+            "keywords": ["testkw1", "testkw2"],
+            "max_assignments": 1,
+            "qualification_type_ids": ["000000000000000000L0", "00000000000000000071"],
+            "review_status": "NotReviewed",
+            "reward": 0.01,
+            "status": "Assignable",
+            "title": "Test Title",
+            "type_id": "3V76OXST9SAE3THKN85FUPK7730050",
+            "worker_url": "https://workersandbox.mturk.com/mturk/preview?groupId=3V76OXST9SAE3THKN85FUPK7730050",
+        }
 
     def test_create_hit_creates_no_sns_subscription_when_asked_not_to(self, with_mock):
         with_mock.mturk.configure_mock(

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -991,7 +991,7 @@ class TestMTurkServiceWithFakeConnection(object):
             "status": "Assignable",
             "title": "Test Title",
             "type_id": "3V76OXST9SAE3THKN85FUPK7730050",
-            "worker_url": "https://workersandbox.mturk.com/mturk/preview?groupId=3V76OXST9SAE3THKN85FUPK7730050",
+            "worker_url": "https://workersandbox.mturk.com/projects/3V76OXST9SAE3THKN85FUPK7730050/tasks",
         }
 
     def test_create_hit_creates_no_sns_subscription_when_asked_not_to(self, with_mock):

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -527,7 +527,6 @@ class TestMTurkService(object):
         hit = with_cleanup.create_hit(
             **standard_hit_config(
                 title="Compensation Immediate",
-                lifetime_days=0.1,
                 question=MTurkQuestions.compensation(sandbox=True),
             )
         )

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -58,7 +58,7 @@ class TestSMTPMailer(object):
         )
         smtp.starttls.assert_called()
         smtp.login.assert_called_once_with("username", "password")
-        smtp.send_message.assert_called_once()
+        smtp.sendmail.assert_called_once()
         smtp.quit.assert_called()
 
         assert len(mailer._sent) == 1
@@ -128,54 +128,36 @@ class TestMessengerFactory(object):
         return admin_notifier
 
     def test_returns_debug_version_if_configured(self, factory, stub_config):
-        from dallinger.notifications import NotifiesAdminViaLogs
+        from dallinger.notifications import LoggingMailer
 
-        assert isinstance(factory(stub_config), NotifiesAdminViaLogs)
+        assert isinstance(factory(stub_config).mailer, LoggingMailer)
 
     def test_returns_emailing_version_if_configured(self, factory, stub_config):
-        from dallinger.notifications import NotifiesAdminByEmail
+        from dallinger.notifications import SMTPMailer
 
         stub_config.extend({"mode": u"sandbox"})
-        assert isinstance(factory(stub_config), NotifiesAdminByEmail)
+        assert isinstance(factory(stub_config).mailer, SMTPMailer)
 
     def test_returns_debug_version_if_email_config_invalid(self, factory, stub_config):
-        from dallinger.notifications import NotifiesAdminViaLogs
+        from dallinger.notifications import LoggingMailer
 
         stub_config.extend({"mode": u"sandbox", "dallinger_email_address": u""})
-        assert isinstance(factory(stub_config), NotifiesAdminViaLogs)
+        assert isinstance(factory(stub_config).mailer, LoggingMailer)
 
 
-class TestNotifiesAdminViaLogs(object):
+class TestNotifiesAdmin(object):
     @pytest.fixture
     def messenger(self, stub_config):
-        from dallinger.notifications import NotifiesAdminViaLogs
+        from dallinger.notifications import NotifiesAdmin
         from dallinger.notifications import EmailConfig
         from dallinger.notifications import LoggingMailer
 
-        return NotifiesAdminViaLogs(EmailConfig(stub_config), LoggingMailer())
+        return NotifiesAdmin(EmailConfig(stub_config), LoggingMailer())
 
-    def test_logs_message_subject_and_body(self, messenger):
+    def test_forwards_to_mailer(self, messenger):
         messenger.send(subject="Some subject", body="Some\nbody")
-        assert messenger._sent == ["Some subject: Some\nbody"]
-
-
-class TestNotifiesAdminByEmail(object):
-    @pytest.fixture
-    def mailer(self):
-        from dallinger.notifications import SMTPMailer
-
-        mailer = mock.Mock(spec=SMTPMailer)
-        yield mailer
-
-    @pytest.fixture
-    def messenger(self, stub_config, mailer):
-        from dallinger.notifications import NotifiesAdminByEmail
-        from dallinger.notifications import EmailConfig
-
-        return NotifiesAdminByEmail(EmailConfig(stub_config), mailer)
-
-    def test_constructs_full_email_for_mailer(self, messenger, mailer):
-        messenger.send(subject="Some subject", body="Some\nbody")
-        messenger.mailer.send.assert_called_once_with(
-            "Some subject", "test@example.com", ["error_contact@test.com"], "Some\nbody"
+        expected = (
+            "LoggingMailer:\nSubject: Some subject\nSender: test@example.com\n"
+            "Recipients: error_contact@test.com\nBody:\nSome\nbody"
         )
+        assert messenger.mailer._sent == [expected]

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -31,52 +31,9 @@ class TestEmailConfig(object):
         )
 
 
-class TestMessengerFactory(object):
+class TestSMTPMailer(object):
     @pytest.fixture
-    def factory(self):
-        from dallinger.notifications import get_messenger
-
-        return get_messenger
-
-    def test_returns_debug_version_if_configured(self, factory, stub_config):
-        from dallinger.notifications import DebugMessenger
-
-        assert isinstance(factory(stub_config), DebugMessenger)
-
-    def test_returns_emailing_version_if_configured(self, factory, stub_config):
-        from dallinger.notifications import EmailingMessenger
-
-        stub_config.extend({"mode": u"sandbox"})
-        assert isinstance(factory(stub_config), EmailingMessenger)
-
-    def test_returns_debug_version_if_email_config_invalid(self, factory, stub_config):
-        from dallinger.notifications import DebugMessenger
-
-        stub_config.extend({"mode": u"sandbox", "dallinger_email_address": u""})
-        assert isinstance(factory(stub_config), DebugMessenger)
-
-
-class TestDebugMessenger(object):
-    @pytest.fixture
-    def messenger(self, stub_config):
-        from dallinger.notifications import DebugMessenger
-        from dallinger.notifications import EmailConfig
-
-        return DebugMessenger(EmailConfig(stub_config))
-
-    def test_logs_message_subject_and_body(self, messenger, message):
-        body = message["body"]
-        subject = message["subject"]
-        with mock.patch("dallinger.notifications.logger") as logger:
-            messenger.send(message)
-            logger.info.assert_called_once_with(
-                "DebugMessenger:\n{}\n{}".format(subject, body)
-            )
-
-
-class TestEmailingMessenger(object):
-    @pytest.fixture
-    def dummy_mailer(self):
+    def smtp(self):
         from smtplib import SMTP
         from dallinger import notifications
 
@@ -87,35 +44,138 @@ class TestEmailingMessenger(object):
         notifications.get_email_server = orig_server
 
     @pytest.fixture
-    def messenger(self, stub_config):
-        from dallinger.notifications import EmailingMessenger
-        from dallinger.notifications import EmailConfig
+    def mailer(self):
+        from dallinger.notifications import SMTPMailer
 
-        return EmailingMessenger(EmailConfig(stub_config))
+        return SMTPMailer(host="host", username="username", password="password")
 
-    def test_send_negotiates_email_server(self, messenger, dummy_mailer, message):
-        messenger.send(message)
-
-        assert messenger.server is dummy_mailer
-        messenger.server.starttls.assert_called()
-        messenger.server.login.assert_called_once_with(
-            "fake email username", "fake email password"
+    def test_send_negotiates_email_server(self, mailer, smtp):
+        mailer.send(
+            subject="Some subject",
+            sender="from@example.com",
+            recipients=["to@example.com"],
+            body="Some\nbody",
         )
-        messenger.server.sendmail.assert_called()
-        messenger.server.quit.assert_called()
-        assert messenger.server.sendmail.call_args[0][0] == u"test@example.com"
-        assert messenger.server.sendmail.call_args[0][1] == u"error_contact@test.com"
+        smtp.starttls.assert_called()
+        smtp.login.assert_called_once_with("username", "password")
+        smtp.send_message.assert_called_once()
+        smtp.quit.assert_called()
 
-    def test_wraps_mail_server_exceptions(self, messenger, dummy_mailer, message):
+        assert len(mailer._sent) == 1
+
+    def test_wraps_mail_server_exceptions(self, mailer, smtp):
         import smtplib
         from dallinger.notifications import MessengerError
 
-        dummy_mailer.login.side_effect = smtplib.SMTPException("Boom!")
+        smtp.login.side_effect = smtplib.SMTPException("Boom!")
         with pytest.raises(MessengerError) as ex_info:
-            messenger.send(message)
+            mailer.send(
+                subject="Some subject",
+                sender="from@example.com",
+                recipients=["to@example.com"],
+                body="Some\nbody",
+            )
         assert ex_info.match("SMTP error")
 
-        dummy_mailer.login.side_effect = Exception("Boom!")
+        smtp.login.side_effect = Exception("Boom!")
         with pytest.raises(MessengerError) as ex_info:
-            messenger.send(message)
+            mailer.send(
+                subject="Some subject",
+                sender="from@example.com",
+                recipients=["to@example.com"],
+                body="Some\nbody",
+            )
         assert ex_info.match("Unknown error")
+
+
+class TestMailerFactory(object):
+    @pytest.fixture
+    def factory(self):
+        from dallinger.notifications import get_mailer
+
+        return get_mailer
+
+    def test_returns_debug_version_if_configured(self, factory, stub_config):
+        from dallinger.notifications import LoggingMailer
+
+        assert isinstance(factory(stub_config), LoggingMailer)
+
+    def test_returns_emailing_version_if_configured(self, factory, stub_config):
+        from dallinger.notifications import SMTPMailer
+
+        stub_config.extend({"mode": u"sandbox"})
+        assert isinstance(factory(stub_config), SMTPMailer)
+
+    def test_returns_debug_version_if_email_config_invalid(self, factory, stub_config):
+        from dallinger.notifications import LoggingMailer
+
+        stub_config.extend({"mode": u"sandbox", "dallinger_email_address": u""})
+        assert isinstance(factory(stub_config), LoggingMailer)
+
+    def test_raises_on_invalid_config_in_strict_mode(self, factory, stub_config):
+        from dallinger.notifications import InvalidEmailConfig
+
+        stub_config.extend({"mode": u"sandbox", "dallinger_email_address": u""})
+        with pytest.raises(InvalidEmailConfig):
+            factory(stub_config, strict=True)
+
+
+class TestMessengerFactory(object):
+    @pytest.fixture
+    def factory(self):
+        from dallinger.notifications import admin_notifier
+
+        return admin_notifier
+
+    def test_returns_debug_version_if_configured(self, factory, stub_config):
+        from dallinger.notifications import NotifiesAdminViaLogs
+
+        assert isinstance(factory(stub_config), NotifiesAdminViaLogs)
+
+    def test_returns_emailing_version_if_configured(self, factory, stub_config):
+        from dallinger.notifications import NotifiesAdminByEmail
+
+        stub_config.extend({"mode": u"sandbox"})
+        assert isinstance(factory(stub_config), NotifiesAdminByEmail)
+
+    def test_returns_debug_version_if_email_config_invalid(self, factory, stub_config):
+        from dallinger.notifications import NotifiesAdminViaLogs
+
+        stub_config.extend({"mode": u"sandbox", "dallinger_email_address": u""})
+        assert isinstance(factory(stub_config), NotifiesAdminViaLogs)
+
+
+class TestNotifiesAdminViaLogs(object):
+    @pytest.fixture
+    def messenger(self, stub_config):
+        from dallinger.notifications import NotifiesAdminViaLogs
+        from dallinger.notifications import EmailConfig
+        from dallinger.notifications import LoggingMailer
+
+        return NotifiesAdminViaLogs(EmailConfig(stub_config), LoggingMailer())
+
+    def test_logs_message_subject_and_body(self, messenger):
+        messenger.send(subject="Some subject", body="Some\nbody")
+        assert messenger._sent == ["Some subject: Some\nbody"]
+
+
+class TestNotifiesAdminByEmail(object):
+    @pytest.fixture
+    def mailer(self):
+        from dallinger.notifications import SMTPMailer
+
+        mailer = mock.Mock(spec=SMTPMailer)
+        yield mailer
+
+    @pytest.fixture
+    def messenger(self, stub_config, mailer):
+        from dallinger.notifications import NotifiesAdminByEmail
+        from dallinger.notifications import EmailConfig
+
+        return NotifiesAdminByEmail(EmailConfig(stub_config), mailer)
+
+    def test_constructs_full_email_for_mailer(self, messenger, mailer):
+        messenger.send(subject="Some subject", body="Some\nbody")
+        messenger.mailer.send.assert_called_once_with(
+            "Some subject", "test@example.com", ["error_contact@test.com"], "Some\nbody"
+        )

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -467,9 +467,9 @@ def mturkservice(active_config):
 class TestMTurkRecruiter(object):
     @pytest.fixture
     def notifies_admin(self):
-        from dallinger.notifications import NotifiesAdminViaLogs
+        from dallinger.notifications import NotifiesAdmin
 
-        mock_notifies_admin = mock.create_autospec(NotifiesAdminViaLogs)
+        mock_notifies_admin = mock.create_autospec(NotifiesAdmin)
         yield mock_notifies_admin
 
     @pytest.fixture

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -5,6 +5,7 @@ from datetime import datetime
 from dallinger.models import Participant
 from dallinger.experiment import Experiment
 from dallinger.mturk import MTurkQualificationRequirements
+from dallinger.mturk import MTurkQuestions
 
 
 class TestModuleFunctions(object):
@@ -508,7 +509,9 @@ class TestMTurkRecruiter(object):
     def test_open_recruitment_single_recruitee_builds_hit(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url="http://fake-domain/ad?recruiter=mturk",
+            question=MTurkQuestions.external(
+                ad_url="http://fake-domain/ad?recruiter=mturk"
+            ),
             description=u"fake HIT description",
             duration_hours=1.0,
             experiment_id="some experiment uid",
@@ -571,7 +574,9 @@ class TestMTurkRecruiter(object):
         }
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url="http://fake-domain/ad?recruiter=mturk",
+            question=MTurkQuestions.external(
+                ad_url="http://fake-domain/ad?recruiter=mturk"
+            ),
             description="fake HIT description",
             duration_hours=1.0,
             experiment_id="some experiment uid",
@@ -923,7 +928,9 @@ class TestMTurkLargeRecruiter(object):
     def test_open_recruitment_single_recruitee_actually_overrecruits(self, recruiter):
         recruiter.open_recruitment(n=1)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url="http://fake-domain/ad?recruiter=mturklarge",
+            question=MTurkQuestions.external(
+                ad_url="http://fake-domain/ad?recruiter=mturklarge"
+            ),
             description="fake HIT description",
             duration_hours=1.0,
             experiment_id="some experiment uid",
@@ -946,7 +953,9 @@ class TestMTurkLargeRecruiter(object):
         num_recruits = recruiter.pool_size + 1
         recruiter.open_recruitment(n=num_recruits)
         recruiter.mturkservice.create_hit.assert_called_once_with(
-            ad_url="http://fake-domain/ad?recruiter=mturklarge",
+            question=MTurkQuestions.external(
+                ad_url="http://fake-domain/ad?recruiter=mturklarge"
+            ),
             description="fake HIT description",
             duration_hours=1.0,
             experiment_id="some experiment uid",


### PR DESCRIPTION
## Description
New `dallinger compensate` command to compensate a worker a specific dollar amount.
New `dallinger email_test` command to validate and test email configuration.

### Changes to existing infrastructure

#### MTurk
The `MTurkService` class, which was initially a hasty port from the psiturk project, was overly rigid about the kinds of HITs you could create; it assumed a HIT would only ever be used to run an experiment. For compensating workers, we use MTurk HITs with nothing to do but click a submit button as a means of paying them when something has gone wrong for them which trying to complete an experiment. A fair bit of this PR involved adding more flexibility to HIT creation via the `MTurkService`, and that's reflected in the large diff.

#### Email
Previous to this work, the only case where Dallinger sent email messages was to notify experiment authors/admins when something was going wrong. Since email setup can be complicated, there's a fallback mechanism to log messages in the case where email config is missing or invalid. Because we were only using this system to email admins, the infrastructure was somewhat over-specified to handle this one use-case, and there was no easy support for sending email messages to arbitrary recipients. This has also been addressed, and the previous "alert the admin" case is a small wrapper around the more general purpose emailing. Again, this means a larger change set.

## Motivation and Context
See #2028 

## Design Rationale
Rather than hard-coding this as an MTurk-specific feature, I added `compensate_worker()` to the Recruiter API, and the CLI command calls the method on the appropriate recruiter ("mturk" is the default). I wrestled with whether this was a good idea, or a case of overly speculative generality. I went ahead with it for two reasons:
1. Dallinger's design already includes too many assumptions about concrete implementations, and we've had to do a lot of fighting back against this when we want to actual deliver on the "pluggability" that's a stated design goal. My thought was that building in the intention to be abstract up front might help us achieve this, and it was no additional effort.
2. With the move to SNS notifications for MTurk last year, I added infrastructure for recruiters to provide Flask routes. If we're going to be working on a "master dashboard" in the near future, we will likely want an API endpoint with the same underlying functionality as the CLI command this PR provides, and having the actual work performed by the recruiter might feel logical for that case.

## How Has This Been Tested?
- [x] Automated tests
- [x] MTurk sandbox testing

## Screenshots (if appropriate):

1. `dallinger compensate`
2. `dallinger email_test`

## Updated compensate command


### Demo
```
$ dallinger compensate --worker_id A...........G --email worker@example.com --dollars 2.50 --sandbox
2020-04-21 16:16:01,320 - /Users/jesses/py_dev/Dallinger3/dallinger/recruiters.py - INFO - Initializing MTurkRecruiter...


You are about to pay worker "A...........G" $2.50 in "sandbox" mode using the "mturk" recruiter.
The worker will be notified by email. Continue? [y/N]: y

❯❯ HIT Details
----------------------  -----------------------------------------------------------------------------
id                      3OPLMF3EU5GB0N4TM9H41BJQFISNL5
type_id                 3H2ZGQZOTY1K27XF1MZJE05BCNUYXU
created                 2020-04-21 16:16:04-07:00
expiration              2020-04-24 16:16:04-07:00
max_assignments         1
title                   Dallinger Compensation HIT
description             For compenation only; no task required.
keywords                []
qualification_type_ids  ['3BR5SIVR7WNK7CZNAVZNB658XCQGEO']
reward                  2.5
review_status           NotReviewed
status                  Assignable
annotation
worker_url              https://workersandbox.mturk.com/projects/3H2ZGQZOTY1K27XF1MZJE05BCNUYXU/tasks
----------------------  -----------------------------------------------------------------------------

❯❯ Qualification Details
-----------  ------------------------------------------------------------------------------------------------------
id           3BR5SIVR7WNK7CZNAVZNB658XCQGEO
created      2020-04-21 16:16:03-07:00
name         Dallinger Compensation Qualification - T6AAE5
description  You have received a qualification to allow you to complete a compensation HIT from Dallinger for $2.5.
status       Active
-----------  ------------------------------------------------------------------------------------------------------

❯❯ Worker Notification
----------  ----------------------------------------------------------------------------------
subject     Dallinger Compensation HIT
sender      admin@example.com
recipients  ['worker@example.com]
body        A special compenstation HIT is available for you to complete.
            Title: Dallinger Compensation HIT
            Reward: $2.50
            URL: https://workersandbox.mturk.com/projects/3H2ZGQZOTY1K27XF1MZJE05BCNUYXU/tasks
----------  ----------------------------------------------------------------------------------
```
## Email validation
My idea for email config checking was separate from the function of compensation, since this is a general state of the experimenter's setup. I added a `dallinger email_test` command, that does two things:

1. It checks to make sure you have all the required config keys set up (it doesn't do much to validate them as email addresses, etc. but this would be easy to add)
2. It sends an email using the configuration, from `dallinger_email_address` to `contact_email_on_error`. If this is working and you receive the email, you can basically have confidence in your configuration generally

You may still have the problem of getting the worker's email wrong, but if that happens, dealing with it with tooling seems like wrong approach.

### Demo

#### Sad Path
```
$ dallinger email_test

❯❯ Email Config
-----------------------  --------------------------
smtp_host                smtp.gmail.com:587
smtp_username            admin@example.com
contact_email_on_error   help@example.com
smtp_password            ???
dallinger_email_address  admin@example.com
-----------------------  --------------------------

❯❯ There are mail configuration problems. Fix these first:
Missing or invalid config values: smtp_password
```

#### Happy Path
```
$ dallinger email_test

❯❯ Email Config
-----------------------  --------------------------
smtp_host                smtp.gmail.com:587
smtp_username            admin@example.com
contact_email_on_error   help@example.com
smtp_password            fug......v
dallinger_email_address  admin@example.com
-----------------------  --------------------------

❯❯ ✓ email config looks good!

❯❯ Sending a test email from admin@example.com to help@example.com

❯❯ ✓ Test email sent successfully to help@example.com!
```
