### PR TITLE
Update deployment.py

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -150,9 +150,9 @@ def deploy_sandbox_shared_setup(
         heroku_app.addon(name)
 
     heroku_config = {
-        "aws_access_key_id": config["aws_access_key_id"],
-        "aws_secret_access_key": config["aws_secret_access_key"],
-        "aws_region": config["aws_region"],
+        "AWS_ACCESS_KEY_ID": config["aws_access_key_id"],
+        "AWS_SECRET_ACCESS_KEY": config["aws_secret_access_key"],
+        "AWS_DEFAULT_REGION": config["aws_region"],
         "auto_recruit": config["auto_recruit"],
         "smtp_username": config["smtp_username"],
         "smtp_password": config["smtp_password"],


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Addresses #3438

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Using **aws_access_key_id**, **aws_secret_access_key**, and **aws_region**  with lower case letters in the `heroku_config` dictionary results in the exception described in the issue above. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually

## Screenshots (if appropriate):
