### PR TITLE
Bugfix: heroku deployments are by definition "remote"

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -191,7 +191,7 @@ class ExplicitFileSource(object):
             shutil.copyfile(from_path, to_path)
 
 
-def assemble_experiment_temp_dir(config, for_remote=False):
+def assemble_experiment_temp_dir(log, config, for_remote=False):
     """Create a temp directory from which to run an experiment.
     If for_remote is set to True the preparation includes bundling
     the local dallinger version if it was installed in editable mode.
@@ -292,10 +292,15 @@ def assemble_experiment_temp_dir(config, for_remote=False):
     requirements_path = Path(dst) / "requirements.txt"
     # Overwrite the requirements.txt file with the contents of the constraints.txt file
     (Path(dst) / "constraints.txt").replace(requirements_path)
-
     if for_remote:
         dallinger_path = get_editable_dallinger_path()
         if dallinger_path:
+            log(
+                "Dallinger is installed as an editable package, "
+                "and so will be copied and deployed in its current state, "
+                "ignoring any version specified in your experiment's "
+                "requirements.txt file!"
+            )
             egg_name = build_and_place(dallinger_path, dst)
             # Replace the line about dallinger in requirements.txt so that
             # it refers to the just generated package
@@ -364,7 +369,7 @@ def setup_experiment(
     if not config.get("dashboard_password", None):
         config.set("dashboard_password", fake.password(length=20, special_chars=False))
 
-    temp_dir = assemble_experiment_temp_dir(config, for_remote=not local_checks)
+    temp_dir = assemble_experiment_temp_dir(log, config, for_remote=not local_checks)
     log("Deployment temp directory: {}".format(temp_dir), chevrons=False)
 
     # Zip up the temporary directory and place it in the cwd.
@@ -501,7 +506,7 @@ def deploy_sandbox_shared_setup(
         config.load()
     heroku.sanity_check(config)
     (heroku_app_id, tmp) = setup_experiment(
-        log, debug=False, app=app, exp_config=exp_config
+        log, debug=False, app=app, exp_config=exp_config, local_checks=False
     )
 
     # Register the experiment using all configured registration services.

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -298,7 +298,7 @@ def assemble_experiment_temp_dir(log, config, for_remote=False):
             log(
                 "Dallinger is installed as an editable package, "
                 "and so will be copied and deployed in its current state, "
-                "ignoring any version specified in your experiment's "
+                "ignoring the dallinger version specified in your experiment's "
                 "requirements.txt file!"
             )
             egg_name = build_and_place(dallinger_path, dst)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,8 @@ def experiment_dir_merged(experiment_dir, active_config):
         # When dallinger is not installed as editable egg the requirements
         # file sent to heroku will include a version pin
         get_editable_dallinger_path.return_value = None
-        destination = assemble_experiment_temp_dir(active_config)
+        log = mock.Mock()
+        destination = assemble_experiment_temp_dir(log, active_config)
         os.chdir(destination)
         yield
     os.chdir(current_dir)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -447,9 +447,12 @@ class TestSetupExperiment(object):
             # When dallinger is not installed as editable egg the requirements
             # file sent to heroku will include a version pin
             get_editable_dallinger_path.return_value = None
-            tmp_dir = assemble_experiment_temp_dir(active_config)
+            log = mock.Mock()
+            tmp_dir = assemble_experiment_temp_dir(log, active_config)
+
         assert "dallinger==" in (Path(tmp_dir) / "requirements.txt").read_text()
 
+    @pytest.mark.slow
     def test_build_egg_if_in_development(self, active_config):
         from dallinger.deployment import assemble_experiment_temp_dir
 
@@ -478,7 +481,10 @@ class TestSetupExperiment(object):
             "dallinger.deployment.get_editable_dallinger_path"
         ) as get_editable_dallinger_path:
             get_editable_dallinger_path.return_value = tmp_egg
-            tmp_dir = assemble_experiment_temp_dir(active_config, for_remote=True)
+            log = mock.Mock()
+            tmp_dir = assemble_experiment_temp_dir(log, active_config, for_remote=True)
+
+        assert "Dallinger is installed as an editable package" in log.call_args[0][0]
         assert "dallinger==" not in (Path(tmp_dir) / "requirements.txt").read_text()
         shutil.rmtree(tmp_dir)
 


### PR DESCRIPTION

## Description
The `local_checks=False` flag was missing on the call to `deploy_sandbox_shared_setup()`, so we were treating a heroku deployment as if it were running locally.

## How Has This Been Tested?
memoryexp3 with Heroku deployment

