### PR TITLE
Fix docker tests

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -47,9 +47,7 @@ bump2version==1.0.1
 bumpversion==0.6.0
     # via dallinger
 cached-property==1.5.2
-    # via
-    #   dallinger
-    #   docker-compose
+    # via dallinger
 certifi==2020.12.5
     # via requests
 cffi==1.14.5
@@ -147,6 +145,7 @@ greenlet==1.0.0
     # via
     #   dallinger
     #   gevent
+    #   sqlalchemy
 gunicorn==20.1.0
     # via dallinger
 identify==2.2.2
@@ -286,7 +285,9 @@ parso==0.8.2
 pathspec==0.8.1
     # via black
 pep517==0.10.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pexpect==4.8.0
     # via
     #   dallinger
@@ -347,8 +348,12 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
-pytest==6.2.3
+pytest-rerunfailures==9.1.1
     # via dallinger
+pytest==6.2.3
+    # via
+    #   dallinger
+    #   pytest-rerunfailures
 python-dateutil==2.8.1
     # via
     #   botocore

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,9 +47,7 @@ bump2version==1.0.1
 bumpversion==0.6.0
     # via dallinger
 cached-property==1.5.2
-    # via
-    #   dallinger
-    #   docker-compose
+    # via dallinger
 certifi==2020.12.5
     # via requests
 cffi==1.14.5
@@ -147,6 +145,7 @@ greenlet==1.0.0
     # via
     #   dallinger
     #   gevent
+    #   sqlalchemy
 gunicorn==20.1.0
     # via dallinger
 identify==2.2.2
@@ -286,7 +285,9 @@ parso==0.8.2
 pathspec==0.8.1
     # via black
 pep517==0.10.0
-    # via build
+    # via
+    #   build
+    #   pip-tools
 pexpect==4.8.0
     # via
     #   dallinger
@@ -347,8 +348,12 @@ pyparsing==2.4.7
     # via packaging
 pyrsistent==0.17.3
     # via jsonschema
-pytest==6.2.3
+pytest-rerunfailures==9.1.1
     # via dallinger
+pytest==6.2.3
+    # via
+    #   dallinger
+    #   pytest-rerunfailures
 python-dateutil==2.8.1
     # via
     #   botocore

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ botocore==1.20.44
     # via
     #   boto3
     #   s3transfer
+build==0.3.1.post1
+    # via dallinger
 cached-property==1.5.2
     # via dallinger
 certifi==2020.12.5
@@ -55,6 +57,7 @@ greenlet==1.0.0
     # via
     #   dallinger
     #   gevent
+    #   sqlalchemy
 gunicorn==20.1.0
     # via dallinger
 idna==2.10
@@ -75,6 +78,10 @@ markupsafe==1.1.1
     # via
     #   jinja2
     #   wtforms
+packaging==20.9
+    # via build
+pep517==0.10.0
+    # via build
 pexpect==4.8.0
     # via dallinger
 psutil==5.8.0
@@ -85,6 +92,8 @@ psycopg2==2.8.6
     #   sqlalchemy-postgres-copy
 ptyprocess==0.7.0
     # via pexpect
+pyparsing==2.4.7
+    # via packaging
 python-dateutil==2.8.1
     # via
     #   botocore
@@ -123,6 +132,10 @@ text-unidecode==1.3
     # via faker
 timeago==1.0.15
     # via dallinger
+toml==0.10.2
+    # via
+    #   build
+    #   pep517
 tzlocal==2.1
     # via
     #   apscheduler

--- a/setup.py
+++ b/setup.py
@@ -91,6 +91,7 @@ setup_args = dict(
             "pycodestyle",
             "pypandoc",
             "pytest",
+            "pytest-rerunfailures",
             "recommonmark",
             "sphinxcontrib-spelling",
             "Sphinx",

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -912,6 +912,12 @@ class TestDebugServer(object):
         )
 
 
+if os.environ.get("CI"):
+    MAX_DOCKER_RERUNS = 5
+else:
+    MAX_DOCKER_RERUNS = 1
+
+
 @pytest.mark.usefixtures("bartlett_dir", "clear_workers", "env")
 @pytest.mark.slow
 @pytest.mark.docker
@@ -949,7 +955,7 @@ class TestDockerServer(object):
             except IOError:
                 pass
 
-    @pytest.mark.flaky(reruns=5)
+    @pytest.mark.flaky(reruns=MAX_DOCKER_RERUNS)
     def test_docker_debug_without_bots(self, env):
         sys.path.append(os.getcwd())
         from experiment import Bot

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -949,6 +949,7 @@ class TestDockerServer(object):
             except IOError:
                 pass
 
+    @pytest.mark.flaky(reruns=5)
     def test_docker_debug_without_bots(self, env):
         sys.path.append(os.getcwd())
         from experiment import Bot


### PR DESCRIPTION
The docker tests have shown to be flaky in CI.

This PR configures them to be retried up to five times when run in CI.

It uses `pytest-rerunfailures`.