### PR TITLE
Issues/2270 heroku id mismatch

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -48,6 +48,7 @@ default_keys = (
     ("dyno_type_worker", six.text_type, []),
     ("EXPERIMENT_CLASS_NAME", six.text_type, []),
     ("group_name", six.text_type, []),
+    ("heroku_app_id_root", six.text_type, []),
     ("heroku_auth_token", six.text_type, [], True),
     ("heroku_python_version", six.text_type, []),
     ("heroku_team", six.text_type, ["team"]),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -439,12 +439,14 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         config.load()
     heroku.sanity_check(config)
 
-    (id, tmp) = setup_experiment(log, debug=False, app=app, exp_config=exp_config)
+    (public_app_id, tmp) = setup_experiment(
+        log, debug=False, app=app, exp_config=exp_config
+    )
 
     # Register the experiment using all configured registration services.
     if config.get("mode") == "live":
         log("Registering the experiment on configured services...")
-        registration.register(id, snapshot=None)
+        registration.register(public_app_id, snapshot=None)
 
     # Log in to Heroku if we aren't already.
     log("Making sure that you are logged in to Heroku.")
@@ -460,12 +462,12 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     git = GitClient(output=out)
     git.init()
     git.add("--all")
-    git.commit('"Experiment {}"'.format(id))
+    git.commit('"Experiment {}"'.format(public_app_id))
 
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
     team = config.get("heroku_team", None)
-    heroku_app = HerokuApp(dallinger_uid=id, output=out, team=team)
+    heroku_app = HerokuApp(dallinger_uid=public_app_id, output=out, team=team)
     heroku_app.bootstrap()
     heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
 
@@ -579,7 +581,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     # Return to the branch whence we came.
     os.chdir(cwd)
 
-    log("Completed deployment of experiment " + id + ".")
+    log("Completed deployment of experiment " + public_app_id + ".")
     return result
 
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -246,8 +246,8 @@ def assemble_experiment_temp_dir(config):
 
     Returns the absolute path of the new directory.
     """
-    app_id = config.get("id")
-    dst = os.path.join(tempfile.mkdtemp(), app_id)
+    exp_id = config.get("id")
+    dst = os.path.join(tempfile.mkdtemp(), exp_id)
 
     # Copy local experiment files, minus some
     ExperimentFileSource(os.getcwd()).selective_copy_to(dst)
@@ -257,7 +257,7 @@ def assemble_experiment_temp_dir(config):
 
     # Save the experiment id
     with open(os.path.join(dst, "experiment_id.txt"), "w") as file:
-        file.write(app_id)
+        file.write(exp_id)
 
     # Copy Dallinger files
     dallinger_root = dallinger_package_path()
@@ -354,13 +354,8 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
     # Generate a unique id for this experiment.
     from dallinger.experiment import Experiment
 
-    generated_uid = public_id = Experiment.make_uuid(app)
-
-    # If the user provided an app name, use it everywhere that's user-facing.
-    if app:
-        public_id = str(app)
-
-    log("Experiment id is " + public_id + "")
+    experiment_uid = heroku_app_id = Experiment.make_uuid(app)
+    log("Experiment UID: {}".format(experiment_uid))
 
     # Load and update the config
     config = get_config()
@@ -368,8 +363,20 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
         config.load()  #
     if exp_config:
         config.extend(exp_config)
-    config.extend({"id": six.text_type(generated_uid)})
 
+    # If the user provided an app name, store it. We'll use it as the basis for
+    # the Heroku app ID. We still have a fair amount of ambiguity around what
+    # this value actually represents (it's not used as _only_ the Heroku app ID).
+    if app:
+        heroku_app_id = str(app)
+        log("Using custom Heroku ID root: {}".format(heroku_app_id))
+
+    config.extend(
+        {
+            "id": six.text_type(experiment_uid),
+            "heroku_app_id_root": six.text_type(heroku_app_id),
+        }
+    )
     temp_dir = assemble_experiment_temp_dir(config)
     log("Deployment temp directory: {}".format(temp_dir), chevrons=False)
 
@@ -377,10 +384,12 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
     if not debug:
         log("Freezing the experiment package...")
         shutil.make_archive(
-            os.path.join(os.getcwd(), "snapshots", public_id + "-code"), "zip", temp_dir
+            os.path.join(os.getcwd(), "snapshots", heroku_app_id + "-code"),
+            "zip",
+            temp_dir,
         )
 
-    return (public_id, temp_dir)
+    return (heroku_app_id, temp_dir)
 
 
 INITIAL_DELAY = 5
@@ -438,15 +447,14 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     if not config.ready:
         config.load()
     heroku.sanity_check(config)
-
-    (public_app_id, tmp) = setup_experiment(
+    (heroku_app_id, tmp) = setup_experiment(
         log, debug=False, app=app, exp_config=exp_config
     )
 
     # Register the experiment using all configured registration services.
     if config.get("mode") == "live":
         log("Registering the experiment on configured services...")
-        registration.register(public_app_id, snapshot=None)
+        registration.register(heroku_app_id, snapshot=None)
 
     # Log in to Heroku if we aren't already.
     log("Making sure that you are logged in to Heroku.")
@@ -462,12 +470,12 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     git = GitClient(output=out)
     git.init()
     git.add("--all")
-    git.commit('"Experiment {}"'.format(public_app_id))
+    git.commit('"Experiment {}"'.format(heroku_app_id))
 
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
     team = config.get("heroku_team", None)
-    heroku_app = HerokuApp(dallinger_uid=public_app_id, output=out, team=team)
+    heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team)
     heroku_app.bootstrap()
     heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
 
@@ -581,7 +589,11 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     # Return to the branch whence we came.
     os.chdir(cwd)
 
-    log("Completed deployment of experiment " + public_app_id + ".")
+    log(
+        "Completed Heroku deployment of experiment ID {} using app ID {}.".format(
+            config.get("id"), heroku_app_id
+        )
+    )
     return result
 
 

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -614,7 +614,7 @@ def lifecycle():
     config = get_config()
 
     data = {
-        "id": config.get("id"),
+        "heroku_app_id": config.get("heroku_app_id_root"),
     }
 
     return render_template(

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -615,6 +615,7 @@ def lifecycle():
 
     data = {
         "heroku_app_id": config.get("heroku_app_id_root"),
+        "sandbox_flag": " --sandbox" if config.get("mode") == "sandbox" else "",
     }
 
     return render_template(

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -613,10 +613,7 @@ def node_details(object_type, obj_id):
 def lifecycle():
     config = get_config()
 
-    data = {
-        "heroku_app_id": config.get("heroku_app_id_root"),
-        "sandbox_flag": " --sandbox" if config.get("mode") == "sandbox" else "",
-    }
+    data = {"heroku_app_id": config.get("heroku_app_id_root")}
 
     return render_template(
         "dashboard_cli.html", title="Experiment lifecycle Dashboard", **data

--- a/dallinger/frontend/templates/dashboard_cli.html
+++ b/dallinger/frontend/templates/dashboard_cli.html
@@ -4,13 +4,13 @@
 <h1>Experiment lifecycle dashboard</h1>
 
     <h2>Shut down experiment</h2>
-    
-    <pre>dallinger destroy --app {{ id }}</pre><button class="copy-button">Copy</button>
+
+    <pre>dallinger destroy --app {{ heroku_app_id }}</pre><button class="copy-button">Copy</button>
 
     <h2>Export data</h2>
-    <pre>dallinger export --app {{ id }}</pre><button class="copy-button">Copy</button>
+    <pre>dallinger export --app {{ heroku_app_id }}</pre><button class="copy-button">Copy</button>
 
-    
+
     <script>
         function copy_text (source) {
             var copied = false;
@@ -20,7 +20,7 @@
             textarea.style.left = '-1000000px';
             document.body.appendChild(textarea);
             textarea.select()
-            
+
             try {
                 var successful = document.execCommand('copy');
                 copied = true;

--- a/dallinger/frontend/templates/dashboard_cli.html
+++ b/dallinger/frontend/templates/dashboard_cli.html
@@ -9,7 +9,7 @@
     <button class="copy-button">Copy</button>
 
     <h2>Export data</h2>
-    <pre>dallinger export --app {{ heroku_app_id }}{{ sandbox_flag }}</pre>
+    <pre>dallinger export --app {{ heroku_app_id }}</pre>
     <button class="copy-button">Copy</button>
 
 

--- a/dallinger/frontend/templates/dashboard_cli.html
+++ b/dallinger/frontend/templates/dashboard_cli.html
@@ -5,10 +5,12 @@
 
     <h2>Shut down experiment</h2>
 
-    <pre>dallinger destroy --app {{ heroku_app_id }}</pre><button class="copy-button">Copy</button>
+    <pre>dallinger destroy --app {{ heroku_app_id }}{{ sandbox_flag }}</pre>
+    <button class="copy-button">Copy</button>
 
     <h2>Export data</h2>
-    <pre>dallinger export --app {{ heroku_app_id }}</pre><button class="copy-button">Copy</button>
+    <pre>dallinger export --app {{ heroku_app_id }}{{ sandbox_flag }}</pre>
+    <button class="copy-button">Copy</button>
 
 
     <script>

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -140,6 +140,7 @@ def stub_config():
         u"description": u"fake HIT description",
         u"duration": 1.0,
         u"dyno_type": u"free",
+        u"heroku_app_id_root": u"fake-customid",
         u"heroku_auth_token": u"heroku secret",
         u"heroku_python_version": u"3.6.10",
         u"heroku_team": u"",

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -764,7 +764,7 @@ class MTurkRecruiter(Recruiter):
         return status
 
     def _disable_autorecruit(self):
-        heroku_app = heroku_tools.HerokuApp(self.config.get("id"))
+        heroku_app = heroku_tools.HerokuApp(self.config.get("heroku_app_id_root"))
         args = json.dumps({"auto_recruit": "false"})
         headers = heroku_tools.request_headers(self.config.get("heroku_auth_token"))
         requests.patch(heroku_app.config_url, data=args, headers=headers)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -572,7 +572,8 @@ class TestDashboardLifeCycleRoutes(object):
     def test_includes_destroy_command(self, active_config, logged_in):
         resp = logged_in.get("/dashboard/lifecycle")
 
-        app_id = active_config.get("id")
+        app_id = active_config.get("heroku_app_id_root")
+
         assert resp.status_code == 200
         assert "<pre>dallinger destroy --app {}</pre>".format(
             app_id

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -8,6 +8,7 @@ import pytest
 import six
 import sys
 import tempfile
+import uuid
 from pytest import raises
 from six.moves import configparser
 
@@ -301,6 +302,33 @@ class TestSetupExperiment(object):
         from dallinger.deployment import setup_experiment as subject
 
         return subject
+
+    def test_generates_exp_and_app_uid_if_none_provided(self, setup_experiment):
+        exp_id, dst = setup_experiment(log=mock.Mock())
+
+        assert isinstance(uuid.UUID(exp_id, version=4), uuid.UUID)
+
+    def test_generated_uid_saved_to_config(self, active_config, setup_experiment):
+        exp_id, dst = setup_experiment(log=mock.Mock())
+
+        assert active_config.get("id") == exp_id
+
+    def test_uses_provided_app_uid(self, setup_experiment):
+        exp_id, dst = setup_experiment(log=mock.Mock(), app="my-custom-app-id")
+
+        assert exp_id == "my-custom-app-id"
+
+    def test_saves_provided_app_uid_to_config(self, active_config, setup_experiment):
+        exp_id, dst = setup_experiment(log=mock.Mock(), app="my-custom-app-id")
+
+        assert "my-custom-app-id" == active_config.get("heroku_app_id_root")
+
+    def test_still_saves_uuid_in_addition_to_custom_app_id(
+        self, active_config, setup_experiment
+    ):
+        exp_id, dst = setup_experiment(log=mock.Mock(), app="my-custom-app-id")
+
+        assert isinstance(uuid.UUID(active_config.get("id"), version=4), uuid.UUID)
 
     def test_setup_creates_new_experiment(self, setup_experiment):
         # Baseline


### PR DESCRIPTION
## Description
Improve support for specifying custom app IDs when calling `dallinger sandbox` and `dallinger deploy`, and use this infrastructure to provide a correct `dallinger destroy` URL on the Lifecycle dashboard.

This PR preserves a potentially custom app ID in a new config variable `heroku_app_id_root`. The Lifecycle dashboard (and the MTurk recruiter, which in a case of surely misplaced responsibility also needs to update Heroku settings) can access the Heroku deployment correctly later, based on the store value.

In addition, a number of attempts at name clarifications are included, though the experiment ID and Heroku app ID concepts are frequently conflated in various places in the code, so this is just a first step in what would ideally be a more thorough cleanup effort.

## Motivation and Context
Fix for #2270

## How Has This Been Tested?
- Automated testing
- "sandbox" and "deploy"

