### PR TITLE
Fix URL to documentation about configuration

### DIFF
--- a/dallinger/frontend/templates/dashboard_home.html
+++ b/dallinger/frontend/templates/dashboard_home.html
@@ -2,7 +2,7 @@
 
 {% block body %}
 <h1>Experiment Configuration</h1>
-<p>The active <a href="http://docs.dallinger.io/en/latest/configuration.html">configuration</a>,
+<p>The active <a href="https://dallinger.readthedocs.io/en/latest/configuration.html">configuration</a>,
     assembled from your configuration files, Dallinger defaults, and any explicit overrides.
 </p>
 <table class="table table-sm table-striped">


### PR DESCRIPTION
## Description
The dashboard link to Dallinger documentation on configuration was broken. This PR updates the link.


## Screen shots
![Dashboard_Home_-_Dashboard](https://user-images.githubusercontent.com/63560/113189720-5a79dd00-9210-11eb-93d7-af73054594bf.png)

Broken:
![Maze_Found_-_Invalid_Host___Read_the_Docs](https://user-images.githubusercontent.com/63560/113189775-6c5b8000-9210-11eb-81fc-6ecaa1d0953a.png)

