### PR TITLE
Fix issue deploying to Dallinger with Redis 6

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -31,7 +31,7 @@ Base = declarative_base()
 Base.query = session.query_property()
 
 redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
-redis_conn = redis.from_url(redis_url)
+redis_conn = redis.from_url(url=redis_url, ssl_cert_reqs="none")
 
 db_user_warning = """
 *********************************************************

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -480,7 +480,7 @@ def deploy_sandbox_shared_setup(
     ready = False
     while not ready:
         try:
-            r = redis.from_url(heroku_app.redis_url)
+            r = redis.from_url(url=heroku_app.redis_url, ssl_cert_reqs="none")
             r.set("foo", "bar")
             ready = True
         except (ValueError, redis.exceptions.ConnectionError):

--- a/dallinger_scripts/worker.py
+++ b/dallinger_scripts/worker.py
@@ -28,7 +28,9 @@ def main():
     redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
     # Specify queue class for improved performance with gevent.
     # see http://carsonip.me/posts/10x-faster-python-gevent-redis-connection-pool/
-    redis_pool = BlockingConnectionPool.from_url(redis_url, queue_class=LifoQueue)
+    redis_pool = BlockingConnectionPool.from_url(
+        url=redis_url, ssl_cert_reqs="none", queue_class=LifoQueue
+    )
     redis_conn = StrictRedis(connection_pool=redis_pool)
 
     with Connection(redis_conn):


### PR DESCRIPTION
## Description
SSL certificate requirements for Redis set to "none" wherever necessary in the code base. 

## Motivation and Context
Heroku recently changed their default Redis version to 6.0 (it was formerly 5.0). This breaks Dallinger when attempting to use non-free Redis add-ons, since Heroku's configuration requires SSL for non-hobby add-ons (Dallinger will still therefore launch the various demos, since those are set to use hobby-grade add-ons). I have attempted several different ways of "fixing" my own SSL certificates, but to no avail. I eventually decided to remove the requirement for SSL entirely from my Redis connections, and a Heroku representative later independently suggested this solution. I did not realize that this problem was due to the upgrade to Redis 6 at the time that I made this change. An alternative approach would be to set the version of Redis that Dallinger requests from Heroku back to 5.0, which should work equally well (though this may be less future-proof?). 

## How Has This Been Tested?
Tested manually on various Dallinger demos with non-free add-ons and on my own experiments.
