### PR TITLE
Ignore sqlalchemy warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.log
 *.db
 *.egg-info
+/build/
 /.coverage*
 /coverage.xml
 /cover/

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -51,6 +51,11 @@ from dallinger.utils import check_call
 from dallinger.utils import generate_random_id
 from dallinger.version import __version__
 
+
+click.disable_unicode_literals_warning = True
+warnings.simplefilter("ignore", category=sa_exc.SAWarning)
+
+
 CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"])
 
 
@@ -111,10 +116,6 @@ def verify_id(ctx, param, app):
             "UUID beginning with {}-...".format(app[5:13])
         )
     return app
-
-
-click.disable_unicode_literals_warning = True
-warnings.simplefilter("ignore", category=sa_exc.SAWarning)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -6,20 +6,23 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from collections import Counter
-from functools import wraps
-from pathlib import Path
+import click
 import os
+import requests
 import shutil
 import signal
 import sys
 import tabulate
 import time
+import warnings
 import webbrowser
 
-import click
-import requests
+from collections import Counter
+from functools import wraps
+from pathlib import Path
 from rq import Worker, Connection
+from sqlalchemy import exc as sa_exc
+
 
 from dallinger.config import get_config
 from dallinger import data
@@ -111,6 +114,7 @@ def verify_id(ctx, param, app):
 
 
 click.disable_unicode_literals_warning = True
+warnings.simplefilter("ignore", category=sa_exc.SAWarning)
 
 
 @click.group(context_settings=CONTEXT_SETTINGS)


### PR DESCRIPTION

## Description
Suppress warnings from SQLAlchemy about duplicate names on polymorphic_identity.

## Motivation and Context
All Dallinger experiment sqlalchemy models trigger warnings because of the way Dallinger imports the experiment module. This is basically distracting noise in the context of developing or deploying and experiment, and we'd probably be better off without seeing these warnings.

See https://github.com/Dallinger/Dallinger/issues/269

## Screenshots (if appropriate):

Without suppression:
```
$ dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/sqlalchemy/orm/mapper.py:1108: SAWarning: Reassigning polymorphic association for identity 'empty' from <Mapper at 0x108ff1850; Empty> to <Mapper at 0x10a1167f0; Nominal>: Check for duplicate use of 'empty' as value for polymorphic_identity.
  util.warn(
/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/sqlalchemy/orm/mapper.py:1108: SAWarning: Reassigning polymorphic association for identity 'fully-connected' from <Mapper at 0x108ff1550; FullyConnected> to <Mapper at 0x10a116b20; Collaborative>: Check for duplicate use of 'fully-connected' as value for polymorphic_identity.
  util.warn(
✓ experiment.py defines 1 experiment
/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/sqlalchemy/orm/mapper.py:1108: SAWarning: Reassigning polymorphic association for identity 'free_recall_list_source' from <Mapper at 0x10a0e15e0; FreeRecallListSource> to <Mapper at 0x10a138970; FreeRecallListSource>: Check for duplicate use of 'free_recall_list_source' as value for polymorphic_identity.
  util.warn(
✓ no file conflicts

❯❯ ✓ Everything looks good!
```

With suppression:
```
$ dallinger verify

❯❯ Verifying current directory as a Dallinger experiment...
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✓ experiment.py defines 1 experiment
✓ no file conflicts

❯❯ ✓ Everything looks good!
```