### PR TITLE
Fix sqlalchemy dialect name

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -24,6 +24,10 @@ logger = logging.getLogger("dallinger.db")
 
 db_url_default = "postgresql://dallinger:dallinger@localhost/dallinger"
 db_url = os.environ.get("DATABASE_URL", db_url_default)
+if db_url.startswith("postgres://"):
+    # The sqlalchemy dialect name needs to be `postgresql`, not `postgres`
+    db_url = f"postgresql://{db_url[11:]}"
+logger.debug(f"Using database URL {db_url}")
 engine = create_engine(db_url, pool_size=1000)
 session_factory = sessionmaker(autocommit=False, autoflush=True, bind=engine)
 session = scoped_session(session_factory)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -375,7 +375,8 @@ def setup_experiment(
 
 def ensure_constraints_file_presence(directory: str):
     """Looks into the path represented by the string `directory`.
-    Does nothing if a `constraints.txt` file exists there.
+    Does nothing if a `constraints.txt` file exists there and is
+    newer than a sibling `requirements.txt` file.
     Otherwise it creates the constraints.txt file based on the
     contents of the `requirements.txt` file.
     If the `requirements.txt` does not exist one is created with
@@ -384,7 +385,12 @@ def ensure_constraints_file_presence(directory: str):
     constraints_path = Path(directory) / "constraints.txt"
     requirements_path = Path(directory) / "requirements.txt"
     if constraints_path.exists():
-        return
+        is_up_to_date = (
+            requirements_path.exists()
+            and constraints_path.lstat().st_mtime > requirements_path.lstat().st_mtime
+        )
+        if is_up_to_date:
+            return
     if not requirements_path.exists():
         requirements_path.write_text("dallinger\n")
     os.environ["CUSTOM_COMPILE_COMMAND"] = "dallinger generate-constraints"

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -391,6 +391,10 @@ def ensure_constraints_file_presence(directory: str):
         )
         if is_up_to_date:
             return
+        else:
+            raise ValueError(
+                "\nChanges detected to requirements.txt: run the command\n    dallinger generate-constraints\nand retry"
+            )
     if not requirements_path.exists():
         requirements_path.write_text("dallinger\n")
     os.environ["CUSTOM_COMPILE_COMMAND"] = "dallinger generate-constraints"

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -402,7 +402,7 @@ def test_request(webapp):
 
 @pytest.fixture
 def debug_experiment(request, env, clear_workers):
-    timeout = request.config.getvalue("recruiter_timeout", 30)
+    timeout = request.config.getvalue("recruiter_timeout", 120)
     # Make sure debug server runs to completion with bots
     p = pexpect.spawn(
         "dallinger", ["debug", "--no-browsers"], env=env, encoding="utf-8"


### PR DESCRIPTION
Possibly because we recently bumped up our versions, this problem started to appear:

```2021-03-16T22:51:00.067813+00:00 app[worker.2]: File "/app/.heroku/src/dallinger/dallinger/db.py", line 27, in <module>
2021-03-16T22:51:00.068028+00:00 app[worker.2]: engine = create_engine(db_url, pool_size=1000)
2021-03-16T22:51:00.068065+00:00 app[worker.2]: File "<string>", line 2, in create_engine
2021-03-16T22:51:00.068324+00:00 app[worker.2]: File "/app/.heroku/python/lib/python3.7/site-packages/sqlalchemy/util/deprecations.py", line 298, in warned
2021-03-16T22:51:00.068693+00:00 app[worker.2]: return fn(*args, **kwargs)
2021-03-16T22:51:00.068739+00:00 app[worker.2]: File "/app/.heroku/python/lib/python3.7/site-packages/sqlalchemy/engine/create.py", line 520, in create_engine
2021-03-16T22:51:00.069181+00:00 app[worker.2]: entrypoint = u._get_entrypoint()
2021-03-16T22:51:00.069207+00:00 app[worker.2]: File "/app/.heroku/python/lib/python3.7/site-packages/sqlalchemy/engine/url.py", line 653, in _get_entrypoint
2021-03-16T22:51:00.069749+00:00 app[worker.2]: cls = registry.load(name)
2021-03-16T22:51:00.069781+00:00 app[worker.2]: File "/app/.heroku/python/lib/python3.7/site-packages/sqlalchemy/util/langhelpers.py", line 342, in load
2021-03-16T22:51:00.070141+00:00 app[worker.2]: "Can't load plugin: %s:%s" % (self.group, name)
2021-03-16T22:51:00.070302+00:00 app[worker.2]: sqlalchemy.exc.NoSuchModuleError: Can't load plugin: sqlalchemy.dialects:postgres```

Apparently `postgres` is not a valid SqlAlchemy dialect name, but `postgresql` is.

Heroku provides us with a `DATABASE_URL` that uses the former wrong spelling.

This PR makes sure that, if we receive a database url starting with `postgres://`, it's changed as early as possible to read `postgresql://` instead.

An unrealated feature is also included in this PR: re-generating `constraints.txt` file if it's older than `requirements.txt` in an experiment directory.