### PR TITLE
Increase docker test timeouts

### DIFF
--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -958,13 +958,13 @@ class TestDockerServer(object):
         try:
             p.expect_exact("Server is running", timeout=180)
             p.expect_exact("Initial recruitment list:", timeout=30)
-            p.expect("New participant requested.*", 50)
+            p.expect("New participant requested.*", 180)
             Bot(re.search("http://[^ \n\r]+", p.after).group()).run_experiment()
-            p.expect("New participant requested.*", 50)
+            p.expect("New participant requested.*", 180)
             Bot(re.search("http://[^ \n\r]+", p.after).group()).run_experiment()
-            p.expect_exact("Recruitment is complete", timeout=240)
+            p.expect_exact("Recruitment is complete", timeout=300)
             p.expect_exact("'status': 'success'", timeout=120)
-            p.expect_exact("Experiment completed", timeout=20)
+            p.expect_exact("Experiment completed", timeout=40)
             p.expect_exact("Stopping bartlett1932_web_1", timeout=20)
             p.expect(pexpect.EOF)
         finally:


### PR DESCRIPTION
The docker test include timeout values. The time it takes to run the tests can vary widely from one run to the next one.
The current values often result in a "false positive" CI failure.

This PR increases these timeouts.