### PR TITLE
Add JS function to allow resuming Participant session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
+- New `dallinger.loadParticipant` function to load participant data into the browser
+  based on an `assignmentId`.
 
 ## [v-6.4.0](https://github.com/dallinger/dallinger/tree/6.4.0) (2020-08003)
 - Bugfix: Fixes for Dashboard monitor layout and color issues

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -26,6 +26,7 @@ from sqlalchemy import create_engine
 from sqlalchemy import distinct
 from sqlalchemy import func
 from sqlalchemy.orm import sessionmaker, scoped_session
+from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
 
 from dallinger import recruiters
 from dallinger.config import get_config, LOCAL_CONFIG
@@ -302,6 +303,21 @@ class Experiment(object):
 
         """
         network.add_node(node)
+
+    def load_participant(self, assignment_id):
+        """Returns a participant object looked up by assignment_id.
+
+        Intended to allow a user to resume a session in a running experiment.
+
+        :param assignment_id: the recruiter Assignment Id
+        :type assignment_id: str
+        :returns: A ``Participant`` instance or ``None`` if there is not a
+                  single matching participant.
+        """
+        try:
+            return Participant.query.filter_by(assignment_id=assignment_id).one()
+        except (NoResultFound, MultipleResultsFound):
+            return None
 
     def data_check(self, participant):
         """Check that the data are acceptable.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -792,6 +792,27 @@ def get_participant(participant_id):
     return success_response(participant=ppt.__json__())
 
 
+@app.route("/participant", methods=["POST"])
+def load_participant():
+    """Get the participant with an assignment id provided in the request.
+    Delegates to :func:`~dallinger.experiments.Experiment.load_participant`.
+    """
+    assignment_id = request_parameter("assignment_id", optional=True)
+    if assignment_id is None:
+        return error_response(
+            error_type="/participant GET: no participant found", status=403
+        )
+    exp = Experiment(session)
+    ppt = exp.load_participant(assignment_id)
+    if ppt is None:
+        return error_response(
+            error_type="/participant GET: no participant found", status=403
+        )
+
+    # return the data
+    return success_response(participant=ppt.__json__())
+
+
 @app.route("/network/<network_id>", methods=["GET"])
 def get_network(network_id):
     """Get the network with the given id."""

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -800,13 +800,13 @@ def load_participant():
     assignment_id = request_parameter("assignment_id", optional=True)
     if assignment_id is None:
         return error_response(
-            error_type="/participant GET: no participant found", status=403
+            error_type="/participant POST: no participant found", status=403
         )
     exp = Experiment(session)
     ppt = exp.load_participant(assignment_id)
     if ppt is None:
         return error_response(
-            error_type="/participant GET: no participant found", status=403
+            error_type="/participant POST: no participant found", status=403
         )
 
     # return the data

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -428,6 +428,38 @@ var dallinger = (function () {
   };
 
   /**
+   * Load an existing `Participant` into the dlgr.identity by making a ``POST``
+   * request to the experiment `/participant` route with an ``assignment_id``.
+   *
+   * @returns {jQuery.Deferred} See :ref:`deferreds-label`
+   */
+  dlgr.loadParticipant = function(assignment_id) {
+    var deferred = $.Deferred(),
+        url = '/participant';
+
+    if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
+      deferred.resolve();
+    } else {
+      $(function () {
+        $('.btn-success').prop('disabled', true);
+        dlgr.post(url, {assignment_id: assignment_id}).done(function (resp) {
+          console.log(resp);
+          $('.btn-success').prop('disabled', false);
+          dlgr.identity.participantId = resp.participant.id;
+          dlgr.identity.recruiter = resp.participant.recruiter_id;
+          dlgr.identity.hitId = resp.participant.hit_id;
+          dlgr.identity.workerId = resp.participant.worker_id;
+          dlgr.identity.assignmentId = assignment_id;
+          dlgr.identity.mode = resp.participant.mode;
+          dlgr.identity.fingerprintHash = resp.participant.fingerprint_hash;
+          deferred.resolve();
+        });
+      });
+    }
+    return deferred;
+  };
+
+  /**
    * Creates a new experiment `Node` for the current partcipant.
    *
    * @example

--- a/docs/source/javascript_api.rst
+++ b/docs/source/javascript_api.rst
@@ -77,6 +77,8 @@ these explicitly:
 
 .. js:autofunction:: dallinger.createParticipant
 
+.. js:autofunction:: dallinger.loadParticipant
+
 .. js:autofunction:: dallinger.hasAdBlocker
 
 .. js:autofunction:: dallinger.submitAssignment

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -63,6 +63,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: create_node
 
+  .. automethod:: load_participant
+
   .. automethod:: data_check
 
   .. automethod:: data_check_failed

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -237,6 +237,13 @@ Create a participant. Returns a JSON description of the participant as
 
 ::
 
+    POST /participant
+
+Loads a participant from a running experiment by ``assignment_id`` and
+returns a JSON description. ``assignment_id`` should be passed as data.
+
+::
+
     POST /question/<participant_id>
 
 Create a question. ``question``, ``response`` and ``question_id`` should

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -46,3 +46,7 @@ class TestExperimentBaseClass(object):
     def test_not_overrecruited_if_waiting_equal_to_quorum(self, exp):
         exp.quorum = 1
         assert not exp.is_overrecruited(waiting_count=1)
+
+    def test_load_participant(self, exp, a):
+        p = a.participant()
+        assert exp.load_participant(p.assignment_id) == p


### PR DESCRIPTION
## Description
Provides an implementation of #2242. Provides a new mechanism for retrieving and setting data about a participant based on an `assignmentId`. There are three components:

A `load_participant` method on the `Experiment` class that takes an `assignment_id` and returns the matching `Participant`. This can be overridden by subclasses to perform other actions required to restore a user session.

A new `/participant` route that takes a `POST` request with an `assignment_id` argument, and calls the above method to retrieve the corresponding participant from the experiment.

A new `dallinger.loadParticipant` function which takes an `assignmentId` which asynchronously retrieves the participant data using the methods above and sets the resulting information in the `dallinger.identity` object. It returns a `Deferred` object to allow subsequent actions to be taken on e.g. `done` or `fail`.

## Motivation and Context
See #2242 for details.

## How Has This Been Tested?
I added automated tests for the new python methods and tested them manually in debug mode using the new `dallinger.loadParticipant` JS function.
