### PR TITLE
Implement --archive option for debug

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -194,10 +194,13 @@ def get_summary(app):
     default=False,
     help="Skip opening browsers",
 )
+@click.option("--archive", default=None, help="Optional path to an experiment archive")
 @require_exp_directory
-def debug(verbose, bot, proxy, no_browsers=False, exp_config=None):
+def debug(verbose, bot, proxy, no_browsers=False, exp_config=None, archive=None):
     """Run the experiment locally."""
-    debugger = DebugDeployment(Output(), verbose, bot, proxy, exp_config, no_browsers)
+    debugger = DebugDeployment(
+        Output(), verbose, bot, proxy, exp_config, no_browsers, archive
+    )
     log(header, chevrons=False)
     debugger.run()
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -414,12 +414,17 @@ class DebugDeployment(HerokuLocalDeployment):
         else:
             if result["status"] == "success":
                 if self.archive:
+                    _archive_path = (
+                        self.archive
+                        if os.path.isabs(self.archive)
+                        else os.path.join(self.original_dir, self.archive)
+                    )
                     self.out.log(
                         "Populating the database with the contents of {}...".format(
-                            self.archive
+                            _archive_path
                         )
                     )
-                    ingest_zip(self.archive, db.engine)
+                    ingest_zip(_archive_path, db.engine)
                 self.out.log(result["recruitment_msg"])
                 dashboard_url = self.with_proxy_port("{}/dashboard/".format(base_url))
                 self.display_dashboard_access_details(dashboard_url)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -20,7 +20,7 @@ from dallinger import heroku
 from dallinger import recruiters
 from dallinger import registration
 from dallinger.config import get_config
-from dallinger.data import bootstrap_db_from_zip
+from dallinger.data import ingest_zip
 from dallinger.heroku.tools import HerokuApp
 from dallinger.heroku.tools import HerokuLocalWrapper
 from dallinger.redis_utils import connect_to_redis
@@ -419,7 +419,7 @@ class DebugDeployment(HerokuLocalDeployment):
                             self.archive
                         )
                     )
-                    bootstrap_db_from_zip(self.archive, db.engine)
+                    ingest_zip(self.archive, db.engine)
                 self.out.log(result["recruitment_msg"])
                 dashboard_url = self.with_proxy_port("{}/dashboard/".format(base_url))
                 self.display_dashboard_access_details(dashboard_url)


### PR DESCRIPTION
## Description

The `dallinger debug` command now accepts the `--archive` parameter used previously in `dallinger deploy` for deploying an experiment from an exported zip file.

## Motivation and Context

Debugging from archive can often be useful in debugging.