### PR TITLE
Increase character limit on app names

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -113,7 +113,7 @@ def verify_id(ctx, param, app):
     elif app[0:5] == "dlgr-":
         raise click.BadParameter(
             "The --app parameter requires the full "
-            "UUID beginning with {}-...".format(app[5:13])
+            "UUID beginning with {}-...".format(app[5:23])
         )
     return app
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -20,7 +20,7 @@ from dallinger.utils import check_call, check_output
 
 def app_name(experiment_uuid):
     """Convert a UUID to a valid Heroku app name."""
-    return "dlgr-" + experiment_uuid[:8]
+    return "dlgr-" + experiment_uuid[:18]
 
 
 def auth_token():

--- a/dallinger/registration.py
+++ b/dallinger/registration.py
@@ -34,7 +34,7 @@ def _create_osf_project(dlgr_id, description=None):
         data={
             "type": "nodes",
             "category": "project",
-            "title": "Experiment dlgr-{}".format(dlgr_id[0:8]),
+            "title": "Experiment dlgr-{}".format(dlgr_id[:18]),
             "description": description,
         },
         headers={"Authorization": "Bearer {}".format(config.get("osf_access_token"))},

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -112,7 +112,7 @@ class TestHerokuUtilFunctions(object):
 
     def test_app_name(self, heroku):
         dallinger_uid = "8fbe62f5-2e33-4274-8aeb-40fc3dd621a0"
-        assert heroku.app_name(dallinger_uid) == "dlgr-8fbe62f5"
+        assert heroku.app_name(dallinger_uid) == "dlgr-8fbe62f5-2e33-4274"
 
     def test_auth_token(self, heroku, check_output):
         check_output.return_value = b"some response "

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -606,7 +606,7 @@ class TestMTurkRecruiter(object):
             max_assignments=1,
             notification_url=u"http://fake-domain{}".format(SNS_ROUTE_PATH),
             reward=0.01,
-            title=u"fake experiment title (dlgr-TEST_EXP)",
+            title=u"fake experiment title (dlgr-TEST_EXPERIMENT_UI)",
             annotation="TEST_EXPERIMENT_UID",
             qualifications=[
                 MTurkQualificationRequirements.min_approval(95),
@@ -650,7 +650,7 @@ class TestMTurkRecruiter(object):
             max_assignments=1,
             notification_url="http://fake-domain{}".format(SNS_ROUTE_PATH),
             reward=0.01,
-            title="fake experiment title (dlgr-TEST_EXP)",
+            title="fake experiment title (dlgr-TEST_EXPERIMENT_UI)",
             annotation="TEST_EXPERIMENT_UID",
             qualifications=[
                 MTurkQualificationRequirements.min_approval(95),
@@ -686,7 +686,7 @@ class TestMTurkRecruiter(object):
             max_assignments=1,
             notification_url="http://fake-domain{}".format(SNS_ROUTE_PATH),
             reward=0.01,
-            title="fake experiment title (dlgr-TEST_EXP)",
+            title="fake experiment title (dlgr-TEST_EXPERIMENT_UI)",
             annotation="TEST_EXPERIMENT_UID",
             qualifications=[
                 MTurkQualificationRequirements.min_approval(95),
@@ -1059,7 +1059,7 @@ class TestMTurkLargeRecruiter(object):
             max_assignments=10,
             notification_url="http://fake-domain{}".format(SNS_ROUTE_PATH),
             reward=0.01,
-            title="fake experiment title (dlgr-TEST_EXP)",
+            title="fake experiment title (dlgr-TEST_EXPERIMENT_UI)",
             annotation="TEST_EXPERIMENT_UID",
             qualifications=[
                 MTurkQualificationRequirements.min_approval(95),
@@ -1084,7 +1084,7 @@ class TestMTurkLargeRecruiter(object):
             max_assignments=num_recruits,
             notification_url="http://fake-domain{}".format(SNS_ROUTE_PATH),
             reward=0.01,
-            title="fake experiment title (dlgr-TEST_EXP)",
+            title="fake experiment title (dlgr-TEST_EXPERIMENT_UI)",
             annotation="TEST_EXPERIMENT_UID",
             qualifications=[
                 MTurkQualificationRequirements.min_approval(95),


### PR DESCRIPTION
## Description
Changes the generated heroku app name to use 18 characters of the Dallinger app id instead of 8.

## Motivation and Context
See #2840 for details.

## How Has This Been Tested?
Automated tests have been updated to reflect the app id length change.