### PR TITLE
Fix for HTTPS inconsistency #2289

### DIFF
--- a/constraints-deps.txt
+++ b/constraints-deps.txt
@@ -95,7 +95,7 @@ urllib3==1.23
 virtualenv==16.0.0
 wcwidth==0.1.7
 webencodings==0.5.1
-werkzeug==0.14.1
+werkzeug==1.0.1
 wheel==0.31.1
 widgetsnbextension==3.4.1
 WTForms==2.3.1

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -6,6 +6,7 @@ import multiprocessing
 import os
 from dallinger.config import get_config
 import logging
+from werkzeug.contrib.fixers import ProxyFix
 
 logger = logging.getLogger(__file__)
 
@@ -52,8 +53,11 @@ class StandaloneServer(Application):
     def load(self):
         """Return our application to be run."""
         app = util.import_app("dallinger.experiment_server.sockets:app")
+        app.secret_key = app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
         if self.options.get("mode") == "debug":
             app.debug = True
+        else:
+            app = ProxyFix(app)
         return app
 
     def load_user_config(self):

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -6,7 +6,7 @@ import multiprocessing
 import os
 from dallinger.config import get_config
 import logging
-from werkzeug.contrib.fixers import ProxyFix
+from werkzeug.middleware.proxy_fix import ProxyFix
 
 logger = logging.getLogger(__file__)
 


### PR DESCRIPTION
## Description
Enables `ProxyFix` middleware when not in production mode to ensure Flask generates https links when serving proxied over https from Heroku. Additionally, sets flask `SECRET_KEY` during gunicorn load to help avoid initial 500 errors when first page load tries to generate CSRF tokens.

## Motivation and Context
See #2289. The `SECRET_KEY` is now set in two places, but I think this is fine because the value is consistent. There may be some need to run the Flask application without the gunicorn wrapper, in which case setting it in the `before_first_request` would still be necessary, but setting it earlier when running in a load-balanced fashion is probably best.

## How Has This Been Tested?
Tested on sandbox (wrapped) and in debug mode (not wrapped). Added automated tests for ProxyFix calls and `SECRET_KEY` setting.

