### PR TITLE
Add skip-flask option to `dallinger develop debug`

### DIFF
--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -49,13 +49,19 @@ def develop():
 
 @develop.command()
 @click.option("--port", default=5000, help="The port Flask is running on")
-def debug(port):
+@click.option(
+    "--skip-flask",
+    is_flag=True,
+    help="Skip launching Flask, so that Flask can be managed externally",
+)
+def debug(port, skip_flask):
     _bootstrap()
 
     q = Queue("default", connection=redis_conn)
     q.enqueue_call(launch_app_and_open_dashboard, kwargs={"port": port})
 
-    subprocess.call(["./run.sh"], cwd="develop")
+    if not skip_flask:
+        subprocess.call(["./run.sh"], cwd="develop")
 
 
 @develop.command()


### PR DESCRIPTION
In order to access IDE debugger support it is useful to add the option to `dallinger develop debug` to skip the launching of the Flask server, so that the Flask server can instead be managed by the IDE. I've therefore added a `skip-flask` option to `dallinger develop debug`. I can confirm that, with this feature, we can now debug Dallinger experiments using the PyCharm IDE.

