### PR TITLE
Generic Recruiter Support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on: [push]
 jobs:
 
   check_mturk_changes:
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
@@ -31,6 +32,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: CI
+    needs: check_mturk_changes
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9]
@@ -98,12 +100,6 @@ jobs:
       - name: Python Installers
         run: |
           pip install --upgrade pip wheel tox
-
-  test:
-    needs:
-      - build
-      - check_mturk_changes
-    steps:
       - name: Before Tox
         run: |
           bundle exec danger
@@ -130,10 +126,6 @@ jobs:
         run: |
           tox -e fast
         if: matrix.python-version != 3.9
-
-  release:
-    needs: test
-    steps:
       - name: Set up deployment
         env:
           CHANDLER_GITHUB_API_TOKEN: ${{ secrets.CHANDLER_GITHUB_API_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,32 @@ name: continuous-integration
 on: [push]
 
 jobs:
+
+  check_mturk_changes:
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+
+      - name: check for mturk changes
+        id: check_files
+        run: |
+          echo "========== check paths of modified files =========="
+          git diff --name-only HEAD^ HEAD > files.txt
+          while IFS= read -r file
+          do
+            echo $file
+            if [[ $file == *mturk.py ]] || [[ $file == *recruiters.py ]]; then
+              echo "This modified file is MTurk related."
+              echo "::set-output name=mturk_changed::true"
+              break
+            else
+              echo "This modified file is not MTurk related."
+              echo "::set-output name=mturk_changed::false"
+            fi
+          done < files.txt
+
   build:
     runs-on: ubuntu-latest
     environment: CI
@@ -35,7 +61,9 @@ jobs:
       - name: Check out Dallinger repository
         uses: actions/checkout@v2
       - name: Install Ubuntu packages
-        run: sudo apt-get --yes install pandoc enchant snapd curl chromium-browser chromium-chromedriver
+        run: sudo apt-get --yes install pandoc enchant snapd curl
+      - name: Chromedriver setup
+        uses: nanasess/setup-chromedriver@v1.0.5
       - name: Install snap packages
         run: sudo snap install --classic heroku
       - name: Set up Node.js
@@ -70,6 +98,12 @@ jobs:
       - name: Python Installers
         run: |
           pip install --upgrade pip wheel tox
+
+  test:
+    needs:
+      - build
+      - check_mturk_changes
+    steps:
       - name: Before Tox
         run: |
           bundle exec danger
@@ -83,7 +117,7 @@ jobs:
           aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
-          tox
+          tox ${{ needs.check_mturk_changes.outputs.mturk_changed == 'true' && '-- --mturkfull' || ''}}
         if: matrix.python-version == 3.9
       - name: Run Fast Tests Only
         env:
@@ -96,6 +130,10 @@ jobs:
         run: |
           tox -e fast
         if: matrix.python-version != 3.9
+
+  release:
+    needs: test
+    steps:
       - name: Set up deployment
         env:
           CHANDLER_GITHUB_API_TOKEN: ${{ secrets.CHANDLER_GITHUB_API_TOKEN }}
@@ -117,4 +155,3 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.0
-    

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check out Dallinger repository
         uses: actions/checkout@v2
       - name: Install Ubuntu packages
-        run: sudo apt-get --yes install pandoc enchant snapd curl
+        run: sudo apt-get --yes install pandoc enchant snapd curl chromium-browser chromium-chromedriver
       - name: Install snap packages
         run: sudo snap install --classic heroku
       - name: Set up Node.js

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -23,11 +23,13 @@ DRIVER_MAP = {
     "phantomjs": webdriver.PhantomJS,
     "firefox": webdriver.Firefox,
     "chrome": webdriver.Chrome,
+    "chrome_headless": webdriver.Chrome,
 }
 CAPABILITY_MAP = {
     "phantomjs": webdriver.DesiredCapabilities.PHANTOMJS,
     "firefox": webdriver.DesiredCapabilities.FIREFOX,
     "chrome": webdriver.DesiredCapabilities.CHROME,
+    "chrome_headless": webdriver.DesiredCapabilities.CHROME,
 }
 
 
@@ -97,6 +99,12 @@ class BotBase(object):
                     kwargs = {
                         "service_args": ["--local-storage-path={}".format(tmpdirname)],
                     }
+                elif driver_type.lower() == "chrome_headless":
+                    from selenium.webdriver.chrome.options import Options
+
+                    chrome_options = Options()
+                    chrome_options.add_argument("--headless")
+                    kwargs = {"chrome_options": chrome_options}
                 driver = driver_class(**kwargs)
 
         if driver is None:

--- a/dallinger/bots.py
+++ b/dallinger/bots.py
@@ -116,7 +116,9 @@ class BotBase(object):
             self.driver.get(self.URL)
             logger.info("Loaded ad page.")
             begin = WebDriverWait(self.driver, 10).until(
-                EC.element_to_be_clickable((By.CLASS_NAME, "btn-primary"))
+                EC.element_to_be_clickable(
+                    (By.CSS_SELECTOR, "button.btn-primary, button.btn-success")
+                )
             )
             begin.click()
             logger.info("Clicked begin experiment button.")

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -23,7 +23,7 @@ assign_qualifications = False
 us_only = False
 
 [Bots]
-webdriver_type = phantomjs
+webdriver_type = chrome_headless
 chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 [Heroku]

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -309,17 +309,22 @@ class Experiment(object):
         """
         network.add_node(node)
 
-    def check_entry_information(self, entry_information):
-        """Accepts a dictionary with information about a recruited user, and
-        validates and optionally modifies that data.
+    def normalize_entry_information(self, entry_information):
+        """Accepts a dictionary with information about a recruited user. Returns
+        a dictionary containing data the needed to create or load a Dallinger
+        Participant. The returned data should include valid ``assignment_id``,
+        ``worker_id``, and ``hit_id`` values. It may also include an
+        ``entry_information`` key which should contain a transformed
+        ``entry_information`` dict which will be stored for newly created
+        participants.
 
-        Returns a dictionary containng data the needed to create or load a
-        Dallinger Participant. The returned data should include valid
-        `assignment_id`, `worker_id`, and `hit_id` values. By default, the
-        extraction of these values is delegated to the recruiter's
-        `check_entry_information` method.
+        By default, the extraction of these values is delegated to the
+        recruiter's `normalize_entry_information` method.
+
+        Returning a dictionary without valid ``hit_id``, ``assignment_id``, or
+        ``worker_id`` will generally result in an exception.
         """
-        entry_data = self.recruiter.check_entry_information(entry_information)
+        entry_data = self.recruiter.normalize_entry_information(entry_information)
         # We need an assignment_id in order to create a participant
         return entry_data
 
@@ -347,6 +352,10 @@ class Experiment(object):
         :type mode: str
         :param recruiter_name: the recruiter name
         :type recruiter_name: str
+        :param fingerprint_hash: the user's fingerprint
+        :type fingerprint_hash: str
+        :param entry_information: a JSON serializable data structure containing
+                                  additional participant entry information
         :returns: A :attr:`~dallinger.models.Participant` instance
         """
         if not recruiter_name:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -310,12 +310,18 @@ class Experiment(object):
         network.add_node(node)
 
     def check_entry_information(self, entry_information):
-        """Accepts data from recruited user, validates it, and returns data
-        needed to create or load a Dallinger Participant. Should raise an
-        error or return an empty dictionary if the `entry_information` is
-        not recognized. Delegates to the recruiter by default.
+        """Accepts a dictionary with information about a recruited user, and
+        validates and optionally modifies that data.
+
+        Returns a dictionary containng data the needed to create or load a
+        Dallinger Participant. The returned data should include valid
+        `assignment_id`, `worker_id`, and `hit_id` values. By default, the
+        extraction of these values is delegated to the recruiter's
+        `check_entry_information` method.
         """
-        return self.recruiter.check_entry_information(entry_information)
+        entry_data = self.recruiter.check_entry_information(entry_information)
+        # We need an assignment_id in order to create a participant
+        return entry_data
 
     def create_participant(
         self,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -309,6 +309,14 @@ class Experiment(object):
         """
         network.add_node(node)
 
+    def check_entry_information(self, entry_information):
+        """Accepts data from recruited user, validates it, and returns data
+        needed to create or load a Dallinger Participant. Should raise an
+        error or return an empty dictionary if the `entry_information` is
+        not recognized. Delegates to the recruiter by default.
+        """
+        return self.recruiter.check_entry_information(entry_information)
+
     def create_participant(
         self,
         worker_id,
@@ -317,6 +325,7 @@ class Experiment(object):
         mode,
         recruiter_name=None,
         fingerprint_hash=None,
+        entry_information=None,
     ):
         """Creates and returns a new participant object. Uses
         :attr:`~dallinger.experiment.Experiment.participant_constructor` as the
@@ -346,6 +355,7 @@ class Experiment(object):
             hit_id=hit_id,
             mode=mode,
             fingerprint_hash=fingerprint_hash,
+            entry_information=entry_information,
         )
         self.session.add(participant)
         return participant

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -771,6 +771,15 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     return success_response(**result)
 
 
+@app.route("/participant", methods=["PUT"])
+def put_participant():
+    entry_information = request.form
+    mode = entry_information.pop("mode")
+    exp = Experiment(session)
+    participant_info = exp.check_entry_information(entry_information)
+    return create_participant(mode=mode, **participant_info)
+
+
 @app.route("/participant/<participant_id>", methods=["GET"])
 def get_participant(participant_id):
     """Get the participant with the given id."""
@@ -790,12 +799,15 @@ def load_participant():
     """Get the participant with an assignment id provided in the request.
     Delegates to :func:`~dallinger.experiments.Experiment.load_participant`.
     """
-    assignment_id = request_parameter("assignment_id", optional=True)
+    entry_information = request.form
+    exp = Experiment(session)
+    participant_info = exp.check_entry_information(entry_information)
+
+    assignment_id = participant_info.get("assignment_id")
     if assignment_id is None:
         return error_response(
             error_type="/participant POST: no participant found", status=403
         )
-    exp = Experiment(session)
     ppt = exp.load_participant(assignment_id)
     if ppt is None:
         return error_response(

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -771,9 +771,9 @@ def create_participant(worker_id, hit_id, assignment_id, mode):
     return success_response(**result)
 
 
-@app.route("/participant", methods=["PUT"])
-def put_participant():
-    entry_information = request.form
+@app.route("/participant", methods=["POST"])
+def post_participant():
+    entry_information = dict(request.form)
     mode = entry_information.pop("mode")
     exp = Experiment(session)
     participant_info = exp.check_entry_information(entry_information)
@@ -794,24 +794,24 @@ def get_participant(participant_id):
     return success_response(participant=ppt.__json__())
 
 
-@app.route("/participant", methods=["POST"])
+@app.route("/load-participant", methods=["POST"])
 def load_participant():
     """Get the participant with an assignment id provided in the request.
     Delegates to :func:`~dallinger.experiments.Experiment.load_participant`.
     """
-    entry_information = request.form
+    entry_information = dict(request.form)
     exp = Experiment(session)
     participant_info = exp.check_entry_information(entry_information)
 
     assignment_id = participant_info.get("assignment_id")
     if assignment_id is None:
         return error_response(
-            error_type="/participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found", status=403
         )
     ppt = exp.load_participant(assignment_id)
     if ppt is None:
         return error_response(
-            error_type="/participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found", status=403
         )
 
     # return the data

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -418,7 +418,7 @@ def advertisement():
     participant = None
 
     exp = Experiment(session)
-    entry_data = exp.check_entry_information(entry_information)
+    entry_data = exp.normalize_entry_information(entry_information)
 
     hit_id = entry_data.get("hit_id")
     assignment_id = entry_data.get("assignment_id")
@@ -584,7 +584,7 @@ def consent():
 
     entry_information = request.args.to_dict()
     exp = Experiment(session)
-    entry_data = exp.check_entry_information(entry_information)
+    entry_data = exp.normalize_entry_information(entry_information)
 
     hit_id = entry_data.get("hit_id")
     assignment_id = entry_data.get("assignment_id")
@@ -802,7 +802,7 @@ def post_participant():
     # Remove the mode from entry_information if provided
     mode = entry_information.pop("mode", config.get("mode"))
     exp = Experiment(session)
-    participant_info = exp.check_entry_information(entry_information)
+    participant_info = exp.normalize_entry_information(entry_information)
     return create_participant(mode=mode, **participant_info)
 
 
@@ -827,7 +827,7 @@ def load_participant():
     """
     entry_information = request.form.to_dict()
     exp = Experiment(session)
-    participant_info = exp.check_entry_information(entry_information)
+    participant_info = exp.normalize_entry_information(entry_information)
 
     assignment_id = participant_info.get("assignment_id")
     if assignment_id is None:

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -299,6 +299,27 @@ var dallinger = (function () {
   };
 
   /**
+   * Convenience method for making an AJAX ``PUT`` request to a specified
+   * route.  Any callbacks provided to the `done()` method of the returned
+   * `Deferred` object will be passed the JSON object returned by the the
+   * API route (referred to as `data` below). Any callbacks provided to the
+   * `fail()` method of the returned `Deferred` object will be passed an
+   * instance of `AjaxRejection`, see :ref:`deferreds-label`.
+   *
+   * @example
+   * var response = dallinger.put('/participant', {hit_id: "AAA", assignment_id: "BBB", worker_id: "CCC", details: {a: 1}});
+   * // Wait for response and handle data or failure
+   * response.done(function (data) {...}).fail(function (rejection) {...});
+   *
+   * @param {string} route - Experiment route, e.g. ``/info/$nodeId``
+   * @param {object} [data] - Optional data to include in request
+   * @returns {jQuery.Deferred} See :ref:`deferreds-label`
+   */
+  dlgr.put = function (route, data) {
+    return ajax('put', route, data);
+  };
+
+  /**
    * Handles experiment errors by requesting feedback from the participant and
    * attempts to complete the experiment (and compensate participants).
    *

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -299,27 +299,6 @@ var dallinger = (function () {
   };
 
   /**
-   * Convenience method for making an AJAX ``PUT`` request to a specified
-   * route.  Any callbacks provided to the `done()` method of the returned
-   * `Deferred` object will be passed the JSON object returned by the the
-   * API route (referred to as `data` below). Any callbacks provided to the
-   * `fail()` method of the returned `Deferred` object will be passed an
-   * instance of `AjaxRejection`, see :ref:`deferreds-label`.
-   *
-   * @example
-   * var response = dallinger.put('/participant', {hit_id: "AAA", assignment_id: "BBB", worker_id: "CCC", details: {a: 1}});
-   * // Wait for response and handle data or failure
-   * response.done(function (data) {...}).fail(function (rejection) {...});
-   *
-   * @param {string} route - Experiment route, e.g. ``/info/$nodeId``
-   * @param {object} [data] - Optional data to include in request
-   * @returns {jQuery.Deferred} See :ref:`deferreds-label`
-   */
-  dlgr.put = function (route, data) {
-    return ajax('put', route, data);
-  };
-
-  /**
    * Handles experiment errors by requesting feedback from the participant and
    * attempts to complete the experiment (and compensate participants).
    *
@@ -456,7 +435,7 @@ var dallinger = (function () {
    */
   dlgr.loadParticipant = function(assignment_id) {
     var deferred = $.Deferred(),
-        url = '/participant';
+        url = '/load-participant';
 
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -101,6 +101,8 @@ var dallinger = (function () {
     set participantId(value) { dlgr.storage.set('participant_id', value); },
     get fingerprintHash() { return dlgr.storage.get('fingerprint_hash'); },
     set fingerprintHash(value) { dlgr.storage.set('fingerprint_hash', value);},
+    get entryInformation() { return dlgr.storage.get('entry_information'); },
+    set entryInformation(value) { dlgr.storage.set('entry_information', value);},
 
     initialize: function () {
       this.recruiter = dlgr.getUrlParameter('recruiter');
@@ -108,6 +110,12 @@ var dallinger = (function () {
       this.workerId = dlgr.getUrlParameter('worker_id');
       this.assignmentId = dlgr.getUrlParameter('assignment_id');
       this.mode = dlgr.getUrlParameter('mode');
+      // Store all url parameters as entry information.
+      // This won't work in IE, but should work in Edge.
+      this.entryInformation = Object.fromEntries(new URLSearchParams(location.search));
+      if (this.entryInformation.mode) {
+        delete this.entryInformation.mode;
+      }
       var _self = this;
       new Fingerprint2().get(function(result){
         _self.fingerprintHash = result;
@@ -390,18 +398,25 @@ var dallinger = (function () {
    *
    * @returns {jQuery.Deferred} See :ref:`deferreds-label`
    */
+  var url;
   dlgr.createParticipant = function() {
-    var deferred = $.Deferred(),
-        url = "/participant/" + dlgr.identity.workerId + "/" + dlgr.identity.hitId +
-          "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
-          (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;
+    var url = "/participant";
+    var data = {};
+    var deferred = $.Deferred();
+    if (dlgr.identity.assignment_id) {
+      url += "/" + dlgr.identity.workerId + "/" + dlgr.identity.hitId +
+            "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
+            (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;
+    } else {
+      data = dlgr.identity.entryInformation;
+    }
 
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();
     } else {
       $(function () {
         $('.btn-success').prop('disabled', true);
-        dlgr.post(url).done(function (resp) {
+        dlgr.post(url, data).done(function (resp) {
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;
@@ -429,20 +444,30 @@ var dallinger = (function () {
 
   /**
    * Load an existing `Participant` into the dlgr.identity by making a ``POST``
-   * request to the experiment `/participant` route with an ``assignment_id``.
+   * request to the experiment `/participant` route with some ``assignment_info``
+   * which can be a scalar ``assignment_id`` or an object with ``entry_information``
+   * parameters
    *
    * @returns {jQuery.Deferred} See :ref:`deferreds-label`
    */
-  dlgr.loadParticipant = function(assignment_id) {
-    var deferred = $.Deferred(),
+  dlgr.loadParticipant = function(assignment_info) {
+    var data,
+        deferred = $.Deferred(),
         url = '/load-participant';
+
+    if (typeof assignment_info == "object") {
+      data = assignment_info;
+      dlgr.identity.entryInformation = assignment_info;
+    } else {
+      data = {assignment_id: assignment_info}
+    }
 
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();
     } else {
       $(function () {
         $('.btn-success').prop('disabled', true);
-        dlgr.post(url, {assignment_id: assignment_id}).done(function (resp) {
+        dlgr.post(url, data).done(function (resp) {
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -464,7 +464,7 @@ var dallinger = (function () {
         deferred = $.Deferred(),
         url = '/load-participant';
 
-    if (typeof assignment_info == "object") {
+    if (typeof assignment_info === "object") {
       data = assignment_info;
       dlgr.identity.entryInformation = assignment_info;
     } else {

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -112,7 +112,12 @@ var dallinger = (function () {
       this.mode = dlgr.getUrlParameter('mode');
       // Store all url parameters as entry information.
       // This won't work in IE, but should work in Edge.
-      this.entryInformation = Object.fromEntries(new URLSearchParams(location.search));
+      var entry_info = {};
+      var query_params = new URLSearchParams(location.search);
+      for (const [k, v] of query_params) {
+        entry_info[k] = v;
+      }
+      this.entryInformation = entry_info;
       if (this.entryInformation.mode) {
         delete this.entryInformation.mode;
       }

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -392,8 +392,8 @@ var dallinger = (function () {
   };
 
   /**
-   * Create a new experiment `Participant` by making a ``POST`` request to
-   * the experiment `/participant/` route. If the experiment requires a
+   * Create a new experiment ``Participant`` by making a ``POST`` request to
+   * the experiment ``/participant/`` route. If the experiment requires a
    * quorum, the response will not resolve until the quorum is met. If the
    * participant is requested after the quorum has already been reached, the
    * ``dallinger.skip_experiment`` flag will be set and the experiment will
@@ -401,9 +401,13 @@ var dallinger = (function () {
    *
    * This method is called automatically by the default waiting room page.
    *
+   * @example
+   * // Create a new participant using entry information from dallinger.identity
+   * result = dallinger.createParticipant();
+   * result.done(function () {... handle ``data.status`` ...});
+   *
    * @returns {jQuery.Deferred} See :ref:`deferreds-label`
    */
-  var url;
   dlgr.createParticipant = function() {
     var url = "/participant";
     var data = {};

--- a/dallinger/frontend/templates/base/ad.html
+++ b/dallinger/frontend/templates/base/ad.html
@@ -33,7 +33,7 @@
 {% block scripts %}
 <script>
     function openwindow(event) {
-        popup = window.open('{{ server_location }}/consent?recruiter={{ recruiter }}&hit_id={{ hitid }}&assignment_id={{ assignmentid }}&worker_id={{ workerid }}&mode={{ mode }}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
+        popup = window.open('{{ server_location }}/consent?{{query_string | safe}}','Popup','toolbar=no,location=no,status=no,menubar=no,scrollbars=yes,resizable=no,width='+1024+',height='+768+'');
         event.target.setAttribute("disabled", "");
     }
 

--- a/dallinger/frontend/templates/base/consent.html
+++ b/dallinger/frontend/templates/base/consent.html
@@ -33,7 +33,7 @@
             <h4>Do you understand and consent to these terms?</h4>
             <br>
             {% block consent_button %}
-            <button type="button" class="btn btn-primary btn-lg" id="consent" onClick="window.location='/instructions/instruct-ready?hit_id={{ hit_id }}&assignment_id={{ assignment_id }}&worker_id={{ worker_id }}&mode={{ mode }}';" style="float: left;">I agree
+            <button type="button" class="btn btn-primary btn-lg" id="consent" onClick="window.location='/instructions/instruct-ready?{{query_string | safe}}';" style="float: left;">I agree
             </button>
             {% endblock consent_button %}
             {% block reject_button %}

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -220,6 +220,11 @@ class Participant(Base, SharedMixin):
     #: the amount the participant was paid as a bonus.
     bonus = Column(Float)
 
+    #: column containing structured data from the recruiter
+    entry_information = Column(
+        JSONB, nullable=False, server_default="{}", default=lambda: {}
+    )
+
     #: String representing the current status of the participant, can be:
     #:
     #:    - ``working`` - participant is working
@@ -265,6 +270,7 @@ class Participant(Base, SharedMixin):
         hit_id,
         mode,
         fingerprint_hash=None,
+        entry_information=None,
     ):
         """Create a participant."""
         self.recruiter_id = recruiter_id
@@ -274,6 +280,8 @@ class Participant(Base, SharedMixin):
         self.unique_id = worker_id + ":" + assignment_id
         self.mode = mode
         self.fingerprint_hash = fingerprint_hash
+        if entry_information:
+            self.entry_information = entry_information
 
     def json_data(self):
         """Return json description of a participant."""
@@ -288,6 +296,7 @@ class Participant(Base, SharedMixin):
             "bonus": self.bonus,
             "status": self.status,
             "object_type": "Participant",
+            "entry_information": self.entry_information,
         }
 
     def nodes(self, type=None, failed=False):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -940,7 +940,7 @@ class BotRecruiter(Recruiter):
             url = "{}/ad?{}".format(base_url, ad_parameters)
             urls.append(url)
             bot = factory(url, assignment_id=assignment, worker_id=worker, hit_id=hit)
-            job = q.enqueue(bot.run_experiment, timeout=self._timeout)
+            job = q.enqueue(bot.run_experiment, job_timeout=self._timeout)
             logger.warning("Created job {} for url {}.".format(job.id, url))
 
         return urls

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -78,6 +78,18 @@ class Recruiter(object):
         """
         raise NotImplementedError
 
+    def check_entry_information(self, entry_information):
+        """Accepts data from recruited user and returns data needed
+        to create or load a Dallinger Participant.
+        May modify the entry information as a side effect. Should raise an error
+        or return an empty dict if the `entry_information` is not valid.
+        """
+        return {
+            "hit_id": entry_information.pop("hit_id", None),
+            "assignment_id": entry_information.pop("assignment_id", None),
+            "worker_id": entry_information.pop("worker_id", None),
+        }
+
     def recruit(self, n=1):
         raise NotImplementedError
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -81,14 +81,22 @@ class Recruiter(object):
     def check_entry_information(self, entry_information):
         """Accepts data from recruited user and returns data needed
         to create or load a Dallinger Participant.
-        May modify the entry information as a side effect. Should raise an error
-        or return an empty dict if the `entry_information` is not valid.
+        May modify the entry information as a side effect.
         """
-        return {
-            "hit_id": entry_information.pop("hit_id", None),
-            "assignment_id": entry_information.pop("assignment_id", None),
-            "worker_id": entry_information.pop("worker_id", None),
+        participant_data = {
+            "hit_id": entry_information.pop(
+                "hitId", entry_information.pop("hit_id", None)
+            ),
+            "assignment_id": entry_information.pop(
+                "assignmentId", entry_information.pop("assignment_id", None)
+            ),
+            "worker_id": entry_information.pop(
+                "workerId", entry_information.pop("worker_id", None)
+            ),
         }
+        if entry_information:
+            participant_data["entry_information"] = entry_information
+        return participant_data
 
     def recruit(self, n=1):
         raise NotImplementedError

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -78,10 +78,18 @@ class Recruiter(object):
         """
         raise NotImplementedError
 
-    def check_entry_information(self, entry_information):
-        """Accepts data from recruited user and returns data needed
-        to create or load a Dallinger Participant.
-        May modify the entry information as a side effect.
+    def normalize_entry_information(self, entry_information):
+        """Accepts data from recruited user and returns data needed to validate,
+        create or load a Dallinger Participant.
+
+        See :func:`~dallinger.experiment.Experiment.create_participant` for
+        details.
+
+        The default implementation extracts ``hit_id``, ``assignment_id``, and
+        ``worker_id`` values directly from the ``entry_information``.
+
+        Returning a dictionary without valid ``hit_id``, ``assignment_id``, or
+        ``worker_id`` will generally result in an exception.
         """
         participant_data = {
             "hit_id": entry_information.pop(

--- a/demos/dlgr/demos/bartlett1932/config.txt
+++ b/demos/dlgr/demos/bartlett1932/config.txt
@@ -1,7 +1,7 @@
 [Experiment]
 mode = sandbox
 auto_recruit = true
-webdriver_type = phantomjs
+webdriver_type = chrome_headless
 num_participants = 3
 
 [MTurk]

--- a/demos/tests/conftest.py
+++ b/demos/tests/conftest.py
@@ -1,3 +1,14 @@
 """Configure tests to use `pytest_dallinger` plugin"""
+import pytest
 
 pytest_plugins = ["pytest_dallinger"]
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)

--- a/dev-constraints.txt
+++ b/dev-constraints.txt
@@ -12,4 +12,12 @@ pytest==6.2.2
 recommonmark==0.7.1
 sphinx==3.4.3
 sphinxcontrib-spelling==7.1.0
+sphinx-js==3.1
+sphinx-rtd-theme==0.5.1
+sphinxcontrib-applehelp==1.0.2
+sphinxcontrib-devhelp==1.0.2
+sphinxcontrib-htmlhelp==1.0.3
+sphinxcontrib-jsmath==1.0.1
+sphinxcontrib-qthelp==1.0.3
+sphinxcontrib-serializinghtml==1.1.4
 tox==3.21.3

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -106,6 +106,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: node_post_request
 
+  .. automethod:: normalize_entry_information
+
   .. automethod:: recruit
 
   .. automethod:: replay_event

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -238,7 +238,7 @@ Create a participant. Returns a JSON description of the participant as
 
 ::
 
-    POST /participant
+    POST /load-participant
 
 Loads a participant from a running experiment by ``assignment_id`` and
 returns a JSON description. ``assignment_id`` should be passed as data.

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -238,10 +238,25 @@ Create a participant. Returns a JSON description of the participant as
 
 ::
 
+    POST /participant
+
+Create a participant from a running experiment using arbitrary
+``entry_information`` passed as POST data. The experiment or recruiter is
+responsible for transforming ``entry_information`` data into the
+``assignment_id``, ``hit_id``, and ``worker_id`` data needed to create a
+participant. See
+:func:`~dallinger.experiment.Experiment.normalize_entry_information`.
+
+
+::
+
     POST /load-participant
 
-Loads a participant from a running experiment by ``assignment_id`` and
-returns a JSON description. ``assignment_id`` should be passed as data.
+Loads a participant from a running experiment by ``assignment_id`` or arbitrary
+``entry_information`` passed as POST data. The experiment or recruiter is
+responsible for transforming ``entry_information`` data into an
+``assignment_id`` data needed to lookup a participant.
+See :func:`~dallinger.experiment.Experiment.normalize_entry_information`.
 
 ::
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,8 +13,10 @@ def check_firefox(request):
 
 @pytest.fixture(scope="module")
 def check_chrome(request):
-    if not request.config.getvalue("chrome"):
-        pytest.skip("--chrome was not specified")
+    if not request.config.getvalue("chrome") and not request.config.getvalue(
+        "chrome_headless"
+    ):
+        pytest.skip("neither --chrome nor --chrome-headless was specified")
 
 
 @pytest.fixture(scope="module")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -13,10 +13,14 @@ def check_firefox(request):
 
 @pytest.fixture(scope="module")
 def check_chrome(request):
-    if not request.config.getvalue("chrome") and not request.config.getvalue(
-        "chrome_headless"
-    ):
-        pytest.skip("neither --chrome nor --chrome-headless was specified")
+    if not request.config.getvalue("chrome"):
+        pytest.skip("--chrome was not specified")
+
+
+@pytest.fixture(scope="module")
+def check_chrome_headless(request):
+    if not request.config.getvalue("chrome_headless"):
+        pytest.skip("--chrome-headless was not specified")
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -53,7 +53,7 @@ class TestBots(object):
         assert isinstance(bot.driver, webdriver.Chrome)
 
     @pytest.mark.usefixtures("check_webdriver")
-    @pytest.mark.usefixtures("check_chrome")
+    @pytest.mark.usefixtures("check_chrome_headless")
     def test_bot_using_webdriver_chrome_headless(self, active_config):
         """Create a bot."""
         active_config.extend(

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -17,21 +17,21 @@ class TestBots(object):
         assert bot
 
     @pytest.mark.slow
-    def test_bot_driver_default_is_phantomjs(self, active_config):
+    def test_bot_driver_default_is_chrome(self, active_config):
         from dallinger.bots import BotBase
 
         bot = BotBase("http://dallinger.io")
-        assert isinstance(bot.driver, webdriver.PhantomJS)
+        assert isinstance(bot.driver, webdriver.Chrome)
         bot.driver.quit()
 
     @pytest.mark.slow
-    def test_bot_using_phantomjs(self, active_config):
+    def test_bot_using_chrome_headless(self, active_config):
         """Create a bot."""
-        active_config.extend({"webdriver_type": u"phantomjs"})
+        active_config.extend({"webdriver_type": u"chrome_headless"})
         from dallinger.bots import BotBase
 
         bot = BotBase("http://dallinger.io")
-        assert isinstance(bot.driver, webdriver.PhantomJS)
+        assert isinstance(bot.driver, webdriver.Chrome)
         bot.driver.quit()
 
     @pytest.mark.usefixtures("check_firefox")
@@ -53,12 +53,12 @@ class TestBots(object):
         assert isinstance(bot.driver, webdriver.Chrome)
 
     @pytest.mark.usefixtures("check_webdriver")
-    @pytest.mark.usefixtures("check_phantomjs")
-    def test_bot_using_webdriver_phantomjs(self, active_config):
+    @pytest.mark.usefixtures("check_chrome")
+    def test_bot_using_webdriver_chrome_headless(self, active_config):
         """Create a bot."""
         active_config.extend(
             {
-                "webdriver_type": u"phantomjs",
+                "webdriver_type": u"chrome_headless",
                 "webdriver_url": self._config.getvalue("webdriver").decode("ascii"),
             }
         )
@@ -66,7 +66,7 @@ class TestBots(object):
 
         bot = BotBase("http://dallinger.io")
         assert isinstance(bot.driver, webdriver.Remote)
-        assert bot.driver.capabilities["browserName"] == "phantomjs"
+        assert bot.driver.capabilities["browserName"] == "chrome"
 
     @pytest.mark.usefixtures("check_webdriver")
     @pytest.mark.usefixtures("check_firefox")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -710,18 +710,18 @@ class TestParticipantByAssignmentRoute(object):
             "dallinger.experiment.Experiment.load_participant"
         ) as load_participant:
             load_participant.side_effect = lambda *args: p
-            webapp.post("/participant", data={"assignment_id": p.assignment_id})
+            webapp.post("/load-participant", data={"assignment_id": p.assignment_id})
             load_participant.assert_called_once_with(p.assignment_id)
 
     def test_load_participant(self, a, webapp):
         p = a.participant()
-        resp = webapp.post("/participant", data={"assignment_id": p.assignment_id})
+        resp = webapp.post("/load-participant", data={"assignment_id": p.assignment_id})
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "success"
         assert data.get("participant").get("status") == u"working"
 
     def test_missing_assignment(self, webapp):
-        resp = webapp.post("/participant")
+        resp = webapp.post("/load-participant")
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
         assert "no participant found" in data.get("html")
@@ -729,7 +729,7 @@ class TestParticipantByAssignmentRoute(object):
     def test_assignment_invalid(self, webapp):
         nonexistent_assignment_id = "asfkhaskjfhhjlkasf"
         resp = webapp.post(
-            "/participant", data={"assignment_id": nonexistent_assignment_id}
+            "/load-participant", data={"assignment_id": nonexistent_assignment_id}
         )
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -110,6 +110,20 @@ class TestAdvertisement(object):
         resp = webapp.get("/ad?hitId=foo&assignmentId=bar&workerId=baz")
         assert b"Thanks for accepting this HIT." in resp.data
 
+    def test_checks_normalize_entry_info(self, webapp):
+        with mock.patch(
+            "dallinger.experiment.Experiment.normalize_entry_information"
+        ) as normalizer:
+            normalizer.side_effect = lambda *args: {
+                "assignment_id": "baz",
+                "worker_id": "bar",
+                "hit_id": "foo",
+                "entry_information": args[-1],
+            }
+            resp = webapp.get("/ad?some_random_info=1")
+            assert b"Thanks for accepting this HIT." in resp.data
+            normalizer.assert_called_once_with({"some_random_info": "1"})
+
     def test_checks_browser_exclusion_rules(self, webapp, active_config):
         active_config.extend({"browser_exclude_rule": u"tablet, bot"})
         resp = webapp.get(
@@ -638,6 +652,23 @@ class TestSimpleGETRoutes(object):
         )
         assert b"Informed Consent Form" in resp.data
 
+    def test_consent_checks_normalize_entry_info(self, webapp):
+        with mock.patch(
+            "dallinger.experiment.Experiment.normalize_entry_information"
+        ) as normalizer:
+            normalizer.side_effect = lambda *args: {
+                "assignment_id": "baz",
+                "worker_id": "bar",
+                "hit_id": "foo",
+                "entry_information": args[-1],
+            }
+            resp = webapp.get(
+                "/consent",
+                query_string={"some_random_info": "1"},
+            )
+            assert b"Informed Consent Form" in resp.data
+            normalizer.assert_called_once_with({"some_random_info": "1"})
+
     def test_not_found(self, webapp):
         resp = webapp.get("/BOGUS")
         assert resp.status_code == 404
@@ -735,6 +766,25 @@ class TestParticipantByAssignmentRoute(object):
         assert data.get("status") == "error"
         assert "no participant found" in data.get("html")
 
+    def test_load_participant_calls_normalize_entry_information(
+        self, a, db_session, webapp
+    ):
+        p = a.participant()
+        with mock.patch(
+            "dallinger.experiment.Experiment.normalize_entry_information"
+        ) as normalizer:
+            normalizer.side_effect = lambda *args: {
+                "assignment_id": p.assignment_id,
+                "worker_id": p.worker_id,
+                "hit_id": p.hit_id,
+                "entry_information": args[-1],
+            }
+            resp = webapp.post("/load-participant", data={"random_info": "123"})
+            data = json.loads(resp.data.decode("utf8"))
+            normalizer.assert_called_once_with({"random_info": "123"})
+            assert data.get("status") == "success"
+            assert data.get("participant").get("status") == u"working"
+
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
 @pytest.mark.slow
@@ -817,6 +867,44 @@ class TestParticipantCreateRoute(object):
         )
 
         assert resp.status_code == 200
+
+    def test_post_participant_calls_normalize_entry_information(
+        self, a, db_session, webapp
+    ):
+        with mock.patch(
+            "dallinger.experiment.Experiment.normalize_entry_information"
+        ) as normalizer:
+            normalizer.side_effect = lambda *args: {
+                "assignment_id": "MY_ASSIGNMENT",
+                "worker_id": "MY_WORKER",
+                "hit_id": "MY_HIT",
+                "entry_information": args[-1],
+            }
+            webapp.post("/participant", data={"my_value": "1"})
+            normalizer.assert_called_once_with({"my_value": "1"})
+
+    def test_post_participant_calls_original_route(self, a, db_session, webapp):
+        with mock.patch(
+            "dallinger.experiment_server.experiment_server.create_participant"
+        ) as create_participant:
+            create_participant.side_effect = lambda *args, **kw: "Result"
+            webapp.post(
+                "/participant",
+                data={
+                    "hitId": "H",
+                    "workerId": "W",
+                    "assignmentId": "A",
+                    "mode": "debug",
+                    "additional_stuff": "1",
+                },
+            )
+            create_participant.assert_called_once_with(
+                hit_id="H",
+                worker_id="W",
+                assignment_id="A",
+                mode="debug",
+                entry_information={"additional_stuff": "1"},
+            )
 
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -760,7 +760,7 @@ class TestParticipantCreateRoute(object):
             create_participant.side_effect = lambda *args: p
             webapp.post("/participant/1/1/1/debug")
             create_participant.assert_called_once_with(
-                "1", "1", "1", "debug", None, None
+                "1", "1", "1", "debug", None, None, None
             )
 
     def test_creates_participant_if_worker_id_unique(self, webapp):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -112,6 +112,25 @@ class TestRecruiter(object):
     def test_backward_compat(self, recruiter):
         assert recruiter() is recruiter
 
+    def test_normalize_entry_information(self, recruiter):
+        normalized = recruiter.normalize_entry_information(
+            {"assignmentId": "A", "workerId": "W", "hitId": "H", "extra_info": "E"}
+        )
+        assert normalized == {
+            "assignment_id": "A",
+            "worker_id": "W",
+            "hit_id": "H",
+            "entry_information": {"extra_info": "E"},
+        }
+        normalized = recruiter.normalize_entry_information(
+            {"assignment_id": "A", "worker_id": "W", "hit_id": "H"}
+        )
+        assert normalized == {
+            "assignment_id": "A",
+            "worker_id": "W",
+            "hit_id": "H",
+        }
+
 
 @pytest.mark.usefixtures("active_config")
 class TestCLIRecruiter(object):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ commands =
     pip install -e .[data,dev,jupyter]
     pip install -e demos
     pip freeze
-    coverage run {envbindir}/pytest . demos/ {posargs} --runslow --phantomjs --mturkfull
+    coverage run {envbindir}/pytest . demos/ {posargs} --runslow --chrome-headless
     coverage combine
     coverage report
     coverage xml
@@ -42,6 +42,29 @@ deps =
     -e demos
 commands =
     {envbindir}/pytest {posargs}
+passenv =
+    CI
+    DATABASE_URL
+    POSTGRES_USER
+    POSTGRES_PASSWORD
+    POSTGRES_DB
+    PORT
+    HOME
+    aws_access_key_id
+    aws_secret_access_key
+    mturk_worker_id
+    threads
+
+[testenv:mturkfull]
+extras =
+    data
+    jupyter
+deps =
+    -r build-requirements.txt
+    -e .
+    -e demos
+commands =
+    {envbindir}/pytest {posargs} --mturkfull --runslow
 passenv =
     CI
     DATABASE_URL


### PR DESCRIPTION
## Description
Implements a general mechanism for validating Ad url parameters and turning them into parameters required to create a participant. Provides a new method `normalize_entry_information` on the `Experiment` class and the base `Recruiter` class. The default `Experiment` method delegates to the recruiter to perform the check. The check method takes an` entry_information` dict and returns a dictionary with parameters needed to create a participant. The default implementation just looks for `hit_id` or `hitId`, `assignment_id` or `assignmentId`, and `worker_id` or `workerId` and uses those directly. Additional parameters are included in the `entry_information` key.

The participant class now has a JSONB column to store the `entry_information` directly.

The experiment server route `POST /participant` which was used to load a participant from an `assignment_id` has been renamed `POST /load-participant` which is a more suitable name and the js method `loadParticipant` now uses that route. A new `POST /participant` route is provided which creates a participant based on `entry_information` data posted to the url. The route uses the `normalize_entry_information` method from the experiment to validate the `entry_information` and transform it into data necessary to create participant.

The ad and consent routes have been updated to not expect specific HIT related query strings, but allow for arbitrary information in the query string to be passed to the server routes and subsequent templates. The Dallinger JS has been updated to store the `entry_information` in the `dallinger.identity` object along with the hit_id, etc. If the `assignment_id` is not set, then `createParticipant` and `loadParticipant` POST the data from `entry_information` to the corresponding routes, otherwise they will behave as before.

I believe this approach provides a very general approach to using arbitrary Ad url parameters to create and load participants, while retaining backwards compatibility.

## Motivation and Context
See issue #2464. I decided to name the validation method `normalize_entry_information` because I realized that Dallinger is highly dependent on having HIT, Assignment, and Worker Ids, so simple validation is not sufficient. The method validates by using the input value to generate the IDs needed to a participant. I decided to put the default logic into the Recruiter class, since the recruiter seems like it should generally be the entity that knows how to turn an arbitrary recruitment url string into unique experiment, assignment, and worker ids. The experiment class can override or modify the recruiter `normalize_entry_information` implementation since it's the only caller of the recruiter implementation.

## How Has This Been Tested?
Tests pass, despite changes to a number of experiment server routes. Additional tests are still needed for the new functionality.

Demo experiments run as expected using the standard MTurk url parameters. I also tested a demo with a custom `normalize_entry_information` method to verify that I could run the demo with an alternate query string scheme.

