### PR TITLE
New docker-ssh stats command

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -5,12 +5,23 @@ parallel = True
 concurrency = gevent
 omit =
     dallinger/heroku/rq_gevent_worker.py
+    dallinger/command_line/appdirs.py
 
 [report]
 fail_under = 61
 show_missing = True
 skip_covered = True
 precision = 1
+exclude_lines =
+    pragma: no cover
+    def __repr__
+    if self.debug:
+    if settings.DEBUG
+    raise AssertionError
+    raise NotImplementedError
+    if 0:
+    if __name__ == .__main__.:
+    class .*\bProtocol\):
 
 [paths]
 source =

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -469,7 +469,7 @@ class Executor:
             "caddy reload -config /etc/caddy/Caddyfile"
         )
 
-    def run_and_echo(self, cmd):
+    def run_and_echo(self, cmd):  # pragma: no cover
         """Execute the given command on the remote host and prints its output
         while it runs. Allows quitting by pressing the letter "q".
         Buffers lines to prevent flickering.

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -7,6 +7,9 @@ from socket import gethostbyname_ex
 from typing import Dict
 from uuid import uuid4
 import logging
+import select
+import sys
+import socket
 
 from jinja2 import Template
 from requests.adapters import HTTPAdapter
@@ -306,6 +309,17 @@ def apps(server):
 
 
 @docker_ssh.command()
+@server_option
+def stats(server):
+    """List dallinger apps running on the remote server."""
+    server_info = CONFIGURED_HOSTS[server]
+    ssh_host = server_info["host"]
+    ssh_user = server_info.get("user")
+    executor = Executor(ssh_host, user=ssh_user)
+    executor.run_and_echo("docker stats")
+
+
+@docker_ssh.command()
 @click.option("--app", required=True, help="Name of the experiment app to export")
 @click.option(
     "--local",
@@ -454,6 +468,42 @@ class Executor:
             "docker-compose -f ~/dallinger/docker-compose.yml exec -T httpserver "
             "caddy reload -config /etc/caddy/Caddyfile"
         )
+
+    def run_and_echo(self, cmd):
+        """Execute the given command on the remote host and prints its output
+        while it runs. Allows quitting by pressing the letter "q".
+        Buffers lines to prevent flickering.
+
+        Adapted from paramiko "interactive.py" demo.
+        """
+        from paramiko.py3compat import u
+
+        chan = self.client.get_transport().open_session()
+        chan.exec_command(cmd)
+        chan.settimeout(0.0)
+
+        buffer = []
+        while True:
+            r, _, _ = select.select([chan, sys.stdin], [], [])
+            if chan in r:
+                try:
+                    x = u(chan.recv(1024))
+                    if len(x) == 0:
+                        sys.stdout.write("\r\n*** EOF\r\n")
+                        break
+                    if "\n" in x:
+                        sys.stdout.write("".join(buffer))
+                        sys.stdout.write(x)
+                        sys.stdout.flush()
+                        buffer = []
+                    else:
+                        buffer.append(x)
+                except socket.timeout:
+                    pass
+            if sys.stdin in r:
+                x = sys.stdin.read(1)
+                if len(x) == 0 or x in "qQ":
+                    break
 
 
 class ExecuteException(Exception):


### PR DESCRIPTION
Provide a new `dallinger docker-ssh stats` command to show per container CPU and memory usage info as displayed by `docker stats` on the remote host:

```
CONTAINER ID   NAME                                  CPU %     MEM USAGE / LIMIT    MEM %     NET I/O           BLOCK I/O         PIDS
edfd18585a96   dlgr-ae9fe938_worker_1                0.00%     77.25MiB / 1.44GiB   5.24%     16.5kB / 18.9kB   43.8MB / 8.19kB   2
1523ee13556e   dlgr-ae9fe938_web_1                   0.13%     154MiB / 1.44GiB     10.44%    46.3kB / 405kB    37.7MB / 16.4kB   9
007e3e921d9c   dlgr-ae9fe938_redis_dlgr-ae9fe938_1   4.18%     5.68MiB / 1.44GiB    0.39%     20.6kB / 14.8kB   17.3MB / 254kB    6
71792c6e8ea7   dallinger_httpserver_1                0.00%     26.62MiB / 1.44GiB   1.81%     3.02MB / 2.57MB   164MB / 156kB     8
d47760bbe7fa   dallinger_postgresql_1                0.00%     38.38MiB / 1.44GiB   2.60%     717kB / 285kB     166MB / 6.98GB    8
```

See #2958