### PR TITLE
Add single recruiter link (#3305)

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -409,6 +409,11 @@ class DebugDeployment(HerokuLocalDeployment):
                     self.open_dashboard(dashboard_url)
                 self.heroku = heroku
                 self.out.log(
+                    "Single recruiter link: {}/ad?recruiter=hotair&generate_tokens=1&mode=debug".format(
+                        base_url
+                    )
+                )
+                self.out.log(
                     "Monitoring the Heroku Local server for recruitment or completion..."
                 )
                 heroku.monitor(listener=self.notify)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -409,11 +409,6 @@ class DebugDeployment(HerokuLocalDeployment):
                     self.open_dashboard(dashboard_url)
                 self.heroku = heroku
                 self.out.log(
-                    "Single recruiter link: {}/ad?recruiter=hotair&generate_tokens=1&mode=debug".format(
-                        base_url
-                    )
-                )
-                self.out.log(
                     "Monitoring the Heroku Local server for recruitment or completion..."
                 )
                 heroku.monitor(listener=self.notify)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -189,10 +189,15 @@ class CLIRecruiter(Recruiter):
         logger.info("Opening CLI recruitment for {} participants".format(n))
         recruitments = self.recruit(n)
         message = (
+            "\nSingle recruitment link: {}/ad?recruiter={}&generate_tokens=1&mode={}\n\n"
             'Search for "{}" in the logs for subsequent recruitment URLs.\n'
             "Open the logs for this experiment with "
             '"dallinger logs --app {}"'.format(
-                NEW_RECRUIT_LOG_PREFIX, self.config.get("id")
+                get_base_url(),
+                self.nickname,
+                self._get_mode(),
+                NEW_RECRUIT_LOG_PREFIX,
+                self.config.get("id"),
             )
         )
         return {"items": recruitments, "message": message}
@@ -260,7 +265,12 @@ class HotAirRecruiter(CLIRecruiter):
         """
         logger.info("Opening HotAir recruitment for {} participants".format(n))
         recruitments = self.recruit(n)
-        message = "Recruitment requests will open browser windows automatically."
+        message = (
+            "\nSingle recruitment link: {}/ad?recruiter={}&generate_tokens=1&mode={}\n\n"
+            "Recruitment requests will open browser windows automatically.".format(
+                get_base_url(), self.nickname, self._get_mode()
+            )
+        )
 
         return {"items": recruitments, "message": message}
 


### PR DESCRIPTION
## Description
Extremely trivial change to add a message in the debug command output with the link to the recruiter ad url using the `generate_tokens` parameter enabled.

## Motivation and Context
See #3305


## How Has This Been Tested?
Ran demo with `--no-browsers` and tested the link was present and worked as expected.