### PR TITLE
Run clock process in debug mode

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -505,7 +505,7 @@ class HerokuLocalWrapper(object):
             "local",
             "-p",
             str(port),
-            "web={},worker={}".format(web_dynos, worker_dynos),
+            "web={},worker={},clock".format(web_dynos, worker_dynos),
         ]
         try:
             options = {

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -500,12 +500,16 @@ class HerokuLocalWrapper(object):
         port = self.config.get("base_port")
         web_dynos = self.config.get("num_dynos_web")
         worker_dynos = self.config.get("num_dynos_worker")
+        clock_dyno = self.config.get("clock_on")
+        dyno_options = "web={},worker={}{}".format(
+            web_dynos, worker_dynos, ",clock" if clock_dyno else ""
+        )
         commands = [
             self.shell_command,
             "local",
             "-p",
             str(port),
-            "web={},worker={},clock".format(web_dynos, worker_dynos),
+            dyno_options,
         ]
         try:
             options = {


### PR DESCRIPTION
This PR gets `dallinger debug` to launch the clock process as well as the web and worker processes (see #2869).

# Motivation

The debug process should resemble the deployment process as closely as possible.

# How has this been tested?

By running `dallinger debug` and inspecting the Heroku logs. 