### PR TITLE
Issue #1885 don't retry launch route in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 
+- No longer retry `/launch` route in debug mode. Additional logging for launch retries.
+
 ## [v-6.0.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-03-24)
 
 - Allow control of which python version will be run on Heroku through a new configuration

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -302,6 +302,12 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):
         if launch_request.ok:
             return launch_data
 
+        error(
+            "Error accessing /launch ({}):\n{}".format(
+                launch_request.status_code, launch_request.text
+            )
+        )
+
         if remaining_attempt:
             delay = delay * BACKOFF_FACTOR
             next_attempt_count = attempts - (remaining_attempt - 1)
@@ -538,7 +544,7 @@ class DebugDeployment(HerokuLocalDeployment):
         time.sleep(4)
         try:
             result = _handle_launch_data(
-                "{}/launch".format(base_url), error=self.out.error
+                "{}/launch".format(base_url), error=self.out.error, attempts=1
             )
         except Exception:
             # Show output from server


### PR DESCRIPTION
## Description
Alters `DebugDeployment` to only make a single attempt to call the `/launch` route. Adds some additional logging on failures.

## Motivation and Context
See #1885

## How Has This Been Tested?
Automated tests have been updated to test that a single attempt is made in debug mode, and that additional logging calls are made. I also manually ran a demo in debug mode.
