### PR TITLE
Add new dyno_type configs to sanity check

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -537,9 +537,13 @@ class HerokuLocalWrapper(object):
 
 def sanity_check(config):
     # check if dyno size is compatible with team configuration.
-    size = config.get("dyno_type")
+    sizes = {
+        config.get("dyno_type"),
+        config.get("dyno_type_web", None),
+        config.get("dyno_type_worker", None),
+    }
     team = config.get("heroku_team", None)
-    if team and size == "free":
+    if team and "free" in sizes:
         raise RuntimeError(
             'Heroku "free" dyno type not compatible '
             "with team/org deployment. Please use a "

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -136,6 +136,24 @@ class TestHerokuUtilFunctions(object):
             heroku.sanity_check(stub_config)
         assert excinfo.match("dyno type not compatible")
 
+    def test_sanity_check_raises_on_invalid_web_dyno_combo(self, heroku, stub_config):
+        assert heroku.sanity_check(stub_config) is None
+        stub_config.set("heroku_team", u"my_team")
+        stub_config.set("dyno_type_web", u"free")
+        with pytest.raises(RuntimeError) as excinfo:
+            heroku.sanity_check(stub_config)
+        assert excinfo.match("dyno type not compatible")
+
+    def test_sanity_check_raises_on_invalid_worker_dyno_combo(
+        self, heroku, stub_config
+    ):
+        assert heroku.sanity_check(stub_config) is None
+        stub_config.set("heroku_team", u"my_team")
+        stub_config.set("dyno_type_worker", u"free")
+        with pytest.raises(RuntimeError) as excinfo:
+            heroku.sanity_check(stub_config)
+        assert excinfo.match("dyno type not compatible")
+
     def test_sanity_check_ok_when_optional_keys_absent(self, heroku, stub_config):
         del stub_config.data[0]["heroku_team"]
         assert heroku.sanity_check(stub_config) is None


### PR DESCRIPTION
## Description
Add `dyno_type_web` and `dyno_type_worker` to sanity check method

## Motivation and Context
This will avoid delayed errors on startup when using a free dyno type with a team configuration. See issues #2088 and #1239

## How Has This Been Tested?
An automated test has been added.
