### PR TITLE
The postgres:// to postgresql:// uri fix should be applied more universally

### DIFF
--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -72,3 +72,12 @@ def test_after_commit_hook(db_session):
         db_session.commit()
 
         assert redis.called_once_with("test", "test")
+
+
+def test_create_db_engine_updates_postgresql_scheme():
+    old_scheme_uri = "postgres://foo:bar@somehost:5432/blah"
+    from dallinger.db import create_db_engine
+
+    engine = create_db_engine(old_scheme_uri)
+
+    assert engine.url.render_as_string().startswith("postgresql://")


### PR DESCRIPTION
## Description
The PR ensures that db url values using the unsupported `postgres` scheme will have the scheme corrected to `postgresql` when the engine is created via `dallinger.db.create_db_engine()`

## Motivation and Context
Fix for #2856 

## How Has This Been Tested?
Automated tests

