### PR TITLE
Allow Dashboard Password to be Set Using Config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Bugfix: Fixes for Dashboard monitor layout and color issues.
 - New customizable database dashboard for viewing live experiment data.
 - Use localhost as hostname when running in debug mode by default.
+- Dashboard credentials can now be set using configuration parameters.
 
 ## [v-6.3.1](https://github.com/dallinger/dallinger/tree/6.3.1) (2020-07-21)
 - Bugfix: Dashboard authentication now works with multiple web processes and dynos

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -38,6 +38,7 @@ default_keys = (
     ("contact_email_on_error", six.text_type, []),
     ("chrome-path", six.text_type, []),
     ("dallinger_email_address", six.text_type, []),
+    ("dashboard_password", six.text_type, [], True),
     ("dashboard_user", six.text_type, [], True),
     ("database_size", six.text_type, []),
     ("database_url", six.text_type, [], True),

--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -12,3 +12,4 @@ logfile = server.log
 loglevel = 0
 threads = auto
 whimsical = true
+dashboard_user = admin

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -380,8 +380,6 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
 
     if not config.get("dashboard_password", None):
         config.set("dashboard_password", fake.password(length=20, special_chars=False))
-    if not config.get("dashboard_user", None):
-        config.set("dashboard_user", "admin")
 
     temp_dir = assemble_experiment_temp_dir(config)
     log("Deployment temp directory: {}".format(temp_dir), chevrons=False)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -507,7 +507,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         "smtp_username": config["smtp_username"],
         "smtp_password": config["smtp_password"],
         "whimsical": config["whimsical"],
-        "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex"),
+        "FLASK_SECRET_KEY": str(codecs.encode(os.urandom(16), "hex")),
     }
 
     # Set up the preferred class as an environment variable, if one is set
@@ -694,7 +694,7 @@ class DebugDeployment(HerokuLocalDeployment):
         self.status_thread = None
         self.no_browsers = no_browsers
         self.environ = {
-            "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex"),
+            "FLASK_SECRET_KEY": str(codecs.encode(os.urandom(16), "hex")),
         }
 
     def configure(self):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -507,7 +507,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         "smtp_username": config["smtp_username"],
         "smtp_password": config["smtp_password"],
         "whimsical": config["whimsical"],
-        "FLASK_SECRET_KEY": str(codecs.encode(os.urandom(16), "hex")),
+        "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex").decode("ascii"),
     }
 
     # Set up the preferred class as an environment variable, if one is set
@@ -694,7 +694,7 @@ class DebugDeployment(HerokuLocalDeployment):
         self.status_thread = None
         self.no_browsers = no_browsers
         self.environ = {
-            "FLASK_SECRET_KEY": str(codecs.encode(os.urandom(16), "hex")),
+            "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex").decode("ascii"),
         }
 
     def configure(self):

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -64,6 +64,11 @@ def _config():
     config = get_config()
     if not config.ready:
         config.load()
+    if config.get("dashboard_password", None):
+        app.config["ADMIN_USER"] = dashboard.User(
+            userid=config.get("dashboard_user", "admin"),
+            password=config.get("dashboard_password"),
+        )
 
     return config
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -60,7 +60,7 @@ app = Flask("Experiment_Server")
 
 @app.before_first_request
 def _config():
-    app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
+    app.secret_key = app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
     config = get_config()
     if not config.ready:
         config.load()

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -136,6 +136,7 @@ def stub_config():
         u"dallinger_email_address": u"test@example.com",
         u"database_size": u"standard-0",
         u"redis_size": u"premium-0",
+        u"dashboard_user": u"admin",
         u"database_url": u"postgresql://postgres@localhost/dallinger",
         u"description": u"fake HIT description",
         u"duration": 1.0,

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -194,6 +194,14 @@ def active_config(stub_config):
 
 
 @pytest.fixture
+def dashboard_config(active_config):
+    active_config.extend(
+        {"dashboard_user": "admin", "dashboard_password": "DUMBPASSWORD"}
+    )
+    return active_config
+
+
+@pytest.fixture
 def db_session():
     import dallinger.db
 

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -196,7 +196,7 @@ def active_config(stub_config):
 @pytest.fixture
 def dashboard_config(active_config):
     active_config.extend(
-        {"dashboard_user": "admin", "dashboard_password": "DUMBPASSWORD"}
+        {"dashboard_user": u"admin", "dashboard_password": u"DUMBPASSWORD"}
     )
     return active_config
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -48,11 +48,18 @@ General
     to ``critical``. Note that ``dallinger debug`` ignores this setting and always
     runs at 0 (``debug``).
 
-
 ``whimsical`` *boolean*
     What's life without whimsy? Controls whether email notifications sent
     regarding various experiment errors are whimsical in tone, or more
     matter-of-fact.
+
+``dashboard_password`` *unicode*
+    An optional password for accessing the Dallinger Dashboard interface. If not
+    specified, a random password will be generated.
+
+``dashboard_user`` *unicode*
+    An optional login name for accessing the Dallinger Dashboard interface. If not
+    specified ``admin`` will be used.
 
 
 Recruitment (General)

--- a/docs/source/monitoring_a_live_experiment.rst
+++ b/docs/source/monitoring_a_live_experiment.rst
@@ -34,9 +34,11 @@ commandline output when launching an experiment using ``dallinger debug``,
 ``dallinger sandbox``, or ``dallinger deploy``.
 
 When running under ``dallinger debug`` a browser window should open with the
-dashboard already logged in. When running on Heroku, the dashboard username
-and password can also be found in the heroku configuration parameters
-``DASHBOARD_USER`` and ``DASHBOARD_PASSWORD``.
+dashboard already logged in. The dashboard username and password can also be
+found in the ``dashboard_user`` and ``dashboard_password`` configuration
+parameters in the deployed ``config.txt`` configuration file. By default the
+user is named ``admin`` and the password is generated randomly, but the user
+name and password can be specified using configuration files.
 
 
 Customizing the Dashboard

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -39,12 +39,15 @@ def browser():
 
 
 @pytest.fixture
-def faster(tempdir):
+def faster(tempdir, active_config):
     with mock.patch.multiple(
         "dallinger.deployment", time=mock.DEFAULT, setup_experiment=mock.DEFAULT
     ) as mocks:
         mocks["setup_experiment"].return_value = ("fake-uid", tempdir)
-
+        # setup_experiment normally sets the dashboard credentials if unset
+        active_config.extend(
+            {"dashboard_user": "admin", "dashboard_password": "DUMBPASSWORD",}
+        )
         yield mocks
 
 
@@ -330,6 +333,14 @@ class TestSetupExperiment(object):
 
         assert isinstance(uuid.UUID(active_config.get("id"), version=4), uuid.UUID)
 
+    def test_dashboard_credentials_saved_to_config(
+        self, active_config, setup_experiment
+    ):
+        exp_id, dst = setup_experiment(log=mock.Mock())
+
+        assert active_config.get("dashboard_user") == "admin"
+        assert active_config.get("dashboard_password") == mock.ANY
+
     def test_setup_creates_new_experiment(self, setup_experiment):
         # Baseline
         exp_dir = os.getcwd()
@@ -584,8 +595,6 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
             aws_access_key_id="fake aws key",
             aws_region="us-east-1",
             aws_secret_access_key="fake aws secret",
-            DASHBOARD_USER="admin",
-            DASHBOARD_PASSWORD=mock.ANY,  # password is random
             FLASK_SECRET_KEY=mock.ANY,  # password is random
             smtp_password="fake email password",
             smtp_username="fake email username",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -46,7 +46,10 @@ def faster(tempdir, active_config):
         mocks["setup_experiment"].return_value = ("fake-uid", tempdir)
         # setup_experiment normally sets the dashboard credentials if unset
         active_config.extend(
-            {"dashboard_user": "admin", "dashboard_password": "DUMBPASSWORD",}
+            {
+                "dashboard_user": six.text_type("admin"),
+                "dashboard_password": six.text_type("DUMBPASSWORD"),
+            }
         )
         yield mocks
 
@@ -338,7 +341,7 @@ class TestSetupExperiment(object):
     ):
         exp_id, dst = setup_experiment(log=mock.Mock())
 
-        assert active_config.get("dashboard_user") == "admin"
+        assert active_config.get("dashboard_user") == six.text_type("admin")
         assert active_config.get("dashboard_password") == mock.ANY
 
     def test_setup_creates_new_experiment(self, setup_experiment):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -18,7 +18,7 @@ class TestAppConfiguration(object):
         active_config.load.assert_called_once()
         assert active_config.ready
 
-    def test_debug_mode_puts_flask_in_debug_mode(self, webapp, active_config):
+    def test_debug_mode_puts_flask_in_debug_mode(self, webapp):
         webapp.application.debug = False
         from dallinger.experiment_server.gunicorn import StandaloneServer
 


### PR DESCRIPTION
## Description
The dashboard credentials are now retrieved from configuration variables (`dashboard_user`, and `dashboard_password`) rather than environment variables. This allows customizing passwords via e.g.
`~/.dallingerconfig`. The defaults are still the same when the configuration variables are unset.

## Motivation and Context
See issue #2276. Users would like to be able to use consistent dashboard passwords across experiment runs.

## How Has This Been Tested?
I tested the new configuration variables manually in debug and sandbox mode. Additionally, I added an automated test that the variables are being set in the config as expected when unset, and updated existing tests to read the variables from the configuration.

