### PR TITLE
Rename Sphinx.add_stylesheet to Sphinx.add_css_file

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -429,4 +429,4 @@ html_static_path.extend(static)
 
 
 def setup(app):
-    app.add_stylesheet('custom.css') # html_static_path is automatically prepended
+    app.add_css_file('custom.css') # html_static_path is automatically prepended


### PR DESCRIPTION
`Sphinx.add_stylesheet` was removed and replaced with `Sphinx.add_css_file` in Sphinx >= 4.

This change will allow updating of Sphinx to a version >= 4.

```
...
...
Making 'mcmcp' demo...
Making 'vox_populi' demo...
Initializing Spelling Checker 7.2.1
making output directory... done

Exception occurred:
  File "/home/runner/work/Dallinger/Dallinger/docs/source/conf.py", line 432, in setup
    app.add_stylesheet('custom.css') # html_static_path is automatically prepended
AttributeError: 'Sphinx' object has no attribute 'add_stylesheet'
The full traceback has been saved in /tmp/sphinx-err-oo4uamew.log, if you want to report the issue to the developers.
Please also report this if it was a user error, so that a better error message can be provided next time.
A bug report can be filed in the tracker at <https://github.com/sphinx-doc/sphinx/issues>. Thanks!
make: *** [Makefile:54: html] Error 2
make: Leaving directory '/home/runner/work/Dallinger/Dallinger/docs'
ERROR: InvocationError for command /usr/bin/make -C docs html (exited with code 2)
```