### PR TITLE
Push docker images on release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,22 +138,22 @@ jobs:
           key: ${{ runner.os }}-buildx2-${{ hashFiles('Dockerfile', 'requirements.txt', 'constraints.txt') }}
           restore-keys: |
             ${{ runner.os }}-buildx2-
-      - name: Build dallingerimages/dallinger docker image
+      - name: Build ghcr.io/dallinger/dallinger docker image
         uses: docker/build-push-action@v2
         with:
           push: false
           load: true
           target: dallinger
-          tags: dallingerimages/dallinger:latest
+          tags: ghcr.io/dallinger/dallinger:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
-      - name: Build dallingerimages/dallinger-bot docker image
+      - name: Build ghcr.io/dallinger/dallinger-bot docker image
         uses: docker/build-push-action@v2
         with:
           push: false
           load: true
           target: dallinger-bot
-          tags: dallingerimages/dallinger-bot:latest
+          tags: ghcr.io/dallinger/dallinger-bot:latest
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Move docker cache
@@ -162,9 +162,9 @@ jobs:
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - uses: actions/checkout@v2
       - name: Make sure dallinger script entry point is working
-        run: docker run --rm dallingerimages/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
+        run: docker run --rm ghcr.io/dallinger/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Make sure dallinger script entry point is working with dallinger source mounted as volume
-        run: docker run -v $PWD/dallinger:/dallinger/dallinger --rm dallingerimages/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
+        run: docker run -v $PWD/dallinger:/dallinger/dallinger --rm ghcr.io/dallinger/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Set up Python 3.9
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Cache Docker layers
@@ -160,7 +161,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
-      - uses: actions/checkout@v2
       - name: Make sure dallinger script entry point is working
         run: docker run --rm ghcr.io/dallinger/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Make sure dallinger script entry point is working with dallinger source mounted as volume

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,9 +135,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx1-${{ hashFiles('Dockerfile') }}
+          key: ${{ runner.os }}-buildx2-${{ hashFiles('Dockerfile', 'requirements.txt', 'constraints.txt') }}
           restore-keys: |
-            ${{ runner.os }}-buildx1-
+            ${{ runner.os }}-buildx2-
       - name: Build dallingerimages/dallinger docker image
         uses: docker/build-push-action@v2
         with:
@@ -145,8 +145,8 @@ jobs:
           load: true
           target: dallinger
           tags: dallingerimages/dallinger:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/base
-          cache-to: type=local,dest=/tmp/.buildx-cache/base
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
       - name: Build dallingerimages/dallinger-bot docker image
         uses: docker/build-push-action@v2
         with:
@@ -154,8 +154,12 @@ jobs:
           load: true
           target: dallinger-bot
           tags: dallingerimages/dallinger-bot:latest
-          cache-from: type=local,src=/tmp/.buildx-cache/bot
-          cache-to: type=local,dest=/tmp/.buildx-cache/bot
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new
+      - name: Move docker cache
+        run: |
+          rm -rf /tmp/.buildx-cache
+          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
       - uses: actions/checkout@v2
       - name: Make sure dallinger script entry point is working
         run: docker run --rm dallingerimages/dallinger python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,9 +136,9 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx2-${{ hashFiles('Dockerfile', 'requirements.txt', 'constraints.txt') }}
+          key: ${{ runner.os }}-buildx3-${{ hashFiles('Dockerfile', 'requirements.txt', 'constraints.txt') }}
           restore-keys: |
-            ${{ runner.os }}-buildx2-
+            ${{ runner.os }}-buildx3-
       - name: Build ghcr.io/dallinger/dallinger docker image
         uses: docker/build-push-action@v2
         with:
@@ -146,8 +146,8 @@ jobs:
           load: true
           target: dallinger
           tags: ghcr.io/dallinger/dallinger:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,mode=max,src=/tmp/.buildx-cache/dallinger
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new/dallinger
       - name: Build ghcr.io/dallinger/dallinger-bot docker image
         uses: docker/build-push-action@v2
         with:
@@ -155,8 +155,8 @@ jobs:
           load: true
           target: dallinger-bot
           tags: ghcr.io/dallinger/dallinger-bot:latest
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,dest=/tmp/.buildx-cache-new
+          cache-from: type=local,mode=max,src=/tmp/.buildx-cache/dallinger-bot
+          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new/dallinger-bot
       - name: Move docker cache
         run: |
           rm -rf /tmp/.buildx-cache

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,3 +53,34 @@ jobs:
         uses: pypa/gh-action-pypi-publish@v1.4.2
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  docker-images:
+    runs-on: ubuntu-latest
+    environment: ghcr
+    steps:
+      - name: Get version
+        id: vars
+        run: echo ::set-output name=version::${GITHUB_REF#refs/*/v}
+      - name: Login to Github ghcr
+        uses: docker/login-action@v1
+        with:
+          # The GHCR_TOKEN in Dallinger's ghcr environment was created by user silviot
+          username: silviot
+          password: ${{ secrets.GHCR_TOKEN }}
+          registry: ghcr.io
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Build ghcr.io/dallinger/dallinger docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          load: false
+          target: dallinger
+          tags: ghcr.io/dallinger/dallinger:${{ steps.vars.outputs.version }}
+      - name: Build ghcr.io/dallinger/dallinger-bot docker image
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          load: false
+          target: dallinger-bot
+          tags: ghcr.io/dallinger/dallinger-bot:${{ steps.vars.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,12 +12,12 @@ RUN apt-get update && \
     apt-get install -y libpq-dev python3-pip python3-dev enchant tzdata pandoc && \
     rm -rf /var/lib/apt/lists/*
 
-COPY constraints.txt  dev-requirements.txt  requirements.txt /dallinger/
+COPY constraints.txt requirements.txt /dallinger/
 WORKDIR /dallinger
 
 RUN --mount=type=cache,target=/root/.cache/pip \
     mkdir /wheelhouse && \
-    python3 -m pip wheel --wheel-dir=/wheelhouse -r requirements.txt
+    python3 -m pip wheel --wheel-dir=/wheelhouse -r requirements.txt -c constraints.txt
 
 
 ###################### Dallinger base image ###################################
@@ -29,14 +29,15 @@ RUN apt-get update && \
     apt-get install -y libpq5 python3-pip enchant tzdata --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
 
-COPY constraints.txt  dev-requirements.txt  requirements.txt /dallinger/
+COPY constraints.txt requirements.txt /dallinger/
 WORKDIR /dallinger
 
 RUN --mount=type=bind,source=/wheelhouse,from=wheels,target=/wheelhouse \
-    python3 -m pip install --find-links /wheelhouse -r requirements.txt
+    (ls -l /wheelhouse || (echo 'You need to enable docker buildkit to build dallinger: DOCKER_BUILDKIT=1' && false) ) &&\
+    python3 -m pip install --find-links file:///wheelhouse -r requirements.txt -c constraints.txt
 
 COPY . /dallinger
-RUN python3 -m pip install --find-links /wheelhouse -e .[data]
+RUN python3 -m pip install --find-links file:///wheelhouse -e .[data]
 
 # Add two ENV variables as a fix when using python3, to prevent this error:
 # Click will abort further execution because Python 3 was configured

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 ###################### Dallinger base image ###################################
 FROM ubuntu:20.04 as dallinger
 ENV DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 
 # Install runtime dependencies
 RUN apt-get update && \
@@ -51,6 +52,7 @@ CMD /bin/bash
 ###################### Dallinger bot image ####################################
 FROM dallinger as dallinger-bot
 ENV DEBIAN_FRONTEND=noninteractive
+LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 
 RUN --mount=type=cache,target=/chromedownload \
     apt update && \

--- a/dallinger/docker/Dockerfile.web
+++ b/dallinger/docker/Dockerfile.web
@@ -1,4 +1,4 @@
-ARG DALLINGER_DOCKER_IMAGE=dallingerimages/dallinger:latest
+ARG DALLINGER_DOCKER_IMAGE=ghcr.io/dallinger/dallinger:latest
 FROM $DALLINGER_DOCKER_IMAGE
 # Use a dallinger base image to build an experiment image
 COPY . /experiment

--- a/dallinger/docker/Dockerfile.worker
+++ b/dallinger/docker/Dockerfile.worker
@@ -1,4 +1,4 @@
-ARG DALLINGER_DOCKER_IMAGE=dallingerimages/dallinger:latest
+ARG DALLINGER_DOCKER_IMAGE=ghcr.io/dallinger/dallinger:latest
 FROM $DALLINGER_DOCKER_IMAGE
 # Use a dallinger base image to build an experiment image
 COPY . /experiment

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -109,7 +109,7 @@ class DockerComposeWrapper(object):
         if self.needs_chrome:
             build_args += [
                 "--build-arg",
-                "DALLINGER_DOCKER_IMAGE=dallingerimages/dallinger-bot",
+                "DALLINGER_DOCKER_IMAGE=ghcr.io/dallinger/dallinger-bot",
             ]
         check_output(
             ["docker-compose", "build"] + build_args,

--- a/docs/source/docker_setup.rst
+++ b/docs/source/docker_setup.rst
@@ -27,8 +27,8 @@ Images can be rebuilt in the project root with:
 
 .. code-block:: shell
 
-    docker build . --target dallinger -t dallingerimages/dallinger
-    docker build . --target dallinger-bot -t dallingerimages/dallinger-bot
+    DOCKER_BUILDKIT=1 docker build . --target dallinger -t ghcr.io/dallinger/dallinger
+    DOCKER_BUILDKIT=1 docker build . --target dallinger-bot -t ghcr.io/dallinger/dallinger-bot
 
 How it works
 ~~~~~~~~~~~~


### PR DESCRIPTION
## Description
This PR adds a github action that is run on pushes to version tags. It builds two docker images (`dallinger` and `dallinger-bot`) and pushes them to the GitHub container registry.

## Motivation and Context
To support the work on docker we need a canonical place to store dallinger images. 

GitHub is launching a container registry service (currently in beta) at ghcr.io.

This PR builds and pushes docker images there:

* https://github.com/orgs/dallinger/packages/container/package/dallinger
* https://github.com/orgs/dallinger/packages/container/package/dallinger-bot

## How Has This Been Tested?
I tested the new action from my fork of this repository. The docker images [were built and pushed successfully](https://github.com/silviot/Dallinger/runs/2279961092?check_suite_focus=true).
