### PR TITLE
Add support for custom task registration from experiment class

### DIFF
--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -6,6 +6,7 @@ from apscheduler.schedulers.blocking import BlockingScheduler
 
 import dallinger
 from dallinger import recruiters
+from dallinger.experiment import EXPERIMENT_TASK_REGISTRATIONS
 from dallinger.models import Participant
 from dallinger.utils import ParticipationTime
 
@@ -48,6 +49,17 @@ def launch():
         config.load()
 
     # Import the experiment.
-    dallinger.experiment.load()
+    experiment_class = dallinger.experiment.load()
+
+    for meth_name in EXPERIMENT_TASK_REGISTRATIONS:
+        task = getattr(experiment_class, meth_name, None)
+        args = EXPERIMENT_TASK_REGISTRATIONS[meth_name]
+        if task is not None:
+            scheduler.add_job(
+                task,
+                trigger=args["trigger"],
+                replace_existing=True,
+                **dict(args["kwargs"])
+            )
 
     scheduler.start()

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -529,7 +529,7 @@ def bot_recruits(request, active_config, recruitment_loop):
 
 
 @pytest.fixture
-def cleared_tasks():
+def tasks_with_cleanup():
     from dallinger import experiment
 
     tasks = experiment.EXPERIMENT_TASK_REGISTRATIONS

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -528,6 +528,17 @@ def bot_recruits(request, active_config, recruitment_loop):
     yield recruit_bots()
 
 
+@pytest.fixture
+def cleared_tasks():
+    from dallinger import experiment
+
+    tasks = experiment.EXPERIMENT_TASK_REGISTRATIONS
+    orig_tasks = tasks.copy()
+    tasks.clear()
+    yield tasks
+    tasks.update(orig_tasks)
+
+
 def pytest_addoption(parser):
     parser.addoption("--chrome", action="store_true", help="Run chrome tests")
     parser.addoption(

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -148,7 +148,7 @@ Amazon Mechanical Turk Recruitment
 
 ``disable_when_duration_exceeded`` *boolean*
     Whether to disable recruiting and expire the HIT when the duration has been
-    exceeded.
+    exceeded. This only has an effect when ``clock_on`` is enabled.
 
 ``us_only`` *boolean*
     Controls whether this HIT is available only to MTurk workers in the U.S.
@@ -228,8 +228,10 @@ Deployment Configuration
     Port of the host.
 
 ``clock_on`` *boolean*
-    If the clock process is on, it will perform a series of checks that ensure
-    the integrity of the database.
+    If the clock process is on, it will enable a task scheduler to run automated
+    background tasks. By default, a single task is registered which performs a
+    series of checks that ensure the integrity of the database. The configuration
+    option ``disable_when_duration_exceeded`` configures the behavior of that task.
 
 ``heroku_python_version`` *unicode*
     The python version to be used on Heroku deployments. The version specification will

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,6 +83,7 @@ designing new experiments for others to use.
     writing_bots
     extra_configuration
     recruitment
+    scheduled_tasks
     private_repo
 
 Core Contribution Documentation

--- a/docs/source/scheduled_tasks.rst
+++ b/docs/source/scheduled_tasks.rst
@@ -1,0 +1,31 @@
+.. _scheduled-tasks:
+
+Scheduled Tasks
+===================
+
+To create a new experiment-specific background tasks, you can register classmethods
+or functions on your experiment class using the :attr:`~dallinger.experiment.scheduled_task`
+decorator::
+
+    from dallinger import experiment
+
+    class MyCustomExperiment(experiment.Experiment):
+        ...
+
+        @scheduled_task("interval", minutes=15)
+        @classmethod
+        def my_background_task(cls):
+            ...
+
+If the ``clock_on`` configuration parameter is enabled, then functions
+registered using this decorator will be run by the clock server on the specified
+interval. You can configure the frequency of the background task via arguments
+to the decorator. The arguments should be identical to those of the
+`appscheduler.scheduled_job <https://apscheduler.readthedocs.io/en/v3.7.0/modules/schedulers/base.html#apscheduler.schedulers.base.BaseScheduler.scheduled_job>`__.
+method. The first argument is the trigger type, which can be one of
+`"interval" <https://apscheduler.readthedocs.io/en/v3.7.0/modules/triggers/interval.html?highlight=trigger>`__,
+`"cron" <https://apscheduler.readthedocs.io/en/v3.7.0/modules/triggers/cron.html?highlight=trigger>`__,
+or `"date" <https://apscheduler.readthedocs.io/en/v3.7.0/modules/triggers/date.html?highlight=trigger>`__.
+See the documentation links above for details on trigger specific arguments.
+The ``"date"`` trigger type can be used without additional arguments to run a
+task immediately when the clock server starts.

--- a/docs/source/scheduled_tasks.rst
+++ b/docs/source/scheduled_tasks.rst
@@ -12,7 +12,7 @@ decorator::
     class MyCustomExperiment(experiment.Experiment):
         ...
 
-        @scheduled_task("interval", minutes=15)
+        @experiment.scheduled_task("interval", minutes=15)
         @classmethod
         def my_background_task(cls):
             ...

--- a/tests/experiment/dallinger_experiment.py
+++ b/tests/experiment/dallinger_experiment.py
@@ -40,6 +40,10 @@ class TestExperiment(Experiment):
         config = get_config()
         return config.get("_is_completed", None)
 
+    @classmethod
+    def test_task(cls):
+        return True
+
 
 class ZSubclassThatSortsLower(TestExperiment):
     @classmethod

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -197,19 +197,19 @@ class TestExperimentBaseClass(object):
 
 
 class TestTaskRegistration(object):
-    def test_deferred_task_decorator(self, cleared_tasks):
+    def test_deferred_task_decorator(self, tasks_with_cleanup):
         from dallinger.experiment import scheduled_task
 
         decorator = scheduled_task("interval", minutes=15)
-        assert len(cleared_tasks) == 0
+        assert len(tasks_with_cleanup) == 0
 
         def fake_task():
             pass
 
         # Decorator does not modify or wrap the function
         assert decorator(fake_task) is fake_task
-        assert len(cleared_tasks) == 1
-        assert cleared_tasks["fake_task"] == {
+        assert len(tasks_with_cleanup) == 1
+        assert tasks_with_cleanup["fake_task"] == {
             "trigger": "interval",
             "kwargs": (("minutes", 15),),
         }

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -194,3 +194,22 @@ class TestExperimentBaseClass(object):
         exp.participant_task_completed(participant)
 
         participant.recruiter.assign_experiment_qualifications.assert_not_called()
+
+
+class TestTaskRegistration(object):
+    def test_deferred_task_decorator(self, cleared_tasks):
+        from dallinger.experiment import scheduled_task
+
+        decorator = scheduled_task("interval", minutes=15)
+        assert len(cleared_tasks) == 0
+
+        def fake_task():
+            pass
+
+        # Decorator does not modify or wrap the function
+        assert decorator(fake_task) is fake_task
+        assert len(cleared_tasks) == 1
+        assert cleared_tasks["fake_task"] == {
+            "trigger": "interval",
+            "kwargs": (("minutes", 15),),
+        }

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -60,11 +60,13 @@ class TestClockScheduler(object):
         assert patched_scheduler.start.called_once()
         assert get_config().ready
 
-    def test_launch_registers_additional_tasks(self, patched_scheduler, cleared_tasks):
+    def test_launch_registers_additional_tasks(
+        self, patched_scheduler, tasks_with_cleanup
+    ):
         jobs = patched_scheduler.get_jobs()
         assert len(jobs) == 1
 
-        cleared_tasks["test_task"] = {
+        tasks_with_cleanup["test_task"] = {
             "trigger": "interval",
             "kwargs": (("minutes", 5),),
         }

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -60,27 +60,22 @@ class TestClockScheduler(object):
         assert patched_scheduler.start.called_once()
         assert get_config().ready
 
-    def test_launch_registers_additional_tasks(self, patched_scheduler):
-        from dallinger import experiment
-
-        jobs = self.clock.scheduler.get_jobs()
+    def test_launch_registers_additional_tasks(self, patched_scheduler, cleared_tasks):
+        jobs = patched_scheduler.get_jobs()
         assert len(jobs) == 1
 
-        experiment.EXPERIMENT_TASK_REGISTRATIONS["test_task"] = {
+        cleared_tasks["test_task"] = {
             "trigger": "interval",
             "kwargs": (("minutes", 5),),
         }
 
-        try:
-            self.clock.launch()
-            jobs = self.clock.scheduler.get_jobs()
-            assert len(jobs) == 2
-            assert (
-                jobs[1].func_ref
-                == "dallinger_experiment.dallinger_experiment:TestExperiment.test_task"
-            )
-        finally:
-            experiment.EXPERIMENT_TASK_REGISTRATIONS.clear()
+        self.clock.launch()
+        jobs = patched_scheduler.get_jobs()
+        assert len(jobs) == 2
+        assert (
+            jobs[1].func_ref
+            == "dallinger_experiment.dallinger_experiment:TestExperiment.test_task"
+        )
 
 
 @pytest.mark.usefixtures("experiment_dir", "active_config")

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -37,6 +37,13 @@ class TestClockScheduler(object):
 
         self.clock = clock
 
+    @pytest.fixture
+    def patched_scheduler(self):
+        from dallinger import heroku
+
+        with mock.patch("apscheduler.schedulers.blocking.BlockingScheduler.start"):
+            yield heroku.clock.scheduler
+
     def teardown(self):
         os.chdir("../..")
 
@@ -48,20 +55,32 @@ class TestClockScheduler(object):
             == "dallinger.heroku.clock:check_db_for_missing_notifications"
         )
 
-    def test_launch_loads_config(self):
-        original_start = self.clock.scheduler.start
-        data = {"launched": False}
+    def test_launch_loads_config(self, patched_scheduler):
+        self.clock.launch()
+        assert patched_scheduler.start.called_once()
+        assert get_config().ready
 
-        def start():
-            data["launched"] = True
+    def test_launch_registers_additional_tasks(self, patched_scheduler):
+        from dallinger import experiment
+
+        jobs = self.clock.scheduler.get_jobs()
+        assert len(jobs) == 1
+
+        experiment.EXPERIMENT_TASK_REGISTRATIONS["test_task"] = {
+            "trigger": "interval",
+            "kwargs": (("minutes", 5),),
+        }
 
         try:
-            self.clock.scheduler.start = start
             self.clock.launch()
-            assert data["launched"]
-            assert get_config().ready
+            jobs = self.clock.scheduler.get_jobs()
+            assert len(jobs) == 2
+            assert (
+                jobs[1].func_ref
+                == "dallinger_experiment.dallinger_experiment:TestExperiment.test_task"
+            )
         finally:
-            self.clock.scheduler.start = original_start
+            experiment.EXPERIMENT_TASK_REGISTRATIONS.clear()
 
 
 @pytest.mark.usefixtures("experiment_dir", "active_config")


### PR DESCRIPTION
## Description
This PR implements a new decorator `@dallinger.experiment.scheduled_task` which allows functions or classmethods on the experiment class to be used as background tasks to be run by the clock server. The task intervals are controlled using the trigger type and arguments from the [`appscheduler`](https://apscheduler.readthedocs.io/en/stable/) used by the clock scheduler.

For example to run a background task every 10 minutes, you could add the following to your experiment class:

```
@scheduled_task("interval", minutes=10)
@classmethod
def my_scheduled_task(cls):
    ... do stuff ...
    return
```

A task can also be run at clock server start using the following:

```
@scheduled_task("date")
@classmethod
def my_one_off_task(cls):
    ... do stuff ...
    return
```

There are three types of triggers available `interval`, `cron`, and `date`. Which follow the specifications from `appscheduler`.

## Motivation and Context
This allows experiments to easily register custom background tasks without running them on the web dyno via the `launch` route, which can cause issues when restarting/scaling instances. See #2639 for details.

## How Has This Been Tested?
I've added automated tests for the clock server registrations and the decorator.

