### PR TITLE
Add Questions (trivial) to DB dashboard

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -192,13 +192,13 @@ class DashboardTabs(object):
 
 
 BROWSEABLE_MODELS = [
-    "Participant",
-    "Node",
     "Info",
     "Network",
+    "Node",
+    "Participant",
+    "Question",
     "Transformation",
     "Transmission",
-    "Question",
 ]
 
 

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -198,6 +198,7 @@ BROWSEABLE_MODELS = [
     "Network",
     "Transformation",
     "Transmission",
+    "Question",
 ]
 
 


### PR DESCRIPTION
## Description
Adds the Question type to the list of models included in the DB dashboard by default.

## Motivation and Context
See #2414

## How Has This Been Tested?
Through the web testing in debug mode only. The change is trivial.
