### PR TITLE
Persist docker deployment infos to a file in the current directory

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -390,13 +390,16 @@ def deploy(mode, server, dns_host, config_options, archive_path):  # pragma: no 
     )
     print(response.json()["recruitment_msg"])
 
-    print("To display the logs for this experiment you can run:")
-    print(
-        f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f"
-    )
-    print(
-        f"You can now log in to the console at https://{experiment_id}.{dns_host}/dashboard as user {cfg['ADMIN_USER']} using password {cfg['dashboard_password']}"
-    )
+    deployment_infos = [
+        "To display the logs for this experiment you can run:",
+        f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f",
+        f"You can now log in to the console at https://{experiment_id}.{dns_host}/dashboard as user {cfg['ADMIN_USER']} using password {cfg['dashboard_password']}",
+    ]
+    for line in deployment_infos:
+        print(line)
+    with open(f"deployment-info_{experiment_id}.txt", "w") as f:
+        for line in deployment_infos:
+            f.write(f"{line}\n")
 
 
 def get_experiment_id_from_archive(archive_path):


### PR DESCRIPTION
When deploying via docker important information is written to the console (STDOUT) at the end of the deployment process. This includes the URL of the deployed experiment, the credentials to log into the dashboard as well as info for how to access the logs.

Unfortunately, all this data is lost when closing the terminal window, e.g. unintentionally, unless it has been manually copied into a file before.

We want the deployment information as described above to be automatically written to a file in the current directory.

See #4096 