### PR TITLE
Issue #2088 configure web and worker dynos separately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
+- Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
 
 ## [v-6.0.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-03-24)
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -36,6 +36,8 @@ default_keys = (
     ("description", six.text_type, []),
     ("duration", float, []),
     ("dyno_type", six.text_type, []),
+    ("dyno_type_web", six.text_type, []),
+    ("dyno_type_worker", six.text_type, []),
     ("group_name", six.text_type, []),
     ("heroku_auth_token", six.text_type, [], True),
     ("heroku_python_version", six.text_type, []),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -416,8 +416,9 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     git.push(remote="heroku", branch="HEAD:master")
 
     log("Scaling up the dynos...")
-    size = config.get("dyno_type")
+    default_size = config.get("dyno_type")
     for process in ["web", "worker"]:
+        size = config.get("dyno_type_" + process, default_size)
         qty = config.get("num_dynos_" + process)
         heroku_app.scale_up_dyno(process, qty, size)
     if config.get("clock_on"):

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -258,14 +258,25 @@ very large difference to how the application behaves.
     more performant on underloaded dynos, so a better heuristic is ``0.25*number_of_bots``.
 
 ``dyno_type``
-    This determines how powerful the heroku dyno that's started is. It applies to both
-    web and worker dyno types. The minimum recommended is ``standard-1x``, which should be
-    sufficient for experiments that do not rely on real-time coordination, such as
-    :doc:`demos/bartlett1932/index`.
-    Experiments that require significant power to process websocket events should consider
-    the higher levels, ``standard-2x``, ``performance-m`` and ``performance-l``. In all but
-    the most intensive experiments, either ``dyno_type`` or ``num_dynos_web`` should be
-    increased, not both.
+    This determines how powerful the heroku dynos started by Dallinger are. It is applied
+    as the default for both web and worker dyno types. The minimum recommended is
+    ``standard-1x``, which should be sufficient for experiments that do not rely on
+    real-time coordination, such as :doc:`demos/bartlett1932/index`. Experiments that
+    require significant power to process websocket events should consider the higher
+    levels, ``standard-2x``, ``performance-m`` and ``performance-l``. In all but the
+    most intensive experiments, either ``dyno_type`` or ``num_dynos_web`` should be
+    increased, not both. See ``dyno_type_web`` and ``dyno_type_worker`` below
+    for information about more specific settings.
+
+``dyno_type_web``
+    This determines how powerful the heroku web dynos are. It applies only to web dynos
+    and will override the default set in ``dyno_type``. See ``dyno_type`` above for details
+    on specific values.
+
+``dyno_type_worker``
+    This determines how powerful the heroku worker dynos are. It applies only to worker
+    dynos and will override the default set in ``dyno_type``.. See ``dyno_type`` above for
+    details on specific values.
 
 ``redis_size``
     A larger value for this increases the number of connections available on the redis dyno.

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -457,6 +457,15 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
             ]
         )
 
+    def test_scales_different_dynos(self, dsss, heroku_mock, active_config):
+        active_config.set("dyno_type", u"ignored")
+        active_config.set("dyno_type_web", u"tiny")
+        active_config.set("dyno_type_worker", u"massive")
+        dsss(log=mock.Mock())
+        heroku_mock.scale_up_dyno.assert_has_calls(
+            [mock.call("web", 1, u"tiny"), mock.call("worker", 1, u"massive")]
+        )
+
     def test_calls_launch(self, dsss, heroku_mock, launch):
         log = mock.Mock()
         dsss(log=log)


### PR DESCRIPTION
## Description
Adds `dyno_type_web` and `dyno_type_worker` configuration options which override the default `dyno_type`.

## Motivation and Context
See issue #2088

## How Has This Been Tested?
New automated test for heroku dyno scaling.
