### PR TITLE
Dashboard Database Actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Delegates participant creation to Experiment `create_participant` method and
   `participant_constructor` attribute to allow experiments to specify custom
   Participant classes.
+- Add extensible actions to the dashboard database view.
 
 ## [v-6.4.0](https://github.com/dallinger/dallinger/tree/6.4.0) (2020-08003)
 - Bugfix: Fixes for Dashboard monitor layout and color issues

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -977,7 +977,7 @@ class Experiment(object):
             return {"message": "No nodes found to fail"}
         return {
             "message": "Failed {}".format(
-                ", ".join("{} {}s".format(c, t) for t, c in counts.items())
+                ", ".join("{} {}s".format(c, t) for t, c in sorted(counts.items()))
             )
         }
 

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -624,7 +624,7 @@ TABLE_DEFAULTS = {
         {
             "extend": "collection",
             "text": "export",
-            "buttons": ["export_json", "csvHtml5", "print",],
+            "buttons": ["export_json", "csvHtml5", "print"],
         },
     ],
 }

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -723,8 +723,10 @@ def database():
         )
 
     is_sandbox = getattr(recruiters.from_config(get_config()), "is_sandbox", None)
-    if is_sandbox is not None:
+    if is_sandbox is True or is_sandbox is False:
         buttons.append("compensate")
+    else:
+        is_sandbox = None
 
     if len(buttons):
         datatables_options["buttons"].append(actions)

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -623,7 +623,7 @@ TABLE_DEFAULTS = {
     "buttons": [
         {
             "extend": "collection",
-            "text": "export",
+            "text": "Export",
             "buttons": ["export_json", "csvHtml5", "print"],
         },
     ],
@@ -707,7 +707,7 @@ def database():
     # Extend with custom actions
     actions = {
         "extend": "collection",
-        "text": "actions",
+        "text": "Actions",
         "buttons": [],
     }
     buttons = actions["buttons"]

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -107,6 +107,7 @@
         text: 'Route Based Action',
         route_name: null,
         action: function (e, dt, node, config) {
+          var confirm;
           const that = this;
           const selected_rows = [];
           eraseMessages();
@@ -119,6 +120,14 @@
           }
           if (selected_rows.length) {
             this.processing(true);
+            confirm = window.confirm(
+              'Are you sure you want to "' + config.text + '" on ' + selected_rows.length + ' items'
+            );
+            if (!confirm) {
+              this.processing(false);
+              flashMessage('Action cancelled', 'info');
+              return
+            }
             $.ajax({
               url: '/dashboard/database/action/' + config.route_name,
               data: JSON.stringify(selected_rows),

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -174,8 +174,8 @@
             flashMessage('No rows selected', 'danger');
             return;
           }
-          const dollars = window.prompt("How much would additional compensation would you like to give to these participants (in US dollars)?", "0.00")
-          if (!dollars || !parseFloat(dollars)) {
+          const dollars = Number(window.prompt("How much would additional compensation would you like to give to these participants (in US dollars)?", "0.00"));
+          if (!dollars || dollars < 0) {
             flashMessage('You must enter a valid number for the compensation amount.')
             return;
           }

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -36,8 +36,8 @@
     };
 
     $(function () {
-      var globals = templateGlobals();
-      var flashMessage = function (msg, level) {
+      const globals = templateGlobals();
+      const flashMessage = function (msg, level) {
         level = level ? level : 'info';
         const $message = $('<div />').addClass('alert')
           .addClass('alert-' + level).attr('role', 'alert').text(msg);
@@ -46,11 +46,11 @@
           scrollTop: $message.offset().top
         }, 500);
       };
-      var eraseMessages = function() {
+      const eraseMessages = function() {
         $('div.alert, #copy-container').remove();
       }
 
-      var copyBox = function(command) {
+      const copyBox = function(command) {
         const $copyContainer = $('<div id="copy-container"/>');
         const $copyButton = $('<button type="button" id="copy-command-button">Copy CLI command to clipboard</button>');
         const $copyResult = $('<div id="copy-result" class="alert alert-success invisible"><strong>Dallinger CLI command copied to clipboard!</strong></div');
@@ -82,7 +82,7 @@
           const data = dt.buttons.exportData();
           const body = data.body;
           const header = data.header;
-          var data_export = [];
+          const data_export = [];
           var i, j, row, item;
           for (i = 0; i < body.length; i++) {
             row = body[i];
@@ -107,13 +107,14 @@
         text: 'Route Based Action',
         route_name: null,
         action: function (e, dt, node, config) {
-          var that = this, selected_rows = [], i;
+          const that = this;
+          const selected_rows = [];
           eraseMessages();
           if (!config.route_name) {
             return;
           }
           const selected = dt.rows( { selected: true } ).data();
-          for (i = 0; i < selected.length; i++) {
+          for (var i = 0; i < selected.length; i++) {
             selected_rows.push(selected[i]);
           }
           if (selected_rows.length) {

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -1,6 +1,11 @@
 {% extends "base/dashboard.html" %}
 {% block stylesheets %}
-<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.21/b-1.6.2/b-colvis-1.6.2/b-print-1.6.2/cr-1.5.2/fc-3.3.1/fh-3.1.7/kt-2.5.2/r-2.2.5/rg-1.1.2/rr-1.2.7/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
+<link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.21/b-1.6.3/b-html5-1.6.3/b-print-1.6.3/fh-3.1.7/r-2.2.5/sp-1.1.1/sl-1.3.1/datatables.min.css"/>
+<style type="text/css">
+  #copy-result { margin-top: 2em; }
+  #copy-command { font-family: monospace; }
+  #copy-command-button { display: inline-block; overflow: hidden; height: 0; width: 0; border: none;}
+</style>
 {% endblock %}
 {% block body %}
 <h1>{{ title }}</h1>
@@ -18,10 +23,165 @@
 {% endblock %}
 {% block libs %}
   {{ super() }}
-  <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.21/b-1.6.2/b-colvis-1.6.2/b-print-1.6.2/cr-1.5.2/fc-3.3.1/fh-3.1.7/kt-2.5.2/r-2.2.5/rg-1.1.2/rr-1.2.7/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
+  <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.21/b-1.6.3/b-html5-1.6.3/b-print-1.6.3/fh-3.1.7/r-2.2.5/sp-1.1.1/sl-1.3.1/datatables.min.js"></script>
   <script>
-    var datatables_options = {{ datatables_options | safe }};
-    $('#database-table').DataTable(datatables_options);
+    function templateGlobals() {
+      // Values inscribed by Jinja2 when this template is rendered.
+      const datatablesOptions = {{ datatables_options | safe }};
+      const isSandbox = {{ is_sandbox | tojson  }};
+      return {
+        datatablesOptions: datatablesOptions,
+        isSandbox: isSandbox
+      }
+    };
+
+    $(function () {
+      var globals = templateGlobals();
+      var flashMessage = function (msg, level) {
+        level = level ? level : 'info';
+        const $message = $('<div />').addClass('alert')
+          .addClass('alert-' + level).attr('role', 'alert').text(msg);
+        $message.insertAfter($('h1'));
+        $([document.documentElement, document.body]).animate({
+          scrollTop: $message.offset().top
+        }, 500);
+      };
+      var eraseMessages = function() {
+        $('div.alert, #copy-container').remove();
+      }
+
+      var copyBox = function(command) {
+        const $copyContainer = $('<div id="copy-container"/>');
+        const $copyButton = $('<button type="button" id="copy-command-button">Copy CLI command to clipboard</button>');
+        const $copyResult = $('<div id="copy-result" class="alert alert-success invisible"><strong>Dallinger CLI command copied to clipboard!</strong></div');
+        const $copyBox = $('<div id="copy-command"></div>');
+
+        $copyContainer.append($copyButton).append($copyResult);
+        $copyResult.append($copyBox)
+        $copyContainer.insertAfter($('.dt-buttons'));
+
+        const commandCB = new ClipboardJS('#copy-command-button', {
+          text: trigger => {return command;}
+        });
+        commandCB.on("success", e => {
+          $copyBox.text(e.text);
+          $copyResult.removeClass("invisible");
+        });
+        commandCB.on("failure", e => {
+          $copyResult.removeClass("invisible");
+          $copyResult.find('> strong').text('Could not copy command to clibpoard!');
+          $copyResult.removeClass('alert-success').addClass('alert-warning');
+        });
+        $copyButton.click();
+      };
+
+      $.fn.dataTable.ext.buttons.export_json = {
+        text: 'Download as JSON',
+        action: function (e, dt, node, config) {
+          this.processing(true);
+          const data = dt.buttons.exportData();
+          const body = data.body;
+          const header = data.header;
+          var data_export = [];
+          var i, j, row, item;
+          for (i = 0; i < body.length; i++) {
+            row = body[i];
+            item = {};
+            for (j = 0; j < header.length; j++) {
+              var value = row[j];
+              if (value === "") {
+                value = null;
+              }
+              item[header[j]] = value;
+            }
+            data_export.push(item);
+          }
+          $.fn.dataTable.fileSave(
+              new Blob([JSON.stringify(data_export, null, 4)]),
+              'dallinger-export.json'
+          );
+          this.processing(false);
+        }
+      };
+      $.fn.dataTable.ext.buttons.route_action = {
+        text: 'Route Based Action',
+        route_name: null,
+        action: function (e, dt, node, config) {
+          var that = this, selected_rows = [], i;
+          eraseMessages();
+          if (!config.route_name) {
+            return;
+          }
+          const selected = dt.rows( { selected: true } ).data();
+          for (i = 0; i < selected.length; i++) {
+            selected_rows.push(selected[i]);
+          }
+          if (selected_rows.length) {
+            this.processing(true);
+            $.ajax({
+              url: '/dashboard/database/action/' + config.route_name,
+              data: JSON.stringify(selected_rows),
+              method: 'POST',
+              dataType: 'json',
+              contentType: "application/json"
+            }).done(function (data) {
+              that.processing(false);
+              location.reload();
+            }).fail(function (data) {
+              that.processing(false);
+              flashMessage('Error response from server, check logs for details.', 'danger');
+            });
+          } else {
+            flashMessage('No rows selected', 'danger');
+          }
+        }
+      };
+
+      function buildCompensateCommand(participant, dollarAmount) {
+        const sandboxOption = globals.isSandbox ? " --sandbox" : "";
+        const command = "dallinger compensate --recruiter " + participant.recruiter + " --worker_id " + participant.worker_id + " --dollars " + dollarAmount + sandboxOption;
+        return command;
+      }
+
+      $.fn.dataTable.ext.buttons.compensate = {
+        text: 'Compensate Command',
+        avaliable: function (dt, config) {
+          const rows = dt.rows().data();
+          var i, row;
+          for (i = 0; i < rows.length; i++) {
+            row = rows[i];
+            if (row.object_type === 'Participant') {
+              return true;
+            }
+          }
+          return false;
+        },
+        action: function (e, dt, node, config) {
+          eraseMessages();
+          var commands = [], i, participant;
+          const selected = dt.rows( { selected: true } ).data();
+          if (selected.length == 0) {
+            flashMessage('No rows selected', 'danger');
+            return;
+          }
+          const dollars = window.prompt("How much would additional compensation would you like to give to these participants (in US dollars)?", "0.00")
+          if (!dollars || !parseFloat(dollars)) {
+            flashMessage('You must enter a valid number for the compensation amount.')
+            return;
+          }
+          for (i = 0; i < selected.length; i++) {
+            participant = selected[i];
+            if (participant.object_type !== 'Participant') {
+              flashMessage('Non-participants found in selection, please correct.', 'danger');
+              return;
+            }
+            commands.push(buildCompensateCommand(participant, dollars));
+          }
+          copyBox(commands.join('; '));
+        }
+      };
+      $('#database-table').DataTable(globals.datatablesOptions);
+    });
   </script>
 
 {% endblock %}

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -72,7 +72,9 @@
           $copyResult.find('> strong').text('Could not copy command to clibpoard!');
           $copyResult.removeClass('alert-success').addClass('alert-warning');
         });
-        $copyButton.click();
+        window.setTimeout(function () {
+          $copyButton.click();
+        }, 100);
       };
 
       $.fn.dataTable.ext.buttons.export_json = {

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -67,7 +67,7 @@
           $copyBox.text(e.text);
           $copyResult.removeClass("invisible");
         });
-        commandCB.on("failure", e => {
+        commandCB.on("error", e => {
           $copyResult.removeClass("invisible");
           $copyResult.find('> strong').text('Could not copy command to clibpoard!');
           $copyResult.removeClass('alert-success').addClass('alert-warning');

--- a/docs/source/monitoring_a_live_experiment.rst
+++ b/docs/source/monitoring_a_live_experiment.rst
@@ -130,6 +130,16 @@ the DataTables data returned by the
 
     .. automethod:: table_data
 
+    .. automethod:: dashboard_database_actions
+       :noindex:
+
+You may also add new actions to the dashboard database view by adding additional
+``title`` and ``name`` pairs to the
+:func:`~dallinger.experiment.Experiment.dashboard_database_actions` output along
+with corresponding methods that process submitted data. The
+:func:`~dallinger.experiment.Experiment.dashboard_fail` method is an example of
+such an action.
+
 
 Papertrail
 ----------

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -68,6 +68,10 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: create_participant
 
+  .. automethod:: dashboard_database_actions
+
+  .. automethod:: dashboard_fail
+
   .. automethod:: data_check
 
   .. automethod:: data_check_failed

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -788,8 +788,8 @@ class TestDashboardDatabase(object):
         # We have two sets of buttons, exports and actions
         exports = dt_options["buttons"][0]
         actions = dt_options["buttons"][1]
-        assert actions["text"] == "actions"
-        assert exports["text"] == "export"
+        assert actions["text"] == "Actions"
+        assert exports["text"] == "Export"
         # We are using a recruiter where compensation isn't possible
         assert render_args["is_sandbox"] is None
         assert "compensate" not in dt_options["buttons"][1]["buttons"]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -79,3 +79,26 @@ class TestExperimentBaseClass(object):
     def test_load_participant(self, exp, a):
         p = a.participant()
         assert exp.load_participant(p.assignment_id) == p
+
+    def test_dashboard_fail(self, exp_with_session, a):
+        p = a.participant()
+        p2 = a.participant()
+        n = a.node()
+        n2 = a.node()
+        n.fail()
+        assert p.failed is False
+        assert p2.failed is False
+        assert n.failed is True
+        assert n2.failed is False
+        data = [
+            {"id": p.id, "object_type": "Participant"},
+            {"id": p2.id, "object_type": "Participant"},
+            {"id": n.id, "object_type": "Node"},
+            {"id": n2.id, "object_type": "Node"},
+        ]
+        result = exp_with_session.dashboard_fail(data)
+        assert result == {"message": "Failed 2 Participants, 1 Nodes"}
+        assert p.failed is True
+        assert p2.failed is True
+        assert n.failed is True
+        assert n2.failed is True

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -97,7 +97,7 @@ class TestExperimentBaseClass(object):
             {"id": n2.id, "object_type": "Node"},
         ]
         result = exp_with_session.dashboard_fail(data)
-        assert result == {"message": "Failed 2 Participants, 1 Nodes"}
+        assert result == {"message": "Failed 1 Nodes, 2 Participants"}
         assert p.failed is True
         assert p2.failed is True
         assert n.failed is True


### PR DESCRIPTION
## Description
This PR implements DataTables button actions for the Dallinger Database Dashboard.

It adds two button groups to the form. The first is called `export`, which includes an option for a JSON export of selected (or all) rows as well as the built-in DataTables CSV and Print options. The second is called `actions` and it contains and action to fail selected nodes, and, when running on MTurk, an action to provide a command to compensate selected participants.

Additionally, the `actions` group can be customized by customizing the Experment `dashboard_database_actions` method to provide additional actions, each with a `name` and a `title`. The action `name` should correspond to a method on the class that accepts a data array and returns a message.

## Motivation and Context
See issue #2257. This work provides an implementation of the actions and customizations described in that ticket.

## How Has This Been Tested?
Extensive automated tests. Manual testing using the psynet non_adaptive demo.
