### PR TITLE
Minor update to network visualistion

### DIFF
--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -309,11 +309,10 @@
         mgroup='good_infos';
         clr = participant.clr;
       }
-
       nodes.push({
         id: my_node_id,
-        label: "info:"+ String(info.id), dashes:true,
-        title: "info: " + info.type + ':' + String(info.id),
+        label: info.type + ": " + String(info.id), dashes:true,
+        title: info.type + ':' + String(info.id),
         group: mgroup,
         icon: {color: clr},
         font: {align: 'inside'},

--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -433,11 +433,6 @@
         }
       }
 
-      if (!is_found) {
-        to=to_min; // use a default strategy that the source is the minimal id
-        //to=my_node_id
-      }
-
       if (net.property1=='True') { // assume that there is a feature in property1 that decide if a network is open or close
         mgroup='group_networks_open';
       } else {
@@ -460,11 +455,13 @@
         data: net
 
       });
-      edges.push({
-        from: from,
-        to: to,
-        color: 'black'
-      });
+      if (is_found) {
+        edges.push({
+          from: from,
+          to: to,
+          color: 'black'
+        });
+      }
       //connect network to father
       edges.push({
         from: father,


### PR DESCRIPTION
I have fixed a couple of small formatting issues with the dashboard network visualisation. 

First, I have updated the text by Infos so that it says the class name rather than just 'info'. This is particularly useful for PsyNet, where the term 'Info' is not so informative.

Second, I have fixed an issue for the display of networks that have no nodes; previously the visualization would draw a line between these networks and an unrelated node from a different network. Now the network is just left without any connections.