### PR TITLE
Fix PytzUsageWarning: Migrate to new way datetimes are localized

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -362,7 +362,7 @@ tz = get_localzone()
 
 
 def when_with_relative_time(dt):
-    now = tz.localize(datetime.now())
+    now = datetime.now().replace(tzinfo=tz)
     formatted = dt.strftime("%a %b %-d")
     return "{} ({})".format(formatted, timeago.format(dt, now))
 
@@ -421,9 +421,9 @@ _fake_hit_data = {
     "assignments_available": 1,
     "assignments_completed": 0,
     "assignments_pending": 0,
-    "created": tz.localize(datetime.now() - timedelta(minutes=10)),
+    "created": (datetime.now() - timedelta(minutes=10)).replace(tzinfo=tz),
     "description": "Fake HIT Description",
-    "expiration": tz.localize(datetime.now() + timedelta(hours=6)),
+    "expiration": (datetime.now() + timedelta(hours=6)).replace(tzinfo=tz),
     "id": "3X7837UUADRXYCA1K7JAJLKC66DJ60",
     "keywords": ["testkw1", "testkw2"],
     "max_assignments": 1,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -166,14 +166,15 @@ def prolific_creds():
 @pytest.fixture
 def fake_parsed_hit():
     """Format returned by dallinger.mturk.MTurkService"""
+    tz = get_localzone()
     return {
         "annotation": "test-experiment-id",
         "assignments_available": 2,
         "assignments_completed": 0,
         "assignments_pending": 0,
-        "created": get_localzone().localize(datetime.now()),
+        "created": datetime.now().replace(tzinfo=tz),
         "description": "Recall a list of words.",
-        "expiration": get_localzone().localize(datetime.now()),
+        "expiration": datetime.now().replace(tzinfo=tz),
         "id": "fake-hit-id",
         "keywords": ["Memory", "wordlist"],
         "max_assignments": 2,

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -111,11 +111,9 @@ def fake_hit_response(**kwargs):
         u"HIT": {
             u"AssignmentDurationInSeconds": 900,
             u"AutoApprovalDelayInSeconds": 0,
-            u"CreationTime": tz.localize(
-                datetime.datetime(2018, 1, 1, 1, 26, 52, 54000)
-            ),
+            u"CreationTime": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(tzinfo=tz),
             u"Description": u"***TEST SUITE HIT***43683",
-            u"Expiration": tz.localize(datetime.datetime(2018, 1, 1, 1, 27, 26, 54000)),
+            u"Expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(tzinfo=tz),
             u"HITGroupId": u"36IAL8HYPYM1MDNBSTAEZW89WH74RJ",
             u"HITId": u"3X7837UUADRXYCA1K7JAJLKC66DJ60",
             u"HITReviewStatus": u"NotReviewed",
@@ -168,7 +166,7 @@ def fake_worker_qualification_response():
     tz = get_localzone()
     canned_response = {
         u"Qualification": {
-            u"GrantTime": tz.localize(datetime.datetime(2018, 1, 1)),
+            u"GrantTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
             u"IntegerValue": 2,
             u"QualificationTypeId": six.text_type(generate_random_id(size=32)),
             u"Status": u"Granted",
@@ -194,7 +192,7 @@ def fake_qualification_type_response():
     canned_response = {
         u"QualificationType": {
             u"AutoGranted": False,
-            u"CreationTime": tz.localize(datetime.datetime(2018, 1, 1)),
+            u"CreationTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
             u"Description": u"***TEST SUITE QUALIFICATION***",
             u"IsRequestable": True,
             u"Name": u"Test Qualification",
@@ -223,12 +221,12 @@ def fake_get_assignment_response():
             "WorkerId": "FAKE_WORKER_ID",
             "HITId": hit["HITId"],
             "AssignmentStatus": "Approved",
-            "AutoApprovalTime": tz.localize(datetime.datetime(2018, 1, 1)),
-            "AcceptTime": tz.localize(datetime.datetime(2018, 1, 1)),
-            "SubmitTime": tz.localize(datetime.datetime(2018, 1, 1)),
-            "ApprovalTime": tz.localize(datetime.datetime(2018, 1, 1)),
-            "RejectionTime": tz.localize(datetime.datetime(2018, 1, 1)),
-            "Deadline": tz.localize(datetime.datetime(2018, 1, 1)),
+            "AutoApprovalTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
+            "AcceptTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
+            "SubmitTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
+            "ApprovalTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
+            "RejectionTime": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
+            "Deadline": datetime.datetime(2018, 1, 1).replace(tzinfo=tz),
             "Answer": "",
             "RequesterFeedback": "",
         },
@@ -932,9 +930,9 @@ class TestMTurkServiceWithFakeConnection(object):
             "assignments_available": 1,
             "assignments_completed": 0,
             "assignments_pending": 0,
-            "created": tz.localize(datetime.datetime(2018, 1, 1, 1, 26, 52, 54000)),
+            "created": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(tzinfo=tz),
             "description": "***TEST SUITE HIT***43683",
-            "expiration": tz.localize(datetime.datetime(2018, 1, 1, 1, 27, 26, 54000)),
+            "expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(tzinfo=tz),
             "id": "3X7837UUADRXYCA1K7JAJLKC66DJ60",
             "keywords": ["testkw1", "testkw2"],
             "max_assignments": 1,

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -364,6 +364,7 @@ def sns_iso(sns):
 @pytest.mark.mturk
 @pytest.mark.usefixtures("check_mturkfull")
 class TestSNSService(object):
+    @pytest.mark.skip(reason="Requires a valid notification URL as of Feb. 2022")
     def test_creates_and_cancel_subscription(self, sns):
         topic_arn = sns.create_subscription("some-exp", "https://some-url")
 

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -111,9 +111,13 @@ def fake_hit_response(**kwargs):
         u"HIT": {
             u"AssignmentDurationInSeconds": 900,
             u"AutoApprovalDelayInSeconds": 0,
-            u"CreationTime": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(tzinfo=tz),
+            u"CreationTime": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(
+                tzinfo=tz
+            ),
             u"Description": u"***TEST SUITE HIT***43683",
-            u"Expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(tzinfo=tz),
+            u"Expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(
+                tzinfo=tz
+            ),
             u"HITGroupId": u"36IAL8HYPYM1MDNBSTAEZW89WH74RJ",
             u"HITId": u"3X7837UUADRXYCA1K7JAJLKC66DJ60",
             u"HITReviewStatus": u"NotReviewed",
@@ -930,9 +934,13 @@ class TestMTurkServiceWithFakeConnection(object):
             "assignments_available": 1,
             "assignments_completed": 0,
             "assignments_pending": 0,
-            "created": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(tzinfo=tz),
+            "created": datetime.datetime(2018, 1, 1, 1, 26, 52, 54000).replace(
+                tzinfo=tz
+            ),
             "description": "***TEST SUITE HIT***43683",
-            "expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(tzinfo=tz),
+            "expiration": datetime.datetime(2018, 1, 1, 1, 27, 26, 54000).replace(
+                tzinfo=tz
+            ),
             "id": "3X7837UUADRXYCA1K7JAJLKC66DJ60",
             "keywords": ["testkw1", "testkw2"],
             "max_assignments": 1,


### PR DESCRIPTION
Related to https://github.com/Dallinger/Dallinger/issues/3793

Get rid of following `PytzUsageWarning` warnings in the log output:

`PytzUsageWarning: The localize method is no longer necessary, as this time zone supports the fold attribute (PEP 495). For more details on migrating to a PEP 495-compliant implementation, see https://pytz-deprecation-shim.readthedocs.io/en/latest/migration.html`