### PR TITLE
Use entry information routing by default

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -424,6 +424,9 @@ var dallinger = (function () {
     var deferred = $.Deferred();
     if (dlgr.identity.entryInformation) {
       data = dlgr.identity.entryInformation;
+      if (dlgr.identity.fingerprintHash) {
+        data.fingerprint_hash = dlgr.identity.fingerprintHash;
+      }
     } else {
       url += "/" + dlgr.identity.workerId + "/" + dlgr.identity.hitId +
             "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -422,12 +422,12 @@ var dallinger = (function () {
     var url = "/participant";
     var data = {};
     var deferred = $.Deferred();
-    if (dlgr.identity.assignmentId) {
+    if (dlgr.identity.entryInformation) {
+      data = dlgr.identity.entryInformation;
+    } else {
       url += "/" + dlgr.identity.workerId + "/" + dlgr.identity.hitId +
             "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
             (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;
-    } else {
-      data = dlgr.identity.entryInformation;
     }
 
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -836,6 +836,30 @@ class TestParticipantCreateRoute(object):
                 entry_information={"additional_stuff": "1"},
             )
 
+    def test_post_participant_removes_fingerprint(self, a, db_session, webapp):
+        with mock.patch(
+            "dallinger.experiment_server.experiment_server.create_participant"
+        ) as create_participant:
+            create_participant.side_effect = lambda *args, **kw: "Result"
+            webapp.post(
+                "/participant",
+                data={
+                    "hitId": "H",
+                    "workerId": "W",
+                    "assignmentId": "A",
+                    "mode": "debug",
+                    "additional_stuff": "1",
+                    "fingerprint_hash": "fffff",
+                },
+            )
+            create_participant.assert_called_once_with(
+                hit_id="H",
+                worker_id="W",
+                assignment_id="A",
+                mode="debug",
+                entry_information={"additional_stuff": "1"},
+            )
+
 
 @pytest.mark.usefixtures("experiment_dir", "db_session")
 @pytest.mark.slow


### PR DESCRIPTION
## Description
Update dallinger2.js `createParticipant` method to use the version of the call that stores `entry_information` by default, falling back to the old mechanism if no `entry_information` can be extracted from the URL/Request (I don't think this should ever occur, but it seems like the safest fallback). The change is pretty trivial.

## Motivation and Context
See #2652

## How Has This Been Tested?
I tested this in debug mode with a couple of demos. Ideally it should probably also be tested in an MTurk sandbox.

