### PR TITLE
Issues/3028 hit submission bug

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1650,6 +1650,8 @@ def _worker_complete(participant_id):
     if event_type is None:
         return
 
+    # Currently we execute this function synchronously, regardless of the
+    # event type:
     worker_function(
         event_type=event_type,
         assignment_id=participant.assignment_id,

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1637,10 +1637,10 @@ def _worker_complete(participant_id):
     session.commit()
 
     # Notify experiment that participant has been marked complete. Doing
-    # this here, rather than in the async worker function, means that
+    # this here, rather than in the worker function, means that
     # the experiment can request qualification assignment before the
     # worker completes the HIT when using a recruiter like MTurk, where
-    # execution of the worker_events.AssignmentSubmitted command is
+    # execution of the `worker_events.AssignmentSubmitted` command is
     # deferred until they've submitted the HIT on the MTurk platform.
     exp = Experiment(session)
     exp.participant_task_completed(participant)

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -216,8 +216,8 @@ def error_page(
         error_text = "There has been an error and so you are unable to continue, sorry!"
 
     if participant is not None:
-        hit_id = (participant.hit_id,)
-        assignment_id = (participant.assignment_id,)
+        hit_id = participant.hit_id
+        assignment_id = participant.assignment_id
         worker_id = participant.worker_id
         participant_id = participant.id
     else:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -518,7 +518,7 @@ class RedisStore(object):
         return "{}:{}".format(self._prefix, key)
 
 
-def run_assign_experiment_mturk_qualifications(worker_id, qualifications):
+def _run_mturk_qualification_assignment(worker_id, qualifications):
     """Provides a way to run qualification assignment asynchronously."""
     recruiter = MTurkRecruiter()
     recruiter._assign_experiment_qualifications(worker_id, qualifications)
@@ -626,7 +626,7 @@ class MTurkRecruiter(Recruiter):
                                (optional) `score` keys
         """
         q = _get_queue()
-        q.enqueue(run_assign_experiment_mturk_qualifications, worker_id, qualifications)
+        q.enqueue(_run_mturk_qualification_assignment, worker_id, qualifications)
 
     def _assign_experiment_qualifications(self, worker_id, qualifications):
         # Called from an async worker.

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1000,8 +1000,14 @@ class TestParticipantNodeCreationRoute(object):
         participant = a.participant()
         participant.status = "submitted"
         db_session.commit()
+
         resp = webapp.post("/node/{}".format(participant.id))
-        assert b"Error type: /node POST, status = submitted" in resp.data
+
+        error_report = resp.data.decode("utf8")
+        assert "Error type: /node POST, status = submitted" in error_report
+        assert "HIT id: {}".format(participant.hit_id) in error_report
+        assert "Assignment id: {}".format(participant.assignment_id) in error_report
+        assert "Worker id: {}".format(participant.worker_id) in error_report
 
     def test_no_network_for_participant_returns_error(self, a, db_session, webapp):
         participant = a.participant()

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -869,7 +869,7 @@ class TestMTurkRecruiter(object):
         )
 
     def test_assign_experiment_qualifications_enques_work(self, recruiter, queue):
-        from dallinger.recruiters import run_assign_experiment_mturk_qualifications
+        from dallinger.recruiters import _run_mturk_qualification_assignment
 
         qualification_params = [
             "some worker id",
@@ -880,7 +880,7 @@ class TestMTurkRecruiter(object):
         recruiter.assign_experiment_qualifications(*qualification_params)
 
         queue.enqueue.assert_called_once_with(
-            run_assign_experiment_mturk_qualifications, *qualification_params
+            _run_mturk_qualification_assignment, *qualification_params
         )
 
     def test_rejects_questionnaire_from_returns_none_if_working(self, recruiter):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -816,10 +816,12 @@ class TestMTurkRecruiter(object):
             },
         }
 
-    def test_assign_experiment_qualifications_creates_nonexistent_qualifications(
+    def test__assign_experiment_qualifications_creates_nonexistent_qualifications(
         self, recruiter
     ):
-        recruiter.assign_experiment_qualifications(
+        # Rationale for testing a "private" method is that it does all the actual
+        # work behind an async call from the public method.
+        recruiter._assign_experiment_qualifications(
             "some worker id",
             [
                 {"name": "One", "description": "Description of One"},
@@ -842,16 +844,18 @@ class TestMTurkRecruiter(object):
             ),
         ]
 
-    def test_assign_experiment_qualifications_assigns_existing_qualifications(
+    def test__assign_experiment_qualifications_assigns_existing_qualifications(
         self, recruiter
     ):
+        # Rationale for testing a "private" method is that it does all the actual
+        # work behind an async call from the public method.
         from dallinger.mturk import DuplicateQualificationNameError
 
         recruiter.mturkservice.create_qualification_type.side_effect = (
             DuplicateQualificationNameError
         )
 
-        recruiter.assign_experiment_qualifications(
+        recruiter._assign_experiment_qualifications(
             "some worker id",
             [
                 {"name": "One", "description": "Description of One"},
@@ -862,6 +866,21 @@ class TestMTurkRecruiter(object):
         assert (
             recruiter.mturkservice.increment_named_qualification_score.call_args_list
             == [mock.call("One", "some worker id"), mock.call("Two", "some worker id")]
+        )
+
+    def test_assign_experiment_qualifications_enques_work(self, recruiter, queue):
+        from dallinger.recruiters import run_assign_experiment_mturk_qualifications
+
+        qualification_params = [
+            "some worker id",
+            [
+                {"name": "One", "description": "Description of One"},
+            ],
+        ]
+        recruiter.assign_experiment_qualifications(*qualification_params)
+
+        queue.enqueue.assert_called_once_with(
+            run_assign_experiment_mturk_qualifications, *qualification_params
         )
 
     def test_rejects_questionnaire_from_returns_none_if_working(self, recruiter):


### PR DESCRIPTION
## Description
I explored a number of ways of doing this, and came back to this one, which introduces pretty minimal change, and keeps the decision about whether a worker process is required in the recruiter, who I think is likely to know best.

* Fixes a bug in the error handling route
* Moves creation and assignment of MTurk qualifications to a background worker process

## Motivation and Context
#3028 

## How Has This Been Tested?
* Automated tests
* Bartlett demo on heroku/mturk sandbox

