### PR TITLE
Cross platform version of md5

### DIFF
--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = d0bfb8e6474319a7832980a687befbb2
+# generate from file with hash  d0bfb8e6474319a7832980a687befbb2

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -279,4 +279,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = d39b0f1bdc6cb1547770afc5c290bb0b
+# generate from file with hash  d39b0f1bdc6cb1547770afc5c290bb0b

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -268,4 +268,4 @@ zope.interface==5.4.0
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  MD5 (requirements.txt) = 0cab82a0f71a21f46d5e1123cd7483ee
+# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee

--- a/scripts/update_experiments_constraints.sh
+++ b/scripts/update_experiments_constraints.sh
@@ -2,6 +2,12 @@
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd $dir/..
 
+# Command to calculate md5sum of a file. Since BSD (Mac OS) has an `md5` binary and Linux has `md5sum`
+# we salomonically decide to ditch both and implement them as a python one liner.
+function md5_cmd () {
+    python3 -c "import hashlib as h;from sys import argv; print(h.md5(open( argv[1], 'rb').read()).hexdigest())" $1
+}
+
 # Update demos constraints
 export CUSTOM_COMPILE_COMMAND=$'./scripts/update_experiments_constraints.sh\n#\n# from the root of the dallinger repository'
 for demo_name in $(ls demos/dlgr/demos/); do
@@ -12,7 +18,7 @@ for demo_name in $(ls demos/dlgr/demos/); do
 -r requirements.txt" > temp-requirements.txt
         pip-compile temp-requirements.txt -o constraints.txt
         rm temp-requirements.txt
-        echo '# generate from file with hash ' $(md5 requirements.txt) >> constraints.txt
+        echo '# generate from file with hash ' $(md5_cmd requirements.txt) >> constraints.txt
         cd -
     fi
 done


### PR DESCRIPTION
On linux the command  `md5sum` is provided by `coreutils` and always present. On BSD systems (like Mac OS) the command `md5` is present.

Instead of using one or the other, this PR makes use of python 3, that should be available in all contexts where Dallinger is used.