### PR TITLE
Issues/2317 unthrottle debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 ## [v-master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
+- Performance improvement: `dallinger debug` now starts up in about half the time
 
 ## [v-6.4.0](https://github.com/dallinger/dallinger/tree/6.4.0) (2020-08003)
 - Bugfix: Fixes for Dashboard monitor layout and color issues

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -62,24 +62,22 @@ header = r"""
 )
 
 
-def log(msg, delay=0.5, chevrons=True, verbose=True):
+def log(msg, chevrons=True, verbose=True):
     """Log a message to stdout."""
     if verbose:
         if chevrons:
             click.echo("\n❯❯ " + msg)
         else:
             click.echo(msg)
-        time.sleep(delay)
 
 
-def error(msg, delay=0.5, chevrons=True, verbose=True):
+def error(msg, chevrons=True, verbose=True):
     """Log a message to stdout."""
     if verbose:
         if chevrons:
             click.secho("\n❯❯ " + msg, err=True, fg="red")
         else:
             click.secho(msg, err=True, fg="red")
-        time.sleep(delay)
 
 
 class Output(object):
@@ -216,22 +214,17 @@ def verify_experiment_module(verbose):
     if len(exps) == 0:
         log(
             "✗ experiment.py does not define an experiment class.",
-            delay=0,
             chevrons=False,
             verbose=verbose,
         )
         ok = False
     elif len(exps) == 1:
         log(
-            "✓ experiment.py defines 1 experiment",
-            delay=0,
-            chevrons=False,
-            verbose=verbose,
+            "✓ experiment.py defines 1 experiment", chevrons=False, verbose=verbose,
         )
     else:
         log(
             "✗ experiment.py defines more than one experiment class.",
-            delay=0,
             chevrons=False,
             verbose=verbose,
         )
@@ -254,7 +247,7 @@ def verify_config(verbose=True):
                 message = "Configuration for {} is invalid: ".format(config_key)
             else:
                 message = "Configuration is invalid: "
-            log("✗ " + message + str(e), delay=0, chevrons=False, verbose=verbose)
+            log("✗ " + message + str(e), chevrons=False, verbose=verbose)
 
             config_value = getattr(e, "dallinger_config_value", None)
             if verbose and config_value:
@@ -264,14 +257,13 @@ def verify_config(verbose=True):
     try:
         base_pay = config.get("base_payment")
     except KeyError:
-        log("✗ No value for base_pay.", delay=0, chevrons=False, verbose=verbose)
+        log("✗ No value for base_pay.", chevrons=False, verbose=verbose)
     else:
         dollarFormat = "{:.2f}".format(base_pay)
 
         if base_pay <= 0:
             log(
                 "✗ base_payment must be positive value in config.txt.",
-                delay=0,
                 chevrons=False,
                 verbose=verbose,
             )
@@ -281,7 +273,6 @@ def verify_config(verbose=True):
             log(
                 "✗ base_payment must be in [dollars].[cents] format in config.txt. Try changing "
                 "{0} to {1}.".format(base_pay, dollarFormat),
-                delay=0,
                 chevrons=False,
                 verbose=verbose,
             )
@@ -314,14 +305,13 @@ def verify_no_conflicts(verbose=True):
         if os.path.exists(f):
             log(
                 "✗ {} OVERWRITES shared frontend files inserted at run-time".format(f),
-                delay=0,
                 chevrons=False,
                 verbose=verbose,
             )
             conflicts = True
 
     if not conflicts:
-        log("✓ no file conflicts", delay=0, chevrons=False, verbose=verbose)
+        log("✓ no file conflicts", chevrons=False, verbose=verbose)
 
     return True
 
@@ -541,8 +531,8 @@ def email_test():
     config = get_config()
     config.load()
     settings = EmailConfig(config)
-    out.log("Email Config", delay=0)
-    out.log(tabulate.tabulate(settings.as_dict().items()), chevrons=False, delay=0)
+    out.log("Email Config")
+    out.log(tabulate.tabulate(settings.as_dict().items()), chevrons=False)
     problems = settings.validate()
     if problems:
         out.error(
@@ -609,16 +599,15 @@ def compensate(recruiter, worker_id, email, dollars, sandbox):
                 "Compensation failed. The recruiter reports the following error:\n{}".format(
                     ex
                 ),
-                delay=0,
             )
             return
 
-    out.log("HIT Details", delay=0)
-    out.log(tabulate.tabulate(result["hit"].items()), chevrons=False, delay=0)
-    out.log("Qualification Details", delay=0)
-    out.log(tabulate.tabulate(result["qualification"].items()), chevrons=False, delay=0)
-    out.log("Worker Notification", delay=0)
-    out.log(tabulate.tabulate(result["email"].items()), chevrons=False, delay=0)
+    out.log("HIT Details")
+    out.log(tabulate.tabulate(result["hit"].items()), chevrons=False)
+    out.log("Qualification Details")
+    out.log(tabulate.tabulate(result["qualification"].items()), chevrons=False)
+    out.log("Worker Notification")
+    out.log(tabulate.tabulate(result["email"].items()), chevrons=False)
 
 
 @dallinger.command()
@@ -794,14 +783,11 @@ def extend_mturk_hit(hit_id, assignments, duration_hours, sandbox):
                 hit_id=hit_id, number=assignments, duration_hours=duration_hours
             )
         except MTurkServiceException as ex:
-            out.error(
-                "HIT extension failed with the following error:\n{}".format(ex),
-                delay=0,
-            )
+            out.error("HIT extension failed with the following error:\n{}".format(ex),)
             return
 
-    out.log("Updated HIT Details", delay=0)
-    out.log(tabulate.tabulate(hit_info.items()), chevrons=False, delay=0)
+    out.log("Updated HIT Details")
+    out.log(tabulate.tabulate(hit_info.items()), chevrons=False)
 
 
 @dallinger.command()
@@ -959,15 +945,13 @@ def verify():
     """Verify that app is compatible with Dallinger."""
     verbose = True
     log(
-        "Verifying current directory as a Dallinger experiment...",
-        delay=0,
-        verbose=verbose,
+        "Verifying current directory as a Dallinger experiment...", verbose=verbose,
     )
     ok = verify_package(verbose=verbose)
     if ok:
-        log("✓ Everything looks good!", delay=0, verbose=verbose)
+        log("✓ Everything looks good!", verbose=verbose)
     else:
-        log("☹ Some problems were found.", delay=0, verbose=verbose)
+        log("☹ Some problems were found.", verbose=verbose)
 
 
 @dallinger.command()

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -398,7 +398,7 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
 
 INITIAL_DELAY = 1
 BACKOFF_FACTOR = 2
-MAX_ATTEMPTS = 4
+MAX_ATTEMPTS = 6
 
 
 def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -396,7 +396,7 @@ def setup_experiment(log, debug=True, verbose=False, app=None, exp_config=None):
     return (heroku_app_id, temp_dir)
 
 
-INITIAL_DELAY = 5
+INITIAL_DELAY = 1
 BACKOFF_FACTOR = 2
 MAX_ATTEMPTS = 4
 
@@ -642,12 +642,12 @@ class HerokuLocalDeployment(object):
         self.setup()
         self.update_dir()
         db.init_db(drop_all=True)
-        self.out.log("Starting up the server...")
         config = get_config()
         environ = None
         if self.environ:
             environ = os.environ.copy()
             environ.update(self.environ)
+        self.out.log("Starting up the Heroku Local server...")
         with HerokuLocalWrapper(
             config, self.out, verbose=self.verbose, env=environ
         ) as wrapper:
@@ -704,7 +704,6 @@ class DebugDeployment(HerokuLocalDeployment):
         base_url = get_base_url()
         self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
         self.out.log("Launching the experiment...")
-        time.sleep(4)
         try:
             result = _handle_launch_data(
                 "{}/launch".format(base_url), error=self.out.error, attempts=1

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -959,7 +959,7 @@ class TestLoad(object):
 
         loader.out.log.assert_has_calls(
             [
-                mock.call("Starting up the server..."),
+                mock.call("Starting up the Heroku Local server..."),
                 mock.call("Ingesting dataset from some_experiment_id-data.zip..."),
                 mock.call(
                     "Server is running on http://localhost:{}. Press Ctrl+C to exit.".format(
@@ -983,7 +983,7 @@ class TestLoad(object):
 
         replay_loader.out.log.assert_has_calls(
             [
-                mock.call("Starting up the server..."),
+                mock.call("Starting up the Heroku Local server..."),
                 mock.call("Ingesting dataset from some_experiment_id-data.zip..."),
                 mock.call(
                     "Server is running on http://localhost:{}. Press Ctrl+C to exit.".format(


### PR DESCRIPTION
## Description
Improve the speed of `dallinger debug`

- Remove the `delay` option entirely from `log` and `error` CLI functions
- Reduce the sleep calls in deployment while waiting for the heroku local server to load, as we now have a backoff/retry system for this
- As there may be further opportunity to speed up launching webbrowsers, hide some implementation detail about how this works from deployment code

## Motivation and Context
Since the days of Wallace, explicit delays have been built in to output statements throughout `dallinger debug` execution. While this may have served a useful purpose at one time, we now have other means of dealing with race conditions, and we just want things to be as fast as possible.

## How Has This Been Tested?
Debug runs for Bartlett1932 experiment

It was awkward to quantitatively benchmark, but it's subjectively considerably faster.


