### PR TITLE
Fix docker tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    environment: CI
     needs: check_mturk_changes
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,15 +195,6 @@ jobs:
         run: pip install --upgrade pip wheel tox
       - name: Chromedriver setup
         uses: nanasess/setup-chromedriver@v1.0.5
-      - name: Run experiment with docker using bots
-        run: |
-          pip install -c dev-requirements.txt .[data]
-          dallinger docker start-services
-          sleep 5
-          cd demos/dlgr/demos/bartlett1932
-          dallinger debug --verbose --bot --no-browsers
-          dallinger docker stop-services
-          dallinger docker remove-services-data
       - name: Run docker tests
         run: tox -e dockertests
       - name: Show docker logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,8 +196,11 @@ jobs:
         run: pip install wheel
       - name: Install python requirements
         run: pip install -r build-requirements.txt .[data]
-      - name: Run docker tests (only one for now)
+      - name: Run docker tests
         run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
+      - name: Show docker logs
+        if: ${{ always() }}
+        run: for container in $(docker ps -a -q); do echo "***** $(docker ps -a|grep $container) *******"; docker logs $container; done
 
 
   pre-commit:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    environment: CI
     needs: check_mturk_changes
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,12 +194,10 @@ jobs:
         run: sudo apt-get --yes install pandoc enchant snapd curl
       - name: Install and upgrade wheel, pip and tox
         run: pip install --upgrade pip wheel tox
-      - name: Install python requirements
-        run: pip install -r build-requirements.txt
-      - name: Install dallinger
-        run: pip install .[data]
+      - uses: nanasess/setup-chromedriver@master
+        name: Setup chromedriver
       - name: Run docker tests
-        run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
+        run: tox -e dockertests
       - name: Show docker logs
         if: ${{ always() }}
         run: for container in $(docker ps -a -q); do echo "***** $(docker ps -a|grep $container) *******"; docker logs $container; done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,8 +194,8 @@ jobs:
         run: sudo apt-get --yes install pandoc enchant snapd curl
       - name: Install and upgrade wheel, pip and tox
         run: pip install --upgrade pip wheel tox
-      - uses: nanasess/setup-chromedriver@master
-        name: Setup chromedriver
+      - name: Chromedriver setup
+        uses: nanasess/setup-chromedriver@v1.0.5
       - name: Run docker tests
         run: tox -e dockertests
       - name: Show docker logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -195,6 +195,15 @@ jobs:
         run: pip install --upgrade pip wheel tox
       - name: Chromedriver setup
         uses: nanasess/setup-chromedriver@v1.0.5
+      - name: Run experiment with docker using bots
+        run: |
+          pip install -c dev-requirements.txt .[data]
+          dallinger docker start-services
+          sleep 5
+          cd demos/dlgr/demos/bartlett1932
+          dallinger debug --verbose --bot --no-browsers
+          dallinger docker stop-services
+          dallinger docker remove-services-data
       - name: Run docker tests
         run: tox -e dockertests
       - name: Show docker logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,10 +192,12 @@ jobs:
               ${{ runner.os }}-
       - name: Install Ubuntu packages
         run: sudo apt-get --yes install pandoc enchant snapd curl
-      - name: Install python wheel package
-        run: pip install wheel
+      - name: Install and upgrade wheel, pip and tox
+        run: pip install --upgrade pip wheel tox
       - name: Install python requirements
-        run: pip install -r build-requirements.txt .[data]
+        run: pip install -r build-requirements.txt
+      - name: Install dallinger
+        run: pip install .[data]
       - name: Run docker tests
         run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
       - name: Show docker logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,6 +174,10 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache/bot
           cache-to: type=local,dest=/tmp/.buildx-cache/bot
       - uses: actions/checkout@v2
+      - name: Make sure dallinger script entry point is working
+        run: docker run --rm dallingerimages/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
+      - name: Make sure dallinger script entry point is working with dallinger source mounted as volume
+        run: docker run -v $PWD/dallinger:/dallinger/dallinger --rm dallingerimages/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:
@@ -191,7 +195,7 @@ jobs:
       - name: Install python wheel package
         run: pip install wheel
       - name: Install python requirements
-        run: pip install -r build-requirements.txt .[data,docker]
+        run: pip install -r build-requirements.txt .[data]
       - name: Run docker tests (only one for now)
         run: RUN_DOCKER=1 pytest -k test_docker_debug --runslow --runbot -rsx -s -v
 

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -51,5 +51,18 @@ def start_services():
         "docker run --rm -d --name dallinger_redis -p 6379:6379 -v dallinger_redis:/data redis redis-server --appendonly yes"
     )
     os.system(
-        "docker run -d --name dallinger_postgres -p 5432:5432 -e POSTGRES_USER=dallinger -e POSTGRES_PASSWORD=dallinger -e POSTGRES_DB=dallinger -v dallinger_postgres:/var/lib/postgresql/data postgres:12"
+        "docker run --rm -d --name dallinger_postgres -p 5432:5432 -e POSTGRES_USER=dallinger -e POSTGRES_PASSWORD=dallinger -e POSTGRES_DB=dallinger -v dallinger_postgres:/var/lib/postgresql/data postgres:12"
     )
+
+
+@docker.command()
+def stop_services():
+    """Stops docker based postgresql and redis services"""
+    os.system("docker stop dallinger_redis")
+    os.system("docker stop dallinger_postgres")
+
+
+@docker.command()
+def remove_services_data():
+    """Remove redis and postgresql data - restores a pristine environment"""
+    os.system("docker volume rm dallinger_redis dallinger_postgres")

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -1,4 +1,5 @@
 import click
+import os
 
 from dallinger.command_line.utils import Output
 from dallinger.command_line.utils import header
@@ -41,3 +42,14 @@ def debug(verbose, bot, proxy, no_browsers=False, exp_config=None):
     )
     log(header, chevrons=False)
     debugger.run()
+
+
+@docker.command()
+def start_services():
+    """Starts postgresql and redis services using docker"""
+    os.system(
+        "docker run --rm -d --name dallinger_redis -p 6379:6379 -v dallinger_redis:/data redis redis-server --appendonly yes"
+    )
+    os.system(
+        "docker run -d --name dallinger_postgres -p 5432:5432 -e POSTGRES_USER=dallinger -e POSTGRES_PASSWORD=dallinger -e POSTGRES_DB=dallinger -v dallinger_postgres:/var/lib/postgresql/data postgres:12"
+    )

--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -16,6 +16,10 @@ services:
     command: redis-server --appendonly yes
     volumes:
       - dallinger_{{ experiment_name }}_redis_data:/data
+    healthcheck:
+        test: "[ $$(redis-cli ping) = 'PONG' ]"
+        interval: 2s
+        timeout: 1s
     ports:
       # bots might need to communicate with redis
       - "6379:6379"

--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -8,6 +8,10 @@ services:
       POSTGRES_DB: dallinger
     volumes:
       - dallinger_{{ experiment_name }}_pg_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 2s
+      timeout: 5s
     ports:
       # bots might need to communicate with postgresql
       - "5432:5432"
@@ -25,6 +29,11 @@ services:
       - "6379:6379"
   worker:
     image: {{ experiment_name }}-worker
+    depends_on:
+      postgresql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
     user: "${UID}:${GID}"
     build: 
       context: .

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -113,9 +113,9 @@ class DockerComposeWrapper(object):
     def start(self):
         self.copy_docker_compse_files()
         env = {"DOCKER_BUILDKIT": "1"}
-        build_arg = "--progress=plain"
+        build_arg = "--progress=plain "
         if self.needs_chrome:
-            build_arg = (
+            build_arg += (
                 "--build-arg DALLINGER_DOCKER_IMAGE=dallingerimages/dallinger-bot"
             )
         check_output(
@@ -134,7 +134,6 @@ class DockerComposeWrapper(object):
                     "initdb",
                 ]
             )
-
         except CalledProcessError:
             self.out.error("There was a problem initializing the database")
             self.stop()

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -113,7 +113,7 @@ class DockerComposeWrapper(object):
     def start(self):
         self.copy_docker_compse_files()
         env = {"DOCKER_BUILDKIT": "1"}
-        build_arg = ""
+        build_arg = "--progress=plain"
         if self.needs_chrome:
             build_arg = (
                 "--build-arg DALLINGER_DOCKER_IMAGE=dallingerimages/dallinger-bot"

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -63,7 +63,7 @@ class DockerComposeWrapper(object):
         volumes = [f"{self.original_dir}:{self.original_dir}"]
         editable_dallinger_path = get_editable_dallinger_path()
         if editable_dallinger_path:
-            volumes.append(f"{editable_dallinger_path}:/dallinger")
+            volumes.append(f"{editable_dallinger_path}/dallinger:/dallinger/dallinger")
         with open(os.path.join(self.tmp_dir, "docker-compose.yml"), "w") as fh:
             fh.write(
                 docker_compose_template.render(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,8 @@ APScheduler
 cached-property
 boto3
 click
+docker
+docker-compose
 faker
 Flask-Sockets
 Flask
@@ -15,6 +17,7 @@ gevent
 greenlet
 gunicorn
 localconfig
+paramiko[ssh]  # Remove this when docker dependencies are removed
 pexpect
 psycopg2
 psutil

--- a/setup.py
+++ b/setup.py
@@ -63,10 +63,6 @@ setup_args = dict(
             "sphinx-js",
             "sphinx_rtd_theme",
         ],
-        'docker': [
-            "docker",
-            "docker-compose"
-        ],
         ':python_version <= "3.7"': ['importlib_metadata'],
     }
 )

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -856,8 +856,8 @@ class TestDockerServer(object):
         )
         p.logfile = sys.stdout
         try:
-            p.expect_exact("Server is running", timeout=300)
-            p.expect_exact("Recruitment is complete", timeout=600)
+            p.expect_exact("Server is running", timeout=60)
+            p.expect_exact("Recruitment is complete", timeout=120)
             p.expect_exact("'status': 'success'", timeout=60)
             p.expect_exact("Experiment completed", timeout=10)
             p.expect_exact("Stopping bartlett1932_web_1", timeout=20)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -845,7 +845,6 @@ class TestDebugServer(object):
 @pytest.mark.slow
 @pytest.mark.docker
 class TestDockerServer(object):
-    @pytest.mark.skip(reason="Fails when run from pytest. Is run separately in CI")
     def test_docker_debug_with_bots(self, env):
         # Make sure debug server runs to completion with bots
         p = pexpect.spawn(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -856,7 +856,7 @@ class TestDockerServer(object):
         )
         p.logfile = sys.stdout
         try:
-            p.expect_exact("Server is running", timeout=60)
+            p.expect_exact("Server is running", timeout=180)
             p.expect_exact("Recruitment is complete", timeout=120)
             p.expect_exact("'status': 'success'", timeout=60)
             p.expect_exact("Experiment completed", timeout=10)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -845,7 +845,6 @@ class TestDebugServer(object):
 @pytest.mark.slow
 @pytest.mark.docker
 class TestDockerServer(object):
-    @pytest.mark.usefixtures("check_runbot")
     def test_docker_debug_with_bots(self, env):
         # Make sure debug server runs to completion with bots
         p = pexpect.spawn(
@@ -869,7 +868,6 @@ class TestDockerServer(object):
             except IOError:
                 pass
 
-    @pytest.mark.usefixtures("check_runbot")
     def test_docker_debug_without_bots(self, env):
         sys.path.append(os.getcwd())
         from experiment import Bot

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -845,6 +845,7 @@ class TestDebugServer(object):
 @pytest.mark.slow
 @pytest.mark.docker
 class TestDockerServer(object):
+    @pytest.mark.skip(reason="Fails when run from pytest. Is run separately in CI")
     def test_docker_debug_with_bots(self, env):
         # Make sure debug server runs to completion with bots
         p = pexpect.spawn(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -845,7 +845,7 @@ class TestDebugServer(object):
 @pytest.mark.slow
 @pytest.mark.docker
 class TestDockerServer(object):
-    @pytest.mark.skip(reason="Fails when run in the CI")
+    @pytest.mark.skipif(bool(os.environ.get("CI")), reason="Fails when run in the CI")
     def test_docker_debug_with_bots(self, env):
         # Make sure debug server runs to completion with bots
         p = pexpect.spawn(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -845,6 +845,7 @@ class TestDebugServer(object):
 @pytest.mark.slow
 @pytest.mark.docker
 class TestDockerServer(object):
+    @pytest.mark.skip(reason="Fails when run in the CI")
     def test_docker_debug_with_bots(self, env):
         # Make sure debug server runs to completion with bots
         p = pexpect.spawn(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -887,7 +887,7 @@ class TestDockerServer(object):
             Bot(re.search("http://[^ \n\r]+", p.after).group()).run_experiment()
             p.expect("New participant requested.*", 30)
             Bot(re.search("http://[^ \n\r]+", p.after).group()).run_experiment()
-            p.expect_exact("Recruitment is complete", timeout=60)
+            p.expect_exact("Recruitment is complete", timeout=120)
             p.expect_exact("'status': 'success'", timeout=60)
             p.expect_exact("Experiment completed", timeout=10)
             p.expect_exact("Stopping bartlett1932_web_1", timeout=20)

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
 setenv =
     RUN_DOCKER = 1
 commands =
-    {envbindir}/pytest {posargs} -m docker --runslow
+    {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless
 
 [testenv:style]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -78,6 +78,15 @@ passenv =
     mturk_worker_id
     threads
 
+[testenv:dockertests]
+deps =
+    -r build-requirements.txt
+    -e .[data]
+setenv =
+    RUN_DOCKER = 1
+commands =
+    {envbindir}/pytest {posargs} -m docker --runslow
+
 [testenv:style]
 commands =
     pip install -r dev-constraints.txt

--- a/tox.ini
+++ b/tox.ini
@@ -86,6 +86,8 @@ setenv =
     RUN_DOCKER = 1
 commands =
     {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s
+passenv =
+    CI
 
 [testenv:style]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
 setenv =
     RUN_DOCKER = 1
 commands =
-    bash -c '{envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s || {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s'
+    {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s
 
 [testenv:style]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
 setenv =
     RUN_DOCKER = 1
 commands =
-    {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless
+    {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s
 
 [testenv:style]
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -85,7 +85,7 @@ deps =
 setenv =
     RUN_DOCKER = 1
 commands =
-    {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s
+    bash -c '{envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s || {envbindir}/pytest {posargs} -m docker --runslow --chrome-headless -s'
 
 [testenv:style]
 commands =


### PR DESCRIPTION
This PR aims at fixing the docker tests.

Some improvements to the docker support are included:

* health checks for postgres and redis, to make sure they're ready when other services are started
* new commands to start postgres and redis services using docker (only needed when using heroku deployments - docker deployments take care of those services alongside the experiment services)
* docker related tests are run with tox

Invoking `dallinger debug --verbose --bot --no-browsers` in the `bartlett1932` directory worked for me locally but I could not get it to run in CI, neither through tox/pytest nor by direct invocation.

On CI the experiments hangs until a timeout. These are the last lines of logs:

```
>>>> ----- Launching experiment...
2021-03-11 17:31:45,119 Initializing BotRecruiter...
2021-03-11 17:31:45,119 Opening Bot recruitment for 1 participants
2021-03-11 17:31:45,119 Recruiting 1 Bot participants
2021-03-11 17:31:45,119 Creating bot with URL: http://web:5000/ad?recruiter=bots&assignmentId=X01U2L&hitId=QU41CJ&workerId=CW8FWQ&mode=sandbox.
2021-03-11 17:31:45,123 Created job 89829db2-bc51-48d2-9c6a-2035755ee274 for url http://web:5000/ad?recruiter=bots&assignmentId=X01U2L&hitId=QU41CJ&workerId=CW8FWQ&mode=sandbox.
2021-03-11 17:31:45,124 Closing Dallinger DB session at flask request end
2021-03-11 17:31:45,129 172.18.0.1 - - [2021-03-11 17:31:45] "POST /launch HTTP/1.1" 200 331 0.149741
```

I'm running a last test to check if the first test to be run is made to fail by some initial state.