### PR TITLE
`dallinger hits` will show all your HITs by default

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -508,7 +508,8 @@ def hits(app, sandbox):
     """
     if app is not None:
         verify_id(None, "--app", app)
-    formatted = []
+    formatted_hit_list = []
+    dateformat = "%Y/%-m/%-d %I:%M:%S %p"
     for h in _current_hits(_mturk_service_from_config(sandbox), app):
         title = h["title"][:40] + "..." if len(h["title"]) > 40 else h["title"]
         description = (
@@ -516,22 +517,22 @@ def hits(app, sandbox):
             if len(h["description"]) > 60
             else h["description"]
         )
-        formatted.append(
+        formatted_hit_list.append(
             [
                 h["id"],
                 title,
                 h["annotation"],
                 h["status"],
-                h["created"],
-                h["expiration"],
+                h["created"].strftime(dateformat),
+                h["expiration"].strftime(dateformat),
                 description,
             ]
         )
     out = Output()
-    out.log("Found {} hit[s]:".format(len(formatted)))
+    out.log("Found {} hit[s]:".format(len(formatted_hit_list)))
     out.log(
         tabulate.tabulate(
-            formatted,
+            formatted_hit_list,
             headers=[
                 "Hit ID",
                 "Title",
@@ -572,7 +573,7 @@ def expire(app, sandbox, exit=True):
         out.log("Expired {} hits: {}".format(len(success), ", ".join(success)))
     if failures:
         out.log(
-            "Could not expire {} hits: {}".format(len(failures), ", ".join(failures))
+            "Could not expire {} hit[s]: {}".format(len(failures), ", ".join(failures))
         )
     if not success and not failures:
         out.log("No hits found for this application.")

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -178,9 +178,17 @@ To limit the output to HITs associated with a Dallinger experiment, specify the 
 expire
 ^^^^^^
 
-Expire (set to status ``Reviewable``) all MTurk HITs for a dallinger app.
+Expire (set to status ``Reviewable``) MTurk HITs.
 
-A required ``--app <app>`` parameter specifies the experiment by its id. An optional ``--sandbox`` flag indicates to look for HITs in the MTurk sandbox.
+With the ``--app <experiment ID>`` parameter, the command will attempt
+to expire any HITs associtated with a specific experiment, based on the
+presence of this ID in the HIT's ``annotation`` field.
+With the ``--hit_id <HIT ID>`` parameter, the command will instead attempt to expire the specified HIT directly.
+An optional ``--sandbox`` flag indicates to look for HITs in the MTurk
+sandbox.
+Note that if a HIT already has the MTurk status ``Reviewable``, the
+command will still report a success (and there is no risk in
+running the command against an already-expired HIT).
 
 extend_mturk_hit
 ^^^^^^^^^^^^^^^^

--- a/docs/source/command_line_utility.rst
+++ b/docs/source/command_line_utility.rst
@@ -81,7 +81,7 @@ An optional ``--no-scrub`` flag will stop the scrubbing of personally
 identifiable information in the export. The scrubbing of PII is enabled by
 default.
 
-email_test
+email-test
 ~~~~~~~~~~
 
 Validate email settings derived from Dallinger Configuration and send a test
@@ -168,16 +168,19 @@ from the MTurk sandbox.
 hits
 ^^^^
 
-List all MTurk HITs for a dallinger app. A required ``--app <app>``
-parameter specifies the experiment by its id. An optional ``--sandbox``
-flag indicates to look for HITs in the MTurk sandbox.
+List all MTurk HITs for your account based on your dallinger AWS configuration, or for a specific dallinger experiment by ID.
+
+By default, all your HITs will be displayed for either the MTurk sandbox
+(if the ``--sandbox`` flag is set) or production environment.
+To limit the output to HITs associated with a Dallinger experiment, specify the full experiment ID with the ``--app <app>`` flag.
+
 
 expire
 ^^^^^^
 
-Expire all MTurk HITs for a dallinger app. A required ``--app <app>``
-parameter specifies the experiment by its id. An optional ``--sandbox``
-flag indicates to look for HITs in the MTurk sandbox.
+Expire (set to status ``Reviewable``) all MTurk HITs for a dallinger app.
+
+A required ``--app <app>`` parameter specifies the experiment by its id. An optional ``--sandbox`` flag indicates to look for HITs in the MTurk sandbox.
 
 extend_mturk_hit
 ^^^^^^^^^^^^^^^^

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,8 @@
 import mock
 import os
 import pytest
+from datetime import datetime
+from tzlocal import get_localzone
 
 pytest_plugins = ["pytest_dallinger"]
 
@@ -138,6 +140,30 @@ def aws_creds():
         "aws_secret_access_key": config.get("aws_secret_access_key"),
     }
     return creds
+
+
+@pytest.fixture
+def fake_parsed_hit():
+    """Format returned by dallinger.mturk.MTurkService"""
+    return {
+        "annotation": "test-experiment-id",
+        "assignments_available": 2,
+        "assignments_completed": 0,
+        "assignments_pending": 0,
+        "created": get_localzone().localize(datetime.now()),
+        "description": "Recall a list of words.",
+        "expiration": get_localzone().localize(datetime.now()),
+        "id": "fake-hit-id",
+        "keywords": ["Memory", "wordlist"],
+        "max_assignments": 2,
+        "qualification_type_ids": ["QUAL_ID_1", "QUAL_ID_2"],
+        "review_status": "NotReviewed",
+        "reward": 2.00,
+        "status": "Reviewable",
+        "title": "Fake HIT Title",
+        "type_id": "fake type id",
+        "worker_url": "http://the-hit-url",
+    }
 
 
 @pytest.fixture

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -57,13 +57,10 @@ def data():
 
 
 @pytest.fixture
-def mturk():
+def mturk(fake_parsed_hit):
     with mock.patch("dallinger.command_line.MTurkService") as mock_mturk:
         mock_instance = mock.Mock()
-        mock_instance.get_hits.return_value = [
-            {"id": "hit-id-1"},
-            {"id": "hit-id-2", "annotation": "exp-id-2"},
-        ]
+        mock_instance.get_hits.return_value = [fake_parsed_hit]
         mock_mturk.return_value = mock_instance
         yield mock_mturk
 
@@ -1140,9 +1137,8 @@ class TestHits(object):
         result = CliRunner().invoke(expire, ["--app", "exp-id-2"])
         assert result.exit_code == 1
         mturk_instance.get_hits.assert_called_once()
-        mturk_instance.expire_hit.call_count = 2
-        assert output.log.call_count == 1
-        assert "Could not expire 2 hits:" in str(output.log.call_args_list[0])
+        mturk_instance.expire_hit.assert_called_once_with(hit_id="fake-hit-id")
+        assert "Could not expire 1 hit[s]:" in str(output.log.call_args_list[0])
 
 
 class TestApps(object):

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -292,10 +292,10 @@ def with_cleanup(aws_creds, request):
     finally:
         try:
             for hit in service.get_hits(test_hits_only):
-                service.disable_hit(hit["id"])
+                service.mturk.delete_hit(HITId=hit["id"])
         except Exception:
             # Broad exception so we don't leak credentials in Travis CI logs
-            pass
+            print("Something went wrong in test HIT cleanup!!!")
 
 
 @pytest.fixture(scope="class")


### PR DESCRIPTION
## Description
### `dallinger hits`
To provide more insight into your MTurk HIT inventory (similar to feature of https://manage-hits-individually.s3.amazonaws.com), allow one to view all their HITs with `dallinger hits` instead of forcing you to specify a Dallinger app ID.

The `--app` parameter is still supported, but is now optional.

### `dallinger expire`
This command now accepts either an experiment/app ID, or a HIT ID, so you can just expire a HIT directly.

## Motivation and Context
In trying to get to the bottom of #2144 I found having no way to view my full HIT list with details such as `annotation` and `status` a major hindrance.

## How Has This Been Tested?
Locally, against an MTurk account provided by @jacobyn 

## Screenshots (if appropriate):

### New default behavior (all HITs)
```
dallinger hits --sandbox
2021-04-06 11:29:07,842 - /Users/jesses/projects/py_dev/Dallinger3/dallinger/experiment.py - ERROR - Could not import experiment.

❯❯ Found 612 hit[s]:
Hit ID                          Title                                        Annotation (experiment ID)            Status      Created                Expiration             Description
------------------------------  -------------------------------------------  ------------------------------------  ----------  ---------------------  ---------------------  ---------------------------------------------------------------
32ZCLEW0B18V30YQKSDMK2G9DTOJPH  MCMCP demo (dlgr-6cdce265)                   6cdce265-fd66-c191-7c24-9e52f1a6f90a  Assignable  2021/3/31 11:13:05 AM  2021/4/24 11:13:05 AM  This app demos an MCMCP experiment.
3VMHWJRYHX4K77ELNTWIZHAKMHPXFH  MCMCP demo (dlgr-03cb183d)                   03cb183d-ae0c-221a-59cf-008c06e70887  Assignable  2021/3/25 12:45:37 PM  2021/4/18 12:45:37 PM  This app demos an MCMCP experiment.
3PUV2Q8SV6SGWKXORR9AMKG7RUBBDN  Memory test (dlgr-bdd3f937)                  bdd3f937-35fc-8896-1c31-a3f4731988f9  Reviewable  2021/3/15 03:21:48 PM  2021/3/15 05:35:47 PM  Recall a list of words.
309D674SH196RSRARVEZ2EYP6UUBCI  TAPPING EXPERIMENT BRAZIL (bonus up to $...  6d41737e-a835-5d9c-add9-164c9e3d97c0  Reviewable  2021/3/15 10:23:16 AM  2021/3/17 10:23:16 AM  This experiment consists of a long session of tapping to rhy...
38XPGNCKHVOI52C13XZHKSG8H7N4VU  War of the Ghosts (dlgr-8a8e9bf5)            8a8e9bf5-335c-4889-3cef-508afb1d83d2  Reviewable  2021/3/11 12:53:00 PM  2021/3/11 12:55:17 PM  Read a brief story and answer some questions about it.
3MGHRFQY2NDIA8P5P7ZZFOUPIC7Y0F  War of the Ghosts (dlgr-a0d5228e)            a0d5228e-20c1-a612-f588-5ebd6ff03cbf  Reviewable  2021/3/11 11:48:05 AM  2021/3/11 12:56:01 PM  Read a brief story and answer some questions about it.
31N9JPQXIR6Z99RNGDX940VZ095HNA  War of the Ghosts (dlgr-8abe7947)            8abe7947-1ac0-8a20-46a5-666d676956e2  Reviewable  2021/3/11 11:22:57 AM  2021/3/11 12:55:36 PM  Read a brief story and answer some questions about it.
3I6NF2WGIIKHJOQ6S7J5PJJCUOR5G8  Test Title                                                                         Reviewable  2021/3/11 10:40:53 AM  2021/3/11 10:41:27 AM  ***TEST SUITE HIT***38047b5863e5bf2f9f86f48e2c7e0586fca44530
3566S7OX5F7Z2DEMYHDZGGT2J5371P  HIT Two                                                                            Reviewable  2021/3/11 10:40:53 AM  2021/3/11 10:41:27 AM  ***TEST SUITE HIT***38047b5863e5bf2f9f86f48e2c7e0586fca44530
31HLTCK4BNJYHI5LYY1ITHDB7CSVG4  Test Title                                                                         Reviewable  2021/3/11 10:40:29 AM  2021/3/11 10:41:03 AM  ***TEST SUITE HIT***38047b5863e5bf2f9f86f48e2c7e0586fca44530
...
...
```
### With `--app` option
```
dallinger hits --sandbox --app bdd3f937-35fc-8896-1c31-a3f4731988f9

❯❯ Found 1 hit[s]:
Hit ID                          Title                        Annotation (experiment ID)            Status      Created                Expiration             Description
------------------------------  ---------------------------  ------------------------------------  ----------  ---------------------  ---------------------  -----------------------
3PUV2Q8SV6SGWKXORR9AMKG7RUBBDN  Memory test (dlgr-bdd3f937)  bdd3f937-35fc-8896-1c31-a3f4731988f9  Reviewable  2021/3/15 03:21:48 PM  2021/3/15 05:35:47 PM  Recall a list of words.
```

