### PR TITLE
Allow `extra_parameters` configuration from classmethod

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -90,7 +90,8 @@ default_keys = (
 class Configuration(object):
 
     SUPPORTED_TYPES = {six.binary_type, six.text_type, int, float, bool}
-    _experiemnt_params_loaded = False
+    _experiment_params_loaded = False
+    _module_params_loaded = False
 
     def __init__(self):
         self._reset()
@@ -108,6 +109,8 @@ class Configuration(object):
         self.synonyms = {}
         self.validators = {}
         self.sensitive = set()
+        self._experiment_params_loaded = False
+        self._module_params_loaded = False
         if register_defaults:
             for registration in default_keys:
                 self.register(*registration)
@@ -291,12 +294,9 @@ class Configuration(object):
                     from dallinger_experiment import extra_parameters
                 except ImportError:
                     pass
-        if (
-            extra_parameters is not None
-            and getattr(extra_parameters, "loaded", None) is None
-        ):
+        if extra_parameters is not None and not self._module_params_loaded:
             extra_parameters()
-            extra_parameters.loaded = True
+            self._module_params_loaded = True
 
 
 config = None

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -90,6 +90,7 @@ default_keys = (
 class Configuration(object):
 
     SUPPORTED_TYPES = {six.binary_type, six.text_type, int, float, bool}
+    _experiemnt_params_loaded = False
 
     def __init__(self):
         self._reset()
@@ -269,6 +270,17 @@ class Configuration(object):
     def register_extra_parameters(self):
         initialize_experiment_package(os.getcwd())
         extra_parameters = None
+
+        # Import and instantiate the experiment class if available
+        # This will run any experiment specific parameter registrations
+        from dallinger.experiment import load
+
+        try:
+            exp_klass = load()
+            exp_klass()
+        except ImportError:
+            pass
+
         try:
             from dallinger_experiment.experiment import extra_parameters
         except ImportError:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -280,9 +280,12 @@ class Configuration(object):
 
         try:
             exp_klass = load()
-            exp_klass()
         except ImportError:
-            pass
+            exp_klass = None
+        exp_params = getattr(exp_klass, "extra_parameters", None)
+        if exp_params is not None and not self._experiment_params_loaded:
+            exp_params()
+            self._experiment_params_loaded = True
 
         try:
             from dallinger_experiment.experiment import extra_parameters

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -146,9 +146,9 @@ class Experiment(object):
 
         # Register custom configs only once
         config = get_config()
-        if not getattr(config, "_experiemnt_params_loaded", False):
+        if not getattr(config, "_experiment_params_loaded", False):
             self.extra_parameters()
-            config._experiemnt_params_loaded = True
+            config._experiment_params_loaded = True
 
         if session:
             self.configure()
@@ -1021,7 +1021,7 @@ class Experiment(object):
 
             try:
                 extra_parameters()
-                extra_parameters.loaded = True
+                config._module_params_loaded = True
             except KeyError:
                 pass
         except ImportError:
@@ -1087,11 +1087,6 @@ class Experiment(object):
         self.import_session.close()
         session.rollback()
         session.close()
-        # Remove marker preventing experiment config variables being reloaded
-        try:
-            del module.extra_parameters.loaded
-        except AttributeError:
-            pass
         config._reset(register_defaults=True)
         del sys.modules["dallinger_experiment"]
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -144,6 +144,12 @@ class Experiment(object):
             # Guard against subclasses replacing this with a @property
             self.public_properties = {}
 
+        # Register custom configs only once
+        config = get_config()
+        if not getattr(config, "_experiemnt_params_loaded", False):
+            self.extra_parameters()
+            config._experiemnt_params_loaded = True
+
         if session:
             self.configure()
 
@@ -160,6 +166,13 @@ class Experiment(object):
                 self.widget = None
         else:
             self.widget = module.ExperimentWidget(self)
+
+    def extra_parameters(self):
+        """Override this method to register new config variables. It is called
+        exactly once during config load or experiment initialization.
+        See :ref:`Extra Configuration <extra-configuration>` for an example.
+        """
+        pass
 
     def configure(self):
         """Load experiment configuration here"""
@@ -1270,7 +1283,10 @@ def load():
         try:
             from dallinger_experiment import experiment
         except ImportError:
-            from dallinger_experiment import dallinger_experiment as experiment
+            try:
+                from dallinger_experiment import dallinger_experiment as experiment
+            except ImportError:
+                import dallinger_experiment as experiment
 
         classes = inspect.getmembers(experiment, is_experiment_class)
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -144,12 +144,6 @@ class Experiment(object):
             # Guard against subclasses replacing this with a @property
             self.public_properties = {}
 
-        # Register custom configs only once
-        config = get_config()
-        if not getattr(config, "_experiment_params_loaded", False):
-            self.extra_parameters()
-            config._experiment_params_loaded = True
-
         if session:
             self.configure()
 
@@ -167,10 +161,11 @@ class Experiment(object):
         else:
             self.widget = module.ExperimentWidget(self)
 
-    def extra_parameters(self):
-        """Override this method to register new config variables. It is called
-        exactly once during config load or experiment initialization.
-        See :ref:`Extra Configuration <extra-configuration>` for an example.
+    @classmethod
+    def extra_parameters(cls):
+        """Override this classmethod to register new config variables. It is
+        called during config load. See
+        :ref:`Extra Configuration <extra-configuration>` for an example.
         """
         pass
 

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -16,11 +16,6 @@ from dallinger.experiment import Experiment
 logger = logging.getLogger(__file__)
 
 
-def extra_parameters():
-    config = get_config()
-    config.register("num_participants", int)
-
-
 class Bartlett1932(Experiment):
     """Define the structure of the experiment."""
 
@@ -39,6 +34,10 @@ class Bartlett1932(Experiment):
         self.initial_recruitment_size = 1
         if session:
             self.setup()
+
+    def extra_parameters(self):
+        config = get_config()
+        config.register("num_participants", int)
 
     def configure(self):
         config = get_config()

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -35,7 +35,8 @@ class Bartlett1932(Experiment):
         if session:
             self.setup()
 
-    def extra_parameters(self):
+    @classmethod
+    def extra_parameters(cls):
         config = get_config()
         config.register("num_participants", int)
 

--- a/demos/tests/test_bartlett.py
+++ b/demos/tests/test_bartlett.py
@@ -18,9 +18,7 @@ class TestBartlett1932(object):
 
     @pytest.fixture
     def bartlett_config(self, active_config):
-        from dlgr.demos.bartlett1932.experiment import extra_parameters
-
-        extra_parameters()
+        active_config.register_extra_parameters()
         active_config.set("num_participants", 3)
         yield active_config
 

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -4,12 +4,13 @@ Extra Configuration
 ===================
 
 To create a new experiment-specific configuration variable, you can override
-the :attr:`~dallinger.experiment.Experiment.extra_parameters` method on your
+the :attr:`~dallinger.experiment.Experiment.extra_parameters` classmethod on your
 custom Experiment class:
 
 ::
 
-    def extra_parameters(self):
+    @classmethod
+    def extra_parameters(cls):
         config = get_config()
         config.register('n', int, [], False)
 

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -13,7 +13,8 @@ custom Experiment class:
         config = get_config()
         config.register('n', int, [], False)
 
-Alternatively you can define an ``extra_parameters`` function in your ``experiment.py`` file:
+Additionally you can define an ``extra_parameters`` function in your ``experiment.py``
+file, and both will be respected:
 
 ::
 

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -1,8 +1,19 @@
+.. _extra-configuration:
+
 Extra Configuration
 ===================
 
-To create a new experiment-specific configuration variable, define
-``extra_parameters`` in your ``experiment.py`` file:
+To create a new experiment-specific configuration variable, you can override
+the :attr:`~dallinger.experiment.Experiment.extra_parameters` method on your
+custom Experiment class:
+
+::
+
+    def extra_parameters(self):
+        config = get_config()
+        config.register('n', int, [], False)
+
+Alternatively you can define an ``extra_parameters`` function in your ``experiment.py`` file:
 
 ::
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -80,6 +80,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: events_for_replay
 
+  .. automethod:: extra_parameters
+
   .. automethod:: fail_participant
 
   .. automethod:: get_network_for_participant

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -3,8 +3,6 @@ import os.path
 from dallinger.config import get_config
 from dallinger.experiment import Experiment
 
-config = get_config()
-
 
 class TestExperiment(Experiment):
     _completed = None
@@ -23,6 +21,10 @@ class TestExperiment(Experiment):
         if session:
             self.setup()
 
+    def extra_parameters(self):
+        config = get_config()
+        config.register("custom_parameter2", bool, [])
+
     @property
     def public_properties(self):
         return {"exists": True}
@@ -34,6 +36,7 @@ class TestExperiment(Experiment):
         return Star(max_size=2)
 
     def is_complete(self):
+        config = get_config()
         return config.get("_is_completed", None)
 
 
@@ -50,6 +53,7 @@ class ZSubclassThatSortsLower(TestExperiment):
 
 
 def extra_parameters():
+    config = get_config()
     config.register("custom_parameter", int, [])
     config.register("_is_completed", bool, [])
 

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -21,7 +21,8 @@ class TestExperiment(Experiment):
         if session:
             self.setup()
 
-    def extra_parameters(self):
+    @classmethod
+    def extra_parameters(cls):
         config = get_config()
         config.register("custom_parameter2", bool, [])
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -216,8 +216,10 @@ class TestConfigurationIntegrationTests(object):
             python.sendline("config = experiment_server._config()")
             python.sendline("print(config.types)")
             if six.PY3:
+                python.expect_exact("custom_parameter2': <class 'bool'>")
                 python.expect_exact("custom_parameter': <class 'int'>")
             else:
+                python.expect_exact("custom_parameter2': <type 'bool'>")
                 python.expect_exact("custom_parameter': <type 'int'>")
         finally:
             python.sendcontrol("d")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -230,8 +230,7 @@ class TestConfigurationIntegrationTests(object):
         config = get_config()
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
-        # Failse with _reset()
-        config.clear()
+        config._reset(register_defaults=True)
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,6 @@ import os
 import sys
 from tempfile import NamedTemporaryFile
 
-import pexpect
 import pytest
 import six
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -206,24 +206,17 @@ worldwide = false
 
 @pytest.mark.usefixtures("experiment_dir_merged")
 class TestConfigurationIntegrationTests(object):
-    @pytest.mark.slow
     def test_experiment_defined_parameters(self):
-        try:
-            python = pexpect.spawn("python", encoding="utf-8")
-            python.read_nonblocking(10000)
-            python.setecho(False)
-            python.sendline("from dallinger.experiment_server import experiment_server")
-            python.sendline("config = experiment_server._config()")
-            python.sendline("print(config.types)")
-            if six.PY3:
-                python.expect_exact("custom_parameter2': <class 'bool'>")
-                python.expect_exact("custom_parameter': <class 'int'>")
-            else:
-                python.expect_exact("custom_parameter2': <type 'bool'>")
-                python.expect_exact("custom_parameter': <type 'int'>")
-        finally:
-            python.sendcontrol("d")
-            python.read()
+        config = get_config()
+        config.register_extra_parameters()
+        config.load_from_file(LOCAL_CONFIG)
+        # From custom module function
+        assert "custom_parameter" in config.types
+        # From custom experiment instance method
+        assert "custom_parameter2" in config.types
+
+        assert config.types["custom_parameter"] is int
+        assert config.types["custom_parameter2"] is bool
 
     def test_reload_config(self):
         # replicate the experiment API runner config loading


### PR DESCRIPTION
## Description
This PR implements an optional `extra_parameters` `classmethod` on the Experiment class. The method is called automatically during experiment initialization. The method should only be called once for a given `Configuration` instance. Includes documentation and test updates.

## Motivation and Context
See issue #2432

## How Has This Been Tested?
Automated tests have been updated to include class based parameter registration. The Bartlett1932 demo has been updated to use a class method for parameter registration.
