### PR TITLE
Remove broken DB Dashboard SearchPanes logic for array data

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -655,13 +655,6 @@ def prep_datatables_options(table_data):
                     "filter": key,
                     "display": display_key,
                 }
-
-            if isinstance(row[key], dict):
-                # Make sure SearchPanes can show dict values reasonably
-                row[key] = json.dumps(value, default=date_handler)
-                row[display_key] = "<code>{}</code>".format(
-                    json.dumps(value, default=date_handler, indent=True)
-                )
                 col["searchPanes"] = {
                     "orthogonal": {
                         "display": "filter",
@@ -672,15 +665,17 @@ def prep_datatables_options(table_data):
                 }
                 if "render" in col:
                     del col["render"]
+
+            if isinstance(row[key], dict):
+                # Make sure SearchPanes can show dict values reasonably
+                row[key] = json.dumps(value, default=date_handler)
+                # Add indentation
+                row[display_key] = "<code>{}</code>".format(
+                    json.dumps(value, default=date_handler, indent=True)
+                )
             elif isinstance(row[key], list):
-                # If the column is all list values allow them to be
-                # filtered separately
-                if not col.get("searchPanes", {}).get("orthogonal"):
-                    col["render"] = {
-                        "_": "{}[, ]".format(key),
-                        "sp": key,
-                    }
-                    col["searchPanes"] = {"orthogonal": "sp"}
+                # Make sure SearchPanes can show list values reasonably
+                row[key] = json.dumps(value, default=date_handler)
 
     return datatables_options
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -715,7 +715,7 @@ class TestDashboardDatabase(object):
         datatables_options = prep_datatables_options(table_data)
         row0 = datatables_options["data"][0]
         assert len(row0) == 2
-        assert row0["col1"] == [1, 2, "three"]
+        assert row0["col1"] == '[1, 2, "three"]'
         assert row0["col1_display"] == '<code>[1, 2, "three"]</code>'
 
         col_info = datatables_options["columns"][0]
@@ -725,11 +725,12 @@ class TestDashboardDatabase(object):
             "filter": "col1",
             "display": "col1_display",
         }
-        assert col_info["render"] == {
-            "_": "col1[, ]",
-            "sp": "col1",
+        assert col_info["searchPanes"]["orthogonal"] == {
+            "display": "filter",
+            "sort": "filter",
+            "search": "filter",
+            "type": "type",
         }
-        assert col_info["searchPanes"]["orthogonal"] == "sp"
 
     def test_prep_datatables_options_renders_mixed(self):
         from dallinger.experiment_server.dashboard import prep_datatables_options
@@ -761,7 +762,7 @@ class TestDashboardDatabase(object):
         }
 
         row0 = datatables_options["data"][0]
-        assert row0["col1"] == [1, 2, "three"]
+        assert row0["col1"] == '[1, 2, "three"]'
         assert row0["col1_display"] == '<code>[1, 2, "three"]</code>'
 
         row1 = datatables_options["data"][1]


### PR DESCRIPTION
## Description
The DB dashboard contained some special handling for Array objects which attempted to allow individual Array items to be filtered. That logic caused issues with rendering Arrays and needed to be removed. The array handling is now identical to the Object/dict handling.

## Motivation and Context
See issue #2313

## How Has This Been Tested?
Manual testing with Array data in `details` column. Updates to automated tests.