### PR TITLE
Revert accidental dependency on dallinger git commit

### DIFF
--- a/demos/dlgr/demos/bartlett1932/requirements.txt
+++ b/demos/dlgr/demos/bartlett1932/requirements.txt
@@ -1,2 +1,1 @@
-#dallinger==6.3.0
--e git://github.com/Dallinger/Dallinger.git@feature/2188-dashboard-wrapper#egg=dallinger
+dallinger==6.3.0


### PR DESCRIPTION
## Description
Fixes #2250

It would be nice to be able to override the required version of dallinger without changing demo requirements.txt files, since this is an easy accidental commit to make. Or maybe a commit hook could catch these....