### PR TITLE
Move control of qualification assignment to Experiment class

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -497,16 +497,18 @@ class Experiment(object):
         return True
 
     def participant_task_completed(self, participant):
-        """Called when an experiment task is finished, generally from the
-        /worker_complete route.
+        """Called when an experiment task is finished and submitted, and prior
+        to data and attendance checks.
 
-        Assign the qualifications to the Participant, via the recruiter.
+        Assigns the qualifications to the Participant, via their recruiter.
         These will include one Qualification for the experiment
         ID, and others for the configured group_name, if it's been set.
 
         Overrecruited participants don't receive qualifications, since they
         haven't actually completed the experiment. This allows them to remain
         eligible for future runs.
+
+        :param participant: the ``Participant`` instance
         """
         if not self.qualification_active:
             logger.info("Qualification assignment is globally disabled; ignoring.")
@@ -515,7 +517,7 @@ class Experiment(object):
         if participant.status == "overrecruited":
             return
 
-        self.recruiter.assign_experiment_qualifications(
+        participant.recruiter.assign_experiment_qualifications(
             worker_id=participant.worker_id, qualifications=self.qualifications
         )
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -522,7 +522,11 @@ class Experiment(object):
         )
 
     def submission_successful(self, participant):
-        """Run when a participant submits successfully."""
+        """Run when a participant's experiment submission passes data
+        and attendence checks.
+
+        :param participant: the ``Participant`` instance
+        """
         pass
 
     def recruit(self):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -239,15 +239,6 @@ class Experiment(object):
             for name in qualification_names
         ]
 
-    @property
-    def qualification_active(self):
-        """A boolean controlling whether any worker qualifications will be
-        assigned. By default this uses the `assign_qualifications` value from
-        config.txt.
-        """
-        config = get_config()
-        return bool(config.get("assign_qualifications"))
-
     def is_overrecruited(self, waiting_count):
         """Returns True if the number of people waiting is in excess of the
         total number expected, indicating that this and subsequent users should
@@ -538,7 +529,8 @@ class Experiment(object):
 
         :param participant: the ``Participant`` instance
         """
-        if not self.qualification_active:
+        config = get_config()
+        if not bool(config.get("assign_qualifications")):
             logger.info("Qualification assignment is globally disabled; ignoring.")
             return
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -211,7 +211,9 @@ class Experiment(object):
         """
         group_qualification_desc = "Experiment group qualification"
         config = get_config()
-        qualification_names = config.get("group_name", "").split(",")
+        qualification_names = [
+            n.strip() for n in config.get("group_name", "").split(",") if n.strip()
+        ]
 
         return {name: group_qualification_desc for name in qualification_names}
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -194,6 +194,8 @@ class Experiment(object):
         By default, workers will always be assigned one qualification specific
         to the experiment run. The property `group_qualifications` defines
         additional qualifications to assign.
+
+        :return dict  of name -> description pairs
         """
         experiment_qualification_desc = "Experiment-specific qualification"
         config = get_config()
@@ -207,7 +209,10 @@ class Experiment(object):
         """Qualifications that likely span more than one experiment run.
 
         By default, the config.txt variable `group_name` is treated
-        as a comma-delimited list of additional qualifications to assign.
+        as a comma-delimited list of additional qualifications to assign,
+        but this property can be overridden to provide different behavior.
+
+        :return dict  of name -> description pairs
         """
         group_qualification_desc = "Experiment group qualification"
         config = get_config()
@@ -219,6 +224,10 @@ class Experiment(object):
 
     @property
     def qualification_active(self):
+        """A boolean controlling whether any worker qualifications will be
+        assigned. By default this uses the `assign_qualifications` value from
+        config.txt.
+        """
         config = get_config()
         return bool(config.get("assign_qualifications"))
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -195,15 +195,23 @@ class Experiment(object):
         to the experiment run. The property `group_qualifications` defines
         additional qualifications to assign.
 
-        Type should be a dictionary of name -> description pairs, or
-        an empty dictionary.
+        Type should be a list of dictionaries with "name", "description", and
+        optionally "score" (an integer), or an empty list.
+
+        If no "score" is provided, the recruiter will increment the worker's
+        current score for the qualification, setting it to 1 if it doesn't
+        previously exist.
         """
         experiment_qualification_desc = "Experiment-specific qualification"
         config = get_config()
-        quals = {config.get("id"): experiment_qualification_desc}
-        quals.update(self.group_qualifications)
+        quals = [
+            {
+                "name": config.get("id"),
+                "description": experiment_qualification_desc,
+            }
+        ]
 
-        return quals
+        return quals + self.group_qualifications
 
     @property
     def group_qualifications(self):
@@ -213,8 +221,12 @@ class Experiment(object):
         as a comma-delimited list of additional qualifications to assign,
         but this property can be overridden to provide different behavior.
 
-        Type should be a dictionary of name -> description pairs, or
-        an empty dictionary.
+        Type should be a list of dictionaries with "name", "description", and
+        optionally "score" (an integer), or an empty list.
+
+        If no "score" is provided, the recruiter will increment the worker's
+        current score for the qualification, setting it to 1 if it doesn't
+        previously exist.
         """
         group_qualification_desc = "Experiment group qualification"
         config = get_config()
@@ -222,7 +234,10 @@ class Experiment(object):
             n.strip() for n in config.get("group_name", "").split(",") if n.strip()
         ]
 
-        return {name: group_qualification_desc for name in qualification_names}
+        return [
+            {"name": name, "description": group_qualification_desc}
+            for name in qualification_names
+        ]
 
     @property
     def qualification_active(self):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -195,7 +195,8 @@ class Experiment(object):
         to the experiment run. The property `group_qualifications` defines
         additional qualifications to assign.
 
-        :return dict  of name -> description pairs
+        Type should be a dictionary of name -> description pairs, or
+        an empty dictionary.
         """
         experiment_qualification_desc = "Experiment-specific qualification"
         config = get_config()
@@ -212,7 +213,8 @@ class Experiment(object):
         as a comma-delimited list of additional qualifications to assign,
         but this property can be overridden to provide different behavior.
 
-        :return dict  of name -> description pairs
+        Type should be a dictionary of name -> description pairs, or
+        an empty dictionary.
         """
         group_qualification_desc = "Experiment group qualification"
         config = get_config()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1557,7 +1557,7 @@ def worker_complete():
 
 def _worker_complete(participant_id):
     participant = models.Participant.query.get(participant_id)
-    if not participant:
+    if participant is None:
         raise KeyError()
 
     if participant.end_time is not None:  # Provide idempotence

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1560,6 +1560,9 @@ def _worker_complete(participant_id):
     if not participant:
         raise KeyError()
 
+    if participant.end_time is not None:  # Provide idempotence
+        return
+
     participant.end_time = datetime.now()
     session.commit()
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1566,8 +1566,9 @@ def _worker_complete(participant_id):
     session.add(participant)
     session.commit()
 
-    # Notify recruiter for possible qualification assignment, etc.
-    participant.recruiter.notify_completed(participant)
+    # Notify experiment that participant has been marked complete
+    exp = Experiment(session)
+    exp.participant_task_completed(participant)
 
     event_type = participant.recruiter.submitted_event()
 

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -180,7 +180,7 @@ class WorkerEvent(object):
     def log(self, message):
         self.experiment.log(message, self.key)
 
-    def update_particant_end_time(self):
+    def update_participant_end_time(self):
         self.participant.end_time = self.now
 
 
@@ -192,7 +192,7 @@ class AssignmentAccepted(WorkerEvent):
 class AssignmentAbandoned(WorkerEvent):
     def __call__(self):
         if self.participant.status == "working":
-            self.update_particant_end_time()
+            self.update_participant_end_time()
             self.participant.status = "abandoned"
             self.experiment.assignment_abandoned(participant=self.participant)
 
@@ -200,7 +200,7 @@ class AssignmentAbandoned(WorkerEvent):
 class AssignmentReturned(WorkerEvent):
     def __call__(self):
         if self.participant.status == "working":
-            self.update_particant_end_time()
+            self.update_participant_end_time()
             self.participant.status = "returned"
             self.experiment.assignment_returned(participant=self.participant)
 
@@ -213,7 +213,7 @@ class AssignmentSubmitted(WorkerEvent):
         if not self.is_eligible(self.participant):
             return
 
-        self.update_particant_end_time()
+        self.update_participant_end_time()
         self.participant.status = "submitted"
         self.commit()
 
@@ -283,7 +283,7 @@ class AssignmentSubmitted(WorkerEvent):
 class BotAssignmentSubmitted(WorkerEvent):
     def __call__(self):
         self.log("Received bot submission.")
-        self.update_particant_end_time()
+        self.update_participant_end_time()
 
         # No checks for bot submission
         self.participant.recruiter.approve_hit(self.assignment_id)
@@ -296,7 +296,7 @@ class BotAssignmentSubmitted(WorkerEvent):
 class BotAssignmentRejected(WorkerEvent):
     def __call__(self):
         self.log("Received rejected bot submission.")
-        self.update_particant_end_time()
+        self.update_participant_end_time()
         self.participant.status = "rejected"
         self.commit()
 
@@ -307,12 +307,12 @@ class BotAssignmentRejected(WorkerEvent):
 class NotificationMissing(WorkerEvent):
     def __call__(self):
         if self.participant.status == "working":
-            self.update_particant_end_time()
+            self.update_participant_end_time()
             self.participant.status = "missing_notification"
 
 
 class AssignmentReassigned(WorkerEvent):
     def __call__(self):
-        self.update_particant_end_time()
+        self.update_participant_end_time()
         self.participant.status = "replaced"
         self.experiment.assignment_reassigned(participant=self.participant)

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -618,10 +618,11 @@ var dallinger = (function () {
    * @param {string} [name=questionnaire] - optional questionnaire name
    */
   dlgr.submitQuestionnaire = function (name) {
-    var inputs = $("form :input");
+    var $inputs = $("form :input");
+    var $button = $("button#submit-questionnaire");
     var spinner = dlgr.BusyForm();
     var formDict = {};
-    $.each(inputs, function(key, input) {
+    $.each($inputs, function(key, input) {
       if (input.name !== "") {
         formDict[input.name] = $(input).val();
       }
@@ -632,9 +633,10 @@ var dallinger = (function () {
       number: 1,
       response: JSON.stringify(formDict)
     });
-    spinner.freeze([$('form :input')]);
-    xhr.done(dlgr.submitAssignment);
-    xhr.always(function () { spinner.unfreeze(); });
+    spinner.freeze([$inputs, $button]);
+    xhr.done(function () {
+      dlgr.submitAssignment().always(function () { spinner.unfreeze(); });
+    });
   };
 
   /**

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -635,7 +635,13 @@ var dallinger = (function () {
     });
     spinner.freeze([$inputs, $button]);
     xhr.done(function () {
-      dlgr.submitAssignment().always(function () { spinner.unfreeze(); });
+      dlgr.submitAssignment().done(function () {
+       spinner.unfreeze();
+      }).fail(function (rejection) {
+        dlgr.error(rejection);
+      });
+    }).fail(function (rejection) {
+      dlgr.error(rejection);
     });
   };
 

--- a/dallinger/frontend/templates/error-complete.html
+++ b/dallinger/frontend/templates/error-complete.html
@@ -1,7 +1,7 @@
 {% extends "layout.html" %}
 
 {% block body %}
-	<div id="container">
+    <div class="main_div">
         <div>
             <h1>Thank you!</h1>
             <hr>
@@ -11,15 +11,15 @@
                 <p>The HIT has been marked as completed.
                     You should be compensated automatically.</p>
                 <p>To enquire about compensation, please contact the researcher at
-                    <a href="mailto:{{contact_address}}">{{contact_address}}
-                        and include your HIT ID: {{hit_id}}</a></p>
+                    <a href="mailto:{{contact_address}}">{{contact_address}}</a>
+                        and include your HIT ID: {{hit_id}}</p>
                 {% else %}
                 <p><b>We were not able to mark this HIT as completed.</b></p>
                 <p>Please contact the researcher at
-                    <a href="mailto:{{contact_address}}">{{contact_address}}
-                        and include your HIT ID: {{hit_id}}</a></p>
+                    <a href="mailto:{{contact_address}}">{{contact_address}}</a>
+                        and include your HIT ID: {{hit_id}}</p>
                 {% endif %}
             </div>
         </div>
-	</div>
+    </div>
 {% endblock %}

--- a/dallinger/frontend/templates/error.html
+++ b/dallinger/frontend/templates/error.html
@@ -1,12 +1,12 @@
 {% extends "layout.html" %}
 
 {% block body %}
-    <div class="container">
+    <div class="main_div">
         <div>
             <h1>Error!</h1>
             <hr>
             <div>
-                <p id="error-text">{{ error_text }}</p>
+                <p id="error-text"><em>{{ error_text }}</em></p>
                 <p>Please let us know how you encountered this error using the form below.</p>
                 <form id="error-response" action="/handle-error" method="POST">
                     <input type="hidden" name="error_type" value="{{ error_type }}" />
@@ -19,10 +19,13 @@
                     {% if request_data %}
                     <input type="hidden" name="request_data" value="{{ request_data }}" />
                     {% endif %}
-                    <textarea name="error_feedback"></textarea>
-                    <input type="submit" value="SUBMIT" />
+                    <div class="form-group">
+                        <textarea class="form-control" name="error_feedback"></textarea>
+                    </div>
+                    <input type="submit" class="btn btn-primary" value="SUBMIT" />
                 </form>
                 {% if compensate == True %}
+                <br>
                 <p>This HIT will be marked as completed and you should be compensated automatically once the above form is submitted.</p>
                 <p>To enquire about compensation, please contact the researcher at <a href="mailto:{{contact_address}}">{{contact_address}}</a> and quote the following information.</p>
                 <p>

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -355,6 +355,22 @@ class MTurkService(object):
             )
         )
 
+    def assign_named_qualification(self, name, worker_id, score, notify=False):
+        """Score a worker for a specific named qualification"""
+        qtype = self.get_qualification_type_by_name(name)
+        if qtype is None:
+            raise QualificationNotFoundException(
+                'No Qualification exists with name "{}"'.format(name)
+            )
+        return self._is_ok(
+            self.mturk.associate_qualification_with_worker(
+                QualificationTypeId=qtype["id"],
+                WorkerId=worker_id,
+                IntegerValue=score,
+                SendNotification=notify,
+            )
+        )
+
     def increment_qualification_score(self, qualification_id, worker_id, notify=False):
         """Increment the current qualification score for a worker, on a
         qualification with the provided ID.

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -613,10 +613,6 @@ class MTurkRecruiter(Recruiter):
         """Assigns MTurk Qualifications to a worker. Do nothing if qualification
         assignment is globally disabled.
         """
-        if not self.qualification_active:
-            logger.info("Qualification assignment is globally disabled; ignoring.")
-            return
-
         for name in qualifications:
             try:
                 self.mturkservice.increment_qualification_score(name, worker_id)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -907,6 +907,11 @@ class MTurkRecruiter(Recruiter):
                 try:
                     self.mturkservice.get_qualification_type_by_name(new["name"])
                 except QualificationNotFoundException:
+                    logger.warn(
+                        "Did not find qualification {}. Trying again...".format(
+                            new["name"]
+                        )
+                    )
                     time.sleep(1)
                 else:
                     new["available"] = True

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -227,8 +227,8 @@ class CLIRecruiter(Recruiter):
     def assign_experiment_qualifications(self, worker_id, qualifications):
         """Assigns recruiter-specific qualifications to a worker."""
         logger.info(
-            "Assign worker ID {} qualifications {}".format(
-                worker_id, ", ".join(qualifications)
+            "Worker ID {} earned these qualifications: {}".format(
+                worker_id, qualifications
             )
         )
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -113,6 +113,10 @@ class Recruiter(object):
         """Throw an error."""
         raise NotImplementedError
 
+    def assign_experiment_qualifications(self, worker_id, qualifications):
+        """Assigns recruiter-specific qualifications to a worker, if supported."""
+        pass
+
     def compensate_worker(self, *args, **kwargs):
         """A recruiter may provide a means to directly compensate a worker."""
         raise NotImplementedError
@@ -219,6 +223,14 @@ class CLIRecruiter(Recruiter):
         """Approve the HIT."""
         logger.info("Assignment {} has been marked for approval".format(assignment_id))
         return True
+
+    def assign_experiment_qualifications(self, worker_id, qualifications):
+        """Assigns recruiter-specific qualifications to a worker."""
+        logger.info(
+            "Assign worker ID {} qualifications {}".format(
+                worker_id, ", ".join(qualifications)
+            )
+        )
 
     def reward_bonus(self, assignment_id, amount, reason):
         """Print out bonus info for the assignment"""
@@ -610,9 +622,7 @@ class MTurkRecruiter(Recruiter):
         }
 
     def assign_experiment_qualifications(self, worker_id, qualifications):
-        """Assigns MTurk Qualifications to a worker. Do nothing if qualification
-        assignment is globally disabled.
-        """
+        """Assigns MTurk Qualifications to a worker."""
         for name in qualifications:
             try:
                 self.mturkservice.increment_qualification_score(name, worker_id)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -918,14 +918,18 @@ class MTurkRecruiter(Recruiter):
             if all([n["available"] for n in result["new_qualifications"]]):
                 break
 
-        unavailable = [q for q in result if not q["available"]]
+        unavailable = [q for q in result["new_qualifications"] if not q["available"]]
         if unavailable:
             logger.warn(
                 "After several attempts, some qualifications are still not ready "
                 "for assignment: {}".format(", ".join(unavailable))
             )
+        # Return just the available among the new ones
+        result["new_qualifications"] = [
+            q for q in result["new_qualifications"] if q["available"]
+        ]
 
-        return [q for q in result if q["available"]]
+        return result
 
     def _resubmitted_msg(self, summary):
         templates = MTurkHITMessages.by_flavor(summary, self.config.get("whimsical"))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -871,7 +871,7 @@ class MTurkRecruiter(Recruiter):
         for name, desc in qualifications.items():
             try:
                 result["new_qualification_ids"].append(
-                    self.mturkservice.create_qualification_type(name, desc)
+                    self.mturkservice.create_qualification_type(name, desc)["id"]
                 )
             except DuplicateQualificationNameError:
                 result["existing_qualification_names"].append(name)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -918,7 +918,14 @@ class MTurkRecruiter(Recruiter):
             if all([n["available"] for n in result["new_qualifications"]]):
                 break
 
-        return result
+        unavailable = [q for q in result if not q["available"]]
+        if unavailable:
+            logger.warn(
+                "After several attempts, some qualifications are still not ready "
+                "for assignment: {}".format(", ".join(unavailable))
+            )
+
+        return [q for q in result if q["available"]]
 
     def _resubmitted_msg(self, summary):
         templates = MTurkHITMessages.by_flavor(summary, self.config.get("whimsical"))

--- a/docs/source/recruitment.rst
+++ b/docs/source/recruitment.rst
@@ -58,7 +58,7 @@ parameterized space of games for the study of human social behavior::
     duration = 0.1
     us_only = true
     approve_requirement = 95
-    group_name = Griduniverse
+    group_name = Griduniverse,Survival
 
 The ``title``, ``description``, and ``keywords`` are important, because this
 is what a potential participant will see when deciding whether to
@@ -73,7 +73,7 @@ complete experiment might benefit from a higher payment figure.
 An experiment with many participants that are recruited sequentially or
 are not required to interact with each other, might benefit from a larger
 window.
- 
+
 Once a participant is looking at your experiment sign on page, the
 ``duration`` parameter controls how long it will wait for participation
 confirmation before timing out. This prevents undecided or forgetful users
@@ -94,12 +94,18 @@ experimenter. The ``approve_requirement`` parameter takes a number from 1 to
 100, representing the percentage of approved experiments that a participant
 must have to be able to participate in the experiment.
 
-The ``group_name`` parameter is used to assign a named qualification to
+The ``group_name`` parameter is used to assign named qualifications to
 participants that complete an experiment. You can use this later to find out
-if a possible participant has already completed the experiment under the
-same group name. Note that it's not enough to set this parameter to have the
-qualification saved. It's necessary to also set the ``assign_qualifications``
-parameter to ``true`` as well.
+if a possible participant has already completed the experiment under the same
+group name. This can be a single value, or a comma-separated list of values
+can be provided, and a qualification will be assigned for each. Note that it's
+not enough to set this parameter to have the qualification saved. It's
+necessary to also set the ``assign_qualifications`` parameter to ``true`` as
+well. As an alternative to (or in combination with) using these configuration
+values, you can also override properties in your experiment class. See
+especially the ``group_qualifications`` property, which is responsible for
+providing name->value qualification definitions in the form of a python
+dictionary.
 
 Finally, the ``qualification_blacklist`` parameter can be used to filter out
 potential participants and prevent them from even viewing the experiment

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -36,9 +36,6 @@ what to do with the database when the server receives requests from outside.
   .. autoattribute:: group_qualifications
     :annotation:
 
-  .. autoattribute:: qualification_active
-    :annotation:
-
   .. autoattribute:: initial_recruitment_size
     :annotation:
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -30,6 +30,15 @@ what to do with the database when the server receives requests from outside.
   .. autoattribute:: recruiter
     :annotation:
 
+  .. autoattribute:: qualifications
+    :annotation:
+
+  .. autoattribute:: group_qualifications
+    :annotation:
+
+  .. autoattribute:: qualification_active
+    :annotation:
+
   .. autoattribute:: initial_recruitment_size
     :annotation:
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -30,12 +30,6 @@ what to do with the database when the server receives requests from outside.
   .. autoattribute:: recruiter
     :annotation:
 
-  .. autoattribute:: qualifications
-    :annotation:
-
-  .. autoattribute:: group_qualifications
-    :annotation:
-
   .. autoattribute:: initial_recruitment_size
     :annotation:
 
@@ -67,6 +61,8 @@ what to do with the database when the server receives requests from outside.
   .. automethod:: bonus
 
   .. automethod:: bonus_reason
+
+  .. automethod:: calculate_qualifications
 
   .. automethod:: collect
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -112,6 +112,8 @@ what to do with the database when the server receives requests from outside.
 
   .. automethod:: normalize_entry_information
 
+  .. automethod:: participant_task_completed
+
   .. automethod:: recruit
 
   .. automethod:: replay_event

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -153,7 +153,9 @@ class TestExperimentBaseClass(object):
 
         participant.recruiter.assign_experiment_qualifications.assert_not_called()
 
-    def test_notify_completed_skips_assigning_qualification_if_overrecruited(self, exp):
+    def test_participant_task_completed_skips_assigning_qualification_if_overrecruited(
+        self, exp
+    ):
         participant = mock.Mock(
             spec=Participant, worker_id="some worker id", status="overrecruited"
         )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -134,9 +134,12 @@ class TestExperimentBaseClass(object):
             == [
                 mock.call(
                     worker_id="some worker id",
-                    qualifications={
-                        "TEST_EXPERIMENT_UID": "Experiment-specific qualification",
-                    },
+                    qualifications=[
+                        {
+                            "name": "TEST_EXPERIMENT_UID",
+                            "description": "Experiment-specific qualification",
+                        },
+                    ],
                 )
             ]
         )
@@ -154,11 +157,20 @@ class TestExperimentBaseClass(object):
             == [
                 mock.call(
                     worker_id="some worker id",
-                    qualifications={
-                        "TEST_EXPERIMENT_UID": "Experiment-specific qualification",
-                        "some-group-1": "Experiment group qualification",
-                        "some-group-2": "Experiment group qualification",
-                    },
+                    qualifications=[
+                        {
+                            "name": "TEST_EXPERIMENT_UID",
+                            "description": "Experiment-specific qualification",
+                        },
+                        {
+                            "name": "some-group-1",
+                            "description": "Experiment group qualification",
+                        },
+                        {
+                            "name": "some-group-2",
+                            "description": "Experiment group qualification",
+                        },
+                    ],
                 )
             ]
         )

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -122,10 +122,9 @@ class TestExperimentBaseClass(object):
             exp.normalize_entry_information({"foo": "bar"})
             normalizer.assert_called_once_with({"foo": "bar"})
 
-    def test_participant_task_completed_adds_group_qualification_if_group(
-        self, active_config, exp
+    def test_participant_task_completed_grants_qualification_for_experiment_id(
+        self, exp
     ):
-        active_config.set("group_name", "some group name")
         participant = mock.Mock(spec=Participant, worker_id="some worker id")
 
         exp.participant_task_completed(participant)
@@ -137,7 +136,28 @@ class TestExperimentBaseClass(object):
                     worker_id="some worker id",
                     qualifications={
                         "TEST_EXPERIMENT_UID": "Experiment-specific qualification",
-                        "some group name": "Experiment group qualification",
+                    },
+                )
+            ]
+        )
+
+    def test_participant_task_completed_adds_group_qualification_if_group(
+        self, active_config, exp
+    ):
+        active_config.set("group_name", " some-group-1, some-group-2  ")
+        participant = mock.Mock(spec=Participant, worker_id="some worker id")
+
+        exp.participant_task_completed(participant)
+
+        assert (
+            participant.recruiter.assign_experiment_qualifications.call_args_list
+            == [
+                mock.call(
+                    worker_id="some worker id",
+                    qualifications={
+                        "TEST_EXPERIMENT_UID": "Experiment-specific qualification",
+                        "some-group-1": "Experiment group qualification",
+                        "some-group-2": "Experiment group qualification",
                     },
                 )
             ]

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,6 +1,8 @@
 import pytest
 import mock
 
+from dallinger.models import Participant
+
 
 def is_uuid(thing):
     return len(thing) == 36
@@ -15,7 +17,8 @@ class TestExperimentBaseClass(object):
         return Experiment
 
     @pytest.fixture
-    def exp(self, klass):
+    def exp(self, active_config, klass):
+        # active_config.set("recruiter", "spy")
         return klass()
 
     @pytest.fixture
@@ -118,3 +121,43 @@ class TestExperimentBaseClass(object):
             }
             exp.normalize_entry_information({"foo": "bar"})
             normalizer.assert_called_once_with({"foo": "bar"})
+
+    def test_participant_task_completed_adds_group_qualification_if_group(
+        self, active_config, exp
+    ):
+        active_config.set("group_name", "some group name")
+        participant = mock.Mock(spec=Participant, worker_id="some worker id")
+
+        exp.participant_task_completed(participant)
+
+        assert (
+            participant.recruiter.assign_experiment_qualifications.call_args_list
+            == [
+                mock.call(
+                    worker_id="some worker id",
+                    qualifications={
+                        "TEST_EXPERIMENT_UID": "Experiment-specific qualification",
+                        "some group name": "Experiment group qualification",
+                    },
+                )
+            ]
+        )
+
+    def test_participant_task_completed_skips_assigning_qualification_if_so_configured(
+        self, active_config, exp
+    ):
+        participant = mock.Mock(spec=Participant, worker_id="some worker id")
+        active_config.set("assign_qualifications", False)
+
+        exp.participant_task_completed(participant)
+
+        participant.recruiter.assign_experiment_qualifications.assert_not_called()
+
+    def test_notify_completed_skips_assigning_qualification_if_overrecruited(self, exp):
+        participant = mock.Mock(
+            spec=Participant, worker_id="some worker id", status="overrecruited"
+        )
+
+        exp.participant_task_completed(participant)
+
+        participant.recruiter.assign_experiment_qualifications.assert_not_called()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -17,8 +17,7 @@ class TestExperimentBaseClass(object):
         return Experiment
 
     @pytest.fixture
-    def exp(self, active_config, klass):
-        # active_config.set("recruiter", "spy")
+    def exp(self, klass):
         return klass()
 
     @pytest.fixture

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -283,21 +283,20 @@ class TestWorkerComplete(object):
 
         assert models.Notification.query.all() == []
 
-    def test_notifies_recruiter_when_participant_completes(
-        self, a, webapp, active_config
-    ):
-        from dallinger.models import Participant
-
-        active_config.extend({"mode": u"sandbox"})
+    def test_notifies_recruiter_when_participant_completes(self, a, webapp):
+        participant = a.participant()
         with mock.patch(
-            "dallinger.recruiters.MTurkRecruiter.notify_completed"
-        ) as notify_completed:
+            "dallinger.experiment_server.experiment_server.Experiment"
+        ) as Experiment:
+
             webapp.post(
                 "/worker_complete",
-                data={"participant_id": a.participant(recruiter_id="mturk").id},
+                data={"participant_id": participant.id},
             )
-            args, _ = notify_completed.call_args
-            assert isinstance(args[0], Participant)
+
+        Experiment.return_value.participant_task_completed.assert_called_once_with(
+            participant
+        )
 
 
 @pytest.mark.usefixtures("experiment_dir")

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -829,19 +829,11 @@ class TestMTurkRecruiter(object):
         ]
         assert recruiter.mturkservice.increment_qualification_score.call_args_list == [
             mock.call(
-                {
-                    "id": "QualificationType id",
-                    "name": "One",
-                    "description": "Description of One",
-                },
+                "QualificationType id",
                 "some worker id",
             ),
             mock.call(
-                {
-                    "id": "QualificationType id",
-                    "name": "Two",
-                    "description": "Description of Two",
-                },
+                "QualificationType id",
                 "some worker id",
             ),
         ]

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -820,7 +820,11 @@ class TestMTurkRecruiter(object):
         self, recruiter
     ):
         recruiter.assign_experiment_qualifications(
-            "some worker id", {"One": "Description of One", "Two": "Description of Two"}
+            "some worker id",
+            [
+                {"name": "One", "description": "Description of One"},
+                {"name": "Two", "description": "Description of Two"},
+            ],
         )
 
         assert recruiter.mturkservice.create_qualification_type.call_args_list == [
@@ -848,7 +852,11 @@ class TestMTurkRecruiter(object):
         )
 
         recruiter.assign_experiment_qualifications(
-            "some worker id", {"One": "Description of One", "Two": "Description of Two"}
+            "some worker id",
+            [
+                {"name": "One", "description": "Description of One"},
+                {"name": "Two", "description": "Description of Two"},
+            ],
         )
 
         assert (


### PR DESCRIPTION
## Description
Addresses issue #2261 

Allow the Experiment to control qualification assignment to workers.

Instead of the Dallinger infrastructure calling the recruiter directly for qualification assignment, this work will now manged by the Experiment in cooperation with the recruiter for a Participant.

## Motivation and Context
The underlying objective is to add flexibility to when MTurk Qualifications are assigned to workers. Currently this is always done after the post-experiment questionnaire is submitted to the `/worker_completed` route. 

The PR proposes moving in the direction of notifying the Experiment class when various experiment lifecycle events happen, and letting the Experiment then request qualification assignment from participant's recruiter reference (to support the MultiRecruiter).

### Backwards compatibility

The status quo is preserved by:
1. adding a new method to the Experiment class (called `participant_task_completed()`) which will be called _instead of_ `Recruiter.notify_completed()` from the `/worker_completed` route, and
2. adding a new public method `assign_experiment_qualifications()` to the `Recruiter` interface.

The default implementation of `Experiment.participant_task_completed()` will just call `Recruiter.assign_experiment_qualifications()` with the same qualifications the recruiter currently manages internally.

Responsibility for parsing config.txt recruitment-related values (`assign_qualifications`, `group_name`) now lies with the Experiment, via a set of new properties: `qualifications_active`, `qualifications`, and `group_qualifications`. The default implementation of these properties preserves the current default behavior by parsing config.txt and translating these into qualification request definitions compatible with the Recruiter's API. However, these can be overridden to provide values in a different way (most obviously, dispensing with config.txt altogether and just defining these values in python.)

### Early (or Multiple) Qualification Assignment

The Experiment class is already called at multiple points, starting from the very beginning of the Participant lifecycle:
1. `create_participant(self, worker_id, hit_id, assignment_id, mode, recruiter_name=None, fingerprint_hash=None)`
2. `create_node(self, participant, network)`
3. `node_post_request(self, participant, node)`

At any of these points, the experiment could assign one or more of the qualifications to the participant's worker ID.

There is also at least one other opportunity to assign qualifications late, without adding any new methods to Experiment:
1. `submission_successful(self, participant)`

### Qualification Creation
We use the `group_name` config variable for defining custom qualifications, and currently assume it's a single value This PR adds support for a comma-separated list.

Further, this PR changes qualification creation to be just-in-time, so that experiments can determine qualifications at run-time.

## Other fixes
* `/worker_complete` route is now idempotent (no-op if `participant.end_time` is not `None`)
* form freezing/disabling fixed for questionnaire

## How Has This Been Tested?
[x] Automated tests
[x] MTurk sandbox with Bartlett1932

## Screenshots (if appropriate):
Bartlett1932 tested over a few runs, with the following config:
```
...
assign_qualifications = True
group_name = red1,green1
...
```

and the following method override:
```python
    def participant_task_completed(self, participant):
        """[blah blah blah]
        """
        if not self.qualification_active:
            logger.info("Qualification assignment is globally disabled; ignoring.")
            return

        if participant.status == "overrecruited":
            return

        quals = self.qualifications
        quals.append({"name": "another", "description": "has a score", "score": 21})
        participant.recruiter.assign_experiment_qualifications(
            worker_id=participant.worker_id, qualifications=quals
        )
```

I was assigned the expected qualifications:

![Assigned_Qualifications_-_Amazon_Mechanical_Turk](https://user-images.githubusercontent.com/63560/113930404-1786af00-97a6-11eb-917e-65d14c9ba28b.png)
