### PR TITLE
Use ExperimentFileSource in module verification

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -194,10 +194,7 @@ def verify_experiment_module(verbose):
     temp_package_name = "TEMP_VERIFICATION_PACKAGE"
     tmp = tempfile.mkdtemp()
     clone_dir = os.path.join(tmp, temp_package_name)
-    to_ignore = shutil.ignore_patterns(
-        os.path.join(".git", "*"), "*.db", "snapshots", "data", "server.log"
-    )
-    shutil.copytree(os.getcwd(), clone_dir, ignore=to_ignore)
+    ExperimentFileSource(os.getcwd()).selective_copy_to(clone_dir)
     initialize_experiment_package(clone_dir)
     from dallinger_experiment import experiment
 


### PR DESCRIPTION

## Description
As part of the effort to improve the speed of `dallinger debug`, avoid copying unnecessary files during the check to verify that the custom experiment folder includes a valid experiment module.

## Motivation and Context
- Independent of performance concerns, we should always use the same mechanism to copy experiment files
- If an experiment directory includes large files that won't be included in an actual experiment deployment (debug or otherwise), there's no reason to copy them needlessly when doing the now-automatic verification check.

## How Has This Been Tested?
- Covered by automated tests
- Additional manual testing

