### PR TITLE
Better logging in test debugging experiments

### DIFF
--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -404,9 +404,10 @@ def test_request(webapp):
 @pytest.fixture
 def debug_experiment(request, env, clear_workers):
     timeout = request.config.getvalue("recruiter_timeout", 120)
+
     # Make sure debug server runs to completion with bots
     p = pexpect.spawn(
-        "dallinger", ["debug", "--no-browsers"], env=env, encoding="utf-8"
+        "dallinger", ["debug", "--no-browsers", "--verbose"], env=env, encoding="utf-8"
     )
     p.logfile = sys.stdout
 
@@ -418,6 +419,7 @@ def debug_experiment(request, env, clear_workers):
             p.expect_exact(u"Local Heroku process terminated", timeout=timeout)
     finally:
         try:
+            print(p.read(1e6))
             p.sendcontrol("c")
             p.read()
         except IOError:

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -444,10 +444,6 @@ def flush_output(p, timeout):
     p.timeout = old_timeout
 
 
-def read_logs_until_exit(p):
-    p.read()
-
-
 @pytest.fixture
 def recruitment_loop(request, debug_experiment):
     def recruitment_looper():


### PR DESCRIPTION
This concerns `debug_experiment`, a fixture for running regression tests using `dallinger debug`.

We have had problems where not all errors in debug experiments were logged in pytest. It turned out that this was due to a couple of reasons:

1. The fixture did not use verbose mode for `dallinger debug`, meaning that important information was missed;
2. The fixture did not propagate all the logs to pytest.

This PR fixes these issues. I can confirm that I am now seeing the missing errors in pytest.