### PR TITLE
Allow dashboard tabs to be hidden

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -102,6 +102,10 @@ class Experiment(object):
         static_folder="static",
     )
 
+    #: Sequence of dashboard route/function names that should be excluded from
+    #: rendering as tabs in the dashboard view.
+    hidden_dashboards = ()
+
     def __init__(self, session=None):
         """Create the experiment class. Sets the default value of attributes."""
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -143,6 +143,12 @@ if exp_klass is not None:  # pragma: no cover
             else:
                 tabs.insert(route["title"], route_name)
 
+    # This hides dashboard tabs from view, but doesn't prevent the routes from
+    # being registered
+    hidden_dashboards = getattr(exp_klass, "hidden_dashboards", ())
+    for route_name in hidden_dashboards:
+        dashboard.dashboard_tabs.remove(route_name)
+
 
 # Ideally, we'd only load recruiter routes if the recruiter is active, but
 # it turns out this is complicated, so for now we always register our

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -44,7 +44,8 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.viewcode',
     'sphinx.ext.napoleon',
-    'sphinx_js'
+    'sphinx_js',
+    'recommonmark',
 ]
 
 try:
@@ -403,11 +404,6 @@ texinfo_documents = [
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #
 # texinfo_no_detailmenu = False
-
-# -- Allow Markdown files -----------------------------------------
-
-extensions = ['recommonmark']
-
 
 # -- Install demo files -------------------------------------------
 

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -42,6 +42,9 @@ what to do with the database when the server receives requests from outside.
   .. autoattribute:: participant_constructor
     :annotation:
 
+  .. autoattribute:: hidden_dashboards
+    :annotation:
+
   .. attribute:: public_properties
 
      dictionary, the properties of this experiment that are exposed


### PR DESCRIPTION
## Description
This PR provides a very simple implementation of #3739 by adding a `hidden_dashboards` attribute to the `Experiment` class. This attribute contains a list of route/function names to be excluded from rendering as dashboard tabs. It also fixes a bug in the documentation configuration that was preventing API documentation from being rendered properly.

## Motivation and Context
See the issue #3739 for motivation

## How Has This Been Tested?
I tested this manually by setting a value for the `hidden_dashboards` attribute on a demo experiment and verifying that the expected tabs were hidden. I did not attempt to write an automated test for this change because it is very small, and executes at import time (which can cause issues for test repeatability). I'd appreciate any ideas for how to reasonably provide automated tests for this change which wouldn't cause other tests (e.g. those relying on the removed dashboard tab) to fail.

