### PR TITLE
Worker ID needs to be optional, to support HIT preview on MTurk

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -403,19 +403,20 @@ def advertisement():
     assignment_id = entry_data.get("assignment_id")
     worker_id = entry_data.get("worker_id")
 
-    if not (hit_id and assignment_id and worker_id):
+    if not (hit_id and assignment_id):
         raise ExperimentError("hit_assign_worker_id_not_set_by_recruiter")
 
-    # Check if this workerId has completed the task before
-    already_participated = (
-        models.Participant.query.filter(
-            models.Participant.worker_id == worker_id
-        ).first()
-        is not None
-    )
+    if worker_id is not None:
+        # Check if this workerId has completed the task before
+        already_participated = (
+            models.Participant.query.filter(
+                models.Participant.worker_id == worker_id
+            ).first()
+            is not None
+        )
 
-    if already_participated:
-        raise ExperimentError("already_did_exp_hit")
+        if already_participated:
+            raise ExperimentError("already_did_exp_hit")
 
     recruiter_name = request.args.get("recruiter")
     if recruiter_name:

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -97,13 +97,13 @@ class TestAppConfiguration(object):
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestAdvertisement(object):
-    def test_returns_error_without_hitId_assignmentId_and_workerId(self, webapp):
+    def test_returns_error_without_hitId_assignmentId(self, webapp):
         resp = webapp.get("/ad")
         assert resp.status_code == 500
         assert b"hit_assign_worker_id_not_set_by_recruiter" in resp.data
 
-    def test_accepts_any_ids(self, webapp):
-        resp = webapp.get("/ad?hitId=foo&assignmentId=bar&workerId=baz")
+    def test_accepts_any_hitId_and_assignmentId(self, webapp):
+        resp = webapp.get("/ad?hitId=foo&assignmentId=bar")
         assert b"Thanks for accepting this HIT." in resp.data
 
     def test_checks_normalize_entry_info(self, webapp):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -97,7 +97,7 @@ class TestAppConfiguration(object):
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestAdvertisement(object):
-    def test_returns_error_without_hitId_assignmentId(self, webapp):
+    def test_returns_error_without_hitId_and_assignmentId(self, webapp):
         resp = webapp.get("/ad")
         assert resp.status_code == 500
         assert b"hit_assign_worker_id_not_set_by_recruiter" in resp.data


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fix for #2582

## Motivation and Context
When previewing a HIT on MTurk, a worker ID is not yet passed as a parameter to the /ad route

## How Has This Been Tested?
* automated tests
* Bartlett in MTurk sandbox

