### PR TITLE
Add timeout and better error info to local Postgres connection check

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -60,13 +60,20 @@ def create_db_engine(db_url, pool_size=1000):
     return create_engine(db_url, pool_size=pool_size)
 
 
-def check_connection():
+def check_connection(timeout_secs=3):
     """Test that postgres is running and that we can connect using the
     configured URI.
 
     Raises a psycopg2.OperationalError on failure.
     """
-    conn = psycopg2.connect(db_url)
+    try:
+        conn = psycopg2.connect(db_url, connect_timeout=timeout_secs)
+    except psycopg2.OperationalError as exc:
+        raise Exception(
+            f"Failed to connect to Postgres at {db_url}. "
+            "Is Postgres running on port 5432?"
+        ) from exc
+
     conn.close()
 
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -320,6 +320,7 @@ def setup_experiment(
     # Verify that the Postgres server is running.
     if local_checks:
         try:
+            log("Checking your local Postgres database connection...")
             db.check_connection()
         except Exception:
             log("There was a problem connecting to the Postgres database!")

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -323,7 +323,7 @@ def setup_experiment(
             log("Checking your local Postgres database connection...")
             db.check_connection()
         except Exception:
-            log("There was a problem connecting to the Postgres database!")
+            log("There was a problem connecting!")
             raise
 
         # Check that the demo-specific requirements are satisfied.


### PR DESCRIPTION
## Description
Provides more information when connecting locally to Postgres fails.

## Motivation and Context
@omonida had a not-so-fun experience where redis was running on the port usually used by Postrges (5432), and when `dallinger debug` started up, it just hung with no info and was very hard to quit:

 ```
dallinger debug --verbose
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✓ experiment.py defines 1 experiment
✗ static/scripts/store+json2.min.js OVERWRITES shared frontend files inserted at run-time

    ____        ____
   / __ \____ _/ / (_)___  ____ ____  _____
  / / / / __ `/ / / / __ \/ __ `/ _ \/ ___/
 / /_/ / /_/ / / / / / / / /_/ /  __/ /
/_____/\__,_/_/_/_/_/ /_/\__, /\___/_/
                        /____/
                                   v7.1.0

                Laboratory automation for
       the behavioral and social sciences.

^C^C^C^C^C^C^C^C^C^C^C^C^C^C^Creset
^C^C^[^[^[^Cquit
^C^C^C^C
```

This PR adds a timeout on the connection, plus some additional troubleshooting details:

```
 dallinger debug --verbose
✓ config.txt is PRESENT
✓ experiment.py is PRESENT
✓ experiment.py defines 1 experiment
✗ static/scripts/store+json2.min.js OVERWRITES shared frontend files inserted at run-time

    ____        ____
   / __ \____ _/ / (_)___  ____ ____  _____
  / / / / __ `/ / / / __ \/ __ `/ _ \/ ___/
 / /_/ / /_/ / / / / / / / /_/ /  __/ /
/_____/\__,_/_/_/_/_/ /_/\__, /\___/_/
                        /____/
                                   v7.1.0

                Laboratory automation for
       the behavioral and social sciences.


❯❯ Checking your local Postgres database connection...

❯❯ There was a problem connecting!
Traceback (most recent call last):
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/db.py", line 70, in check_connection
    conn = psycopg2.connect(db_url, connect_timeout=timeout_secs)
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/psycopg2/__init__.py", line 127, in connect
    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)
psycopg2.OperationalError: timeout expired


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/bin/dallinger", line 33, in <module>
    sys.exit(load_entry_point('dallinger', 'console_scripts', 'dallinger')())
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/jesses/projects/py_dev/dlgr_demos/vaelgates_dallinger_demos/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/command_line/utils.py", line 72, in wrapper
    return f(**kwargs)
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/command_line/__init__.py", line 209, in debug
    debugger.run()
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/deployment.py", line 688, in run
    self.setup()
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/deployment.py", line 665, in setup
    self.exp_id, self.tmp_dir = setup_experiment(
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/deployment.py", line 324, in setup_experiment
    db.check_connection()
  File "/Users/jesses/projects/py_dev/Dallinger3/dallinger/db.py", line 72, in check_connection
    raise Exception(
Exception: Failed to connect to Postgres at postgresql://dallinger:dallinger@localhost/dallinger. Is Postgres running on port 5432?
```

## How Has This Been Tested?
Debug mode with redis running on port 5432


