### PR TITLE
Document `dallinger docker start-services`

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -40,6 +40,7 @@ os.environ['PATH'] = (
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -406,16 +406,8 @@ texinfo_documents = [
 
 # -- Allow Markdown files -----------------------------------------
 
-from recommonmark.parser import CommonMarkParser
+extensions = ['recommonmark']
 
-source_parsers = {
-    '.md': CommonMarkParser
-}
-
-source_suffix = [
-    '.rst',
-    '.md'
-]
 
 # -- Install demo files -------------------------------------------
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -4,7 +4,7 @@ Developer Installation
 Dallinger is tested with Ubuntu 18.04 LTS, 16.04 LTS, 14.04 LTS and Mac OS X locally.
 If you are attempting to use Dallinger on Microsoft Windows, running Ubuntu in a virtual machine is the recommend method.
 
-If you are interested in using Dallinger with Docker, read more :doc:`here <docker_setup>`.
+If you are interested in using Dallinger with Docker, read more :doc:`here <docker_support>`.
 
 
 Mac OS X

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -15,6 +15,29 @@ Using Dallinger with Docker
 ---------------------------
 Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_support>`.
 
+Installing Docker
+~~~~~~~~~~~~~~~~~
+
+To install Docker on Linux, run this command:
+::
+
+    curl https://get.docker.com | sudo sh
+
+On Mac OS X you can download Docker Desktop from the official Docker website: https://docs.docker.com/desktop/mac/install/
+
+Using docker to run postgres and redis
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Dallinger can start a postgres database and a redis server for you. To do this, run the following command:
+::
+
+    dallinger docker start-services
+
+To free up resources you can stop the services when they're not needed anymore:
+::
+
+    dallinger docker stop-services
+
 
 Mac OS X
 --------
@@ -53,6 +76,8 @@ Should that not work for whatever reason, you can search `here <https://docs.pyt
 
 Install Postgresql
 ~~~~~~~~~~~~~~~~~~
+
+The easiest way to install Postgresql :ref:`is to use docker<Using docker to run postgres and redis>`.
 
 On Mac OS X, we recommend installing using Homebrew:
 ::
@@ -133,6 +158,8 @@ More information on the Heroku CLI is available at `heroku.com <https://devcente
 
 Install Redis
 ~~~~~~~~~~~~~
+
+The easiest way to install Redis :ref:`is to use docker<Using docker to run postgres and redis>`.
 
 Debugging experiments requires you to have Redis installed and the Redis
 server running.

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -13,7 +13,7 @@ We do not recommended running Dallinger with Microsoft Windows, however if you d
 
 Using Dallinger with Docker
 ---------------------------
-Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_setup>`.
+Docker is a containerization tool used for developing isolated software environments. Read more about using Dallinger with Docker :doc:`here<docker_support>`.
 
 
 Mac OS X

--- a/docs/source/installing_dallinger_for_users.rst
+++ b/docs/source/installing_dallinger_for_users.rst
@@ -25,6 +25,8 @@ To install Docker on Linux, run this command:
 
 On Mac OS X you can download Docker Desktop from the official Docker website: https://docs.docker.com/desktop/mac/install/
 
+.. _docker-for-postgres-and-redis:
+
 Using docker to run postgres and redis
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -77,7 +79,7 @@ Should that not work for whatever reason, you can search `here <https://docs.pyt
 Install Postgresql
 ~~~~~~~~~~~~~~~~~~
 
-The easiest way to install Postgresql :ref:`is to use docker<Using docker to run postgres and redis>`.
+The easiest way to install Postgresql :ref:`is to use docker <docker-for-postgres-and-redis>`.
 
 On Mac OS X, we recommend installing using Homebrew:
 ::
@@ -159,7 +161,7 @@ More information on the Heroku CLI is available at `heroku.com <https://devcente
 Install Redis
 ~~~~~~~~~~~~~
 
-The easiest way to install Redis :ref:`is to use docker<Using docker to run postgres and redis>`.
+The easiest way to install Redis :ref:`is to use docker <docker-for-postgres-and-redis>`.
 
 Debugging experiments requires you to have Redis installed and the Redis
 server running.


### PR DESCRIPTION
See #3104

## Document `dallinger docker start-services` 

## Motivation and Context
Starting redis and postgres using docker is much easier, and dallinger ships with a command to use them.
