### PR TITLE
Another RtD fix attempt

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,5 +3,7 @@ build:
 
 python:
   version: 3.8
-
-requirements_file: dev-requirements.txt
+  install:
+      - requirements: dev-requirements.txt
+      - method: pip
+        path: .

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,3 +1,4 @@
+version: 2
 build:
   image: latest
 


### PR DESCRIPTION
## Description
Update RtD config to install Dallinger using pip and use the new syntax for installing the requirements. See [most recent build failure](https://readthedocs.org/projects/dallinger/builds/14252821/).

## Motivation and Context
See #2957

## How Has This Been Tested?
Can only be tested by merging to master AFAIK. 🤞 Should be very low risk, since RtD is already broken.
