### PR TITLE
More complete debug output on errors

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -453,7 +453,7 @@ class HerokuLocalWrapper(object):
         if not success:
             self.stop(signal.SIGKILL)
             raise HerokuStartupError(
-                "Failed to start for unknown reason: {}".format(self._record)
+                "Failed to start for unknown reason: {}".format("".join(self._record))
             )
         return True
 


### PR DESCRIPTION
## Description
Sometimes an error occurs and `dallinger debug` immediately shuts down the process before logging the traceback has been output. This PR introduces an extra step after detecting an error. It will now read out the process output until it hits a new error, the process has exited, or one second has elapsed (it's a very short time because this is generally just a buffering issue, and the output should be available immediately).

## Motivation and Context
See #2532 

## How Has This Been Tested?
Manual testing with an intentionally broken demo, and a known issue in an older revision of a psynet demo. Automated tests to ensure the new method is called on errors, and executes as expected.

