### PR TITLE
Demos that add nodes to network on initialization need to explicitly commit

### DIFF
--- a/demos/dlgr/demos/bartlett1932/experiment.py
+++ b/demos/dlgr/demos/bartlett1932/experiment.py
@@ -56,6 +56,7 @@ class Bartlett1932(Experiment):
             super(Bartlett1932, self).setup()
             for net in self.networks():
                 self.models.WarOfTheGhostsSource(network=net)
+            self.session.commit()
 
     def create_network(self):
         """Return a new network."""

--- a/demos/dlgr/demos/function_learning/experiment.py
+++ b/demos/dlgr/demos/function_learning/experiment.py
@@ -36,6 +36,7 @@ class FunctionLearning(Experiment):
             super(FunctionLearning, self).setup()
             for net in self.networks():
                 self.models.SinusoidalFunctionSource(network=net)
+            self.session.commit()
 
     def create_network(self):
         """Create a new network."""

--- a/demos/dlgr/demos/iterated_drawing/experiment.py
+++ b/demos/dlgr/demos/iterated_drawing/experiment.py
@@ -37,6 +37,7 @@ class IteratedDrawing(Experiment):
             super(IteratedDrawing, self).setup()
             for net in self.networks():
                 self.models.DrawingSource(network=net)
+            self.session.commit()
 
     def create_network(self):
         """Return a new network."""

--- a/demos/dlgr/demos/mcmcp/experiment.py
+++ b/demos/dlgr/demos/mcmcp/experiment.py
@@ -46,6 +46,7 @@ class MCMCP(Experiment):
             super(MCMCP, self).setup()
             for net in self.networks():
                 self.models.AnimalSource(network=net)
+            self.session.commit()
 
     def create_network(self):
         """Create a new network."""

--- a/demos/dlgr/demos/rogers/experiment.py
+++ b/demos/dlgr/demos/rogers/experiment.py
@@ -93,6 +93,7 @@ class RogersExperiment(Experiment):
             env = self.models.RogersEnvironment(network=net)
             env.proportion = self.color_proportion_for_network(net)
             env.create_information()
+        self.session.commit()
 
     def color_proportion_for_network(self, net):
         if net.role == "practice":


### PR DESCRIPTION
## Description
Demos that add nodes to network on initialization need to explicitly commit a transaction to ensure these nodes get written to the database.

## Motivation and Context
Currently we rely on a combination of luck and the fact that the /launch route makes a commit after opening recruitment. In other contexts, the state of the database after experiment initialization will likely differ from expectations, since the network will be written to the DB, but additional nodes (Source nodes, for example) will only be transient.

## How Has This Been Tested?
Bartlett demo, in the context of working on `dallinger develop`
