### PR TITLE
Allow Custom Participant Class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 - New `dallinger.loadParticipant` function to load participant data into the browser
   based on an `assignmentId`
 - Performance improvement: `dallinger debug` now starts up in about half the time
+- Delegates participant creation to Experiment `create_participant` method and
+  `participant_constructor` attribute to allow experiments to specify custom
+  Participant classes.
 
 ## [v-6.4.0](https://github.com/dallinger/dallinger/tree/6.4.0) (2020-08003)
 - Bugfix: Fixes for Dashboard monitor layout and color issues

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -82,7 +82,11 @@ class Experiment(object):
     channel = None
     exp_config = None
     replay_path = "/"
-    participant_class = Participant
+
+    #: Constructor for Participant objects. Callable returning an instance of
+    #: :attr:`~dallinger.models.Participant` or a sub-class. Used by
+    #: :func:`~dallinger.experiment.Experiment.create_participant`.
+    participant_constructor = Participant
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
@@ -314,12 +318,28 @@ class Experiment(object):
         recruiter_name=None,
         fingerprint_hash=None,
     ):
+        """Creates and returns a new participant object. Uses
+        :attr:`~dallinger.experiment.Experiment.participant_constructor` as the
+        constructor.
+
+        :param worker_id: the recruiter Worker Id
+        :type worker_id: str
+        :param hit_id: the recruiter HIT Id
+        :type hit_id: str
+        :param assignment_id: the recruiter Assignment Id
+        :type assignment_id: str
+        :param mode: the application mode
+        :type mode: str
+        :param recruiter_name: the recruiter name
+        :type recruiter_name: str
+        :returns: A :attr:`~dallinger.models.Participant` instance
+        """
         if not recruiter_name:
             recruiter = self.recruiter
             if recruiter:
                 recruiter_name = recruiter.nickname
 
-        participant = self.participant_class(
+        participant = self.participant_constructor(
             recruiter_id=recruiter_name,
             worker_id=worker_id,
             assignment_id=assignment_id,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -82,6 +82,7 @@ class Experiment(object):
     channel = None
     exp_config = None
     replay_path = "/"
+    participant_class = Participant
 
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
@@ -303,6 +304,31 @@ class Experiment(object):
 
         """
         network.add_node(node)
+
+    def create_participant(
+        self,
+        worker_id,
+        hit_id,
+        assignment_id,
+        mode,
+        recruiter_name=None,
+        fingerprint_hash=None,
+    ):
+        if not recruiter_name:
+            recruiter = self.recruiter
+            if recruiter:
+                recruiter_name = recruiter.nickname
+
+        participant = self.participant_class(
+            recruiter_id=recruiter_name,
+            worker_id=worker_id,
+            assignment_id=assignment_id,
+            hit_id=hit_id,
+            mode=mode,
+            fingerprint_hash=fingerprint_hash,
+        )
+        self.session.add(participant)
+        return participant
 
     def load_participant(self, assignment_id):
         """Returns a participant object looked up by assignment_id.

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -36,6 +36,9 @@ what to do with the database when the server receives requests from outside.
   .. autoinstanceattribute:: known_classes
     :annotation:
 
+  .. autoinstanceattribute:: participant_constructor
+    :annotation:
+
   .. autoinstanceattribute:: public_properties
     :annotation:
 
@@ -63,7 +66,7 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: create_node
 
-  .. automethod:: load_participant
+  .. automethod:: create_participant
 
   .. automethod:: data_check
 
@@ -82,6 +85,8 @@ what to do with the database when the server receives requests from outside.
   .. automethod:: is_complete
 
   .. automethod:: is_overrecruited
+
+  .. automethod:: load_participant
 
   .. automethod:: log
 

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -233,7 +233,8 @@ Returns a JSON description of the requested participant as
     POST /participant/<worker_id>/<hit_id>/<assignment_id>/<mode>
 
 Create a participant. Returns a JSON description of the participant as
-``participant``.
+``participant``. Delegates participant creation to
+:func:`~dallinger.experiment.Experiment.create_participant`
 
 ::
 

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -752,6 +752,17 @@ class TestParticipantCreateRoute(object):
 
             yield mock_class
 
+    def test_create_participant_calls_experiment_method(self, a, webapp):
+        p = a.participant()
+        with mock.patch(
+            "dallinger.experiment.Experiment.create_participant"
+        ) as create_participant:
+            create_participant.side_effect = lambda *args: p
+            webapp.post("/participant/1/1/1/debug")
+            create_participant.assert_called_once_with(
+                "1", "1", "1", "debug", None, None
+            )
+
     def test_creates_participant_if_worker_id_unique(self, webapp):
         worker_id = "1"
         hit_id = "1"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -740,13 +740,14 @@ class TestParticipantByAssignmentRoute(object):
 @pytest.mark.slow
 class TestParticipantCreateRoute(object):
     @pytest.fixture
-    def overrecruited(self):
+    def overrecruited(self, a):
         with mock.patch(
             "dallinger.experiment_server.experiment_server.Experiment"
         ) as mock_class:
             mock_exp = mock.Mock(name="the experiment")
             mock_exp.is_overrecruited.return_value = True
             mock_exp.quorum = 50
+            mock_exp.create_participant.return_value = a.participant()
             mock_class.return_value = mock_exp
 
             yield mock_class


### PR DESCRIPTION
## Description
Implements #2258 allowing experiment developers to customize the class/process for adding partcipants to the experiment. This PR includes three changes (and documentation/test updates):

1) Adds a `create_participant` method to the `dallinger.experiment.Experiment` class.
2) Updates the `/participant/` creation route to delegate to `dallinger.experiment.Experiment.create_participant`.
3) Adds a `participant_constructor` attribute to `dallinger.experiment.Experiment` which defaults to `dallinger.models.Participant` and is used by `create_participant`. Experimenters who simply want to replace `Participant` with a subclass can override this attribute to use their custom class. It is only necessary to override `create_participant` to provide more complex behavior.

## Motivation and Context
See issue #2258

## How Has This Been Tested?
Automated tests for new methods, updated tests for existing methods. Logic is largely unchanged with some indirection added.
