### PR TITLE
Fixed #2775. Typo in dashboard.

### DIFF
--- a/dallinger/frontend/templates/dashboard_mturk.html
+++ b/dallinger/frontend/templates/dashboard_mturk.html
@@ -146,7 +146,7 @@
         const durationOption = hoursDiff > 0 ? " --duration_hours " + hoursDiff : ""
         const sandboxOption = globals.isSandbox ? " --sandbox" : "";
 
-        const command = "dallinger extend_mturk_hit --hit_id " + globals.HITId + assignmentOption + durationOption + sandboxOption;
+        const command = "dallinger extend-mturk-hit --hit_id " + globals.HITId + assignmentOption + durationOption + sandboxOption;
 
         return command;
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixed typo in dashboard for extending a hit. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Issue: #2775

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I ran the `bartlett1932` demo in debug to check that dashboard command matched that of `dallinger -h`. 

## Screenshots (if appropriate):
Note that the two commands now agree. 
<img width="501" alt="Screen Shot 2021-04-23 at 5 21 52 PM" src="https://user-images.githubusercontent.com/20927930/115931158-a6f3b980-a458-11eb-9178-7bf5fb9eba51.png">
<img width="570" alt="Screen Shot 2021-04-23 at 5 22 30 PM" src="https://user-images.githubusercontent.com/20927930/115931144-a22f0580-a458-11eb-93dd-17efbcc9fcc3.png">