### PR TITLE
Ad route URL parameters are actually camel-case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           tox ${{ needs.check_mturk_changes.outputs.mturk_changed == 'true' && '-- --mturkfull' || ''}}
+          npm run test --coverage
         if: matrix.python-version == 3.9
       - name: Run Fast Tests Only
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,7 @@ jobs:
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           tox -e fast
+          npm run test --coverage
         if: matrix.python-version != 3.9
       - name: Set up deployment
         env:

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -106,9 +106,9 @@ var dallinger = (function () {
 
     initialize: function () {
       this.recruiter = dlgr.getUrlParameter('recruiter');
-      this.hitId = dlgr.getUrlParameter('hit_id');
-      this.workerId = dlgr.getUrlParameter('worker_id');
-      this.assignmentId = dlgr.getUrlParameter('assignment_id');
+      this.hitId = dlgr.getUrlParameter('hitId');
+      this.workerId = dlgr.getUrlParameter('workerId');
+      this.assignmentId = dlgr.getUrlParameter('assignmentId');
       this.mode = dlgr.getUrlParameter('mode');
       // Store all url parameters as entry information.
       // This won't work in IE, but should work in Edge.
@@ -416,7 +416,7 @@ var dallinger = (function () {
     var url = "/participant";
     var data = {};
     var deferred = $.Deferred();
-    if (dlgr.identity.assignment_id) {
+    if (dlgr.identity.assignmentId) {
       url += "/" + dlgr.identity.workerId + "/" + dlgr.identity.hitId +
             "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
             (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -101,7 +101,7 @@ describe('identity', function () {
 
   beforeEach(function () {
     window.history.pushState({}, 'Test Title',
-      'test.html?recruiter=hotair&hit_id=HHH&assignment_id=AAA&worker_id=WWW&mode=debug'
+      'test.html?recruiter=hotair&hitId=HHH&assignmentId=AAA&workerId=WWW&mode=debug'
     );
 
     dlgr = require('./dallinger2').dallinger;

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -76,6 +76,11 @@ add the ``mturkfull`` option when running the tests::
 
   pytest --mturkfull --runslow
 
+To run the JavaScript tests, run::
+
+  npm run test --coverage
+
+
 Linting
 ~~~~~~~
 


### PR DESCRIPTION
## Description
URL parameters passed to the /ad route by both MTurk and Dallinger's own recruiters use camelCase for `workerId`, `hitId`, and `assignmentId`, but we were not parsing the URL with this convention in mind. We were instead assuming snake case (`worker_id`, etc.). The caused delays (at least) in getting these values set correctly in the `dallinger.identity` JS object.

This PR also reinstates running of JS tests as part of the CI build, documents how to run them locally.

## Motivation and Context
Fix for #2604 

## How Has This Been Tested?
* Bartlett1932, in debug
* Updated jest test


