### PR TITLE
Bugfix in dlgr.loadParticipant

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -500,7 +500,7 @@ var dallinger = (function () {
           dlgr.identity.recruiter = resp.participant.recruiter_id;
           dlgr.identity.hitId = resp.participant.hit_id;
           dlgr.identity.workerId = resp.participant.worker_id;
-          dlgr.identity.assignmentId = assignment_id;
+          dlgr.identity.assignmentId = resp.participant.assignment_id;
           dlgr.identity.mode = resp.participant.mode;
           dlgr.identity.fingerprintHash = resp.participant.fingerprint_hash;
           deferred.resolve();

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -500,7 +500,7 @@ var dallinger = (function () {
           dlgr.identity.recruiter = resp.participant.recruiter_id;
           dlgr.identity.hitId = resp.participant.hit_id;
           dlgr.identity.workerId = resp.participant.worker_id;
-          dlgr.identity.assignmentId = resp.participant.assignment_id;
+          dlgr.identity.assignmentId = resp.participant.assignment_id || data.assignment_id;
           dlgr.identity.mode = resp.participant.mode;
           dlgr.identity.fingerprintHash = resp.participant.fingerprint_hash;
           deferred.resolve();


### PR DESCRIPTION
## Description

`dlgr.loadParticipant` originally referred to a global `assignment_id`, but I think this was a mistake, and it meant to refer to `resp.participant.assignment_id`.

## Motivation and Context

The function didn't work for me without this change.

## How Has This Been Tested?

I made the fix, and now the `loadParticipant` functionality works well for me.