### PR TITLE
Bump to python 3.10 by default for full CI runs and Heroku deployment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     needs: check_mturk_changes
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10]
     services:
       redis:
         image: redis
@@ -114,7 +114,7 @@ jobs:
         run: |
           tox ${{ needs.check_mturk_changes.outputs.needs_mturk_tests == 'true' && '-- --mturkfull' || ''}}
           npm run test --coverage
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.10
       - name: Run Fast Tests Only
         env:
           DATABASE_URL: postgresql://dallinger:dallinger@localhost/dallinger
@@ -126,11 +126,11 @@ jobs:
         run: |
           tox -e fast
           npm run test --coverage
-        if: matrix.python-version != 3.9
+        if: matrix.python-version != 3.10
       - name: Codecov.io check
         run: |
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.python-version == 3.9
+        if: matrix.python-version == 3.10
 
   docker:
     runs-on: ubuntu-latest
@@ -176,10 +176,10 @@ jobs:
         run: docker run --rm ghcr.io/dallinger/dallinger:${{ steps.vars.outputs.version }} python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Make sure dallinger script entry point is working with dallinger source mounted as volume
         run: docker run -v $PWD/dallinger:/dallinger/dallinger --rm ghcr.io/dallinger/dallinger:${{ steps.vars.outputs.version }} python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v2
         with:
-            python-version: "3.9"
+            python-version: "3.10"
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           tox ${{ needs.check_mturk_changes.outputs.needs_mturk_tests == 'true' && '-- --mturkfull' || ''}}
           npm run test --coverage
-        if: matrix.python-version == "3.10"
+        if: matrix.python-version == 3.10
       - name: Run Fast Tests Only
         env:
           DATABASE_URL: postgresql://dallinger:dallinger@localhost/dallinger
@@ -126,11 +126,11 @@ jobs:
         run: |
           tox -e fast
           npm run test --coverage
-        if: matrix.python-version != "3.10"
+        if: matrix.python-version != 3.10
       - name: Codecov.io check
         run: |
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.python-version == "3.10"
+        if: matrix.python-version == 3.10
 
   docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
     needs: check_mturk_changes
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     services:
       redis:
         image: redis
@@ -114,7 +114,7 @@ jobs:
         run: |
           tox ${{ needs.check_mturk_changes.outputs.needs_mturk_tests == 'true' && '-- --mturkfull' || ''}}
           npm run test --coverage
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == "3.10"
       - name: Run Fast Tests Only
         env:
           DATABASE_URL: postgresql://dallinger:dallinger@localhost/dallinger
@@ -126,11 +126,11 @@ jobs:
         run: |
           tox -e fast
           npm run test --coverage
-        if: matrix.python-version != 3.10
+        if: matrix.python-version != "3.10"
       - name: Codecov.io check
         run: |
           bash <(curl -s https://codecov.io/bash)
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == "3.10"
 
   docker:
     runs-on: ubuntu-latest

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -30,7 +30,7 @@ chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 [Heroku]
 clock_on = False
-heroku_python_version = 3.9.2
+heroku_python_version = 3.10.2
 sentry = False
 redis_size = premium-0
 worker_multiplier = 1.5

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Framework :: Pytest",
     ],
     include_package_data=True,


### PR DESCRIPTION


## Description
Move to python 3.10 as "primarily supported" version (meaning, we do the most aggressive testing in CI, and we deploy using this version on Heroku by default).

## Motivation and Context
- Take advantage of improved error messages in 3.10
- Stay on the front edge of python version support

## How Has This Been Tested?
TODO:
- [x] Does CI pass?
- [x] Does Heroku deployment work?

## Screenshots (if appropriate):
