### PR TITLE
Fix broken Travis builds resulting from node version change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ services:
 before_install:
   - rm -rf ~/.local/share/heroku
   - rvm install 2.6.2
+  - nvm install 10
   - pip install --upgrade setuptools pip wheel
 install:
   - pip install tox==3.1.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ services:
 before_install:
   - rm -rf ~/.local/share/heroku
   - rvm install 2.6.2
-  - nvm install 10
+  - nvm install 10  # OS node version became incompatible in 7/2020, so now we choose explicitly
   - pip install --upgrade setuptools pip wheel
 install:
   - pip install tox==3.1.2


### PR DESCRIPTION
## Description
Travis builds are breaking because the default node version is now incompatible. This ensures a compatible node version.