### PR TITLE
Log submitted participant values and full exception on failure

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -826,7 +826,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         db.logger.exception(
             "Error creating particant using these values: {}".format(participant_vals)
         )
-        msg = "/participant POST: required values were missing or invalid."
+        msg = "/participant POST: an error occurred while registering the participant."
         return error_response(error_type=msg, status=400)
 
     session.flush()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -811,15 +811,23 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
 
     # Create the new participant.
     exp = Experiment(session)
-    participant = exp.create_participant(
-        worker_id,
-        hit_id,
-        assignment_id,
-        mode,
-        recruiter_name,
-        fingerprint_hash,
-        entry_information,
-    )
+    participant_vals = {
+        "worker_id": worker_id,
+        "hit_id": hit_id,
+        "assignment_id": assignment_id,
+        "mode": mode,
+        "recruiter_name": recruiter_name,
+        "fingerprint_hash": fingerprint_hash,
+        "entry_information": entry_information,
+    }
+    try:
+        participant = exp.create_participant(**participant_vals)
+    except Exception:
+        db.logger.exception(
+            "Error creating particant using these values: {}".format(participant_vals)
+        )
+        msg = "/participant POST: required values were missing or invalid."
+        return error_response(error_type=msg, status=400)
 
     session.flush()
     overrecruited = exp.is_overrecruited(nonfailed_count)


### PR DESCRIPTION
## Description
This PR adds error handling and logging to the `create_participant()` function (and Flask route) to provide more information when participant creation fails.

## Motivation and Context
See #3153 

## How Has This Been Tested?
* Bartlett1932 demo, by manipulating `dallinger.identity` values with the browser dev tools
* Automated test

