### PR TITLE
Facilitate support for custom recruiters

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -42,7 +42,6 @@ default_keys = (
     ("dashboard_user", six.text_type, [], True),
     ("database_size", six.text_type, []),
     ("database_url", six.text_type, [], True),
-    ("debug_recruiter", six.text_type, []),
     ("description", six.text_type, []),
     ("duration", float, []),
     ("dyno_type", six.text_type, []),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -42,6 +42,7 @@ default_keys = (
     ("dashboard_user", six.text_type, [], True),
     ("database_size", six.text_type, []),
     ("database_url", six.text_type, [], True),
+    ("debug_recruiter", six.text_type, []),
     ("description", six.text_type, []),
     ("duration", float, []),
     ("dyno_type", six.text_type, []),

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1192,7 +1192,6 @@ def _descendent_classes(cls):
             yield cls
 
 
-
 def by_name(name):
     """Attempt to return a recruiter class by name.
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1172,7 +1172,7 @@ def from_config(config):
     # Special case 3: if we're not using bots and we're in debug mode,
     # ignore any configured recruiter:
     if debug_mode:
-        return HotAirRecruiter()
+        return by_name(config.get("debug_recruiter", "HotAirRecruiter"))
 
     # Configured recruiter:
     if recruiter is not None:
@@ -1192,16 +1192,16 @@ def _descendent_classes(cls):
             yield cls
 
 
-BY_NAME = {}
-for cls in _descendent_classes(Recruiter):
-    BY_NAME[cls.__name__] = BY_NAME[cls.nickname] = cls
-
 
 def by_name(name):
     """Attempt to return a recruiter class by name.
 
     Actual class names and known nicknames are both supported.
     """
+    BY_NAME = {}
+    for cls in _descendent_classes(Recruiter):
+        BY_NAME[cls.__name__] = BY_NAME[cls.nickname] = cls
+
     klass = BY_NAME.get(name)
     if klass is not None:
         return klass()

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1170,9 +1170,9 @@ def from_config(config):
             return recruiter
 
     # Special case 3: if we're not using bots and we're in debug mode,
-    # ignore any configured recruiter:
+    # if present, use the configured recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
-        return by_name(config.get("debug_recruiter", "HotAirRecruiter"))
+        return by_name(config.get("recruiter", "HotAirRecruiter"))
 
     # Configured recruiter:
     if recruiter is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1170,9 +1170,9 @@ def from_config(config):
             return recruiter
 
     # Special case 3: if we're not using bots and we're in debug mode,
-    # if present, use the configured recruiter or else fallback to HotAirRecruiter:
+    # ignore any configured recruiter:
     if debug_mode:
-        return by_name(config.get("recruiter", "HotAirRecruiter"))
+        return by_name(config.get("debug_recruiter", "HotAirRecruiter"))
 
     # Configured recruiter:
     if recruiter is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1197,10 +1197,10 @@ def by_name(name):
 
     Actual class names and known nicknames are both supported.
     """
-    BY_NAME = {}
+    by_name = {}
     for cls in _descendent_classes(Recruiter):
-        BY_NAME[cls.__name__] = BY_NAME[cls.nickname] = cls
+        by_name[cls.__name__] = by_name[cls.nickname] = cls
 
-    klass = BY_NAME.get(name)
+    klass = by_name.get(name)
     if klass is not None:
         return klass()

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1170,7 +1170,7 @@ def from_config(config):
             return recruiter
 
     # Special case 3: if we're not using bots and we're in debug mode,
-    # ignore any configured recruiter:
+    # if present, use the configured debug_recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
         return by_name(config.get("debug_recruiter", "HotAirRecruiter"))
 


### PR DESCRIPTION
Allow for the declaration of a specific `Recruiter` class in config.txt.

## Description
This pull request accomplishes two things:
1. Allow for a custom `Recruiter` class in debug mode other than `HotRecruiter` by introducing a new config variable `debug_recruiter`.
2. Return at runtime the correct custom `Recruiter` class from the `by_name` function in recruiter.py

## Motivation and Context
Specific `Recruiter` classes are otherwise not set correctly, incl. in debug mode..
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested by running experiments in debug/sandbox mode in combination with custom `Recruiter` classes.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):
