### PR TITLE
Use python 3.10 base image for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 ###################### Image with build tools to compile wheels ###############
-FROM ubuntu:20.04 as wheels
+FROM python:3.10-bullseye as wheels
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL Description="Dallinger base docker image" Version="1.0"
@@ -9,7 +9,7 @@ EXPOSE 5000
 
 # Install build dependencies
 RUN apt-get update && \
-    apt-get install -y libpq-dev python3-pip python3-dev enchant tzdata pandoc && \
+    apt-get install -y libpq-dev python3-pip python3-dev tzdata pandoc && \
     python3 -m pip install -U pip && \
     rm -rf /var/lib/apt/lists/*
 
@@ -22,13 +22,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 
 ###################### Dallinger base image ###################################
-FROM ubuntu:20.04 as dallinger
+FROM python:3.10-bullseye as dallinger
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 
 # Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y libpq5 python3-pip enchant tzdata --no-install-recommends && \
+    apt-get install -y libpq5 python3-pip tzdata --no-install-recommends && \
     python3 -m pip install -U pip && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Description
Depend on official python docker images and use version 3.10 

## Motivation and Context
Currently the docker build uses `ubuntu:20.04` as base image, and the python version shipped by default with that image.
This makes changing the python version cumbersome.
By using the python image as base, there's a well defined point where we can change the pyhton version used to build docker images.

## How Has This Been Tested?
Automated tests are passing.