### PR TITLE
Split out tests that create S3 buckets

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,6 +123,12 @@ def pytest_addoption(parser):
         action="store_true",
         help="Run griduinverse tests and fail if not all pass",
     )
+    parser.addoption(
+        "--s3buckets",
+        action="store_true",
+        default=False,
+        help="Run tests which create S3 buckets",
+    )
 
 
 def pytest_collection_modifyitems(config, items):

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -25,14 +25,13 @@ def zip_path():
     return os.path.join("tests", "datasets", "test_export.zip")
 
 
-@pytest.mark.slow
-class TestDataS3Integration(object):
-    """Tests that interact with the network and S3, and are slow as a result.
+@pytest.mark.s3buckets
+@pytest.mark.skipif(
+    not pytest.config.getvalue("s3buckets"), reason="--s3buckets was not specified"
+)
+class TestDataS3BucketCreation(object):
+    """Tests that actually create Buckets on S3.
     """
-
-    def test_connection_to_s3(self):
-        s3 = dallinger.data._s3_resource()
-        assert s3
 
     def test_user_s3_bucket_first_time(self):
         bucket = dallinger.data.user_s3_bucket(canonical_user_id=generate_random_id())
@@ -49,6 +48,17 @@ class TestDataS3Integration(object):
     def test_user_s3_bucket_no_id_provided(self):
         bucket = dallinger.data.user_s3_bucket()
         assert bucket
+
+
+@pytest.mark.slow
+class TestDataS3Integration(object):
+    """Tests that interact with the network and S3, but do not create
+    S3 buckets.
+    """
+
+    def test_connection_to_s3(self):
+        s3 = dallinger.data._s3_resource()
+        assert s3
 
     @pytest.mark.skip
     def test_data_loading(self):


### PR DESCRIPTION
## Description
This PR segregates these tests into a class which gets skipped unless a `--s3buckets` flag is included when running tests.

## Motivation and Context
Tests that create S3 buckets have historically failed randomly on Travis, and are now failing regularly due to bucket creation limits. We are paying for far more than we're getting out of these tests, which largely verify AWS S3 behavior, and exercise code that is extremely stable in Dallinger.

## How Has This Been Tested?
It's all about Travis CI.


