### PR TITLE
Open dashboard window asynchronously

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -406,7 +406,7 @@ class DebugDeployment(HerokuLocalDeployment):
                 dashboard_url = self.with_proxy_port("{}/dashboard/".format(base_url))
                 self.display_dashboard_access_details(dashboard_url)
                 if not self.no_browsers:
-                    self.open_dashboard(dashboard_url)
+                    self.async_open_dashboard(dashboard_url)
                 self.heroku = heroku
                 self.out.log(
                     "Monitoring the Heroku Local server for recruitment or completion..."
@@ -442,6 +442,9 @@ class DebugDeployment(HerokuLocalDeployment):
                 config.get("dashboard_password"),
             )
         )
+
+    def async_open_dashboard(self, url):
+        threading.Thread(target=self.open_dashboard, name="Open dashboard", kwargs={"url": url}).start()
 
     def open_dashboard(self, url):
         config = get_config()

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -444,7 +444,9 @@ class DebugDeployment(HerokuLocalDeployment):
         )
 
     def async_open_dashboard(self, url):
-        threading.Thread(target=self.open_dashboard, name="Open dashboard", kwargs={"url": url}).start()
+        threading.Thread(
+            target=self.open_dashboard, name="Open dashboard", kwargs={"url": url}
+        ).start()
 
     def open_dashboard(self, url):
         config = get_config()

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -407,6 +407,11 @@ class DebugDeployment(HerokuLocalDeployment):
                 self.display_dashboard_access_details(dashboard_url)
                 if not self.no_browsers:
                     self.async_open_dashboard(dashboard_url)
+
+                # A little delay here ensures that the experiment window always opens
+                # after the dashboard window.
+                time.sleep(0.1)
+
                 self.heroku = heroku
                 self.out.log(
                     "Monitoring the Heroku Local server for recruitment or completion..."


### PR DESCRIPTION
## Description

Modified `dallinger debug` to open the dashboard asynchronously.

## Motivation and Context

Previously `dallinger debug` opened the dashboard synchronously, and due to a limitation of the underlying web driver this delayed the opening of the experiment window by five seconds. This can be avoided by opening the dashboard asynchronously. This closes #3897.

## How Has This Been Tested?

By manually running `dallinger debug`.