### PR TITLE
Fix deployment environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out Dallinger repository
         uses: actions/checkout@v2
       - name: Install Ubuntu packages
-        run: sudo apt-get --yes install enchant snapd curl
+        run: sudo apt-get --yes install pandoc enchant snapd curl
       - name: Chromedriver setup
         uses: nanasess/setup-chromedriver@v1.0.5
       - name: Install snap packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Check out Dallinger repository
         uses: actions/checkout@v2
       - name: Install Ubuntu packages
-        run: sudo apt-get --yes install pandoc enchant snapd curl
+        run: sudo apt-get --yes install enchant snapd curl
       - name: Chromedriver setup
         uses: nanasess/setup-chromedriver@v1.0.5
       - name: Install snap packages
@@ -71,8 +71,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: '10'
-      - name: Install node packages
-        run: yarn --frozen-lockfile --ignore-engines
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
@@ -176,7 +174,7 @@ jobs:
               ${{ runner.os }}-pip-
               ${{ runner.os }}-
       - name: Install Ubuntu packages
-        run: sudo apt-get --yes install pandoc enchant snapd curl
+        run: sudo apt-get --yes install enchant snapd curl
       - name: Install and upgrade wheel, pip and tox
         run: pip install --upgrade pip wheel tox
       - name: Chromedriver setup

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,6 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
-    environment: CI
     needs: check_mturk_changes
     strategy:
       matrix:
@@ -128,20 +127,6 @@ jobs:
           tox -e fast
           npm run test --coverage
         if: matrix.python-version != 3.9
-      - name: Set up deployment
-        env:
-          CHANDLER_GITHUB_API_TOKEN: ${{ secrets.CHANDLER_GITHUB_API_TOKEN }}
-        run: |
-          pandoc --from=markdown --to=rst --output=README.rst README.md
-          pip install build
-          python -m build --sdist --wheel .
-          chandler push --tag-prefix=v
-        if: matrix.python-version == 3.9 && contains(github.ref, '/tags/v')
-      - name: Deploy
-        uses: pypa/gh-action-pypi-publish@master
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
-        if: matrix.python-version == 3.9 && contains(github.ref, '/tags/v')
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,55 @@
+name: Release
+on: 
+  push:
+    tags:
+      - v*
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: pypi
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Ubuntu packages
+        run: sudo apt-get --yes install curl enchant pandoc
+      - name: Set up Ruby
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: 2.6
+      - name: Install Chandler
+        run: gem install chandler -v 0.7.0
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '10'
+      - name: Install node packages
+        run: yarn --frozen-lockfile --ignore-engines
+      - name: Cache pip
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('*.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+            ${{ runner.os }}-
+      - name: Python Installers
+        run: pip install --upgrade pip wheel tox
+      - name: Wait on tests
+        uses: lewagon/wait-on-check-action@v0.2
+        with:
+          ref: ${{ github.ref }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10
+          running-workflow-name: 'release'
+      - name: Set up deployment
+        env:
+          CHANDLER_GITHUB_API_TOKEN: ${{ secrets.CHANDLER_GITHUB_API_TOKEN }}
+        run: |
+          pandoc --from=markdown --to=rst --output=README.rst README.md
+          pip install build
+          python -m build --sdist --wheel .
+          chandler push --tag-prefix=v
+      - name: Deploy
+        uses: pypa/gh-action-pypi-publish@v1.4.2
+        with:
+          password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
## Description
This PR changes the way the release to pypi and to github releases is managed wrt its integration with github actions

## Motivation and Context
Currently the secrets are stored in the `CI` environment. Environments are meant to host secrets that, when used, have an effect on the outside world.
For Dallinger the following secrets are in this category (and should live in [the environment named `pypi`](https://github.com/Dallinger/Dallinger/settings/environments/201786602/edit)):
* PYPI_API_TOKEN
* CHANDLER_GITHUB_API_TOKEN

while these ones are used to run tests (and should live in [the repository secrets](https://github.com/Dallinger/Dallinger/settings/secrets/actions)):
* MTURK_WORKER_ID
* AWS_ACCESS_KEY_ID
* AWS_SECRET_ACCESS_KEY

For this PR to work the secrets above need to be set up.

## How Has This Been Tested?
I used my credentials on https://test.pypi.org/ to test the deployment actions.
This is the successful test run: https://github.com/silviot/Dallinger/runs/2114366730
