### PR TITLE
Install docker only as an optional dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.direnv
+.git
+*.db
+*.dmg
+node_modules
+snapshots
+data
+server.log
+__pycache__
+.tox
+Dockerfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,9 @@ jobs:
       - name: Install python wheel package
         run: pip install wheel
       - name: Install python requirements
-        run: pip install -r build-requirements.txt .[data]
+        run: |
+          pip install -r build-requirements.txt .[data]
+          pip install -r build-requirements.txt .[docker]
       - name: Run docker tests (only one for now)
         run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,7 @@ jobs:
       - name: Install python wheel package
         run: pip install wheel
       - name: Install python requirements
-        run: |
-          pip install -r build-requirements.txt .[data]
-          pip install -r build-requirements.txt .[docker]
+        run: pip install -r build-requirements.txt .[data,docker]
       - name: Run docker tests (only one for now)
         run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
 

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -1,6 +1,5 @@
 import click
 
-from dallinger.deployment import DockerDebugDeployment
 from dallinger.command_line.utils import Output
 from dallinger.command_line.utils import header
 from dallinger.command_line.utils import log
@@ -35,6 +34,8 @@ def docker():
 @require_exp_directory
 def debug(verbose, bot, proxy, no_browsers=False, exp_config=None):
     """Run the experiment locally using docker compose."""
+    from dallinger.docker.deployment import DockerDebugDeployment
+
     debugger = DockerDebugDeployment(
         Output(), verbose, bot, proxy, exp_config, no_browsers
     )

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -26,7 +26,6 @@ from dallinger import registration
 from dallinger.config import get_config
 from dallinger.heroku.tools import HerokuApp
 from dallinger.heroku.tools import HerokuLocalWrapper
-from dallinger.docker.tools import DockerComposeWrapper
 from dallinger.utils import connect_to_redis
 from dallinger.utils import dallinger_package_path
 from dallinger.utils import ensure_directory
@@ -774,25 +773,6 @@ class DebugDeployment(HerokuLocalDeployment):
         if self.complete:
             return HerokuLocalWrapper.MONITOR_STOP
         return super(DebugDeployment, self).notify(message)
-
-
-class DockerDebugDeployment(DebugDeployment):
-    """Run the experiment in a local docker-compose based environment."""
-
-    DEPLOY_NAME = "Docker"
-    WRAPPER_CLASS = DockerComposeWrapper
-    DO_INIT_DB = False  # The DockerComposeWrapper will take care of it
-
-    def setup(self):
-        """Override setup to be able to build the experiment directory
-        without a working postgresql (it will work inside the docker compose env).
-        Maybe the postgres check can be removed altogether?
-        """
-        self.exp_id, self.tmp_dir = setup_experiment(
-            self.out.log,
-            exp_config=self.exp_config,
-            local_checks=False,
-        )
 
 
 class LoaderDeployment(HerokuLocalDeployment):

--- a/dallinger/docker/deployment.py
+++ b/dallinger/docker/deployment.py
@@ -1,0 +1,27 @@
+from dallinger.deployment import DebugDeployment
+from dallinger.deployment import setup_experiment
+
+
+class DockerDebugDeployment(DebugDeployment):
+    """Run the experiment in a local docker-compose based environment."""
+
+    DEPLOY_NAME = "Docker"
+    WRAPPER_CLASS = None
+    DO_INIT_DB = False  # The DockerComposeWrapper will take care of it
+
+    def __init__(self, *args, **kwargs):
+        from .tools import DockerComposeWrapper
+
+        super(DockerDebugDeployment, self).__init__(*args, **kwargs)
+        self.WRAPPER_CLASS = DockerComposeWrapper
+
+    def setup(self):
+        """Override setup to be able to build the experiment directory
+        without a working postgresql (it will work inside the docker compose env).
+        Maybe the postgres check can be removed altogether?
+        """
+        self.exp_id, self.tmp_dir = setup_experiment(
+            self.out.log,
+            exp_config=self.exp_config,
+            local_checks=False,
+        )

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ gevent
 greenlet
 gunicorn
 localconfig
-paramiko[ssh]
+paramiko
 pexpect
 psycopg2
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ gevent
 greenlet
 gunicorn
 localconfig
-paramiko
 pexpect
 psycopg2
 psutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,6 @@ APScheduler
 cached-property
 boto3
 click
-docker
-docker-compose
 faker
 Flask-Sockets
 Flask

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,10 @@ setup_args = dict(
             "sphinx-js",
             "sphinx_rtd_theme",
         ],
+        'docker': [
+            "docker",
+            "docker-compose"
+        ],
         ':python_version <= "3.7"': ['importlib_metadata'],
     }
 )


### PR DESCRIPTION
## Description
Do not install `docker` and `docker-compose` dependencies unless the `[docker]` extra is specified with

```
pip install dallinger[docker]
```

## Motivation and Context
#2568 introduced `docker` and `docker-compose` as unconditional dependencies.
This caused #2581 and is not necessary in most cases, in particular when using a  Heroku sandbox.
This PR fixes #2579 

## How Has This Been Tested?
CI

## Additions
In addition there is a .dockerignore file that I worked on in the context of the previous PR but forgot to commit.