### PR TITLE
Undo changes on master related to fail_reason and experiment_params

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -144,12 +144,6 @@ class Experiment(object):
             # Guard against subclasses replacing this with a @property
             self.public_properties = {}
 
-        # Register custom configs only once
-        config = get_config()
-        if not getattr(config, "_experiment_params_loaded", False):
-            self.extra_parameters()
-            config._experiment_params_loaded = True
-
         if session:
             self.configure()
 
@@ -166,13 +160,6 @@ class Experiment(object):
                 self.widget = None
         else:
             self.widget = module.ExperimentWidget(self)
-
-    def extra_parameters(self):
-        """Override this method to register new config variables. It is called
-        exactly once during config load or experiment initialization.
-        See :ref:`Extra Configuration <extra-configuration>` for an example.
-        """
-        pass
 
     def configure(self):
         """Load experiment configuration here"""
@@ -1018,7 +1005,7 @@ class Experiment(object):
 
             try:
                 extra_parameters()
-                config._module_params_loaded = True
+                extra_parameters.loaded = True
             except KeyError:
                 pass
         except ImportError:
@@ -1084,6 +1071,11 @@ class Experiment(object):
         self.import_session.close()
         session.rollback()
         session.close()
+        # Remove marker preventing experiment config variables being reloaded
+        try:
+            del module.extra_parameters.loaded
+        except AttributeError:
+            pass
         config._reset(register_defaults=True)
         del sys.modules["dallinger_experiment"]
 
@@ -1275,10 +1267,7 @@ def load():
         try:
             from dallinger_experiment import experiment
         except ImportError:
-            try:
-                from dallinger_experiment import dallinger_experiment as experiment
-            except ImportError:
-                import dallinger_experiment as experiment
+            from dallinger_experiment import dallinger_experiment as experiment
 
         classes = inspect.getmembers(experiment, is_experiment_class)
 

--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -16,6 +16,11 @@ from dallinger.experiment import Experiment
 logger = logging.getLogger(__file__)
 
 
+def extra_parameters():
+    config = get_config()
+    config.register("num_participants", int)
+
+
 class Bartlett1932(Experiment):
     """Define the structure of the experiment."""
 
@@ -34,10 +39,6 @@ class Bartlett1932(Experiment):
         self.initial_recruitment_size = 1
         if session:
             self.setup()
-
-    def extra_parameters(self):
-        config = get_config()
-        config.register("num_participants", int)
 
     def configure(self):
         config = get_config()

--- a/demos/tests/test_bartlett.py
+++ b/demos/tests/test_bartlett.py
@@ -18,7 +18,9 @@ class TestBartlett1932(object):
 
     @pytest.fixture
     def bartlett_config(self, active_config):
-        active_config.register_extra_parameters()
+        from dlgr.demos.bartlett1932.experiment import extra_parameters
+
+        extra_parameters()
         active_config.set("num_participants", 3)
         yield active_config
 

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -1,20 +1,8 @@
-.. _extra-configuration:
-
 Extra Configuration
 ===================
 
-To create a new experiment-specific configuration variable, you can override
-the :attr:`~dallinger.experiment.Experiment.extra_parameters` method on your
-custom Experiment class:
-
-::
-
-    def extra_parameters(self):
-        config = get_config()
-        config.register('n', int, [], False)
-
-Additionally you can define an ``extra_parameters`` function in your ``experiment.py``
-file, and both will be respected:
+To create a new experiment-specific configuration variable, define
+``extra_parameters`` in your ``experiment.py`` file:
 
 ::
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -78,8 +78,6 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: events_for_replay
 
-  .. automethod:: extra_parameters
-
   .. automethod:: fail_participant
 
   .. automethod:: get_network_for_participant

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Run griduinverse tests and fail if not all pass",
     )
+    parser.addoption(
+        "--s3buckets",
+        action="store_true",
+        default=False,
+        help="Run tests which create S3 buckets",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -3,6 +3,8 @@ import os.path
 from dallinger.config import get_config
 from dallinger.experiment import Experiment
 
+config = get_config()
+
 
 class TestExperiment(Experiment):
     _completed = None
@@ -21,10 +23,6 @@ class TestExperiment(Experiment):
         if session:
             self.setup()
 
-    def extra_parameters(self):
-        config = get_config()
-        config.register("custom_parameter2", bool, [])
-
     @property
     def public_properties(self):
         return {"exists": True}
@@ -36,7 +34,6 @@ class TestExperiment(Experiment):
         return Star(max_size=2)
 
     def is_complete(self):
-        config = get_config()
         return config.get("_is_completed", None)
 
 
@@ -53,7 +50,6 @@ class ZSubclassThatSortsLower(TestExperiment):
 
 
 def extra_parameters():
-    config = get_config()
     config.register("custom_parameter", int, [])
     config.register("_is_completed", bool, [])
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -25,14 +25,13 @@ def zip_path():
     return os.path.join("tests", "datasets", "test_export.zip")
 
 
-@pytest.mark.slow
-class TestDataS3Integration(object):
-    """Tests that interact with the network and S3, and are slow as a result.
+@pytest.mark.s3buckets
+@pytest.mark.skipif(
+    not pytest.config.getvalue("s3buckets"), reason="--s3buckets was not specified"
+)
+class TestDataS3BucketCreation(object):
+    """Tests that actually create Buckets on S3.
     """
-
-    def test_connection_to_s3(self):
-        s3 = dallinger.data._s3_resource()
-        assert s3
 
     def test_user_s3_bucket_first_time(self):
         bucket = dallinger.data.user_s3_bucket(canonical_user_id=generate_random_id())
@@ -49,6 +48,17 @@ class TestDataS3Integration(object):
     def test_user_s3_bucket_no_id_provided(self):
         bucket = dallinger.data.user_s3_bucket()
         assert bucket
+
+
+@pytest.mark.slow
+class TestDataS3Integration(object):
+    """Tests that interact with the network and S3, but do not create
+    S3 buckets.
+    """
+
+    def test_connection_to_s3(self):
+        s3 = dallinger.data._s3_resource()
+        assert s3
 
     @pytest.mark.skip
     def test_data_loading(self):


### PR DESCRIPTION
## Description
Undoes merged PRs that caused issues. Avoided using revert to simplify history and rebases.

## Motivation and Context
People need to be able to use master with experiments that currently fail due to these half-finished changes.
