### PR TITLE
Allow configuration of duration exceeded behavior for MTurk Recruiter

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -43,6 +43,7 @@ default_keys = (
     ("database_size", six.text_type, []),
     ("database_url", six.text_type, [], True),
     ("description", six.text_type, []),
+    ("disable_when_duration_exceeded", bool, []),
     ("duration", float, []),
     ("dyno_type", six.text_type, []),
     ("dyno_type_web", six.text_type, []),

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -21,6 +21,7 @@ enable_global_experiment_registry = False
 auto_recruit = False
 assign_qualifications = False
 us_only = False
+disable_when_duration_exceeded = True
 
 [Bots]
 webdriver_type = chrome_headless

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -135,6 +135,7 @@ def stub_config():
         u"contact_email_on_error": u"error_contact@test.com",
         u"dallinger_email_address": u"test@example.com",
         u"database_size": u"standard-0",
+        u"disable_when_duration_exceeded": True,
         u"enable_global_experiment_registry": False,
         u"redis_size": u"premium-0",
         u"dashboard_user": u"admin",

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -727,7 +727,7 @@ class MTurkRecruiter(Recruiter):
                 self._send_notification_missing_rest_notification_for(participant)
                 unsubmitted.append(summary)
 
-        disable_hit = self.config.get("disable_when_duration_exceeded", True)
+        disable_hit = self.config.get("disable_when_duration_exceeded")
         if disable_hit and unsubmitted:
             self._disable_autorecruit()
             self.close_recruitment()

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -727,7 +727,8 @@ class MTurkRecruiter(Recruiter):
                 self._send_notification_missing_rest_notification_for(participant)
                 unsubmitted.append(summary)
 
-        if unsubmitted:
+        disable_hit = self.config.get("disable_when_duration_exceeded", True)
+        if disable_hit and unsubmitted:
             self._disable_autorecruit()
             self.close_recruitment()
             pick_one = unsubmitted[0]

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -146,6 +146,10 @@ Amazon Mechanical Turk Recruitment
 ``duration`` *float*
     How long in hours participants have until the HIT will time out.
 
+``disable_when_duration_exceeded`` *boolean*
+    Whether to disable recruiting and expire the HIT when the duration has been
+    exceeded.
+
 ``us_only`` *boolean*
     Controls whether this HIT is available only to MTurk workers in the U.S.
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -995,6 +995,25 @@ class TestMTurkRecruiter(object):
             participants[0].hit_id
         )
 
+    def test_flag_prevents_disabling_autorecruit(self, a, recruiter, requests):
+        recruiter.mturkservice.get_assignment.return_value = {"status": None}
+        participants = [a.participant()]
+
+        recruiter.config.set("disable_when_duration_exceeded", False)
+        recruiter.notify_duration_exceeded(participants, datetime.now())
+
+        requests.patch.assert_not_called()
+
+    def test_flag_prevents_expiring_hit(self, a, recruiter):
+        recruiter.mturkservice.get_assignment.return_value = {"status": None}
+        participants = [a.participant()]
+
+        recruiter.config.set("disable_when_duration_exceeded", False)
+
+        recruiter.notify_duration_exceeded(participants, datetime.now())
+
+        recruiter.mturkservice.expire_hit.assert_not_called()
+
 
 class TestRedisTally(object):
     @pytest.fixture


### PR DESCRIPTION
## Description
Adds a new config parameter `disable_when_duration_exceeded` which is enabled by default. The default experiment behavior is unchanged. When this parameter is set to `False` the duration exceeded event triggered by the clock server will not disable the MTurk auto-recruit or expire the hit.

## Motivation and Context
See #2617

## How Has This Been Tested?
I added new automated tests for this feature, and existing tests for the original behavior all still pass.