### PR TITLE
Add argument to /ad url that allows for auto-generation of entry info

### DIFF
--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -48,3 +48,12 @@ an ad-blocker. Try disabling your ad-blocker and refresh the page.
 It is worth noting here that occasionally if an experiment does not exit gracefully,
 one maybe required to manually cleanup some left over python processes, before running the same or another experiment with dallinger.
 See :doc:`Troubleshooting <troubleshooting>` for details.
+
+If you'd like to share a demo url with multiple participants you can use the
+``generate_tokens`` argument to the `/ad` url. For example:
+
+http://0.0.0.0:5000/ad?generate_tokens=1&mode=debug
+
+Passing ``generate_tokens`` instead of entry information (e.g. ``hitId``,
+``assignmentId``, ``workerId``) will automatically generate random entry
+information for the participant.

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -141,6 +141,25 @@ class TestAdvertisement(object):
         assert resp.status_code == 500
         assert b"already_did_exp_hit" in resp.data
 
+    def test_generate_tokens_redirects(self, webapp):
+        resp = webapp.get("/ad?generate_tokens=1")
+        assert resp.status_code == 302
+        assert "/ad?" in resp.location
+        assert "hitId=" in resp.location
+        assert "assignmentId=" in resp.location
+        assert "workerId=" in resp.location
+        assert "generate_tokens" not in resp.location
+
+    def test_generate_tokens_preserves_args(self, webapp):
+        resp = webapp.get(
+            "/ad?generate_tokens=1&mode=debug&recruiter=hotair&workerId=BLAH"
+        )
+        assert resp.status_code == 302
+        assert "hitId=" in resp.location
+        assert "mode=debug" in resp.location
+        assert "recruiter=hotair" in resp.location
+        assert "workerId=BLAH" in resp.location
+
 
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow


### PR DESCRIPTION
## Description
This PR adds a new optional url parameter to the `/ad` route which allows for automatic generation of the recruiter entry information parameters (`hitId`, `assignmentId`, `workerId`). When an ad url is sent with `?generate_tokens=1` the ad route will redirect to the ad route with all request arguments (except `generate_tokens`) preserved, and random values for any of the standard entry information parameters that weren't provided.

I added some documentation of this feature in `demoing_dallinger.rst`, but I'm not quite sure if that's the right place for it.

## Motivation and Context
See #2974. This should allow passing a single link to recruit users for an experiment using the HotAir recruiter or any recruiter that will accept randomized entry info values.

## How Has This Been Tested?
There are two new automated tests for the redirector, and I manually tested it using a demo experiment.

