### PR TITLE
Expose directory from the host when deploying with docker

### DIFF
--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -28,6 +28,9 @@ services:
     {%- endfor %}
     networks:
       - dallinger
+    volumes:
+      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+
   web:
     image: {{ experiment_image }}
     user: "${UID}:${GID}"
@@ -41,6 +44,8 @@ services:
       dallinger:
         aliases:
           - {{ experiment_id }}_web
+    volumes:
+      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
 
 volumes:
   dallinger_{{ experiment_id }}_redis_data:


### PR DESCRIPTION
See #3140 

<!--- Provide a general summary of your changes in the Title above -->

## Expose a directory on the host when deploying with `dallinger docker-ssh`
The directory inside the container (the one that the experiment code needs to write to) is always `/var/lib/dallinger`, regardless of experiment id.
Files written to such directory in the container will end up in `/var/lib/dallinger/{{ experiment_id }}` on the host.
The owner of the files will be root, since the dallinger containers currently run the web server and the worker using the `root` user inside the container.

## Motivation and Context
Experiments might need access to a persistent filesystem.

## How Has This Been Tested?
I checked that the container has the expected asset by entering it with `docker exec` and writing a file to `/var/lib/dallinger`.
I didn't yet test the case when the experiment is exported and reimported.