### PR TITLE
Issues/2436 incompatible redis

### DIFF
--- a/dallinger/command_line.py
+++ b/dallinger/command_line.py
@@ -62,13 +62,13 @@ header = r"""
 )
 
 
-def log(msg, chevrons=True, verbose=True):
+def log(msg, chevrons=True, verbose=True, **kw):
     """Log a message to stdout."""
     if verbose:
         if chevrons:
-            click.echo("\n❯❯ " + msg)
+            click.echo("\n❯❯ " + msg, **kw)
         else:
-            click.echo(msg)
+            click.echo(msg, **kw)
 
 
 def error(msg, chevrons=True, verbose=True):

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -5,7 +5,6 @@ from functools import wraps
 import logging
 import os
 import psycopg2
-import redis
 import sys
 import time
 import random
@@ -18,6 +17,8 @@ from sqlalchemy.orm import sessionmaker, scoped_session
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.exc import OperationalError
 
+from dallinger.utils import connect_to_redis
+
 
 logger = logging.getLogger("dallinger.db")
 
@@ -29,9 +30,7 @@ session = scoped_session(session_factory)
 
 Base = declarative_base()
 Base.query = session.query_property()
-
-redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
-redis_conn = redis.from_url(url=redis_url, ssl_cert_reqs="none")
+redis_conn = connect_to_redis()
 
 db_user_warning = """
 *********************************************************

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -477,15 +477,17 @@ def deploy_sandbox_shared_setup(
     heroku_app.set_multiple(**heroku_config)
 
     # Wait for Redis database to be ready.
-    log("Waiting for Redis...")
+    log("Waiting for Redis...", nl=False)
     ready = False
     while not ready:
         try:
             r = connect_to_redis(url=heroku_app.redis_url)
             r.set("foo", "bar")
             ready = True
+            log("\n✓ connected at {}".format(heroku_app.redis_url), chevrons=False)
         except (ValueError, redis.exceptions.ConnectionError):
             time.sleep(2)
+            log(".", chevrons=False, nl=False)
 
     log("Saving the URL of the postgres database...")
     config.extend({"database_url": heroku_app.db_url})

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -26,6 +26,7 @@ from dallinger import registration
 from dallinger.config import get_config
 from dallinger.heroku.tools import HerokuApp
 from dallinger.heroku.tools import HerokuLocalWrapper
+from dallinger.utils import connect_to_redis
 from dallinger.utils import dallinger_package_path
 from dallinger.utils import ensure_directory
 from dallinger.utils import get_base_url
@@ -480,7 +481,7 @@ def deploy_sandbox_shared_setup(
     ready = False
     while not ready:
         try:
-            r = redis.from_url(url=heroku_app.redis_url, ssl_cert_reqs="none")
+            r = connect_to_redis(url=heroku_app.redis_url)
             r.set("foo", "bar")
             ready = True
         except (ValueError, redis.exceptions.ConnectionError):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -859,7 +859,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
     pool_size = 10
 
     def __init__(self, *args, **kwargs):
-        self.counter = kwargs.get("counter", RedisTally())
+        self.counter = kwargs.get("counter") or RedisTally()
         super(MTurkLargeRecruiter, self).__init__()
 
     def open_recruitment(self, n=1):

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -6,20 +6,21 @@ import os
 import random
 import redis
 import shutil
-from six.moves.urllib.parse import urlparse
 import string
 import subprocess
 import sys
 import tempfile
 import webbrowser
 from pkg_resources import get_distribution
+from six.moves.urllib.parse import urlparse
 
 from dallinger.config import get_config
 from dallinger.compat import is_command
 
 
 def connect_to_redis(url=None):
-    """Connect to Redis.
+    """Return a connection to Redis.
+
     If a URL is supplied, it will be used, otherwise an environment variable
     is checked before falling back to a default.
 
@@ -30,6 +31,7 @@ def connect_to_redis(url=None):
     connection_args = {"url": redis_url}
     if urlparse(redis_url).scheme == "rediss":
         connection_args["ssl_cert_reqs"] = None
+
     return redis.from_url(**connection_args)
 
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -4,7 +4,9 @@ import io
 import locale
 import os
 import random
+import redis
 import shutil
+from six.moves.urllib.parse import urlparse
 import string
 import subprocess
 import sys
@@ -14,6 +16,21 @@ from pkg_resources import get_distribution
 
 from dallinger.config import get_config
 from dallinger.compat import is_command
+
+
+def connect_to_redis(url=None):
+    """Connect to Redis.
+    If a URL is supplied, it will be used, otherwise an environment variable
+    is checked before falling back to a default.
+
+    Since we are generally running on Heroku, and configuring SSL certificates
+    is challenging, we disable cert requirements on secure connections.
+    """
+    redis_url = url or os.getenv("REDIS_URL", "redis://localhost:6379")
+    connection_args = {"url": redis_url}
+    if urlparse(redis_url).scheme == "rediss":
+        connection_args["ssl_cert_reqs"] = None
+    return redis.from_url(**connection_args)
 
 
 def get_base_url():

--- a/dallinger_scripts/worker.py
+++ b/dallinger_scripts/worker.py
@@ -13,24 +13,30 @@ def main():
     # (which has the side effect of applying gevent monkey patches)
     # in the worker process. This way other processes can import the
     # redis connection without that side effect.
+    import logging
     import os
     from redis import BlockingConnectionPool, StrictRedis
     from rq import Queue, Connection
+    from six.moves.urllib.parse import urlparse
     from dallinger.heroku.rq_gevent_worker import GeventWorker as Worker
-
     from dallinger.config import initialize_experiment_package
 
     initialize_experiment_package(os.getcwd())
-
-    import logging
 
     logging.basicConfig(format="%(asctime)s %(message)s", level=logging.DEBUG)
     redis_url = os.getenv("REDIS_URL", "redis://localhost:6379")
     # Specify queue class for improved performance with gevent.
     # see http://carsonip.me/posts/10x-faster-python-gevent-redis-connection-pool/
-    redis_pool = BlockingConnectionPool.from_url(
-        url=redis_url, ssl_cert_reqs="none", queue_class=LifoQueue
-    )
+
+    connection_args = {
+        "url": redis_url,
+        "queue_class": LifoQueue,
+    }
+    # Since we are generally running on Heroku, and configuring SSL certificates
+    # is challenging, we disable cert requirements on secure connections.
+    if urlparse(redis_url).scheme == "rediss":
+        connection_args["ssl_cert_reqs"] = None
+    redis_pool = BlockingConnectionPool.from_url(**connection_args)
     redis_conn = StrictRedis(connection_pool=redis_pool)
 
     with Connection(redis_conn):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -65,8 +65,8 @@ def fake_git():
 @pytest.fixture
 def fake_redis():
     mock_connection = mock.Mock(name="fake redis connection")
-    with mock.patch("dallinger.deployment.redis") as redis_module:
-        redis_module.from_url.return_value = mock_connection
+    with mock.patch("dallinger.deployment.connect_to_redis") as connect:
+        connect.return_value = mock_connection
         yield mock_connection
 
 


### PR DESCRIPTION
[expanded on initial PR from @stefanuddenberg PR https://github.com/Dallinger/Dallinger/pull/2433]

## Description
Suppress SSL certificate verification for redis connections on Heroku.

### Included Changes

1. In cases where a redis connection uses SSL (the `rediss` scheme), disable SSL certificate checks when building the connection.
2. Bug fix for the `MTurkLargeRecruiter`, where a redis connection was created needlessly in tests
3. Give more feedback when establishing a connection to redis during deployment

## Motivation and Context
Heroku recently changed their default Redis version to 6.0 (it was formerly 5.0). This breaks Dallinger when attempting to use non-free Redis add-ons, since Heroku's configuration requires SSL for non-hobby add-ons (Dallinger will still therefore launch the various demos, since those are set to use hobby-grade add-ons). @stefanuddenberg attempted several different ways of "fixing" his SSL certificates, but to no avail. We decided to remove the requirement for SSL certificate verification from Redis connections, and a Heroku representative later independently suggested this solution. 

## How Has This Been Tested? 
- Changes are fully covered by existing automated tests
- Manual testing in debug mode using Bartlett1932 demo
- Tested manually on various Dallinger demos with non-free add-ons and on @stefanuddenberg's own experiments
