### PR TITLE
Release6.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,11 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 
+## [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
 - Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
+- Regression fix: experiment files with non-ascii characters in file names are again supported
+- Documentation for including dependencies on private repositories
 
 ## [v-6.0.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-03-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ## [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
 - No longer retry `/launch` route in debug mode. Additional logging for launch retries.
 - Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
-- Regression fix: experiment files with non-ascii characters in file names are again supported
+- Regression fix: experiment files with apostrophes and non-ascii characters in file names are again supported
 - Documentation for including dependencies on private repositories
 
 ## [v-6.0.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-03-24)

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "6.0.0"
+__version__ = "6.1.0"

--- a/demos/dlgr/demos/bartlett1932/requirements.txt
+++ b/demos/dlgr/demos/bartlett1932/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/chatroom/requirements.txt
+++ b/demos/dlgr/demos/chatroom/requirements.txt
@@ -1,2 +1,2 @@
-dallinger==6.0.0
+dallinger==6.1.0
 nltk==3.3

--- a/demos/dlgr/demos/concentration/requirements.txt
+++ b/demos/dlgr/demos/concentration/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/function_learning/requirements.txt
+++ b/demos/dlgr/demos/function_learning/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/iterated_drawing/requirements.txt
+++ b/demos/dlgr/demos/iterated_drawing/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/mcmcp/requirements.txt
+++ b/demos/dlgr/demos/mcmcp/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/rogers/requirements.txt
+++ b/demos/dlgr/demos/rogers/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/sheep_market/requirements.txt
+++ b/demos/dlgr/demos/sheep_market/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/snake/requirements.txt
+++ b/demos/dlgr/demos/snake/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/twentyfortyeight/requirements.txt
+++ b/demos/dlgr/demos/twentyfortyeight/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/dlgr/demos/vox_populi/requirements.txt
+++ b/demos/dlgr/demos/vox_populi/requirements.txt
@@ -1,1 +1,1 @@
-dallinger==6.0.0
+dallinger==6.1.0

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==6.0.0
+Dallinger==6.1.0

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="6.0.0",
+    version="6.1.0",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 6.0.0
+current_version = 6.1.0
 commit = False
 tag = False
 tag_name = v{new_version}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup_args = dict(
     name='dallinger',
     packages=['dallinger', 'dallinger_scripts'],
-    version="6.0.0",
+    version="6.1.0",
     description='Laboratory automation for the behavioral and social sciences',
     url='http://github.com/Dallinger/Dallinger',
     maintainer='Jordan Suchow',

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -495,12 +495,12 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         )
 
     def test_scales_different_dynos(self, dsss, heroku_mock, active_config):
-        active_config.set("dyno_type", u"ignored")
-        active_config.set("dyno_type_web", u"tiny")
-        active_config.set("dyno_type_worker", u"massive")
+        active_config.set("dyno_type", "ignored")
+        active_config.set("dyno_type_web", "tiny")
+        active_config.set("dyno_type_worker", "massive")
         dsss(log=mock.Mock())
         heroku_mock.scale_up_dyno.assert_has_calls(
-            [mock.call("web", 1, u"tiny"), mock.call("worker", 1, u"massive")]
+            [mock.call("web", 1, "tiny"), mock.call("worker", 1, "massive")]
         )
 
     def test_calls_launch(self, dsss, heroku_mock, launch):
@@ -590,7 +590,7 @@ class Test_handle_launch_data(object):
                 json=mock.Mock(return_value={"message": "msg!"}),
                 raise_for_status=mock.Mock(side_effect=HTTPError),
                 status_code=500,
-                text=u"Failure",
+                text="Failure",
             )
             with pytest.raises(HTTPError):
                 handler("/some-launch-url", error=log, delay=0.05, attempts=3)
@@ -743,10 +743,10 @@ class TestDebugServer(object):
             with mock.patch("dallinger.deployment.requests.post") as mock_post:
                 mock_post.return_value = mock.Mock(
                     ok=False,
-                    json=mock.Mock(return_value={"message": u"msg!"}),
+                    json=mock.Mock(return_value={"message": "msg!"}),
                     raise_for_status=mock.Mock(side_effect=HTTPError),
                     status_code=500,
-                    text=u"Failure",
+                    text="Failure",
                 )
                 debugger.run()
 
@@ -755,7 +755,7 @@ class TestDebugServer(object):
             [
                 mock.call("Error accessing /launch (500):\nFailure"),
                 mock.call("Experiment launch failed, check web dyno logs for details."),
-                mock.call(u"msg!"),
+                mock.call("msg!"),
             ]
         )
 


### PR DESCRIPTION

## Description

### [v-6.1.0](https://github.com/Dallinger/Dallinger/tree/v6.0.0) (2020-04-10)
- No longer retry `/launch` route in debug mode. Additional logging for launch retries.
- Allow setting of separate optional `dyno_type_web` and `dyno_type_worker` parameters.
- Regression fix: experiment files with non-ascii characters in file names are again supported
- Documentation for including dependencies on private repositories


