### PR TITLE
Catch AlreadyFailedError in failure cascade

### DIFF
--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -161,7 +161,9 @@ class SharedMixin(object):
         the `failure_cascade` property.
         """
         if self.failed is True:
-            raise AttributeError("Cannot fail {} - it has already failed.".format(self))
+            raise AlreadyFailedError(
+                "Cannot fail {} - it has already failed.".format(self)
+            )
         else:
             self.failed = True
             self.failed_reason = reason
@@ -175,6 +177,14 @@ class SharedMixin(object):
                     obj.fail(reason=wrapped_reason)
                 except TypeError:
                     obj.fail()
+                except AlreadyFailedError:
+                    pass
+
+
+class AlreadyFailedError(AttributeError):
+    """
+    Raised when trying to fail an object that has already been failed.
+    """
 
 
 class Participant(Base, SharedMixin):


### PR DESCRIPTION
## Description
Currently Dallinger propagates failures from certain objects (e.g. Infos) to other associated objects (e.g. Nodes) via what is called a 'failure cascade'. However the cascade currently fails if one of those associated objects is failed already. This is fixed by the current pull request, as well as introducing a new error class: `AlreadyFailedError`.

## How Has This Been Tested?
I wanted to introduce a unit test for this but have been struggling to run the Dallinger tests locally. When I run `pytest tests/test_models.py --runslow` from the root directory, I get this error message:

Exception: Package was not imported from the requested path! (/Users/peter.harrison/git/dallinger not in ['/Users/peter.harrison/git/dallinger/dallinger'])

Does anyone have any ideas about how to fix it?