### PR TITLE
Use local dev-requirements.txt if there's no such file on github for dallinger version currently in use

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -529,7 +529,15 @@ def ensure_constraints_file_presence(directory: str):
     try:
         os.chdir(directory)
         url = f"https://raw.githubusercontent.com/Dallinger/Dallinger/v{__version__}/dev-requirements.txt"
-        if requests.get(url).status_code == 404:
+        try:
+            response = requests.get(url)
+        except requests.exceptions.ConnectionError:
+            raise RuntimeError(
+                """It looks like you're offline. Dallinger can't generate constraints
+To get a valid constraints.txt file you can copy the requirements.txt file:
+cp requirements.txt constraints.txt"""
+            )
+        if response.status_code != 200:
             print(f"{url} not found. Using local dev-requirements.txt")
             url_path = abspath_from_egg("dallinger", "dev-requirements.txt")
             if not url_path.exists():

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -6,6 +6,7 @@ import os
 import pkg_resources
 import random
 import re
+import requests
 import shutil
 import string
 import subprocess
@@ -528,6 +529,17 @@ def ensure_constraints_file_presence(directory: str):
     try:
         os.chdir(directory)
         url = f"https://raw.githubusercontent.com/Dallinger/Dallinger/v{__version__}/dev-requirements.txt"
+        if requests.get(url).status_code == 404:
+            print(f"{url} not found. Using local dev-requirements.txt")
+            url_path = abspath_from_egg("dallinger", "dev-requirements.txt")
+            if not url_path.exists():
+                print(
+                    f"{url_path} is not a valid file. Either use a released dallinger version for this experiment or install dallinger in editable mode"
+                )
+                raise ValueError(
+                    "Can't find constraints for dallinger version {__version__}"
+                )
+            url = str(url_path)
         print(f"Compiling constraints.txt file from requirements.txt and {url}")
         compile_info = f"dallinger generate-constraints\n#\n# Compiled from a requirement.txt file with md5sum: {requirements_path_hash}"
         with TemporaryDirectory() as tmpdirname:


### PR DESCRIPTION
See #3184

## Description
If the `requirements-dev.txt` file for the current Dallinger version can't be found on github the local one is looked up (and can be found if dallinger was installed in editable mode) and used.

## Motivation and Context
Currently `dallinger generate-constraints` tries hard to make sure experiments have versions of their dependecy pinned to the same versions as the ones included in the docker base image for the Dallinger version they depend on. This is to prevent, for instance, the case when they specify a different psycopg version that will need to be compiled to create a docker image for the experiment, and the compilation will fail because of the lack of a compiler in the image.

## How Has This Been Tested?
I successfully ran `dallinger generate-constraints` on the `iterated_drawing` demo experiment with a local master version (`7.9.0a1`).

## Offline case
When offline the constraints can't be generated. If they're needed to proceed with operations that  require a `contraints.txt` file for the experiment, a copy of `¶equirements.txt` can be used.
This PR includes a message to suggest this fix when offline.