### PR TITLE
Remove active participants from network monitor dashboard

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -765,13 +765,6 @@ class Experiment(object):
             )
         )
 
-        # Active participants have more than 10 infos
-        active_participants = 0
-        for p in participants:
-            if len(p.infos(failed="all")) > 10:
-                active_participants += 1
-        stats["Participants"]["active"] = active_participants
-
         # Count up our networks by role
         network_roles = self.session.query(Network.role, func.count(Network.role))
         network_counts = network_roles.group_by(Network.role).all()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -405,7 +405,6 @@ class TestDashboardMonitorRoute(object):
         resp_text = resp.data.decode("utf8")
         assert "<h3>Participants</h3>" in resp_text
         assert "<li>working: 0</li>" in resp_text
-        assert "<li>active: 0</li>" in resp_text
 
     def test_statistics_show_working(self, logged_in, db_session):
         from dallinger.models import Participant


### PR DESCRIPTION
## Description
Removes active participants computation from dashboard network monitor statistics. The method did not return useful information and likely caused performance issues (see #2311 and #2312).

## Motivation and Context
See #2312 (also performance issues described in #2311)

## How Has This Been Tested?
Manual testing, automated test update.
