### PR TITLE
Implement graphical network monitoring dashboard

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -201,6 +201,7 @@ def assemble_experiment_temp_dir(config):
     frontend_files = [
         os.path.join("static", "css", "bootstrap.min.css"),
         os.path.join("static", "css", "dallinger.css"),
+        os.path.join("static", "css", "dashboard.css"),
         os.path.join("static", "scripts", "jquery-3.5.1.min.js"),
         os.path.join("static", "scripts", "popper.min.js"),
         os.path.join("static", "scripts", "bootstrap.min.js"),
@@ -220,6 +221,7 @@ def assemble_experiment_temp_dir(config):
         os.path.join("templates", "waiting.html"),
         os.path.join("templates", "login.html"),
         os.path.join("templates", "dashboard_home.html"),
+        os.path.join("templates", "dashboard_monitor.html"),
         os.path.join("templates", "dashboard_mturk.html"),
         os.path.join("templates", "dashboard_wrapper.html"),
         os.path.join("static", "robots.txt"),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -206,6 +206,7 @@ def assemble_experiment_temp_dir(config):
         os.path.join("static", "scripts", "popper.min.js"),
         os.path.join("static", "scripts", "bootstrap.min.js"),
         os.path.join("static", "scripts", "dallinger2.js"),
+        os.path.join("static", "scripts", "network-monitor.js"),
         os.path.join("static", "scripts", "reqwest.min.js"),
         os.path.join("static", "scripts", "require.js"),
         os.path.join("static", "scripts", "reconnecting-websocket.js"),

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -672,7 +672,7 @@ class Experiment(object):
         :param \**kw: arguments passed in from the request
         :returns: An ``OrderedDict()`` mapping panel titles to HTML strings
                   to render in the dashboard sidebar.
-        """
+        """  # noqa
         stats = self.monitoring_statistics(**kw)
         panels = OrderedDict()
         for tab in stats:
@@ -685,7 +685,7 @@ class Experiment(object):
         :param \**kw: arguments passed in from the request
         :returns: An ``OrderedDict()`` mapping panel titles to data structures
                   describing the experiment state.
-        """
+        """  # noqa
         participants = Participant.query
         nodes = Node.query
         infos = Info.query
@@ -710,7 +710,7 @@ class Experiment(object):
         # Count up our networks by role
         network_roles = self.session.query(Network.role, func.count(Network.role))
         network_counts = network_roles.group_by(Network.role).all()
-        failed_networks = network_roles.filter(Network.failed == True)
+        failed_networks = network_roles.filter(Network.failed == True)  # noqa
         failed_counts = dict(failed_networks.group_by(Network.role).all())
         network_stats = {}
         for role, count in network_counts:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -36,6 +36,7 @@ from dallinger.data import load as data_load
 from dallinger.data import find_experiment_export
 from dallinger.data import ingest_zip
 from dallinger.db import init_db, db_url
+from dallinger import models
 from dallinger.models import Network, Node, Info, Transformation, Participant, Vector
 from dallinger.heroku.tools import HerokuApp
 from dallinger.information import Gene, Meme, State
@@ -807,7 +808,7 @@ class Experiment(object):
             "trans": jtransformations,
         }
 
-    def node_visualization_html(self, object_type, id):
+    def node_visualization_html(self, object_type, obj_id):
         """Returns a string with custom HTML visualization for a given object
         referenced by the object base type and id.
 
@@ -818,11 +819,10 @@ class Experiment(object):
 
         :returns: A valid HTML string to be inserted into the monitoring dashboard
         """
-        from dallinger import models
 
         model = getattr(models, object_type, None)
         if model is not None:
-            obj = self.session.query(model).filter(model.id == id).one()
+            obj = self.session.query(model).get(int(obj_id))
             if getattr(obj, "visualization_html", None):
                 return obj.visualization_html
         return ""

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -749,6 +749,9 @@ class Experiment(object):
         jnetworks = [n.__json__() for n in Network.query.all()]
         jinfos = [n.__json__() for n in Info.query.all()]
         jparticipants = [n.__json__() for n in Participant.query.all()]
+        jtransformations = []
+        if kw.get("transformations"):
+            jtransformations = [n.__json__() for n in Transformation.query.all()]
 
         jvectors = [
             {
@@ -766,7 +769,7 @@ class Experiment(object):
             "vectors": jvectors,
             "infos": jinfos,
             "participants": jparticipants,
-            "trans": [],
+            "trans": jtransformations,
         }
 
     @property

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -35,7 +35,7 @@ from dallinger.data import load as data_load
 from dallinger.data import find_experiment_export
 from dallinger.data import ingest_zip
 from dallinger.db import init_db, db_url
-from dallinger.models import Network, Node, Info, Transformation, Participant
+from dallinger.models import Network, Node, Info, Transformation, Participant, Vector
 from dallinger.heroku.tools import HerokuApp
 from dallinger.information import Gene, Meme, State
 from dallinger.nodes import Agent, Source, Environment
@@ -743,6 +743,31 @@ class Experiment(object):
             )
 
         return stats
+
+    def network_structure(self, **kw):
+        jnodes = [n.__json__() for n in Node.query.all()]
+        jnetworks = [n.__json__() for n in Network.query.all()]
+        jinfos = [n.__json__() for n in Info.query.all()]
+        jparticipants = [n.__json__() for n in Participant.query.all()]
+
+        jvectors = [
+            {
+                "origin_id": v.origin_id,
+                "destination_id": v.destination_id,
+                "id": v.id,
+                "failed": v.failed,
+            }
+            for v in Vector.query.all()
+        ]
+
+        return {
+            "networks": jnetworks,
+            "nodes": jnodes,
+            "vectors": jvectors,
+            "infos": jinfos,
+            "participants": jparticipants,
+            "trans": [],
+        }
 
     @property
     def usable_replay_range(self):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -807,6 +807,26 @@ class Experiment(object):
             "trans": jtransformations,
         }
 
+    def node_visualization_html(self, object_type, id):
+        """Returns a string with custom HTML visualization for a given object
+        referenced by the object base type and id.
+
+        :param object_type: The base object class name, e.g. ``Network``, ``Node``, ``Info``, ``Participant``, etc.
+        :type object_type: str
+        :param id: The ``id`` of the object
+        :type id: int
+
+        :returns: A valid HTML string to be inserted into the monitoring dashboard
+        """
+        from dallinger import models
+
+        model = getattr(models, object_type, None)
+        if model is not None:
+            obj = self.session.query(model).filter(model.id == id).one()
+            if getattr(obj, "visualization_html", None):
+                return obj.visualization_html
+        return ""
+
     @property
     def usable_replay_range(self):
         """The range of times that represent the active part of the experiment"""

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -18,6 +18,7 @@ from flask_login import UserMixin
 from flask_login.utils import login_url as make_login_url
 from dallinger import recruiters
 from dallinger.config import get_config
+from .utils import date_handler
 
 
 logger = logging.getLogger(__name__)
@@ -498,7 +499,7 @@ def monitoring():
         "dashboard_monitor.html",
         title="Experiment Monitoring",
         panes=panes,
-        network_structure=json.dumps(network_structure),
+        network_structure=json.dumps(network_structure, default=date_handler),
         net_roles=net_roles,
         net_ids=net_ids,
     )

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -505,11 +505,11 @@ def monitoring():
     )
 
 
-@dashboard.route("/node_details/<object_type>/<id>")
+@dashboard.route("/node_details/<object_type>/<obj_id>")
 @login_required
-def node_details(object_type, id):
+def node_details(object_type, obj_id):
     from dallinger.experiment_server.experiment_server import Experiment, session
 
     exp = Experiment(session)
-    html_data = exp.node_visualization_html(object_type, id)
+    html_data = exp.node_visualization_html(object_type, obj_id)
     return Response(html_data, status=200, mimetype="text/html")

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -482,6 +482,10 @@ def monitoring():
 
     exp = Experiment(session)
     panes = exp.monitoring_panels(**request.args)
+    network_structure = json.dumps(exp.network_structure(**request.args))
     return render_template(
-        "dashboard_monitor.html", title="Experiment Monitoring", panes=panes
+        "dashboard_monitor.html",
+        title="Experiment Monitoring",
+        panes=panes,
+        network_structure=network_structure,
     )

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -502,3 +502,13 @@ def monitoring():
         net_roles=net_roles,
         net_ids=net_ids,
     )
+
+
+@dashboard.route("/node_details/<object_type>/<id>")
+@login_required
+def node_details(object_type, id):
+    from dallinger.experiment_server.experiment_server import Experiment, session
+
+    exp = Experiment(session)
+    html_data = exp.node_visualization_html(object_type, id)
+    return Response(html_data, status=200, mimetype="text/html")

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -215,6 +215,7 @@ dashboard_tabs = DashboardTabs(
         DashboardTab("Home", "dashboard.index"),
         DashboardTab("Heroku", "dashboard.heroku", heroku_children),
         DashboardTab("MTurk", "dashboard.mturk"),
+        DashboardTab("Monitoring", "dashboard.monitoring"),
     ]
 )
 
@@ -472,3 +473,15 @@ def mturk():
     }
 
     return render_template("dashboard_mturk.html", title="MTurk Dashboard", data=data)
+
+
+@dashboard.route("/monitoring")
+@login_required
+def monitoring():
+    from dallinger.experiment_server.experiment_server import Experiment, session
+
+    exp = Experiment(session)
+    panes = exp.monitoring_panels(**request.args)
+    return render_template(
+        "dashboard_monitor.html", title="Experiment Monitoring", panes=panes
+    )

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -482,10 +482,10 @@ def monitoring():
 
     exp = Experiment(session)
     panes = exp.monitoring_panels(**request.args)
-    network_structure = json.dumps(exp.network_structure(**request.args))
+    network_structure = exp.network_structure(**request.args)
     return render_template(
         "dashboard_monitor.html",
         title="Experiment Monitoring",
         panes=panes,
-        network_structure=network_structure,
+        network_structure=json.dumps(network_structure),
     )

--- a/dallinger/frontend/static/css/dashboard.css
+++ b/dallinger/frontend/static/css/dashboard.css
@@ -80,4 +80,11 @@ button#refresh:after {
 #element-details pre {
     width: 100%;
     padding: 10px;
+    margin: 0;
+}
+
+#element-details .node-details {
+    width: 100%;
+    padding: 0 10px;
+    margin: 0 0 10px;
 }

--- a/dallinger/frontend/static/css/dashboard.css
+++ b/dallinger/frontend/static/css/dashboard.css
@@ -1,0 +1,63 @@
+h1 {
+    margin: 20px 0;
+}
+h2 {
+    margin-bottom: 10px;
+}
+.d-flex #sidebar {
+    flex: 0 0 220px;
+    margin-right: 10px;
+}
+.d-flex main {
+    width: auto;
+    max-width: unset !important;
+}
+button#refresh {
+    border: 1px solid black;
+    padding: 10px;
+    width: 100%;
+    text-align: center;
+    font-size: 30px;
+}
+button#refresh:after {
+    content: "\25B6";
+    color: green;
+    padding-left: 15px;
+    font-size: 40px;
+    position: relative;
+    bottom: -5px;
+    line-height: 30px;
+}
+.sidebar-pane h2 {
+    font-size: 22px;
+}
+.sidebar-pane h3 {
+    font-size: 18px;
+}
+.sidebar-pane {
+    background-color: #F6F6F6;
+    margin-top: 10px;
+    padding: 5px 10px;
+}
+.sidebar-pane .sub-pane {
+    background-color: white;
+    border: 1px solid #E6E6E6;
+    padding: 10px;
+    margin-top: 10px;
+}
+.sub-pane ul {
+    padding-left: 20px;
+}
+
+#graph-pane {
+    border: #DDDDDD;
+    padding: 10px;
+    min-height: 400px;
+    width: 100%;
+}
+pre {
+    background-color: #F2F2E9;
+    border: 3px solid #34487E;
+    min-height: 200px;
+    padding: 20px;
+}

--- a/dallinger/frontend/static/css/dashboard.css
+++ b/dallinger/frontend/static/css/dashboard.css
@@ -34,6 +34,24 @@ button#refresh:after {
 .sidebar-pane h3 {
     font-size: 18px;
 }
+.sidebar-pane fieldset {
+    border: 1px solid #B6B6B6;
+    padding: 5px 10px;
+    margin-bottom: 10px;
+}
+.sidebar-pane legend {
+    font-size: 16px;
+    margin-bottom: 3px;
+}
+.sidebar-pane .field {
+    display: flex;
+    align-items: center;
+    margin-bottom: 5px;
+}
+.sidebar-pane .field label {
+    margin-left: 5px;
+    margin-bottom: 0;
+}
 .sidebar-pane {
     background-color: #F6F6F6;
     margin-top: 10px;

--- a/dallinger/frontend/static/css/dashboard.css
+++ b/dallinger/frontend/static/css/dashboard.css
@@ -48,16 +48,18 @@ button#refresh:after {
 .sub-pane ul {
     padding-left: 20px;
 }
-
-#graph-pane {
-    border: #DDDDDD;
-    padding: 10px;
-    min-height: 400px;
+#mynetwork {
     width: 100%;
+    height: 500px;
+    border: 1px solid lightgray;
 }
-pre {
+#element-details {
     background-color: #F2F2E9;
     border: 3px solid #34487E;
     min-height: 200px;
-    padding: 20px;
+    padding: 10px;
+}
+#element-details pre {
+    width: 100%;
+    padding: 10px;
 }

--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -126,14 +126,14 @@
     var i, j, from, to, roles, net, networks_roles, my_role, mclr,
         is_found, roles_colors, clr, rr, gg, bb, count_nodes,
         participant, participant_id, node, msg, mgroup, vector,
-        info, my_node_id, foid_to_infonum, tran, group_fathers,
-        gtitle, min_id, to_min, father;
+        info, my_node_id, tran, group_fathers, gtitle, min_id,
+        to_min, father;
     var nodes = []; // list of all nodes
     var edges = []; // list of all edges
     var list_of_nodes=[]; // list of objects with nodes (not only nodes for example networks)
     var list_of_participants=[]; // list of objects with participants
     var list_of_node_indx=[]; // list of objects with nodes
-    var map_infoid_to_infonum=[]; // map info id  to nodes in the visualization
+    var map_infoid_to_infonum={}; // map info id to nodes in the visualization
 
     /// These lines finds all the roles that involved  in this networks (typically "experiment"/"practice" but this is general)
     roles=[]; // list of unique roles
@@ -251,6 +251,7 @@
         to: list_of_node_indx[to],
         arrows:'to',
         title: ('vector:' + String(vector.id) + ' (' + String(vector.origin_id) + '→' + String(vector.destination_id) + ')'),
+        data: vector,
         color: mclr
       });
     }
@@ -259,7 +260,7 @@
     for (i = 0; i< net_structure.infos.length; i++) {
       info=net_structure.infos[i];
       count_nodes++;
-      foid_to_infonum[info.id]=count_nodes;
+      map_infoid_to_infonum[info.id]=count_nodes;
 
       my_node_id=count_nodes;
       to=my_node_id;
@@ -292,10 +293,10 @@
           from: list_of_node_indx[from],
           to: to,
           dashes:true,
+          data: participant,
           label: "participant: "+ String(participant_id), font: {size:15, color:participant.clr, strokeWidth:0, strokeColor:'yellow',align: 'top'},
           //arrows:'to', dashes:true,
           title: "participant: " + String(participant_id) + '(' + participant.status + ')',
-          data: participant
         });
       } else {
         edges.push({
@@ -464,7 +465,7 @@
       for (var i = 0; i < el_ids.length; i++) {
         var node_id = el_ids[i];
         var node = network.body[el_type.toLowerCase()][node_id];
-        if (node.options.title || node.options.data) {
+        if (node.options.title) {
           if (i == 0) {
             var title_el = document.createElement('h4');
             title_el.textContent = el_type;
@@ -473,6 +474,8 @@
           var sub_title_el = document.createElement('h5');
           sub_title_el.textContent = node.options.title;
           stats.appendChild(sub_title_el);
+        }
+        if (node.options.data) {
           var pre_el = document.createElement('pre');
           pre_el.textContent = JSON.stringify(node.options.data, null, 2);
           stats.appendChild(pre_el);

--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -11,7 +11,7 @@
           direction: 'UD',
           sortMethod: 'directed',
           edgeMinimization: false, // this is super important as of a bug in the library
-          nodeSpacing: 80, // important due to a bug in the library
+          nodeSpacing: 100, // important due to a bug in the library
           treeSpacing: 200 // important due to a bug in the librarys
         }
       },

--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -1,0 +1,492 @@
+(function () {
+  var network = null;
+  var net_structure = window.network_structure || {}; // this  is a container for all the data coming from the route
+
+  /// set display options and groups: this will modify the way the network show up.
+  function getOptions() {
+    var options = {
+      layout: {
+        improvedLayout: false,
+        hierarchical: {
+          direction: 'UD',
+          sortMethod: 'directed',
+          edgeMinimization: false, // this is super important as of a bug in the library
+          nodeSpacing: 80, // important due to a bug in the library
+          treeSpacing: 200 // important due to a bug in the librarys
+        }
+      },
+      interaction: {
+        dragNodes :false,
+        hover: false,
+      },
+      physics: {
+        enabled: false,
+        stabilization:  false
+      },
+      edges: {
+        width: 2
+      },
+
+      groups: {
+
+        failed_nodes: {
+          color: 'red'
+        },
+
+        good_nodes: {
+          font: {
+            color: '#ffffff'
+          }
+        },
+
+        failed_sources: {
+          color: {background:'red', border:'black'},
+          border: 5,
+          size: 30
+        },
+
+        good_sources: {
+          color: {background:'blue', border:'black'},
+          border: 5,
+          size: 30,
+          font: {
+            color: '#ffffff'
+          }
+        },
+
+        group_networks_open: {
+          shape: 'icon',
+          icon: {
+            face: 'FontAwesome',
+            code: '\uf0c2',
+            size: 80,
+            color: 'green'
+          },
+          font: {
+            size: 14,
+            color: 'green'
+          }
+        },
+
+        group_networks_close: {
+          shape: 'icon',
+          icon: {
+            face: 'FontAwesome',
+            code: '\uf0c2',
+            size: 80,
+            color: 'rgb(0,0,100)'
+          },
+          font: {
+            size: 14,
+            color: 'blue'
+          }
+        },
+
+        group_father: {
+          shape: 'icon',
+          icon: {
+            face: 'FontAwesome',
+            code: '\uf0c2',
+            size: 120,
+            color: 'green'
+          },
+          font: {
+            size: 25,
+            color: '#000000'
+          }
+        },
+
+        good_infos: {
+          shape: 'icon',
+          icon: {
+            face: 'FontAwesome',
+            code: '\uf0e5',
+            size: 30,
+            color:'blue'
+          }
+        },
+
+        failed_infos: {
+          shape: 'icon',
+          icon: {
+            face: 'FontAwesome',
+            code: '\uf0e5',
+            size: 30,
+            color: 'red'
+          }
+        }
+      }
+    };
+    return options;
+  }
+
+  /// Draw the network
+  /// This long function is drawing the network structure.
+  function getnNetwork() {
+    var i, j, from, to, roles, net, networks_roles, my_role, mclr,
+        is_found, roles_colors, clr, rr, gg, bb, count_nodes,
+        participant, participant_id, node, msg, mgroup, vector,
+        info, my_node_id, foid_to_infonum, tran, group_fathers,
+        gtitle, min_id, to_min, father;
+    var nodes = []; // list of all nodes
+    var edges = []; // list of all edges
+    var list_of_nodes=[]; // list of objects with nodes (not only nodes for example networks)
+    var list_of_participants=[]; // list of objects with participants
+    var list_of_node_indx=[]; // list of objects with nodes
+    var map_infoid_to_infonum=[]; // map info id  to nodes in the visualization
+
+    /// These lines finds all the roles that involved  in this networks (typically "experiment"/"practice" but this is general)
+    roles=[]; // list of unique roles
+    networks_roles=[]; // the role of each network
+    for (i = 0; i< net_structure.networks.length; i++) {
+      net=net_structure.networks[i];
+      my_role=net.role;
+
+      is_found = false;
+      for (j=0;j<roles.length;j++) {
+        if (my_role.localeCompare(roles[j])==0) {
+          is_found=true;
+          break;
+        }
+
+      }
+      if (!is_found) {
+        networks_roles[net.id]=roles.length;
+        roles[roles.length]=my_role;
+
+      } else{
+        networks_roles[net.id]=j;
+      }
+    }
+
+    roles_colors=[]; ///  assign pseudorandom colors for each role
+    for (j=0;j<roles.length;j++) {
+      rr= 50 + (((j+3)*11557)  % 200); // pseudorandom colors
+      gg= 50 + (((j+3171)*31511) % 200);
+      bb= 50 +  (((j+371)*11517) % 200);
+      clr='rgb('+String(rr)+','+ String(gg)+',' + String (bb)+')';
+      roles_colors[j]=clr;
+    }
+
+    // find all participants and make list, also asigned unique colors to participants
+    for (i = 0; i< net_structure.participants.length; i++) {
+      participant=net_structure.participants[i];
+      participant_id=participant.id;
+      if (participant_id==null) {
+        participant_id=0;
+        participant='<empty>';
+      }
+      rr= 10 +  (((i+357)*2551)  % 150); // pseudorandom colors
+      gg= 30 +  (((i+3571)*2511) % 200);
+      bb= 100 + (((i+3571)*2511) % 150);
+      participant.clr='rgb('+String(rr)+','+ String(gg)+',' + String (bb)+')';
+      list_of_participants[participant_id]=participant;
+    }
+
+    // preperation to push to the graph all nodes from the data
+    count_nodes=0;
+    for (i = 0; i< net_structure.nodes.length; i++) {
+      node=net_structure.nodes[i];
+      count_nodes++; // count the nodes
+      list_of_nodes[node.id]=node;
+      list_of_node_indx[node.id]=count_nodes;
+
+      /// find if the node is a source:
+      if (node.type.toLowerCase().search('source')>0) {
+        msg='source:';
+        if (node.failed) {
+          mgroup='failed_sources';
+        } else {
+          mgroup='good_sources';
+        }
+      } else {
+        msg='';
+        if (node.failed) {
+          mgroup='failed_nodes';
+        } else {
+          mgroup='good_nodes';
+        }
+      }
+
+      // find participant and show it on the graph
+      participant_id=node.participant_id;
+      participant={};
+      if (participant_id==null) {
+        participant_id=0;
+        if (!node.failed) {
+          participant.clr='blue';
+        }
+      } else {
+        participant=list_of_participants[participant_id];
+      }
+      if (node.failed) {
+        clr='red';
+      } else {
+        clr=participant.clr;
+      }
+
+      nodes.push({
+        id: list_of_node_indx[node.id],
+        label: msg+String(node.id),
+        title: (node.type || '') + ':' + String(node.id),
+        color:clr,
+        group: mgroup,
+        font: {align: 'inside'},
+        data: node
+      });
+    }
+
+    // create edges for vectors
+    for (i = 0; i< net_structure.vectors.length; i++) {
+      vector=net_structure.vectors[i];
+      from = vector.origin_id;
+      to = vector.destination_id;
+      if (vector.failed) {
+        mclr='red';
+      } else {
+        mclr='blue';
+      }
+      edges.push({
+        from: list_of_node_indx[from],
+        to: list_of_node_indx[to],
+        arrows:'to',
+        title: ('vector:' + String(vector.id) + ' (' + String(vector.origin_id) + '→' + String(vector.destination_id) + ')'),
+        color: mclr
+      });
+    }
+
+    // now pushes infos
+    for (i = 0; i< net_structure.infos.length; i++) {
+      info=net_structure.infos[i];
+      count_nodes++;
+      foid_to_infonum[info.id]=count_nodes;
+
+      my_node_id=count_nodes;
+      to=my_node_id;
+      from=info.origin_id;
+      participant_id=list_of_nodes[from].participant_id;
+      participant={};
+      if (participant_id==null) {
+        participant_id=0;
+        participant.clr='black';
+        participant='<empty>';
+      } else {
+        participant=list_of_participants[participant_id];
+      }
+      if (info.failed) {
+        mgroup='failed_infos';
+      } else {
+        mgroup='good_infos';
+      }
+      nodes.push({
+        id: my_node_id,
+        label: "info:"+ String(info.id), dashes:true,
+        title: "info: " + info.type + ':' + String(info.id),
+        group: mgroup,
+        font: {align: 'inside'},
+        data: info
+
+      });
+      if (participant_id>0) {
+        edges.push({
+          from: list_of_node_indx[from],
+          to: to,
+          dashes:true,
+          label: "participant: "+ String(participant_id), font: {size:15, color:participant.clr, strokeWidth:0, strokeColor:'yellow',align: 'top'},
+          //arrows:'to', dashes:true,
+          title: "participant: " + String(participant_id) + '(' + participant.status + ')',
+          data: participant
+        });
+      } else {
+        edges.push({
+          from: list_of_node_indx[from],
+          to: to,
+          dashes:true
+        });
+      }
+    }
+
+    // create edges for transformation
+    for (i = 0; i< net_structure.trans.length; i++) {
+      tran=net_structure.trans[i];
+      from = tran.origin_id;
+      to = tran.destination_id;
+      var from_n=map_infoid_to_infonum[from];
+      var to_n=map_infoid_to_infonum[to];
+
+      if (tran.failed) {
+        rr=200;
+        gg=100;
+        bb=100;
+        mclr='rgb('+String(rr)+','+ String(gg)+',' + String (bb)+')';
+      } else {
+        //mclr='black'
+        rr=200;
+        gg=200;
+        bb=200;
+        mclr='rgb('+String(rr)+','+ String(gg)+',' + String (bb)+')';
+      }
+      edges.push({
+        from: from_n,
+        to: to_n,
+        arrows:'to',
+        dashes:true,
+        title: 'transformation:' + String(tran.id) + '(' + String(tran.info_in_id) + '→' +  String(tran.info_out_id) + ')',
+        color: mclr,
+        data: tran
+      });
+    }
+
+    // This is needed to group networks according to roles
+    // we used "father" for all the network and connect it
+    // so the visualization will group things according to their role
+    group_fathers=[];
+    for (j=0;j<roles.length;j++) {
+      //group fathers of all practice networks
+      count_nodes++;
+      my_node_id=count_nodes;
+      clr=roles_colors[j];
+      gtitle=roles[j] + ' networks';
+
+      nodes.push({
+        id: my_node_id,
+        label: gtitle,
+        title: gtitle,
+        group: 'group_father',
+        font: {align: 'inside'},
+        icon: {
+          face: 'FontAwesome',
+          code: '\uf0c2',
+          size: 120,
+          color: clr
+        }
+      });
+      group_fathers[j]=my_node_id;
+    }
+
+
+    //connect network to correct source (or father)
+    for (i = 0; i< net_structure.networks.length; i++) {
+      net=net_structure.networks[i];
+      count_nodes++;
+      my_node_id=count_nodes;
+      from=my_node_id;
+      is_found=false;
+
+      min_id=99999999;
+      // find the node with minimal id that belong to this network
+      for (j = 0; j< net_structure.nodes.length; j++) {
+        node=net_structure.nodes[j];
+        if ((node.id<=min_id) && (node.network_id==net.id))  {
+          min_id=node.id;
+          to_min=list_of_node_indx[node.id];
+
+        }
+      }
+
+      // find the source that belong to this network
+      for (j = 0; j< net_structure.nodes.length; j++) {
+        node=net_structure.nodes[j];
+        if ((node.type.toLowerCase().search('source')>0) && (node.network_id==net.id))  {
+          is_found=true;
+          to=list_of_node_indx[node.id];
+          break;
+        }
+      }
+
+      if (!is_found) {
+        to=to_min; // use a default strategy that the source is the minimal id
+        //to=my_node_id
+      }
+
+      if (net.property1=='True') { // assume that there is a feature in property1 that decide if a network is open or close
+        mgroup='group_networks_open';
+      } else {
+        mgroup='group_networks_close';
+      }
+
+      father=group_fathers[networks_roles[net.id]]; // find father network
+      clr=roles_colors[networks_roles[net.id]];
+      nodes.push({
+        id: my_node_id,
+        label: "network:"+ String(net.id),
+        title: "network: " + net.type + ':' + String(net.id) + ' (' + net.role + ')',
+        group: mgroup,
+        font: {align: 'inside'},
+        icon: {
+          face: 'FontAwesome',
+          code: '\uf0c2',
+          color: clr
+        },
+        data: net
+
+      });
+      edges.push({
+        from: from,
+        to: to,
+        color: 'black'
+      });
+      //connect network to father
+      edges.push({
+        from: father,
+        to: from,
+        color: 'white',
+        font: {align: 'inside'}
+      });
+
+    }
+
+    return {nodes:nodes, edges:edges};
+  }
+
+  function destroy() {
+    if (network !== null) {
+      network.destroy();
+      network = null;
+    }
+  }
+
+  function draw() {
+
+    destroy();
+
+    var data = getnNetwork();
+
+    // create a network
+    var container = document.getElementById('mynetwork');
+
+    var options=getOptions();
+    network = new window.vis.Network(container, data, options);
+
+    var stats = document.getElementById('element-details');
+
+    var append_stats = function (el_ids, el_type) {
+      for (var i = 0; i < el_ids.length; i++) {
+        var node_id = el_ids[i];
+        var node = network.body[el_type.toLowerCase()][node_id];
+        if (node.options.title || node.options.data) {
+          if (i == 0) {
+            var title_el = document.createElement('h4');
+            title_el.textContent = el_type;
+            stats.appendChild(title_el);
+          }
+          var sub_title_el = document.createElement('h5');
+          sub_title_el.textContent = node.options.title;
+          stats.appendChild(sub_title_el);
+          var pre_el = document.createElement('pre');
+          pre_el.textContent = JSON.stringify(node.options.data, null, 2);
+          stats.appendChild(pre_el);
+        }
+      }
+    };
+    // add event listeners
+    network.on('select', function (params) {
+      stats.textContent = '';
+      append_stats(params.nodes, 'Nodes');
+      append_stats(params.edges, 'Edges');
+    });
+  }
+
+  window.render_network_monitor = draw;
+  window.addEventListener('load', window.render_network_monitor);
+})();

--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -479,6 +479,12 @@
           var pre_el = document.createElement('pre');
           pre_el.textContent = JSON.stringify(node.options.data, null, 2);
           stats.appendChild(pre_el);
+          if (node.options.data.id && node.options.data.object_type) {
+            var custom_node = document.createElement('div');
+            custom_node.classList.add('node-details');
+            stats.appendChild(custom_node);
+            $(custom_node).load('/dashboard/node_details/' + node.options.data.object_type + '/' + String(node.options.data.id));
+          }
         }
       }
     };

--- a/dallinger/frontend/templates/base/dashboard.html
+++ b/dallinger/frontend/templates/base/dashboard.html
@@ -6,6 +6,7 @@
         <title>{% block title %}{{title}} - {{app_id}} Dashboard{% endblock %}</title>
         {% block replace_stylesheets %}
           <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
+          <link rel="stylesheet" href="/static/css/dashboard.css" type="text/css">
           {% block stylesheets %}
           {% endblock %}
         {% endblock %}

--- a/dallinger/frontend/templates/dashboard_home.html
+++ b/dallinger/frontend/templates/dashboard_home.html
@@ -1,9 +1,7 @@
 {% extends "base/dashboard.html" %}
 
 {% block body %}
-<h1>Welcome User: "{{ current_user.get_id() }}"!</h1>
-
-<h2>Experiment Configuration</h2>
+<h1>Experiment Configuration</h1>
 <p>The active <a href="http://docs.dallinger.io/en/latest/configuration.html">configuration</a>,
     assembled from your configuration files, Dallinger defaults, and any explicit overrides.
 </p>

--- a/dallinger/frontend/templates/dashboard_monitor.html
+++ b/dallinger/frontend/templates/dashboard_monitor.html
@@ -1,5 +1,8 @@
 {% extends "base/dashboard.html" %}
-
+{% block stylesheets %}
+  <link rel="stylesheet" href="http://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css"/>
+  <link href="https://unpkg.com/vis@4.17.0/dist/vis-network.min.css" rel="stylesheet" type="text/css"/>
+{% endblock %}
 {% block body %}
 <h1>{{ title }}</h1>
 <div id="monitor-wrapper" class="d-flex justify-content-between align-items-stretch">
@@ -23,13 +26,13 @@
     </div>
   </aside>
   <main class="flex-fill">
-    <section id="graph-pane">
+    <section id="mynetwork">
       <h2>Graph</h2>
     </section>
     <section id="details-pane">
       <h2>Details</h2>
-      <pre>
-      </pre>
+      <div id="element-details">
+      </div>
     </section>
   </main>
   </div>
@@ -40,6 +43,9 @@
     $('#settings-pane input').on('change', function() {
       $(this).parent('form').submit();
     });
+    window.network_structure = JSON.parse('{{ network_structure | safe }}');
   </script>
-{% endblock %}
+  <script src="https://unpkg.com/vis@4.17.0/dist/vis.min.js"></script>
+  <script src="/static/scripts/network-monitor.js"></script>
 
+{% endblock %}

--- a/dallinger/frontend/templates/dashboard_monitor.html
+++ b/dallinger/frontend/templates/dashboard_monitor.html
@@ -1,0 +1,45 @@
+{% extends "base/dashboard.html" %}
+
+{% block body %}
+<h1>{{ title }}</h1>
+<div id="monitor-wrapper" class="d-flex justify-content-between align-items-stretch">
+  <aside id="sidebar">
+    <button id="refresh" onclick="window.location.reload();">Refresh</button>
+    <div id="statistics-pane" class="sidebar-pane">
+      <h2>Statistics</h2>
+      {% for pane in panes %}
+        <div class="sub-pane">
+          <h3>{{ pane }}</h3>
+          {{ panes[pane]|safe }}
+        </div>
+      {% endfor %}
+    </div>
+    <div id="settings-pane" class="sidebar-pane">
+      <h2>Settings</h2>
+      <form method="GET">
+        <input name="transformations" type="checkbox" {{ "checked" if request.args.get("transformations") else "" }}/>
+        <label for="transformations">Show transformations</label>
+      </form>
+    </div>
+  </aside>
+  <main class="flex-fill">
+    <section id="graph-pane">
+      <h2>Graph</h2>
+    </section>
+    <section id="details-pane">
+      <h2>Details</h2>
+      <pre>
+      </pre>
+    </section>
+  </main>
+  </div>
+{% endblock %}
+{% block libs %}
+  {{ super() }}
+  <script>
+    $('#settings-pane input').on('change', function() {
+      $(this).parent('form').submit();
+    });
+  </script>
+{% endblock %}
+

--- a/dallinger/frontend/templates/dashboard_monitor.html
+++ b/dallinger/frontend/templates/dashboard_monitor.html
@@ -20,8 +20,36 @@
     <div id="settings-pane" class="sidebar-pane">
       <h2>Settings</h2>
       <form method="GET">
-        <input name="transformations" type="checkbox" {{ "checked" if request.args.get("transformations") else "" }}/>
-        <label for="transformations">Show transformations</label>
+        {% if net_roles|length > 1 %}
+        <fieldset id="network-roles">
+          <legend>Network Roles</legend>
+          {% for val, count in net_roles %}
+          <div class="field">
+            <input id="val-{{ val }}" type="checkbox" name="network_roles" value="{{ val }}" {{ "checked" if (not request.args.get("network_roles") or val in request.args.getlist("network_roles")) else "" }} />
+            <label for="val-{{ val }}">{{ val }} (count: {{ count }})</label>
+          </div>
+          {% endfor %}
+        </fieldset>
+        {% endif %}
+        {% if net_ids|length > 1 %}
+        <fieldset id="network-ids">
+          <legend>Network Ids</legend>
+          {% for val in net_ids %}
+          <div class="field">
+            <input id="val-{{ val }}" type="checkbox" name="network_ids" value="{{ val }}" {{ "checked" if (not request.args.get("network_ids") or val|string in request.args.getlist("network_ids")) else "" }} />
+            <label for="val-{{ val }}">{{ val }}</label>
+          </div>
+          {% endfor %}
+        </fieldset>
+        {% endif %}
+        <div class="field">
+          <input name="collapsed" type="checkbox" {{ "checked" if request.args.get("collapsed") else "" }}/>
+          <label for="transformations">Collapse (networks and sources only)</label>
+        </div>
+        <div class="field">
+          <input name="transformations" type="checkbox" {{ "checked" if request.args.get("transformations") else "" }}/>
+          <label for="transformations">Show transformations</label>
+        </div>
       </form>
     </div>
   </aside>
@@ -41,7 +69,7 @@
   {{ super() }}
   <script>
     $('#settings-pane input').on('change', function() {
-      $(this).parent('form').submit();
+      $(this).parents('form').submit();
     });
     window.network_structure = {{ network_structure | safe }};
   </script>

--- a/dallinger/frontend/templates/dashboard_monitor.html
+++ b/dallinger/frontend/templates/dashboard_monitor.html
@@ -43,7 +43,7 @@
     $('#settings-pane input').on('change', function() {
       $(this).parent('form').submit();
     });
-    window.network_structure = JSON.parse('{{ network_structure | safe }}');
+    window.network_structure = {{ network_structure | safe }};
   </script>
   <script src="https://unpkg.com/vis@4.17.0/dist/vis.min.js"></script>
   <script src="/static/scripts/network-monitor.js"></script>

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -189,10 +189,11 @@ class Participant(Base, SharedMixin):
             "assignment_id": self.assignment_id,
             "hit_id": self.hit_id,
             "mode": self.mode,
-            "end_time": self.end_time,
+            "end_time": self.end_time.isoformat() if self.end_time else None,
             "base_pay": self.base_pay,
             "bonus": self.bonus,
             "status": self.status,
+            "object_type": "Participant",
         }
 
     def nodes(self, type=None, failed=False):
@@ -341,6 +342,7 @@ class Question(Base, SharedMixin):
             "participant_id": self.participant_id,
             "question": self.question,
             "response": self.response,
+            "object_type": "Question",
         }
 
 
@@ -388,6 +390,7 @@ class Network(Base, SharedMixin):
             "max_size": self.max_size,
             "full": self.full,
             "role": self.role,
+            "object_type": "Network",
         }
 
     """ ###################################
@@ -639,6 +642,7 @@ class Node(Base, SharedMixin):
             "type": self.type,
             "network_id": self.network_id,
             "participant_id": self.participant_id,
+            "object_type": "Node",
         }
 
     """ ###################################
@@ -1388,6 +1392,7 @@ class Vector(Base, SharedMixin):
             "origin_id": self.origin_id,
             "destination_id": self.destination_id,
             "network_id": self.network_id,
+            "object_type": "Vector",
         }
 
     """#######################################
@@ -1489,6 +1494,7 @@ class Info(Base, SharedMixin):
             "origin_id": self.origin_id,
             "network_id": self.network_id,
             "contents": self.contents,
+            "object_type": "Info",
         }
 
     def fail(self):
@@ -1676,8 +1682,11 @@ class Transmission(Base, SharedMixin):
             "destination_id": self.destination_id,
             "info_id": self.info_id,
             "network_id": self.network_id,
-            "receive_time": self.receive_time,
+            "receive_time": self.receive_time.isoformat()
+            if self.receive_time
+            else None,
             "status": self.status,
+            "object_type": "Transmission",
         }
 
     def fail(self):
@@ -1768,6 +1777,7 @@ class Transformation(Base, SharedMixin):
             "info_out_id": self.info_out_id,
             "node_id": self.node_id,
             "network_id": self.network_id,
+            "object_type": "Transformation",
         }
 
     def fail(self):

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -66,9 +66,13 @@ class SharedMixin(object):
         """Return json description of a participant."""
         model_data = {
             "id": self.id,
-            "creation_time": self.creation_time,
+            "creation_time": self.creation_time.isoformat()
+            if self.creation_time
+            else None,
             "failed": self.failed,
-            "time_of_death": self.time_of_death,
+            "time_of_death": self.time_of_death.isoformat()
+            if self.time_of_death
+            else None,
             "property1": self.property1,
             "property2": self.property2,
             "property3": self.property3,

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -59,6 +59,11 @@ class SharedMixin(object):
     #: a generic column for storing structured JSON data
     details = Column(JSONB, nullable=False, server_default="{}", default=lambda: {})
 
+    #: HTML string to display in visualizations (e.g. the Network
+    #: Montioring Dashboard). You can override this with a dynamic ``@property``
+    #: on sub-classes.
+    visualization_html = ""
+
     def json_data(self):
         return {}
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -71,13 +71,9 @@ class SharedMixin(object):
         """Return json description of a participant."""
         model_data = {
             "id": self.id,
-            "creation_time": self.creation_time.isoformat()
-            if self.creation_time
-            else None,
+            "creation_time": self.creation_time,
             "failed": self.failed,
-            "time_of_death": self.time_of_death.isoformat()
-            if self.time_of_death
-            else None,
+            "time_of_death": self.time_of_death,
             "property1": self.property1,
             "property2": self.property2,
             "property3": self.property3,
@@ -194,7 +190,7 @@ class Participant(Base, SharedMixin):
             "assignment_id": self.assignment_id,
             "hit_id": self.hit_id,
             "mode": self.mode,
-            "end_time": self.end_time.isoformat() if self.end_time else None,
+            "end_time": self.end_time,
             "base_pay": self.base_pay,
             "bonus": self.bonus,
             "status": self.status,
@@ -1687,9 +1683,7 @@ class Transmission(Base, SharedMixin):
             "destination_id": self.destination_id,
             "info_id": self.info_id,
             "network_id": self.network_id,
-            "receive_time": self.receive_time.isoformat()
-            if self.receive_time
-            else None,
+            "receive_time": self.receive_time,
             "status": self.status,
             "object_type": "Transmission",
         }

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -321,6 +321,11 @@ def a(db_session):
             # nodes.Source is intended to be abstract
             return self._build(nodes.RandomBinaryStringSource, defaults)
 
+        def transformation(self, **kw):
+            defaults = {}
+            defaults.update(kw)
+            return self._build(models.Transformation, defaults)
+
         def _build(self, klass, attrs):
             # Some of our default values are factories:
             for k, v in attrs.items():

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -236,15 +236,15 @@ def struct_to_html(data):
     elif isinstance(data, dict):
         if len(data) == 2 and "count" in data and "failed" in data:
             if data["count"]:
-                failed = float(data["failed"]) / data["count"] * 100
+                failed_percentage = float(data["failed"]) / data["count"] * 100
             else:
-                failed = 0
+                failed_percentage = 0
             value = "{} total, {} failed ({:.1f}%)".format(
-                data["count"], data["failed"], failed
+                data["count"], data["failed"], failed_percentage
             )
-            if failed == 100:
+            if failed_percentage == 100:
                 value = '<span class="all-failures">{}</span>'.format(value)
-            elif failed > 0:
+            elif failed_percentage > 0:
                 value = '<span class="some-failures">{}</span>'.format(value)
             elif data["count"]:
                 value = '<span class="no-failures">{}</span>'.format(value)

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -226,3 +226,19 @@ def wrap_subprocess_call(func, wrap_stdout=True):
 check_call = wrap_subprocess_call(subprocess.check_call)
 call = wrap_subprocess_call(subprocess.call)
 check_output = wrap_subprocess_call(subprocess.check_output, wrap_stdout=False)
+
+
+def struct_to_html(data):
+    parts = ["<ul>"]
+    if isinstance(data, (list, tuple)):
+        for i in data:
+            parts.append(struct_to_html(i))
+    elif isinstance(data, dict):
+        for k in data:
+            item = struct_to_html(data[k])
+            parts.append("<li>{}: {}</li>".format(k, item))
+    else:
+        return str(data)
+
+    parts.append("</ul>")
+    return "\n".join(parts)

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -234,6 +234,22 @@ def struct_to_html(data):
         for i in data:
             parts.append(struct_to_html(i))
     elif isinstance(data, dict):
+        if len(data) == 2 and "count" in data and "failed" in data:
+            if data["count"]:
+                failed = float(data["failed"]) / data["count"] * 100
+            else:
+                failed = 0
+            value = "{} total, {} failed ({:.1f}%)".format(
+                data["count"], data["failed"], failed
+            )
+            if failed == 100:
+                value = '<span class="all-failures">{}</span>'.format(value)
+            elif failed > 0:
+                value = '<span class="some-failures">{}</span>'.format(value)
+            elif data["count"]:
+                value = '<span class="no-failures">{}</span>'.format(value)
+            return value
+
         for k in data:
             item = struct_to_html(data[k])
             parts.append("<li>{}: {}</li>".format(k, item))

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -63,6 +63,9 @@ columns that are common across tables:
 .. autoattribute:: dallinger.models.SharedMixin.time_of_death
     :annotation:
 
+.. autoattribute:: dallinger.models.SharedMixin.visualization_html
+    :annotation:
+
 Network
 -------
 

--- a/docs/source/monitoring_a_live_experiment.rst
+++ b/docs/source/monitoring_a_live_experiment.rst
@@ -59,7 +59,7 @@ could add the following code to add a "My Experiment" tab to the dashboard:
   dashboard_tabs.insert("My Experiment", "my-experiment")
 
 
-The dashboard also supports nested tab/menus using the :attr:`~dallinger.experiment_server.dashboard.DashboardTabs` object:
+The dashboard also supports nested tab/menus using the :attr:`~dallinger.experiment_server.dashboard.DashboardTab` object:
 
 .. code-block:: python
 

--- a/docs/source/monitoring_a_live_experiment.rst
+++ b/docs/source/monitoring_a_live_experiment.rst
@@ -91,11 +91,27 @@ available tabs on your experiment's dashboard:
 
     .. automethod:: remove
 
-The ``DashboardTab`` object used by the ``insert_tab`` methods provide the following API:
+
+The ``DashboardTab`` object used by the various ``insert_tab`` methods provide
+the following API:
 
 .. autoclass:: DashboardTab
 
     .. automethod:: __init__
+
+
+The dashboard monitoring view can be extended by adding panes to the sidebar or
+extending the existing panes. This can be done customizing the ``monitoring_panels``
+and/or ``monitoring_statistics`` methods of your experiment class:
+
+.. module:: dallinger.experiment
+
+.. autoclass:: Experiment
+   :noindex:
+
+    .. automethod:: monitoring_panels
+
+    .. automethod:: monitoring_statistics
 
 
 Papertrail

--- a/docs/source/monitoring_a_live_experiment.rst
+++ b/docs/source/monitoring_a_live_experiment.rst
@@ -59,7 +59,7 @@ could add the following code to add a "My Experiment" tab to the dashboard:
   dashboard_tabs.insert("My Experiment", "my-experiment")
 
 
-The dashboard also supports nested tab/menus using the ``DashboardTab`` object:
+The dashboard also supports nested tab/menus using the :attr:`~dallinger.experiment_server.dashboard.DashboardTabs` object:
 
 .. code-block:: python
 
@@ -92,8 +92,7 @@ available tabs on your experiment's dashboard:
     .. automethod:: remove
 
 
-The ``DashboardTab`` object used by the various ``insert_tab`` methods provide
-the following API:
+The :attr:`~dallinger.experiment_server.dashboard.DashboardTab` object used by the various ``insert_tab*`` methods provide the following API:
 
 .. autoclass:: DashboardTab
 
@@ -101,8 +100,13 @@ the following API:
 
 
 The dashboard monitoring view can be extended by adding panes to the sidebar or
-extending the existing panes. This can be done customizing the ``monitoring_panels``
-and/or ``monitoring_statistics`` methods of your experiment class:
+extending the existing panes. This can be done customizing the
+:attr:`~dallinger.experiment.Experiment.monitoring_panels` and/or
+:attr:`~dallinger.experiment.Experiment.monitoring_statistics` methods of
+your experiment class. Additionally, you can customize the display of the selected
+nodes customizing the :attr:`~dallinger.experiment.Experiment.node_visualization_html`
+method, or the :attr:`~dallinger.models.SharedMixin.visualization_html` property on your
+model class:
 
 .. module:: dallinger.experiment
 
@@ -112,6 +116,8 @@ and/or ``monitoring_statistics`` methods of your experiment class:
     .. automethod:: monitoring_panels
 
     .. automethod:: monitoring_statistics
+
+    .. automethod:: node_visualization_html
 
 
 Papertrail

--- a/tests/experiment/templates/dashboard_home.html
+++ b/tests/experiment/templates/dashboard_home.html
@@ -1,0 +1,5 @@
+{% extends "base/dashboard.html" %}
+
+{% block body %}
+<h1>Welcome User: "{{ current_user.get_id() }}"!</h1>
+{% endblock %}

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -410,7 +410,7 @@ class TestDashboardMonitorRoute(object):
 
 
 @pytest.mark.usefixtures("experiment_dir_merged", "webapp")
-class TestDashboardNetworkStructure(object):
+class TestDashboardNetworkInfo(object):
     @pytest.fixture
     def multinetwork_experiment(self, a, db_session):
         from dallinger.experiment_server.experiment_server import Experiment
@@ -545,3 +545,13 @@ class TestDashboardNetworkStructure(object):
         assert len(network_structure["infos"]) == 0
         assert len(network_structure["participants"]) == 1
         assert len(network_structure["trans"]) == 0
+
+    def test_custom_node_html(self, multinetwork_experiment):
+        custom_html = multinetwork_experiment.node_visualization_html("Info", 1)
+        assert custom_html == ""
+        bogus_content = multinetwork_experiment.node_visualization_html("Bogus", 1)
+        assert bogus_content == ""
+        # The HTML is customized using a property on the model class
+        with mock.patch("dallinger.nodes.Source.visualization_html") as node_html:
+            custom_html = multinetwork_experiment.node_visualization_html("Node", 1)
+            assert custom_html is node_html

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -373,3 +373,17 @@ class TestDashboardMTurkRoutes(object):
         assert "This experiment does not use the MTurk Recruiter." in resp.data.decode(
             "utf8"
         )
+
+
+@pytest.mark.usefixtures("experiment_dir_merged")
+class TestDashboardMonitorRoute(object):
+    def test_requires_login(self, webapp):
+        assert webapp.get("/dashboard/monitoring").status_code == 401
+
+    def test_has_statistics(self, logged_in):
+        resp = logged_in.get("/dashboard/monitoring")
+
+        assert resp.status_code == 200
+        resp_text = resp.data.decode("utf8")
+        assert "<h3>Participants</h3>" in resp_text
+        assert "<li>working: 0</li>" in resp_text

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,7 +97,7 @@ class TestModels(object):
             "max_size": 1e6,
             "full": False,
             "role": "default",
-            "creation_time": net.creation_time.isoformat(),
+            "creation_time": net.creation_time,
             "failed": False,
             "time_of_death": None,
             "property1": None,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,7 +97,7 @@ class TestModels(object):
             "max_size": 1e6,
             "full": False,
             "role": "default",
-            "creation_time": net.creation_time,
+            "creation_time": net.creation_time.isoformat(),
             "failed": False,
             "time_of_death": None,
             "property1": None,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -106,6 +106,7 @@ class TestModels(object):
             "property4": None,
             "property5": None,
             "details": {},
+            "object_type": "Network",
         }
 
         # test nodes()


### PR DESCRIPTION
## Description
This PR integrates the psynet network monitor into the dashboard. It essentially reuses the code as-is, with some code cleanup. The node details have been moved into the Details pane, and transformations are only shown if requested. When a node is clicked, and AJAX request is made to retrieve a custom HTML visualization for the node. By default this is looked up using a `visualization_html` property on the Model class, but the mechanism can be customized further using the `Experiment.node_visualization_html` method which looks up that property by default.

Filters are in place to limit the view to networks and sources only, specific networks only, specific network roles only, and to show/hide all transformations.

Documentation has been updated to reflect the customization mechanisms.

## Motivation and Context
See issues #2219, #2220, #2221

## How Has This Been Tested?
* Manual testing with the psynet `non_adaptive` demo and `Bartlett1932` (when using the psynet demo, it's best to remove the `bootstrap.min.js` from the experiment and allow the newer version from Dallinger to be copied in).
* Automated tests for new methods and routes.


