### PR TITLE
Fix sandbox password issue

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+import codecs
 import json
 import os
 import pkg_resources
@@ -491,6 +492,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         "whimsical": config["whimsical"],
         "DASHBOARD_PASSWORD": fake.password(length=20, special_chars=False),
         "DASHBOARD_USER": config.get("dashboard_user", "admin"),
+        "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex"),
     }
 
     # Set up the preferred class as an environment variable, if one is set
@@ -677,6 +679,7 @@ class DebugDeployment(HerokuLocalDeployment):
         self.environ = {
             "DASHBOARD_PASSWORD": fake.password(special_chars=False),
             "DASHBOARD_USER": self.exp_config.get("dashboard_user", "admin"),
+            "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex"),
         }
 
     def configure(self):

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -60,6 +60,9 @@ app = Flask("Experiment_Server")
 
 @app.before_first_request
 def _config():
+    app.config["SECRET_KEY"] = os.environ.get(
+        "FLASK_SECRET_KEY", "THIS IS A BAD SECRET"
+    )
     config = get_config()
     if not config.ready:
         config.load()
@@ -92,7 +95,6 @@ login.login_view = "dashboard.login"
 login.request_loader(dashboard.load_user_from_request)
 login.user_loader(dashboard.load_user)
 login.unauthorized_handler(dashboard.unauthorized)
-app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
 app.config["dashboard_tabs"] = dashboard.dashboard_tabs
 
 """Basic routes."""

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -60,9 +60,7 @@ app = Flask("Experiment_Server")
 
 @app.before_first_request
 def _config():
-    app.config["SECRET_KEY"] = os.environ.get(
-        "FLASK_SECRET_KEY", "THIS IS A BAD SECRET"
-    )
+    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
     config = get_config()
     if not config.ready:
         config.load()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1,6 +1,5 @@
 """ This module provides the backend Flask server that serves an experiment. """
 
-import codecs
 from datetime import datetime
 import gevent
 from json import dumps
@@ -93,7 +92,7 @@ login.login_view = "dashboard.login"
 login.request_loader(dashboard.load_user_from_request)
 login.user_loader(dashboard.load_user)
 login.unauthorized_handler(dashboard.unauthorized)
-app.config["SECRET_KEY"] = codecs.encode(os.urandom(16), "hex")
+app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
 app.config["dashboard_tabs"] = dashboard.dashboard_tabs
 
 """Basic routes."""

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -297,7 +297,7 @@ class TestExperimentFilesSource(object):
 @pytest.mark.usefixtures("bartlett_dir", "active_config", "reset_sys_modules")
 class TestSetupExperiment(object):
     @pytest.fixture
-    def setup_experiment(self):
+    def setup_experiment(self, env):
         from dallinger.deployment import setup_experiment as subject
 
         return subject

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -558,6 +558,7 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
             aws_secret_access_key="fake aws secret",
             DASHBOARD_USER="admin",
             DASHBOARD_PASSWORD=mock.ANY,  # password is random
+            FLASK_SECRET_KEY=mock.ANY,  # password is random
             smtp_password="fake email password",
             smtp_username="fake email username",
             whimsical=True,

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -57,11 +57,9 @@ class TestAppConfiguration(object):
                 assert server.options["workers"] == u"2"
 
     def test_flask_secret_loaded_from_environ(self, webapp):
-        import os
-
-        os.environ["FLASK_SECRET_KEY"] = "A TEST SECRET KEY"
-        webapp.get("/")
-        assert webapp.application.config["SECRET_KEY"] == "A TEST SECRET KEY"
+        with mock.patch("os.environ", {"FLASK_SECRET_KEY": "A TEST SECRET KEY"}):
+            webapp.get("/")
+            assert webapp.application.config["SECRET_KEY"] == "A TEST SECRET KEY"
 
 
 @pytest.mark.usefixtures("experiment_dir")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -56,6 +56,13 @@ class TestAppConfiguration(object):
                 server.load_user_config()
                 assert server.options["workers"] == u"2"
 
+    def test_flask_secret_loaded_from_environ(self, webapp):
+        import os
+
+        os.environ["FLASK_SECRET_KEY"] = "A TEST SECRET KEY"
+        webapp.get("/")
+        assert webapp.application.config["SECRET_KEY"] == "A TEST SECRET KEY"
+
 
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow


### PR DESCRIPTION
Switch to determining the Flask secret at launch time and setting it via the environment. This seems to fix the sandbox login issues reported in #2251

## Description
The flask `SECRET_KEY` is now determined based on environment variables set during launch (like the password), and read before serving requests, rather than being generated experiment server import time. That should allow the CSRF validation to operate reliably.

## Motivation and Context
Fix for #2251

## How Has This Been Tested?
Tested via sandbox deploy
