### PR TITLE
Add failed_reason attr/column, and use it to capture cascading failures

### DIFF
--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -113,10 +113,14 @@ class SharedMixin(object):
         return wrapped_reason
 
     @property
-    def failure_cascade_iter(self):
-        """Query and return each type of related object which needs to be failed
-        before moving on to the next type. This ensures that retrived objects
-        have not already been fail()-ed by some previous cascading call.
+    def _failure_cascade_iter(self):
+        """Lazily query and return each type of related object which needs to be
+        failed before moving on to the next type. This ensures that retrived
+        objects have not already been fail()-ed by some previous cascading
+        call.
+
+        `self.failure_cascade` is a (potentially empty) list of callables
+        implemented by concrete subclasses.
         """
         for source in self.failure_cascade:
             for obj in source():
@@ -140,7 +144,7 @@ class SharedMixin(object):
             self.time_of_death = timenow()
             wrapped_reason = self._wrap_failed_reason(reason)
 
-            for obj in self.failure_cascade_iter:
+            for obj in self._failure_cascade_iter:
                 # For backwards compatibility with custom subclasses
                 # that do not expect to receive a "reason" argument:
                 try:

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -69,6 +69,18 @@ class SharedMixin(object):
     #: on sub-classes.
     visualization_html = ""
 
+    @property
+    def failure_cascade(self):
+        """List of callables to determine which related objects to fail
+        when ``fail()`` is called on this object.
+
+        By default, no related objects are failed, but subclasses can provide
+        a list of functions (typically bound instance methods) which will be
+        called in order to retrieve additional objects on which to call
+        ``fail()``.
+        """
+        return []
+
     def json_data(self):
         """Returns a JSON serializable ``dict`` (``datetime`` values allowed)
         to describe this object. This method can be overridden by sub-classes
@@ -324,7 +336,9 @@ class Participant(Base, SharedMixin):
 
     @property
     def failure_cascade(self):
-        """When we fail, we fail our related Nodes and Questions"""
+        """When we fail, propagate the failure to our related
+        Nodes and Questions.
+        """
         return [self.nodes, self.questions]
 
     @property
@@ -376,11 +390,6 @@ class Question(Base, SharedMixin):
         self.number = number
         self.question = question
         self.response = response
-
-    @property
-    def failure_cascade(self):
-        """When we fail, we have no related objects to fail in turn."""
-        return []
 
     def json_data(self):
         """Return json description of a question."""
@@ -596,7 +605,8 @@ class Network(Base, SharedMixin):
 
     @property
     def failure_cascade(self):
-        """When we fail, we fail all our non-failed Nodes also."""
+        """When we fail, propagate the failure to our related Nodes.
+        """
         return [self.nodes]
 
     def calculate_full(self):
@@ -1097,8 +1107,7 @@ class Node(Base, SharedMixin):
         You cannot fail a node that has already failed, but you
         can fail a dead node.
 
-        Set node.failed to True and :attr:`~dallinger.models.Node.time_of_death`
-        to now. Instruct all not-failed vectors connected to this node, infos
+        Instruct all not-failed vectors connected to this node, infos
         made by this node, transmissions to or from this node and
         transformations made by this node to fail.
         """
@@ -1452,7 +1461,8 @@ class Vector(Base, SharedMixin):
 
     @property
     def failure_cascade(self):
-        """When we fail, fail related Transmissions also."""
+        """When we fail, propagate the failure to our related Transmissions.
+        """
         return [self.transmissions]
 
 
@@ -1522,8 +1532,9 @@ class Info(Base, SharedMixin):
 
     @property
     def failure_cascade(self):
-        """Instruct all transmissions and transformations involving this
-        info to fail."""
+        """When we fail, propagate the failure to our related
+        Transmissions and Transformations.
+        """
         return [self.transmissions, self.transformations]
 
     def transmissions(self, status="all"):
@@ -1698,11 +1709,6 @@ class Transmission(Base, SharedMixin):
             "object_type": "Transmission",
         }
 
-    @property
-    def failure_cascade(self):
-        """When we fail, no related objects are failed."""
-        return []
-
 
 class Transformation(Base, SharedMixin):
     """An instance of one info being transformed into another."""
@@ -1785,11 +1791,6 @@ class Transformation(Base, SharedMixin):
             "network_id": self.network_id,
             "object_type": "Transformation",
         }
-
-    @property
-    def failure_cascade(self):
-        """When we fail, no related objects are failed."""
-        return []
 
 
 class Notification(Base, SharedMixin):

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -78,6 +78,16 @@ class SharedMixin(object):
         a list of functions (typically bound instance methods) which will be
         called in order to retrieve additional objects on which to call
         ``fail()``.
+
+        Example:
+        The following implentation would cause ``fail()`` to be called on each
+        value returned by ``self.nodes()``, and then on each value returned by
+        ``self.questions()``:
+
+        >>> @property
+        >>> def failure_cascade(self):
+        >>>     return [self.nodes, self.questions]
+
         """
         return []
 
@@ -139,7 +149,7 @@ class SharedMixin(object):
                 yield obj
 
     def fail(self, reason=None):
-        """Fail an entity in the Network (or the Network itself).
+        """Fail this object, and potentially its related objects.
 
         Set :attr:`~dallinger.models.SharedMixin.failed` to ``True`` and
         :attr:`~dallinger.models.SharedMixin.time_of_death` to now.
@@ -147,9 +157,8 @@ class SharedMixin(object):
         If a `reason` argument is passed, this will be stored in
         :attr:`~dallinger.models.SharedMixin.failed_reason`.
 
-        Failure will then be propagated to related objects returned
-        by the methods returned by the concrete subclass's `failure_cascade`
-        property.
+        Failure will then be propagated to related objects as defined by
+        the `failure_cascade` property.
         """
         if self.failed is True:
             raise AttributeError("Cannot fail {} - it has already failed.".format(self))

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -141,6 +141,8 @@ class SharedMixin(object):
             wrapped_reason = self._wrap_failed_reason(reason)
 
             for obj in self.failure_cascade_iter:
+                # For backwards compatibility with custom subclasses
+                # that do not expect to receive a "reason" argument:
                 try:
                     obj.fail(reason=wrapped_reason)
                 except TypeError:

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -132,6 +132,9 @@ class SharedMixin(object):
         Set :attr:`~dallinger.models.SharedMixin.failed` to ``True`` and
         :attr:`~dallinger.models.SharedMixin.time_of_death` to now.
 
+        If a `reason` argument is passed, this will be stored in
+        :attr:`~dallinger.models.SharedMixin.failed_reason`.
+
         Failure will then be propagated to related objects returned
         by the methods returned by the concrete subclass's `failure_cascade`
         property.

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -269,6 +269,16 @@ def a(db_session):
             defaults.update(kw)
             return self._build(models.Network, defaults)
 
+        def question(self, **kw):
+            defaults = {
+                "participant": self.participant,
+                "question": "A question...",
+                "response": "A question response...",
+                "number": 1,
+            }
+            defaults.update(kw)
+            return self._build(models.Question, defaults)
+
         def burst(self, **kw):
             defaults = {}
             defaults.update(kw)

--- a/docs/source/classes.rst
+++ b/docs/source/classes.rst
@@ -30,6 +30,9 @@ and another :class:`Info`. A :class:`Question` is a survey response created by a
 SharedMixin
 -----------
 
+Columns
+~~~~~~~
+
 All Dallinger classes inherit from a ``SharedMixin`` which provides multiple
 columns that are common across tables:
 
@@ -60,11 +63,22 @@ columns that are common across tables:
 .. autoattribute:: dallinger.models.SharedMixin.failed
     :annotation:
 
+.. autoattribute:: dallinger.models.SharedMixin.failed_reason
+    :annotation:
+
 .. autoattribute:: dallinger.models.SharedMixin.time_of_death
     :annotation:
 
+Dynamic Properties and Methods
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Properties, attributes and methods inherited by subclasses, and which
+can be overridden:
+
 .. autoattribute:: dallinger.models.SharedMixin.visualization_html
     :annotation:
+
+.. autoattribute:: dallinger.models.SharedMixin.failure_cascade
 
 .. automethod:: dallinger.models.SharedMixin.json_data
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -99,6 +99,7 @@ class TestModels(object):
             "role": "default",
             "creation_time": net.creation_time,
             "failed": False,
+            "failed_reason": None,
             "time_of_death": None,
             "property1": None,
             "property2": None,
@@ -722,6 +723,18 @@ class TestModels(object):
         assert len(participant.nodes(failed=True)) == 1
         assert len(participant.questions()) == 1
         assert participant.questions()[0].failed is True
+
+    def test_fail_participant_captures_cascade_in_failure_reason(self, a):
+        net = a.network()
+        participant = a.participant()
+        node = a.node(network=net, participant=participant)
+        question = a.question(participant=participant)
+
+        participant.fail("Boom!")
+
+        assert participant.failed_reason == "Boom!"
+        assert node.failed_reason == "Boom!->Participant1"
+        assert question.failed_reason == "Boom!->Participant1"
 
     def test_participant_json(self, db_session):
         participant = models.Participant(

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -77,7 +77,7 @@ class TestNetworks(object):
         transmission = node1.transmissions()[0]
         vector = node1.vectors()[0]
 
-        net.fail("Boom!")
+        net.fail(reason="Boom!")
 
         assert net.failed_reason == "Boom!"
         assert node1.failed_reason == "Boom!->Network1"

--- a/tests/test_networks.py
+++ b/tests/test_networks.py
@@ -44,6 +44,58 @@ class TestNetworks(object):
         assert len(net.nodes(failed="all")) == 6
         assert len(net.nodes(failed=True)) == 1
 
+    def test_network_failure_captures_cascade_in_failure_reason(self, a):
+        net = a.network()
+        node1 = a.node(network=net)
+        node2 = a.node(network=net)
+        node1.connect(whom=node2)
+        info = a.info(origin=node1)
+        node1.transmit(what=node1.infos()[0], to_whom=node2)
+        transmission = node1.transmissions()[0]
+        vector = node1.vectors()[0]
+
+        net.fail()
+
+        assert net.failed_reason is None
+        assert node1.failed_reason == "->Network1"
+        assert node2.failed_reason == "->Network1"
+        # Can't know which node is failed first, so check for either route:
+        assert info.failed_reason in {"->Network1->Node1", "->Network1->Node2"}
+        assert vector.failed_reason in {"->Network1->Node1", "->Network1->Node2"}
+        assert transmission.failed_reason in {
+            "->Network1->Node1->Vector1",
+            "->Network1->Node2->Vector1",
+        }
+
+    def test_network_failure_propagates_explicit_failure_reason(self, a):
+        net = a.network()
+        node1 = a.node(network=net)
+        node2 = a.node(network=net)
+        node1.connect(whom=node2)
+        info = a.info(origin=node1)
+        node1.transmit(what=node1.infos()[0], to_whom=node2)
+        transmission = node1.transmissions()[0]
+        vector = node1.vectors()[0]
+
+        net.fail("Boom!")
+
+        assert net.failed_reason == "Boom!"
+        assert node1.failed_reason == "Boom!->Network1"
+        assert node2.failed_reason == "Boom!->Network1"
+        # Can't know which node is failed first, so check for either route:
+        assert info.failed_reason in {
+            "Boom!->Network1->Node1",
+            "Boom!->Network1->Node2",
+        }
+        assert vector.failed_reason in {
+            "Boom!->Network1->Node1",
+            "Boom!->Network1->Node2",
+        }
+        assert transmission.failed_reason in {
+            "Boom!->Network1->Node1->Vector1",
+            "Boom!->Network1->Node2->Vector1",
+        }
+
     def test_network_agents(self, db_session):
         net = networks.Network()
         db_session.add(net)
@@ -519,7 +571,7 @@ class GenerationalAgent(nodes.Agent):
 
 
 @pytest.mark.slow
-class TestDiscreteGenerational(TestNetworks):
+class TestDiscreteGenerational(object):
 
     n_gens = 4
     gen_size = 4


### PR DESCRIPTION
## Description
Adds a `failed_reason` SQLAlchemy attribute to all classes inheriting from `dallinger.models.SharedMixin`. See #2254 

## Motivation and Context
It is useful to be able to track the reason an object was `fail()`ed.

## Breaking change?
I'm hazy on whether adding a DB column and accessing it represents a breaking change requiring a major release.

## How Has This Been Tested?
* automated tests
* superficial debug tests using Bartlett1932

## Examples:
Assume a Network with some related Nodes and Vectors received a `fail()` message.

When an explicit reason was passed to `fail()`, which was propagated from Network downwards:
```python
>>> explicit = 'Boom!->Network1->Node1->Vector1'

>>> original_reason, *chain = explicit.split('->')
>>> original_reason
'Boom!'
>>> chain
['Network1', 'Node1', 'Vector1']
```

When no explicit reason was passed:
```python
>>> implicit = '->Network1->Node1->Vector1'
>>> original_reason, *chain = implicit.split('->')
>>> original_reason
''
>>> chain
['Network1', 'Node1', 'Vector1']
```

When the `failed_reason` is on the original object, rather than triggered from a cascading failure:
```python
>>> root_only = 'Boom1!'
>>> original_reason, *chain = root_only.split('->')
>>> original_reason
'Boom1!'
>>> chain
[]
```
