### PR TITLE
Support bootstrapping a deployment from an experiment archive

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_install:
   - nvm install 10  # OS node version became incompatible in 7/2020, so now we choose explicitly
   - pip install --upgrade pip wheel
 install:
-  - pip install setuptools\<50.0
+  - pip install "setuptools<50.0"  # setuptools 50.0.3 caused errors creating a virtualenv
   - pip install tox==3.1.2
   - gem install danger
   - gem install danger-commit_lint

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,8 +42,9 @@ before_install:
   - rm -rf ~/.local/share/heroku
   - rvm install 2.6.2
   - nvm install 10  # OS node version became incompatible in 7/2020, so now we choose explicitly
-  - pip install --upgrade setuptools pip wheel
+  - pip install --upgrade pip wheel
 install:
+  - pip install setuptools\<50.0
   - pip install tox==3.1.2
   - gem install danger
   - gem install danger-commit_lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   Participant classes.
 - Add extensible actions to the dashboard database view.
 - Disable global S3 experiment registration by default.
+- Provide a new `--archive` option to `dallinger deploy` and `dallinger sandbox` which makes it possible to start an experiment run with the database populated from an experiment archive created with `dallinger export`
+
 
 ## [v-6.4.0](https://github.com/dallinger/dallinger/tree/6.4.0) (2020-08003)
 - Bugfix: Fixes for Dashboard monitor layout and color issues

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -448,7 +448,7 @@ def _mturk_service_from_config(sandbox):
 
 
 def postlaunch_db_bootstrapper(zip_path, log):
-    def bootstrap_db(heroku_app, config, launch_data):
+    def bootstrap_db(heroku_app, config):
         # Pre-populate the database if an archive was given
         log("Ingesting dataset from {}...".format(os.path.basename(zip_path)))
         engine = db.create_db_engine(heroku_app.db_url)

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -471,14 +471,10 @@ def _deploy_in_mode(mode, verbose, log, app=None, archive=None):
             )
         postlaunch.append(postlaunch_db_bootstrapper(archive_path, log))
 
-    # Load configuration.
     config = get_config()
     config.load()
-
-    # Set the mode.
     config.extend({"mode": mode, "logfile": "-"})
 
-    # Do shared setup.
     deploy_sandbox_shared_setup(
         log=log, verbose=verbose, app=app, postlaunch_actions=postlaunch
     )

--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -447,7 +447,7 @@ def _mturk_service_from_config(sandbox):
     )
 
 
-def postlaunch_db_bootstrapper(zip_path, log):
+def prelaunch_db_bootstrapper(zip_path, log):
     def bootstrap_db(heroku_app, config):
         # Pre-populate the database if an archive was given
         log("Ingesting dataset from {}...".format(os.path.basename(zip_path)))
@@ -462,21 +462,21 @@ def _deploy_in_mode(mode, verbose, log, app=None, archive=None):
         verify_id(None, None, app)
 
     log(header, chevrons=False)
-    postlaunch = []
+    prelaunch = []
     if archive:
         archive_path = os.path.abspath(archive)
         if not os.path.exists(archive_path):
             raise click.BadParameter(
                 'Experiment archive "{}" does not exist.'.format(archive_path)
             )
-        postlaunch.append(postlaunch_db_bootstrapper(archive_path, log))
+        prelaunch.append(prelaunch_db_bootstrapper(archive_path, log))
 
     config = get_config()
     config.load()
     config.extend({"mode": mode, "logfile": "-"})
 
     deploy_sandbox_shared_setup(
-        log=log, verbose=verbose, app=app, postlaunch_actions=postlaunch
+        log=log, verbose=verbose, app=app, prelaunch_actions=prelaunch
     )
 
 

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -269,6 +269,15 @@ def export(id, local=False, scrub_pii=False):
     return path_to_data
 
 
+def bootstrap_db_from_zip(zip_path, engine):
+    """Given a path to a zip archive created with `export()`, first empty the
+    database, then recreate it based on the data stored in the included .csv
+    files.
+    """
+    db.init_db(drop_all=True, bind=engine)
+    ingest_zip(zip_path, engine=engine)
+
+
 def ingest_zip(path, engine=None):
     """Given a path to a zip file created with `export()`, recreate the
     database with the data stored in the included .csv files.

--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -296,13 +296,11 @@ def ingest_zip(path, engine=None):
             ingest_to_model(file, model, engine)
 
 
-def fix_autoincrement(table_name):
+def fix_autoincrement(engine, table_name):
     """Auto-increment pointers are not updated when IDs are set explicitly,
     so we manually update the pointer so subsequent inserts work correctly.
     """
-    db.engine.execute(
-        "select setval('{0}_id_seq', max(id)) from {0}".format(table_name)
-    )
+    engine.execute("select setval('{0}_id_seq', max(id)) from {0}".format(table_name))
 
 
 def ingest_to_model(file, model, engine=None):
@@ -316,7 +314,7 @@ def ingest_to_model(file, model, engine=None):
     postgres_copy.copy_from(
         file, model, engine, columns=columns, format="csv", HEADER=False
     )
-    fix_autoincrement(model.__table__.name)
+    fix_autoincrement(engine, model.__table__.name)
 
 
 def archive_data(id, src, dst):

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -53,6 +53,10 @@ Consult the developer guide for more information.
 """
 
 
+def create_db_engine(db_url, pool_size=1000):
+    return create_engine(db_url, pool_size=pool_size)
+
+
 def check_connection():
     """Test that postgres is running and that we can connect using the
     configured URI.

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -396,7 +396,9 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):
     launch_request.raise_for_status()
 
 
-def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
+def deploy_sandbox_shared_setup(
+    log, verbose=True, app=None, exp_config=None, postlaunch_actions=None
+):
     """Set up Git, push to Heroku, and launch the app."""
     if verbose:
         out = None
@@ -524,6 +526,11 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         "dashboard_url": "{}/dashboard/".format(heroku_app.url),
         "recruitment_msg": launch_data.get("recruitment_msg", None),
     }
+
+    if postlaunch_actions is not None:
+        for task in postlaunch_actions:
+            task(heroku_app, config, launch_data)
+
     log("Experiment details:")
     log("App home: {}".format(result["app_home"]), chevrons=False)
     log("Dashboard URL: {}".format(result["dashboard_url"]), chevrons=False)
@@ -547,7 +554,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     return result
 
 
-def _deploy_in_mode(mode, app, verbose, log):
+def _deploy_in_mode(mode, app, verbose, log, postlaunch_actions):
     # Load configuration.
     config = get_config()
     config.load()
@@ -556,7 +563,9 @@ def _deploy_in_mode(mode, app, verbose, log):
     config.extend({"mode": mode, "logfile": "-"})
 
     # Do shared setup.
-    deploy_sandbox_shared_setup(log, verbose=verbose, app=app)
+    deploy_sandbox_shared_setup(
+        log, verbose=verbose, app=app, postlaunch_actions=postlaunch_actions
+    )
 
 
 class HerokuLocalDeployment(object):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -515,6 +515,10 @@ def deploy_sandbox_shared_setup(
     if config.get("clock_on"):
         heroku_app.scale_up_dyno("clock", 1, size)
 
+    if postlaunch_actions is not None:
+        for task in postlaunch_actions:
+            task(heroku_app, config)
+
     # Launch the experiment.
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
@@ -526,10 +530,6 @@ def deploy_sandbox_shared_setup(
         "dashboard_url": "{}/dashboard/".format(heroku_app.url),
         "recruitment_msg": launch_data.get("recruitment_msg", None),
     }
-
-    if postlaunch_actions is not None:
-        for task in postlaunch_actions:
-            task(heroku_app, config, launch_data)
 
     log("Experiment details:")
     log("App home: {}".format(result["app_home"]), chevrons=False)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -488,9 +488,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     config.extend({"database_url": heroku_app.db_url})
     config.write()
     git.add("config.txt")
-    time.sleep(0.25)
     git.commit("Save URL for database")
-    time.sleep(0.25)
 
     log("Generating dashboard links...")
     heroku_addons = heroku_app.addon_parameters()
@@ -500,9 +498,7 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
     config.extend({"infrastructure_debug_details": heroku_addons})
     config.write()
     git.add("config.txt")
-    time.sleep(0.25)
     git.commit("Save URLs for heroku addon management")
-    time.sleep(0.25)
 
     # Launch the Heroku app.
     log("Pushing code to Heroku...")
@@ -516,8 +512,6 @@ def deploy_sandbox_shared_setup(log, verbose=True, app=None, exp_config=None):
         heroku_app.scale_up_dyno(process, qty, size)
     if config.get("clock_on"):
         heroku_app.scale_up_dyno("clock", 1, size)
-
-    time.sleep(8)
 
     # Launch the experiment.
     log("Launching the experiment on the remote server and starting recruitment...")

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -554,20 +554,6 @@ def deploy_sandbox_shared_setup(
     return result
 
 
-def _deploy_in_mode(mode, app, verbose, log, postlaunch_actions):
-    # Load configuration.
-    config = get_config()
-    config.load()
-
-    # Set the mode.
-    config.extend({"mode": mode, "logfile": "-"})
-
-    # Do shared setup.
-    deploy_sandbox_shared_setup(
-        log, verbose=verbose, app=app, postlaunch_actions=postlaunch_actions
-    )
-
-
 class HerokuLocalDeployment(object):
 
     exp_id = None

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -397,7 +397,7 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):
 
 
 def deploy_sandbox_shared_setup(
-    log, verbose=True, app=None, exp_config=None, postlaunch_actions=None
+    log, verbose=True, app=None, exp_config=None, prelaunch_actions=None
 ):
     """Set up Git, push to Heroku, and launch the app."""
     if verbose:
@@ -515,8 +515,8 @@ def deploy_sandbox_shared_setup(
     if config.get("clock_on"):
         heroku_app.scale_up_dyno("clock", 1, size)
 
-    if postlaunch_actions is not None:
-        for task in postlaunch_actions:
+    if prelaunch_actions is not None:
+        for task in prelaunch_actions:
             task(heroku_app, config)
 
     # Launch the experiment.

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -698,7 +698,7 @@ class MTurkRecruiter(Recruiter):
         return bool(self.config.get("assign_qualifications"))
 
     def current_hit_id(self):
-        """Return the most recent HIT with our experiment ID
+        """Return the ID of the most recent HIT with our experiment ID
         in the annotation, if any such HITs exist.
         """
         experiment_id = self.config.get("id")
@@ -709,7 +709,9 @@ class MTurkRecruiter(Recruiter):
         )
         if not hits:
             return None
-        return sorted(hits, key=lambda k: k["created"])[-1]
+
+        most_recent = sorted(hits, key=lambda k: k["created"])[-1]
+        return most_recent["id"]
 
     def approve_hit(self, assignment_id):
         try:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -685,12 +685,9 @@ class MTurkRecruiter(Recruiter):
         hits = self.mturkservice.get_hits(
             hit_filter=lambda h: h["annotation"] == experiment_id
         )
-        try:
-            next(hits)
-        except StopIteration:
-            return False
-        else:
+        for _ in hits:
             return True
+        return False
 
     @property
     def qualification_active(self):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -681,8 +681,17 @@ class MTurkRecruiter(Recruiter):
 
     @property
     def is_in_progress(self):
-        # Has this recruiter resulted in any participants?
-        return bool(Participant.query.filter_by(recruiter_id=self.nickname).first())
+        """Does an MTurk HIT for the current experiment ID already exist?"""
+        experiment_id = self.config.get("id")
+        hits = self.mturkservice.get_hits(
+            hit_filter=lambda h: h["annotation"] == experiment_id
+        )
+        try:
+            next(hits)
+        except StopIteration:
+            return False
+        else:
+            return True
 
     @property
     def qualification_active(self):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -20,7 +20,6 @@ from dallinger.heroku import tools as heroku_tools
 from dallinger.notifications import get_mailer
 from dallinger.notifications import admin_notifier
 from dallinger.notifications import MessengerError
-from dallinger.models import Participant
 from dallinger.models import Recruitment
 from dallinger.mturk import MTurkQualificationRequirements
 from dallinger.mturk import MTurkQuestions

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -706,8 +706,20 @@ class MTurkRecruiter(Recruiter):
         if not hits:
             return None
 
-        most_recent = sorted(hits, key=lambda k: k["created"])[-1]
-        return most_recent["id"]
+        if len(hits) == 1:
+            return hits[0]["id"]
+
+        # This is unlikely, but we might have more than one HIT if one was created
+        # directly via the MTurk UI.
+        hit_ids = [h["id"] for h in sorted(hits, key=lambda k: k["created"])]
+        most_recent = hit_ids[-1]
+        logger.warn(
+            "More than one HIT found annotated with experiment ID {}: ({}). "
+            "Using {}, as it is the most recently created.".format(
+                experiment_id, ", ".join(hit_ids), most_recent
+            )
+        )
+        return most_recent
 
     def approve_hit(self, assignment_id):
         try:

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -14,3 +14,4 @@ sphinx-js==2.7
 sphinx==1.7.9
 sphinxcontrib-spelling==4.2.0
 tox==3.2.1
+virtualenv==20.0.31

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -14,4 +14,3 @@ sphinx-js==2.7
 sphinx==1.7.9
 sphinxcontrib-spelling==4.2.0
 tox==3.2.1
-virtualenv==20.0.31

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -38,10 +38,13 @@ specify an alternative port when opening browser windows.
 sandbox
 ^^^^^^^
 
-Runs the experiment on MTurk's sandbox using Heroku as a server. An optional
-``--verbose`` flag prints more detailed logs to the command line. An optional
-``--app <app>`` parameter specifies the experiment id, if not specified, a new
+Runs the experiment on MTurk's sandbox using Heroku as a server.
+An optional ``--verbose`` flag prints more detailed logs to the command line.
+An optional ``--app <app>`` parameter specifies the experiment id. If not specified, a new
 unique experiment experiment id is automatically generated.
+An optional ``--archive <relative file path>`` parameter specifies an experiment archive
+(previously created with ``dallinger export``) from which to pre-populate the database
+before starting recruitment.
 
 deploy
 ^^^^^^
@@ -51,6 +54,9 @@ Runs the experiment live on MTurk using Heroku as a server. An optional
 ``--bot`` flag forces the bot recruiter to be used, rather than the configured
 recruiter. An optional ``--app <app>`` parameter specifies the experiment id,
 if not specified, a new unique experiment id is automatically generated.
+An optional ``--archive <relative file path>`` parameter specifies an experiment archive
+(previously created with ``dallinger export``) from which to pre-populate the database
+before starting recruitment.
 
 logs
 ^^^^

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -259,13 +259,13 @@ class TestSandboxAndDeploy(object):
     def test_uses_specified_app_id(self, sandbox, dsss):
         CliRunner().invoke(sandbox, ["--verbose", "--app", "some app id"])
         dsss.assert_called_once_with(
-            app="some app id", verbose=True, log=mock.ANY, postlaunch_actions=[]
+            app="some app id", verbose=True, log=mock.ANY, prelaunch_actions=[]
         )
 
     def test_works_with_no_app_id(self, sandbox, dsss):
         CliRunner().invoke(sandbox, ["--verbose"])
         dsss.assert_called_once_with(
-            app=None, verbose=True, log=mock.ANY, postlaunch_actions=[]
+            app=None, verbose=True, log=mock.ANY, prelaunch_actions=[]
         )
 
     def test_sandbox_puts_mode_in_config(self, sandbox, active_config, dsss):
@@ -290,7 +290,7 @@ class TestSandboxAndDeploy(object):
         CliRunner().invoke(sandbox, ["--verbose", "--archive", tempdir])
 
         dsss.assert_called_once_with(
-            app=None, verbose=True, log=mock.ANY, postlaunch_actions=[mock.ANY]
+            app=None, verbose=True, log=mock.ANY, prelaunch_actions=[mock.ANY]
         )
 
     def test_rejects_invalid_archive_path(self, sandbox, dsss):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -598,6 +598,15 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
 
         heroku.sanity_check.assert_called_once_with(active_config)
 
+    def test_runs_postlaunch_actions(self, dsss, heroku_mock, active_config):
+        log = mock.Mock()
+        action = mock.Mock()
+        dsss(log=log, postlaunch_actions=[action])
+
+        action.assert_called_once_with(
+            heroku_mock, active_config, {"recruitment_msg": "fake\nrecruitment\nlist"}
+        )
+
 
 @pytest.mark.skipif(
     not pytest.config.getvalue("heroku"), reason="--heroku was not specified"

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -598,14 +598,12 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
 
         heroku.sanity_check.assert_called_once_with(active_config)
 
-    def test_runs_postlaunch_actions(self, dsss, heroku_mock, active_config):
+    def test_runs_prelaunch_actions(self, dsss, heroku_mock, active_config):
         log = mock.Mock()
         action = mock.Mock()
-        dsss(log=log, postlaunch_actions=[action])
+        dsss(log=log, prelaunch_actions=[action])
 
-        action.assert_called_once_with(
-            heroku_mock, active_config, {"recruitment_msg": "fake\nrecruitment\nlist"}
-        )
+        action.assert_called_once_with(heroku_mock, active_config)
 
 
 @pytest.mark.skipif(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -619,31 +619,6 @@ class TestDeploySandboxSharedSetupFullSystem(object):
         assert app_name.startswith("dlgr")
 
 
-@pytest.mark.usefixtures("active_config")
-class Test_deploy_in_mode(object):
-    @pytest.fixture
-    def dim(self):
-        from dallinger.deployment import _deploy_in_mode
-
-        return _deploy_in_mode
-
-    @pytest.fixture
-    def dsss(self):
-        with mock.patch(
-            "dallinger.deployment.deploy_sandbox_shared_setup"
-        ) as mock_dsss:
-            yield mock_dsss
-
-    def test_sets_mode_in_config(self, active_config, dim, dsss):
-        dim("live", "some app id", verbose=True, log=mock.Mock())
-        dsss.assert_called_once()
-        assert active_config.get("mode") == "live"
-
-    def test_sets_logfile_to_dash_for_some_reason(self, active_config, dim, dsss):
-        dim("live", "some app id", verbose=True, log=mock.Mock())
-        assert active_config.get("logfile") == "-"
-
-
 @pytest.mark.usefixtures("bartlett_dir")
 @pytest.mark.slow
 class Test_handle_launch_data(object):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -987,7 +987,7 @@ class TestMTurkLargeRecruiter(object):
             active_config.extend({"mode": u"sandbox"})
             r = MTurkLargeRecruiter(counter=counter)
             r.mturkservice = mturkservice
-            r.current_hit_id = mock.Mock(return_value="fake HIT id")
+            # r.current_hit_id = mock.Mock(return_value="fake HIT id")
             return r
 
     def test_open_recruitment_raises_error_if_experiment_in_progress(
@@ -1056,26 +1056,30 @@ class TestMTurkLargeRecruiter(object):
             ],
         )
 
-    def test_recruit_draws_on_initial_pool_before_extending_hit(self, recruiter):
+    def test_recruit_draws_on_initial_pool_before_extending_hit(
+        self, fake_hit, recruiter
+    ):
         recruiter.open_recruitment(n=recruiter.pool_size - 1)
         recruiter.recruit(n=1)
 
         recruiter.mturkservice.extend_hit.assert_not_called()
-
+        recruiter.mturkservice.get_hits.return_value = iter([fake_hit])
         recruiter.recruit(n=1)
 
         recruiter.mturkservice.extend_hit.assert_called_once_with(
-            "fake HIT id", duration_hours=1.0, number=1
+            fake_hit["id"], duration_hours=1.0, number=1
         )
 
     def test_recruits_more_immediately_if_initial_recruitment_exceeds_pool_size(
-        self, recruiter
+        self, fake_hit, recruiter
     ):
         recruiter.open_recruitment(n=recruiter.pool_size + 1)
+        recruiter.mturkservice.get_hits.return_value = iter([fake_hit])
+
         recruiter.recruit(n=5)
 
         recruiter.mturkservice.extend_hit.assert_called_once_with(
-            "fake HIT id", duration_hours=1.0, number=5
+            fake_hit["id"], duration_hours=1.0, number=5
         )
 
     def test_recruit_auto_recruit_off_does_not_extend_hit(self, recruiter):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -699,6 +699,14 @@ class TestMTurkRecruiter(object):
     def test_current_hit_id_with_no_active_experiment(self, recruiter):
         assert recruiter.current_hit_id() is None
 
+    def test_current_hit_id_with_multiple_hits_uses_most_recent(
+        self, fake_hit, recruiter
+    ):
+        newer_hit = fake_hit.copy()
+        newer_hit["created"] = get_localzone().localize(datetime.now())
+        recruiter.mturkservice.get_hits.return_value = iter([fake_hit, newer_hit])
+        assert recruiter.current_hit_id() == newer_hit["id"]
+
     def test_recruit_auto_recruit_on_recruits_for_current_hit(
         self, fake_hit, recruiter
     ):


### PR DESCRIPTION
## Description
Provide a new `--archive` option to `dallinger deploy` and `dallinger sandbox` which makes it possible to start an experiment run with the database populated from an experiment archive created with `dallinger export`.

### Included changes
Divided into three sections, for clarity (hopefully).

#### 1. Core "business value"
- When an exported experiment archive is provided, overwrite the remote database during deployment, before the `/launch` route is called, so that the new experiment picks up where the archived experiment left off

#### 2. Required supporting infrastructure
The most complicated aspect of this feature turned out to be the need to support multiple HITs related to a single experiment. Previously, we could assume that there was only one HIT, and its ID could be found by querying the Heroku postgres database for any Participant created via MTurk, and using the record's `hit_id` property. We will now potentially have Participants with a mix of HIT Ids, so this is no longer possible.

The target functionality requires some rudimentary support for experiments with multiple related MTurk HITs:
- Reimplement `MTurkRecruiter.is_in_progress` to check if there are MTurk HITs annotated with the current experiment ID, rather than checking the heroku Postgres database for any Participant records created via that recruiter
- Reimplement `MTurkRecruiter.current_hit_id()` to search MTurk for HITs annotated with the current experiment ID, rather than checking the heroku Postgres database for any Participant record created via MTurk and grabbing the `hit_id` property

**Note** The above changes have significant performance implications for code where the current active HIT Id is required. An example is the MTurk Dashboard, which displays a view of the current HIT. The time required to find this HIT causes the page to load quite slowly.

We may be able to mitigate this category of problem by storing HIT information locally, but no such optimization is include here.

#### 3. Other unrelated improvements
- Removed obsolete explicit `time.sleep()` statements in heroku deployment code

### Caveats and Disclaimers
I'm confident I have not hunted down all the implications of the multiple-hits-per-experiment change, described above. Some more code review on this will be important, but so will some fairly serious testing in the wild.

## Motivation and Context
See #2259

## How Has This Been Tested?
- Automated tests
- Heroku + MTurk sandbox, using an export of Bartlett1932


