### PR TITLE
Issues/2114 dallinger develop: underpinnings

### DIFF
--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -1,5 +1,6 @@
 from dallinger.config import get_config
 from dallinger.config import initialize_experiment_package
+from dallinger.utils import copy_files_by_recipe
 from dallinger.utils import ExperimentFileSource
 from dallinger.version import __version__
 from functools import wraps
@@ -141,7 +142,7 @@ def verify_experiment_module(verbose):
     temp_package_name = "TEMP_VERIFICATION_PACKAGE"
     tmp = tempfile.mkdtemp()
     clone_dir = os.path.join(tmp, temp_package_name)
-    ExperimentFileSource(os.getcwd()).selective_copy_to(clone_dir)
+    copy_files_by_recipe(ExperimentFileSource(os.getcwd()).recipe_for_copy(clone_dir))
     initialize_experiment_package(clone_dir)
     from dallinger_experiment import experiment
 

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -1,6 +1,5 @@
 from dallinger.config import get_config
 from dallinger.config import initialize_experiment_package
-from dallinger.utils import copy_files_by_recipe
 from dallinger.utils import ExperimentFileSource
 from dallinger.version import __version__
 from functools import wraps
@@ -142,7 +141,7 @@ def verify_experiment_module(verbose):
     temp_package_name = "TEMP_VERIFICATION_PACKAGE"
     tmp = tempfile.mkdtemp()
     clone_dir = os.path.join(tmp, temp_package_name)
-    copy_files_by_recipe(ExperimentFileSource(os.getcwd()).recipe_for_copy(clone_dir))
+    ExperimentFileSource(os.getcwd()).apply_to(clone_dir)
     initialize_experiment_package(clone_dir)
     from dallinger_experiment import experiment
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -336,6 +336,19 @@ class TestSetupExperiment(object):
         assert found_in(os.path.join("templates", "exit_recruiter_mturk.html"), dst)
         assert found_in(os.path.join("templates", "launch.html"), dst)
 
+        assert found_in(os.path.join("templates", "dashboard_lifecycle.html"), dst)
+        assert found_in(os.path.join("templates", "dashboard_database.html"), dst)
+        assert found_in(os.path.join("templates", "dashboard_heroku.html"), dst)
+        assert found_in(os.path.join("templates", "dashboard_home.html"), dst)
+        assert found_in(os.path.join("templates", "dashboard_monitor.html"), dst)
+        assert found_in(os.path.join("templates", "dashboard_mturk.html"), dst)
+
+        assert found_in(os.path.join("templates", "base", "ad.html"), dst)
+        assert found_in(os.path.join("templates", "base", "consent.html"), dst)
+        assert found_in(os.path.join("templates", "base", "dashboard.html"), dst)
+        assert found_in(os.path.join("templates", "base", "layout.html"), dst)
+        assert found_in(os.path.join("templates", "base", "questionnaire.html"), dst)
+
     def test_setup_uses_specified_python_version(self, active_config, setup_experiment):
         active_config.extend({"heroku_python_version": "3.8.7"})
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -217,12 +217,9 @@ class TestExperimentFilesSource(object):
         destination = tempfile.mkdtemp()
         source = subject()
 
-        result = next(source.recipe_for_copy(destination))
+        source.apply_to(destination)
 
-        assert result == (
-            os.path.abspath(legit_file),
-            os.path.join(destination, "some/subdir/John Doe's file.txt"),
-        )
+        assert (Path(destination) / "some/subdir/John Doe's file.txt").is_file()
 
     def test_recipe_for_copy_accepts_explicit_root(self, subject):
         legit_file = "./some/subdir/legit.txt"
@@ -232,12 +229,9 @@ class TestExperimentFilesSource(object):
         destination = tempfile.mkdtemp()
         source = subject(os.getcwd())
 
-        result = next(source.recipe_for_copy(destination))
+        source.apply_to(destination)
 
-        assert result == (
-            os.path.join(os.getcwd(), "some/subdir/legit.txt"),
-            os.path.join(destination, "some/subdir/legit.txt"),
-        )
+        assert (Path(destination) / legit_file).is_file()
 
     def test_recipe_for_copy_resolves_nonascii_filenames_with_git(self, subject):
         legit_file = "".join(["a", "̊", " ", "f", "i", "l", "e"])
@@ -246,12 +240,9 @@ class TestExperimentFilesSource(object):
         destination = tempfile.mkdtemp()
         source = subject()
 
-        result = next(source.recipe_for_copy(destination))
+        source.apply_to(destination)
 
-        assert result == (
-            os.path.join(os.getcwd(), legit_file),
-            os.path.join(destination, legit_file),
-        )
+        assert (Path(destination) / legit_file).is_file()
 
     def test_recipe_for_copy_resolves_nonascii_filenames_with_git2(self, subject):
         legit_file = "".join(["å", " ", "f", "i", "l", "e"])
@@ -260,12 +251,20 @@ class TestExperimentFilesSource(object):
         destination = tempfile.mkdtemp()
         source = subject()
 
-        result = next(source.recipe_for_copy(destination))
+        source.apply_to(destination)
 
-        assert result == (
-            os.path.join(os.getcwd(), legit_file),
-            os.path.join(destination, legit_file),
-        )
+        assert (Path(destination) / legit_file).is_file()
+
+    def test_apply_to_resolves_nonascii_filenames_with_git2(self, subject):
+        legit_file = "".join(["å", " ", "f", "i", "l", "e"])
+        with open(legit_file, "w") as f:
+            f.write("12345")
+        destination = tempfile.mkdtemp()
+        source = subject()
+
+        source.apply_to(destination)
+
+        assert (Path(destination) / legit_file).is_file()
 
 
 @pytest.mark.usefixtures("bartlett_dir", "active_config", "reset_sys_modules")


### PR DESCRIPTION
## Description
This PR changes no outward functionality, but lays the groundwork for being able to symlink various files into a directory rather than copy them.

## Motivation and Context
As a first step, this work separates _defining_ what files need to by copied into the generated temp  directory from actually doing the copying. This will facilitate swapping out the copy operation for symlink creation instead.

A secondary perk of this work is that it does away with most of the fussiness of adding new files to Dallinger's `frontend` to be deployed when running experiments. I left all the individual file checks in tests (and in fact added even more) because I wanted to feel very confident in the change for now.

## How Has This Been Tested?
* automated tests
* Bartlett demo

## Notes
* @silviot has begun using the python 3.5+ `Path` class in some other work. A lot of the code in the PR would be a good candidate for updating to that library, but I'm not very familiar with it yet, and did not make that change.
