### PR TITLE
Finishing the hot-refresh implementation

### DIFF
--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -53,34 +53,9 @@ def debug(port):
     _bootstrap()
 
     q = Queue("default", connection=redis_conn)
-    q.enqueue_call(initiate_launch, kwargs={"port": port})
+    q.enqueue_call(launch_app_and_open_dashboard, kwargs={"port": port})
 
     subprocess.call(["./run.sh"], cwd="develop")
-
-
-def initiate_launch(port):
-    url = BASE_URL.format(port) + "launch"
-    _handle_launch_data(url, error=log, delay=1.0)
-    open_dashboard(port)
-
-
-def open_dashboard(port):
-    _browser("dashboard", port)
-    # subprocess.call(["dallinger", "develop", "browser", "--route", "dashboard", "--port", str(port)])
-    # port = 5000
-    # config = get_config()
-    # config.load()
-    # open_browser(dashboard_url(config, port))
-
-
-@develop.command()
-@click.option("--port", default=5000, help="The port Flask is running on")
-def launch(port):
-    """Send a POST to the /launch route"""
-    url = BASE_URL.format(port) + "launch"
-    result = _handle_launch_data(url, error=log, attempts=1)
-    if result and "status" in result:
-        log(result["status"])
 
 
 @develop.command()
@@ -90,10 +65,24 @@ def bootstrap(exp_config=None):
 
 
 def _bootstrap(exp_config=None):
-    """Run the experiment locally."""
+    """Creates a directory called 'develop' which will be used to host the development version of the experiment."""
     bootstrapper = DevelopmentDeployment(Output(), exp_config)
     log(header, chevrons=False)
     bootstrapper.run()
+
+
+def launch_app_and_open_dashboard(port):
+    _launch_app(port)
+    _open_dashboard(port)
+
+
+def _launch_app(port):
+    url = BASE_URL.format(port) + "launch"
+    _handle_launch_data(url, error=log, delay=1.0)
+
+
+def _open_dashboard(port):
+    _browser("dashboard", port)
 
 
 @develop.command()

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -346,7 +346,6 @@ def initialize_experiment_package(path):
     init_py = os.path.join(path, "__init__.py")
     if not os.path.exists(init_py):
         open(init_py, "a").close()
-
     # Retain already set experiment module
     if sys.modules.get("dallinger_experiment") is not None:
         return
@@ -362,4 +361,5 @@ def initialize_experiment_package(path):
         )
     sys.modules["dallinger_experiment"] = package
     package.__package__ = "dallinger_experiment"
+    package.__name__ = "dallinger_experiment"
     sys.path.pop(0)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -353,7 +353,7 @@ def initialize_experiment_package(path):
     basename = os.path.basename(path)
     sys.path.insert(0, dirname)
     package = __import__(basename)
-    if path not in package.__path__:
+    if str(path) not in str(package.__path__):
         raise Exception(
             "Package was not imported from the requested path! ({} not in {})".format(
                 path, package.__path__

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -353,7 +353,7 @@ def initialize_experiment_package(path):
     basename = os.path.basename(path)
     sys.path.insert(0, dirname)
     package = __import__(basename)
-    if str(path) not in str(package.__path__):
+    if Path(path) not in [Path(p) for p in package.__path__]:
         raise Exception(
             "Package was not imported from the requested path! ({} not in {})".format(
                 path, package.__path__

--- a/dallinger/dev_server/app.py
+++ b/dallinger/dev_server/app.py
@@ -1,4 +1,7 @@
+import atexit
 import gevent.monkey
+import subprocess
+import werkzeug
 
 gevent.monkey.patch_all()  # Patch before importing app and all its dependencies
 
@@ -8,3 +11,13 @@ from dallinger.experiment_server.experiment_server import app  # noqa: E402, F40
 
 
 os.environ["FLASK_SECRET_KEY"] = codecs.encode(os.urandom(16), "hex").decode("ascii")
+
+if werkzeug.serving.is_running_from_reloader():
+    worker = subprocess.Popen(["dallinger_heroku_worker"])
+    clock = subprocess.Popen(["dallinger_heroku_clock"])
+
+    def cleanup():
+        worker.kill()
+        clock.kill()
+
+    atexit.register(cleanup)

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -2,18 +2,9 @@
 export FLASK_APP="app.py"
 export FLASK_ENV="development"
 
-# We want to run the worker and clock process in the background,
-# but also have them terminate when control-c is sent to the
-# foreground Flask process:
-trap 'kill $WORKER_PID; kill $CLOCK_PID; exit' INT
-dallinger_heroku_worker &
-WORKER_PID=$!
-dallinger_heroku_clock &
-CLOCK_PID=$!
-
 # --eager-loading is required because we're patching IO with gevent.monkey.patch_all()
 # See somewhat indirect reference:
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
 echo "Starting flask..."
 echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
-flask run --eager-loading "$@" || kill $WORKER_PID; kill $CLOCK_PID; exit
+flask run --eager-loading "$@"

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -18,6 +18,8 @@ from wtforms.validators import DataRequired, ValidationError
 from flask_login import current_user, login_required, login_user, logout_user
 from flask_login import UserMixin
 from flask_login.utils import login_url as make_login_url
+
+import dallinger.db
 from dallinger import recruiters
 from dallinger.heroku.tools import HerokuApp
 from dallinger.config import get_config
@@ -595,6 +597,13 @@ def node_details(object_type, obj_id):
     exp = Experiment(session)
     html_data = exp.node_visualization_html(object_type, obj_id)
     return Response(html_data, status=200, mimetype="text/html")
+
+
+@dashboard.route("/init_db", methods=["POST"])
+@login_required
+def init_db():
+    dallinger.db.init_db(drop_all=True)
+    return success_response()
 
 
 @dashboard.route("/lifecycle")

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -12,7 +12,7 @@
         Certain files (in particular, JS scripts) are cached by the browser,
         and so might not be updated by an ordinary refresh.
         In such cases you may need to force the browser to do a non-cached refresh.
-        The shortcut for this on Mac is Cmd-Shift-R.
+        The shortcut for this is typically Cmd-Shift-R (Mac) or Ctrl-Shift-R (Linux, Windows).
     </p>
 
     <button id="new-participant" class="btn btn-primary">New participant</button>

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -1,32 +1,69 @@
 {% extends "base/dashboard.html" %}
 
+{% block stylesheets %}
+    <style>
+        .dev-tools-section {
+            margin-top: 30px;
+            margin-bottom: 30px;
+        }
+    </style>
+{% endblock %}
+
 {% block body %}
     <h1>Development Mode Tools</h1>
 
-    <p>
-        You can update your experiment code while the experiment is running;
-        if you refresh the browser, you should be able to see your changes.
-    </p>
-    <p>
-        <strong>Note:</strong>
-        Certain files (in particular, JS scripts) are cached by the browser,
-        and so might not be updated by an ordinary refresh.
-        In such cases you may need to force the browser to do a non-cached refresh.
-        The shortcut for this is typically Cmd-Shift-R (Mac) or Ctrl-Shift-R (Linux, Windows).
-    </p>
+    <div class="dev-tools-section">
+        <p>
+            You can update your experiment code while the experiment is running;
+            if you refresh the browser, you should be able to see your changes.
+        </p>
+        <p>
+            <strong>Note:</strong>
+            Certain files (in particular, JS scripts) are cached by the browser,
+            and so might not be updated by an ordinary refresh.
+            In such cases you may need to force the browser to do a non-cached refresh.
+            The shortcut for this is typically Cmd-Shift-R (Mac) or Ctrl-Shift-R (Linux, Windows).
+        </p>
+    </div>
 
-    <button id="new-participant" class="btn btn-primary">New participant</button>
+    <div class="dev-tools-section">
+        <button id="new-participant" class="btn btn-primary" onclick="handleNewParticipant()">New participant</button>
+
+        <button id="init-db" class="btn btn-danger" onclick="handleInitDB()">Reset database</button>
+    </div>
+
+    <div class="dev-tools-section">
+        <h2>Messages</h2>
+
+        <pre id="messages"></pre>
+    </div>
+
 {% endblock %}
 
 {% block scripts %}
     <script type="text/javascript">
+        function log(data) {
+            let messages = $("#messages");
+            let time = new Date().toLocaleTimeString();
+            let text = JSON.stringify(data, null, 4)
+            messages.append("\n" + time + " - " + text);
+        }
+
         function handleNewParticipant() {
             let url = "/ad?generate_tokens=true&recruiter=hotair";
+            log("Recruiting new participant...");
             window.open(url, "_blank").focus();
         }
 
-        $(function () {
-            $("#new-participant").click(handleNewParticipant);
-        })
+        function handleInitDB() {
+            if (confirm("Are you sure you want to reset the database? All existing data will be lost.")) {
+                log("Initializing database reset...");
+                $.ajax({
+                    type: "POST",
+                    url: "/dashboard/init_db",
+                    success: log
+                });
+            }
+        }
     </script>
 {% endblock %}

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -1,49 +1,67 @@
 {% extends "base/dashboard.html" %}
 
 {% block body %}
-<h1>Development Server Dashboard</h1>
+<h1>Development Mode Tools</h1>
 
-<button id="launch-route-post" class="btn btn-primary">Launch</button>
+<button id="new-participant" class="btn btn-primary">New participant</button>
 
-<h2>Server Responses</h2>
-<pre id="console"></pre>
+{% set dashboard_launch_route = false %}
 
+{% if dashboard_launch_route %}
+    // The experimenter should not normally have to call the launch route manually;
+    // instead they should just restart the server.
+    // We leave this code here in case it becomes useful for future debugging.
+    <button id="launch-route-post" class="btn btn-primary">Launch</button>
+
+    <h2>Server Responses</h2>
+    <pre id="console"></pre>
+{% endif %}
 
 {% endblock %}
 
 {% block scripts %}
-<script type="text/javascript">
+    <script type="text/javascript">
+        function handleNewParticipant() {
+            let url = "/ad?generate_tokens=true&recruiter=hotair";
+            window.open(url, "_blank").focus();
+        }
 
-    function onLaunchSuccess(data) {
-        var $console = $("#console"),
-            response = JSON.stringify(data, null, 4);
-
-        $console.append("\n" + response);
-    };
-
-    function postToLaunchRoute(callback) {
-        var url = "/launch",
-        data = {};
-
-        $.ajax({
-            type: "POST",
-            url: url,
-            data: data,
-            success: callback,
-            dataType: "json"
-        });
-    };
-
-    function handleLaunchButton(event) {
-        var $button = $(event.currentTarget);
-
-        postToLaunchRoute(onLaunchSuccess);
-    };
+        $(function () {
+            $("#new-participant").click(handleNewParticipant);
+        })
 
 
-    $(function () {
-        $("#launch-route-post").click(handleLaunchButton);
-    })
+        {% if dashboard_launch_route %}
+            function onLaunchSuccess(data) {
+                var $console = $("#console"),
+                    response = JSON.stringify(data, null, 4);
 
-</script>
+                $console.append("\n" + response);
+            }
+
+            function postToLaunchRoute(callback) {
+                var url = "/launch",
+                data = {};
+
+                $.ajax({
+                    type: "POST",
+                    url: url,
+                    data: data,
+                    success: callback,
+                    dataType: "json"
+                });
+            }
+
+            function handleLaunchButton(event) {
+                var $button = $(event.currentTarget);
+
+                postToLaunchRoute(onLaunchSuccess);
+            }
+
+            $(function () {
+                $("#launch-route-post").click(handleLaunchButton);
+            })
+
+        {% endif %}
+    </script>
 {% endblock %}

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -5,18 +5,6 @@
 
 <button id="new-participant" class="btn btn-primary">New participant</button>
 
-{% set dashboard_launch_route = false %}
-
-{% if dashboard_launch_route %}
-    // The experimenter should not normally have to call the launch route manually;
-    // instead they should just restart the server.
-    // We leave this code here in case it becomes useful for future debugging.
-    <button id="launch-route-post" class="btn btn-primary">Launch</button>
-
-    <h2>Server Responses</h2>
-    <pre id="console"></pre>
-{% endif %}
-
 {% endblock %}
 
 {% block scripts %}
@@ -29,39 +17,5 @@
         $(function () {
             $("#new-participant").click(handleNewParticipant);
         })
-
-
-        {% if dashboard_launch_route %}
-            function onLaunchSuccess(data) {
-                var $console = $("#console"),
-                    response = JSON.stringify(data, null, 4);
-
-                $console.append("\n" + response);
-            }
-
-            function postToLaunchRoute(callback) {
-                var url = "/launch",
-                data = {};
-
-                $.ajax({
-                    type: "POST",
-                    url: url,
-                    data: data,
-                    success: callback,
-                    dataType: "json"
-                });
-            }
-
-            function handleLaunchButton(event) {
-                var $button = $(event.currentTarget);
-
-                postToLaunchRoute(onLaunchSuccess);
-            }
-
-            $(function () {
-                $("#launch-route-post").click(handleLaunchButton);
-            })
-
-        {% endif %}
     </script>
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,6 @@ setup_args = dict(
     },
     install_requires=[
         "APScheduler",
-        "atexit",
         "cached-property",
         "boto3",
         "build",
@@ -81,7 +80,6 @@ setup_args = dict(
         "tzlocal",
         "ua-parser",
         "user-agents",
-        "werkzeug",
     ],
     extras_require={
         "jupyter": [

--- a/setup.py
+++ b/setup.py
@@ -81,6 +81,7 @@ setup_args = dict(
         "tzlocal",
         "ua-parser",
         "user-agents",
+        "werkzeug",
     ],
     extras_require={
         "jupyter": [

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,7 @@ setup_args = dict(
     },
     install_requires=[
         "APScheduler",
+        "atexit",
         "cached-property",
         "boto3",
         "build",


### PR DESCRIPTION
@jessesnyder did most of the work on a hot-refreshing version of `dallinger debug`. However as it currently stood one had to run a series of commands in different directories to get it working. This pull request streamlines the process to match the simplicity of `dallinger debug`. One simply runs `dallinger developer debug` from the experiment directory, waits a few moments, then the dashboard appears, presenting a button which the user can press to open a new participant window.

Note: I have also extended the hot-refresh functionality to include clock and worker processes.

Note: this PR also includes a commit cherry-picked from #3929, concerning `initialize_experiment_package`.