### PR TITLE
Fix egg-link path lookup

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -359,7 +359,7 @@ def get_editable_dallinger_path():
     for path_item in sys.path:
         egg_link = os.path.join(path_item, "dallinger.egg-link")
         if os.path.isfile(egg_link):
-            return open(egg_link).read().split()[0]
+            return open(egg_link).readlines()[0].strip()
     return None
 
 

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -1173,3 +1173,16 @@ class TestApps(object):
             ["UID", "Started", "URL"],
             tablefmt=u"psql",
         )
+
+
+def test_get_editable_dallinger_path():
+    from dallinger.utils import get_editable_dallinger_path
+
+    with mock.patch("dallinger.utils.os.path.isfile") as isfile:
+        isfile.return_value = True
+        with mock.patch("dallinger.utils.open") as open:
+            open.return_value.readlines.return_value = [
+                "/a path/where many/directories/have/a/space/in them\n"
+            ]
+            result = get_editable_dallinger_path()
+            assert result == "/a path/where many/directories/have/a/space/in them"


### PR DESCRIPTION
## Description
I think this fixes the space issue when looking up a path in the egg-link file. I wasn't able to reproduce the issue, but I think the cause of the problem is quite clear. Instead of reading the whole egg-link file and splitting on whitespace, it should now read in just the first line and strip leading/trailing spaces (e.g. trailing newline).

## Motivation and Context
See #2861

## How Has This Been Tested?
I was not able to test this (except via a python prompt to verify the issue with the original code), but I'm fairly certain it should resolve the problem with determining the directory from the `.egg-link` file.
