### PR TITLE
Change dallinger debug from 0.0.0.0 to localhost

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 - New customizable database dashboard for viewing live experiment data.
+- Use localhost as hostname when running in debug mode by default.
 
 ## [v-6.3.1](https://github.com/dallinger/dallinger/tree/6.3.1) (2020-07-21)
 - Bugfix: Dashboard authentication now works with multiple web processes and dynos

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -17,6 +17,9 @@ from dallinger.config import get_config
 def get_base_url():
     config = get_config()
     host = os.getenv("HOST", config.get("host"))
+    if host == "0.0.0.0":
+        host = "localhost"
+
     if "herokuapp.com" in host:
         if host.startswith("https://"):
             base_url = host

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -887,7 +887,9 @@ class TestDebugServer(object):
         # Only one launch attempt should be made in debug mode
         debugger.out.error.assert_has_calls(
             [
-                mock.call("Error accessing http://0.0.0.0:5000/launch (500):\nFailure"),
+                mock.call(
+                    "Error accessing http://localhost:5000/launch (500):\nFailure"
+                ),
                 mock.call("Experiment launch failed, check web dyno logs for details."),
                 mock.call("msg!"),
             ]
@@ -948,7 +950,7 @@ class TestLoad(object):
                 mock.call("Starting up the server..."),
                 mock.call("Ingesting dataset from some_experiment_id-data.zip..."),
                 mock.call(
-                    "Server is running on http://0.0.0.0:{}. Press Ctrl+C to exit.".format(
+                    "Server is running on http://localhost:{}. Press Ctrl+C to exit.".format(
                         os.environ.get("base_port", 5000)
                     )
                 ),
@@ -972,7 +974,7 @@ class TestLoad(object):
                 mock.call("Starting up the server..."),
                 mock.call("Ingesting dataset from some_experiment_id-data.zip..."),
                 mock.call(
-                    "Server is running on http://0.0.0.0:{}. Press Ctrl+C to exit.".format(
+                    "Server is running on http://localhost:{}. Press Ctrl+C to exit.".format(
                         os.environ.get("base_port", 5000)
                     )
                 ),

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -1121,50 +1121,56 @@ class TestMultiRecruiter(object):
     def test_open_recruitment(self, recruiter):
         result = recruiter.open_recruitment(n=3)
         assert len(result["items"]) == 3
-        assert result["items"][0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result["items"][1].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result["items"][2].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result["items"][0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result["items"][1].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result["items"][2].startswith(
+            "http://localhost:5000/ad?recruiter=hotair"
+        )
 
     def test_open_recruitment_over_recruit(self, recruiter):
         result = recruiter.open_recruitment(n=5)
         assert len(result["items"]) == 3
-        assert result["items"][0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result["items"][1].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result["items"][2].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result["items"][0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result["items"][1].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result["items"][2].startswith(
+            "http://localhost:5000/ad?recruiter=hotair"
+        )
 
     def test_open_recruitment_twice(self, recruiter):
         result = recruiter.open_recruitment(n=1)
         assert len(result["items"]) == 1
-        assert result["items"][0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
+        assert result["items"][0].startswith("http://localhost:5000/ad?recruiter=cli")
 
         result2 = recruiter.open_recruitment(n=3)
         assert len(result2["items"]) == 2
-        assert result2["items"][0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result2["items"][1].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result2["items"][0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result2["items"][1].startswith(
+            "http://localhost:5000/ad?recruiter=hotair"
+        )
 
     def test_recruit(self, recruiter):
         result = recruiter.recruit(n=3)
         assert len(result) == 3
-        assert result[0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[1].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[2].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result[0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[1].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[2].startswith("http://localhost:5000/ad?recruiter=hotair")
 
     def test_over_recruit(self, recruiter):
         result = recruiter.recruit(n=5)
         assert len(result) == 3
-        assert result[0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[1].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[2].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result[0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[1].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[2].startswith("http://localhost:5000/ad?recruiter=hotair")
 
     def test_recruit_partial(self, recruiter):
         result = recruiter.open_recruitment(n=1)
         assert len(result["items"]) == 1
-        assert result["items"][0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
+        assert result["items"][0].startswith("http://localhost:5000/ad?recruiter=cli")
 
         result2 = recruiter.recruit(n=3)
         assert len(result2) == 2
-        assert result2[0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result2[1].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result2[0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result2[1].startswith("http://localhost:5000/ad?recruiter=hotair")
 
         result3 = recruiter.recruit(n=2)
         assert len(result3) == 0
@@ -1176,14 +1182,14 @@ class TestMultiRecruiter(object):
         recruiter = MultiRecruiter()
         result = recruiter.recruit(n=10)
         assert len(result) == 8
-        assert result[0].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[1].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[2].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
-        assert result[3].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[4].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[5].startswith("http://0.0.0.0:5000/ad?recruiter=cli")
-        assert result[6].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
-        assert result[7].startswith("http://0.0.0.0:5000/ad?recruiter=hotair")
+        assert result[0].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[1].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[2].startswith("http://localhost:5000/ad?recruiter=hotair")
+        assert result[3].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[4].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[5].startswith("http://localhost:5000/ad?recruiter=cli")
+        assert result[6].startswith("http://localhost:5000/ad?recruiter=hotair")
+        assert result[7].startswith("http://localhost:5000/ad?recruiter=hotair")
 
     def test_close_recruitment(self, recruiter):
         patch1 = mock.patch("dallinger.recruiters.CLIRecruiter.close_recruitment")

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -223,8 +223,14 @@ class TestBaseURL(object):
         yield instance
         config.config = None
 
-    def test_local_base_url(self, subject, config):
-        config.set("host", u"localhost")
+    def test_base_url_uses_environment(self, subject, config):
+        config.set("host", u"127.0.0.1")
+        config.set("base_port", 5000)
+        config.set("num_dynos_web", 1)
+        assert subject() == u"http://127.0.0.1:5000"
+
+    def test_local_base_url_converts(self, subject, config):
+        config.set("host", u"0.0.0.0")
         config.set("base_port", 5000)
         config.set("num_dynos_web", 1)
         assert subject() == u"http://localhost:5000"


### PR DESCRIPTION
## Description
Changes displayed hostname to `localhost` when the `host` config is set to the debug default of `0.0.0.0`. The application should still listen on all interfaces, but the displayed and auto-opened urls will use `localhost` to help ensure they don't trigger browser security issues.

## Motivation and Context
See #2272

## How Has This Been Tested?
New test for the host change. Updated tests that depended on old debug default value.