### PR TITLE
Mention Prolific on documentation home page

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,11 +1,11 @@
 Dallinger
 ~~~~~~~~~
 
-Dallinger is a tool to automate experiments that use combinations of automated bots and human subjects recruited on platforms like Mechanical Turk.
+Dallinger is a tool to automate experiments that use combinations of automated bots and human subjects recruited on platforms like Mechanical Turk and Prolific.
 
 Dallinger allows crowd sourced experiments to be abstracted into single function calls that can be inserted into higher-order algorithms. It fully automates the process of recruiting participants, obtaining informed consent, arranging participants into a network, running the experiment, coordinating communication, recording and managing the data, and paying the participants.
 
-The Dallinger technology stack consists of: Python, Redis, Web Sockets, Heroku, AWS, Mechanical Turk, boto, Flask, PostgreSQL, SQLAlchemy, Gunicorn, Pytest and gevent among others.
+The Dallinger technology stack consists of: Python, Redis, Web Sockets, Heroku, AWS, Mechanical Turk, Prolific, boto, Flask, PostgreSQL, SQLAlchemy, Gunicorn, Pytest and gevent among others.
 
 User Documentation
 ^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
## Description
Added a couple of mentions of Prolific to the documentation home page, for parity with Mechanical Turk.

## Motivation and Context
Prolific is keen that we make it clear that people can use Prolific with Dallinger.