### PR TITLE
Adopt more cautious import strategy

### DIFF
--- a/dallinger/__init__.py
+++ b/dallinger/__init__.py
@@ -1,20 +1,5 @@
 """This is Dallinger, a platform for simulating evolution with people."""
 
-from . import (
-    bots,
-    command_line,
-    config,
-    models,
-    information,
-    nodes,
-    networks,
-    processes,
-    transformations,
-    experiment,
-    experiments,
-    heroku,
-    registration,
-)
 from .patches import patch
 
 import logging

--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -9,9 +9,6 @@ from dallinger.command_line.utils import log
 from dallinger.command_line.utils import Output
 from dallinger.command_line.utils import require_exp_directory
 from dallinger.config import get_config
-from dallinger.deployment import DevelopmentDeployment
-from dallinger.deployment import _handle_launch_data
-from dallinger.utils import open_browser
 
 
 logger = logging.getLogger(__name__)
@@ -47,6 +44,8 @@ def develop():
 @click.option("--port", default=5000, help="The port Flask is running on")
 def launch(port):
     """Send a POST to the /launch route"""
+    from dallinger.deployment import _handle_launch_data
+
     url = BASE_URL.format(port) + "launch"
     result = _handle_launch_data(url, error=log, attempts=1)
     if result and "status" in result:
@@ -57,6 +56,8 @@ def launch(port):
 @require_exp_directory
 def bootstrap(exp_config=None):
     """Run the experiment locally."""
+    from dallinger.deployment import DevelopmentDeployment
+
     bootstrapper = DevelopmentDeployment(Output(), exp_config)
     log(header, chevrons=False)
     bootstrapper.run()
@@ -75,6 +76,8 @@ def browser(route=None, port=5000):
     config.load()
     url_factory = valid_routes.get(route)
     if url_factory is not None:
+        from dallinger.utils import open_browser
+
         open_browser(url_factory(config, port))
     else:
         click.echo(

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -12,11 +12,8 @@ import uuid
 from datetime import datetime
 from pathlib import Path
 from shlex import quote
-from heroku3.core import Heroku as Heroku3Client
-import requests
 
 from dallinger import heroku
-from dallinger import registration
 from dallinger.config import get_config
 from dallinger.config import LOCAL_CONFIG
 from dallinger.heroku.tools import HerokuApp
@@ -25,7 +22,6 @@ from dallinger.command_line.utils import header
 from dallinger.command_line.utils import log
 from dallinger.command_line.utils import require_exp_directory
 from dallinger.command_line.utils import verify_id
-from dallinger.deployment import _handle_launch_data
 from dallinger.utils import abspath_from_egg
 from dallinger.utils import GitClient
 from dallinger.utils import setup_experiment
@@ -203,6 +199,9 @@ REGISTRY_UNAUTHORIZED_HELP_TEXT = [
 @click.option("--config", "-c", "config_options", nargs=2, multiple=True)
 def deploy_image(image, mode, config_options):
     """Deploy Heroku app using a docker image and MTurk."""
+    import requests
+    from heroku3.core import Heroku as Heroku3Client
+
     config = get_config()
     config.load()
     dashboard_password = secrets.token_urlsafe(8)
@@ -284,7 +283,11 @@ def deploy_image(image, mode, config_options):
 
     print("Launching experiment")
     app_url = f"https://{app_hostname}"
+
+    from dallinger.deployment import _handle_launch_data
+
     launch_data = _handle_launch_data(f"{app_url}/launch", print)
+
     print(launch_data.get("recruitment_msg"))
 
     print(
@@ -316,6 +319,8 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     )
     # Register the experiment using all configured registration services.
     if config.get("mode") == "live":
+        from dallinger import registration
+
         log("Registering the experiment on configured services...")
         registration.register(heroku_app_id, snapshot=None)
 
@@ -418,7 +423,11 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
     log("Calling {}".format(launch_url), chevrons=False)
+
+    from dallinger.deployment import _handle_launch_data
+
     launch_data = _handle_launch_data(launch_url, error=log)
+
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -1,6 +1,5 @@
 import logging
 import sys
-import user_agents
 
 from datetime import timedelta
 from flask import make_response
@@ -138,6 +137,8 @@ class ValidatesBrowser(object):
 
     def is_supported(self, user_agent_string):
         """Check user agent against configured exclusions."""
+        import user_agents
+
         user_agent_obj = user_agents.parse(user_agent_string)
         browser_ok = True
         for rule in self.exclusions:


### PR DESCRIPTION
## Description

I moved various expensive import calls into the functions that require them, thereby significantly speeding up the overhead of importing various Dallinger modules (in particular the `command_line` module.

## Motivation and Context

Historically Dallinger has taken an eager approach towards importing modules. As a result, import times for Dallinger's own modules have been unnecessarily slow. This can be fixed by relocating expensive import calls into the functions that need those imports. 

## How Has This Been Tested?

The pre-existing automated tests should cover these changes.