### PR TITLE
Update default python version for Heroku

### DIFF
--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -28,7 +28,7 @@ chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 [Heroku]
 clock_on = False
-heroku_python_version = 3.9.1
+heroku_python_version = 3.9.2
 sentry = False
 redis_size = premium-0
 worker_multiplier = 1.5

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -144,7 +144,7 @@ def stub_config():
         u"dyno_type": u"free",
         u"heroku_app_id_root": u"fake-customid",
         u"heroku_auth_token": u"heroku secret",
-        u"heroku_python_version": u"3.9.1",
+        u"heroku_python_version": u"3.9.2",
         u"heroku_team": u"",
         u"host": u"0.0.0.0",
         u"id": u"TEST_EXPERIMENT_UID",  # This is a significant value; change with caution.


### PR DESCRIPTION

## Description
3.9.1, our current default version, has been deprecated on Heroku due to a security problem, so this updates the default to 3.9.2 for Heroku deployment.