### PR TITLE
Instructions to develop an experiment with only docker as a dependency

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6
+          ruby-version: 2.7
       - name: Install Chandler
         run: gem install chandler -v 0.7.0
       - name: Set up Node.js

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,8 @@ LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 
 # Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y libpq5 python3-pip enchant tzdata --no-install-recommends && \
+    apt-get install -y libpq5 python3-pip enchant busybox tzdata --no-install-recommends && \
+    busybox --install && \
     python3 -m pip install -U pip && \
     rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -50,6 +50,8 @@ RUN python3 -m pip install --find-links file:///wheelhouse -e .[data]
 ENV LC_ALL C.UTF-8
 ENV LANG C.UTF-8
 
+ENV SKIP_DEPENDENCY_CHECK true
+
 CMD /bin/bash
 
 ###################### Dallinger bot image ####################################

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,7 +41,7 @@ RUN --mount=type=bind,source=/wheelhouse,from=wheels,target=/wheelhouse \
     python3 -m pip install --find-links file:///wheelhouse -r requirements.txt -c constraints.txt
 
 COPY . /dallinger
-RUN python3 -m pip install --find-links file:///wheelhouse -e .[data]
+RUN python3 -m pip install --find-links file:///wheelhouse -e .[data,docker]
 
 # Add two ENV variables as a fix when using python3, to prevent this error:
 # Click will abort further execution because Python 3 was configured

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,19 +52,18 @@ ENV LANG C.UTF-8
 
 ENV SKIP_DEPENDENCY_CHECK true
 
-# Also install docker client package to support using the dallinger image without docker
+# Also install docker client package (docker-ce-cli) to support using the dallinger image without docker
 
-# Install runtime dependencies
-# RUN apt-get update && \
-#     apt-get install -y ca-certificates curl gnupg lsb-release && \
-#     mkdir -p /etc/apt/keyrings && \
-#     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-#     echo \
-#     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-#     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-#     apt-get update && \
-#     apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin && \
-#     rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian \
+    bullseye stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce-cli && \
+    rm -rf /var/lib/apt/lists/*
 
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ ENV LANG C.UTF-8
 
 ENV SKIP_DEPENDENCY_CHECK true
 
-# Also install docker client package (docker-ce-cli) to support using the dallinger image without docker
+# Also install docker client package (docker-ce-cli) to support using the dallinger image without installing dallinger:
+# some dallinger commands depend on the docker binaries being available (the dallinger commands will invoke docker on
+# bahalf of the user). So they need to be availble in the same context dallinger is run, i.e. inside a container.
 
 RUN apt-get update && \
     apt-get install -y ca-certificates curl gnupg && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,16 +55,16 @@ ENV SKIP_DEPENDENCY_CHECK true
 # Also install docker client package to support using the dallinger image without docker
 
 # Install runtime dependencies
-RUN apt-get update && \
-    apt-get install -y ca-certificates curl gnupg lsb-release && \
-    mkdir -p /etc/apt/keyrings && \
-    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
-    echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
-    apt-get update && \
-    apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin && \
-    rm -rf /var/lib/apt/lists/*
+# RUN apt-get update && \
+#     apt-get install -y ca-certificates curl gnupg lsb-release && \
+#     mkdir -p /etc/apt/keyrings && \
+#     curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+#     echo \
+#     "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+#     $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+#     apt-get update && \
+#     apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin && \
+#     rm -rf /var/lib/apt/lists/*
 
 
 CMD /bin/bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 ###################### Image with build tools to compile wheels ###############
-FROM ubuntu:20.04 as wheels
+FROM python:3.10-bullseye as wheels
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL Description="Dallinger base docker image" Version="1.0"
@@ -9,7 +9,7 @@ EXPOSE 5000
 
 # Install build dependencies
 RUN apt-get update && \
-    apt-get install -y libpq-dev python3-pip python3-dev enchant tzdata pandoc && \
+    apt-get install -y libpq-dev python3-pip python3-dev tzdata pandoc && \
     python3 -m pip install -U pip && \
     rm -rf /var/lib/apt/lists/*
 
@@ -22,13 +22,13 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 
 ###################### Dallinger base image ###################################
-FROM ubuntu:20.04 as dallinger
+FROM python:3.10-bullseye as dallinger
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 
 # Install runtime dependencies
 RUN apt-get update && \
-    apt-get install -y libpq5 python3-pip enchant busybox tzdata --no-install-recommends && \
+    apt-get install -y libpq5 python3-pip busybox tzdata --no-install-recommends && \
     busybox --install && \
     python3 -m pip install -U pip && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,6 +52,21 @@ ENV LANG C.UTF-8
 
 ENV SKIP_DEPENDENCY_CHECK true
 
+# Also install docker client package to support using the dallinger image without docker
+
+# Install runtime dependencies
+RUN apt-get update && \
+    apt-get install -y ca-certificates curl gnupg lsb-release && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg && \
+    echo \
+    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+    $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null && \
+    apt-get update && \
+    apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin && \
+    rm -rf /var/lib/apt/lists/*
+
+
 CMD /bin/bash
 
 ###################### Dallinger bot image ####################################

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -894,7 +894,6 @@ def apps():
 
 
 @dallinger.command()
-@require_exp_directory
 def generate_constraints():
     """Update an experiment's constraints.txt pinned dependencies based on requirements.txt."""
     experiment_dir = Path(os.getcwd())

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -496,7 +496,7 @@ def script_command(cmd):
 
 
 def script_command_linux(cmd):
-    return ["script", "-q", "--command", " ".join(cmd)]
+    return ["script", "-q", "--command", " ".join(cmd), "/dev/null"]
 
 
 def script_command_mac(cmd):

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -168,9 +168,7 @@ if len(CONFIGURED_HOSTS) == 1:
     server_prompt = False
 else:
     default_server = None
-    server_prompt = (
-        "Choose one of the configured servers (add one with `dallinger docker-ssh servers add`)\n",
-    )
+    server_prompt = "Choose one of the configured servers (add one with `dallinger docker-ssh servers add`)\n"
 server_option = click.option(
     "--server",
     required=True,

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -7,4 +7,4 @@ export FLASK_ENV="development"
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
 echo "Starting flask..."
 echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
-flask run --eager-loading ${FlASK_OPTIONS} "$@"
+flask run --eager-loading ${FLASK_OPTIONS} "$@"

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 export FLASK_APP="app.py"
-export FLASK_ENV="development"
+export FLASK_DEBUG=1
 
 # --eager-loading is required because we're patching IO with gevent.monkey.patch_all()
 # See somewhat indirect reference:
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
 echo "Starting flask..."
 echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
-flask run --eager-loading ${FLASK_OPTIONS} "$@"
+flask run ${FLASK_OPTIONS} "$@"

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -7,4 +7,4 @@ export FLASK_ENV="development"
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
 echo "Starting flask..."
 echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
-flask run --eager-loading "$@"
+flask run --eager-loading ${FlASK_OPTIONS} "$@"

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -315,9 +315,13 @@ def build_image(
     # We rely on the already installed dallinger: the docker image tag has been chosen
     # based on the contents of this file. This makes sure dallinger stays installed from
     # /dallinger, and that it doesn't waste space with two copies in two different layers.
-    RUN mkdir ~/.ssh && echo "Host *\n    StrictHostKeyChecking no" >> ~/.ssh/config
+
+    # Some experiments might only list dallinger as dependency
+    # If they do the grep command will exit non-0, the pip command will not run
+    # but the whole `RUN` group will succeed thanks to the last `true` invocation
+    RUN mkdir -p ~/.ssh && echo "Host *\n    StrictHostKeyChecking no" >> ~/.ssh/config
     RUN {ssh_mount} grep -v ^dallinger requirements.txt > /tmp/requirements_no_dallinger.txt && \
-        python3 -m pip install -r /tmp/requirements_no_dallinger.txt
+        python3 -m pip install -r /tmp/requirements_no_dallinger.txt || true
     ENV PORT=5000
     CMD dallinger_heroku_web
     """

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -391,7 +391,11 @@ def check_local_db_connection(log):
 def check_experiment_dependencies(requirement_file):
     """Verify that the dependencies defined in a requirements file are
     in fact installed.
+    If the environment variable SKIP_DEPENDENCY_CHECK is set, no check
+    will be performed.
     """
+    if os.environ.get("SKIP_DEPENDENCY_CHECK"):
+        return
     try:
         with open(requirement_file, "r") as f:
             dependencies = [r for r in f.readlines() if r[:3] != "-e "]
@@ -511,7 +515,12 @@ def ensure_constraints_file_presence(directory: str):
 
     If the `requirements.txt` does not exist one is created with
     `dallinger` as its only dependency.
+
+    If the environment variable SKIP_DEPENDENCY_CHECK is set, no action
+    will be performed.
     """
+    if os.environ.get("SKIP_DEPENDENCY_CHECK"):
+        return
     constraints_path = Path(directory) / "constraints.txt"
     requirements_path = Path(directory) / "requirements.txt"
     if not requirements_path.exists():
@@ -612,7 +621,8 @@ def assemble_experiment_temp_dir(log, config, for_remote=False):
 
     requirements_path = Path(dst) / "requirements.txt"
     # Overwrite the requirements.txt file with the contents of the constraints.txt file
-    (Path(dst) / "constraints.txt").replace(requirements_path)
+    if not os.environ.get("SKIP_DEPENDENCY_CHECK"):
+        (Path(dst) / "constraints.txt").replace(requirements_path)
     if for_remote:
         dallinger_path = get_editable_dallinger_path()
         if dallinger_path and not os.environ.get("DALLINGER_NO_EGG_BUILD"):

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -98,3 +98,32 @@ The admin password can be found in the develop `config.txt` file:
 .. code-block:: shell
 
     grep dashboard_password ./develop/config.txt
+
+
+Deploy the experiment image using ssh
+=====================================
+
+We're going to use variations of the same command, so we create an alias for convenience.
+
+.. code-block:: shell
+
+    alias docker-dallinger='docker run --rm -ti -v ~/.ssh:/home/.ssh -v /etc/passwd:/etc/passwd -v /etc/shadow:/etc/shadow -v ~/.local/share/dallinger/:/home/.local/share/dallinger/ -e HOME=/home -e DALLINGER_NO_EGG_BUILD=1 -u $(id -u ${USER}):$(id -g ${USER}) -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
+
+
+Then we can use the alias to run dallinger inside a container:
+
+.. code-block:: shell
+
+    docker-dallinger docker-ssh servers list
+
+Create a remote server with
+
+.. code-block:: shell
+
+    docker-dallinger docker-ssh servers add
+
+[STILL NOT WORKING] And deploy to it with
+
+.. code-block:: shell
+
+    docker-dallinger docker-ssh deploy

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -106,8 +106,11 @@ Deploy the experiment image using ssh
 We're going to use variations of the same command, so we create an alias for convenience.
 
 .. code-block:: shell
-
+    # On Linux you can use:
     alias docker-dallinger='docker run --rm -ti -v /etc/group:/etc/group -v ~/.docker:/root/.docker -v ~/.local/share/dallinger/:/root/.local/share/dallinger/ -e HOME=/root -e DALLINGER_NO_EGG_BUILD=1 -v /var/run/docker.sock:/var/run/docker.sock -v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
+
+    # On Mac Os you can use:
+    alias docker-dallinger='docker run --rm -ti -v /etc/group:/etc/group -v ~/.docker:/root/.docker -v ~/.local/share/dallinger/:/root/.local/share/dallinger/ -e HOME=/root -e DALLINGER_NO_EGG_BUILD=1 -v /var/run/docker.sock:/var/run/docker.sock -v  ~/.ssh:/root/.ssh -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
 
 
 Then we can use the alias to run dallinger inside a container:

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -90,7 +90,7 @@ Start the development server with docker:
 
 .. code-block:: shell
 
-    docker run --name dallinger --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/experiment --network dallinger -p 5000:5000 -e FlASK_OPTIONS='-h 0.0.0.0' -e REDIS_URL=redis://dallinger_redis:6379 -e DATABASE_URL=postgresql://dallinger:dallinger@dallinger_postgres/dallinger ${EXPERIMENT_IMAGE} dallinger develop debug
+    docker run --name dallinger --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/experiment --network dallinger -p 5000:5000 -e FLASK_OPTIONS='-h 0.0.0.0' -e REDIS_URL=redis://dallinger_redis:6379 -e DATABASE_URL=postgresql://dallinger:dallinger@dallinger_postgres/dallinger ${EXPERIMENT_IMAGE} dallinger develop debug
 
 You can now access the running dallinger instance on http://localhost:5000/dashboard
 The admin password can be found in the develop `config.txt` file:

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -4,6 +4,12 @@ This guide goes through the necessary steps to achieve this.
 Set up services
 ===============
 
+Create the dallinger docker network (if not present already):
+
+.. code-block:: shell
+
+    docker network create dallinger
+
 Start services needed by dallinger:
 
 .. code-block:: shell
@@ -11,20 +17,29 @@ Start services needed by dallinger:
     docker run -d --name dallinger_redis --network=dallinger -v dallinger_redis:/data redis redis-server --appendonly yes
     docker run -d --name dallinger_postgres --network=dallinger -e POSTGRES_USER=dallinger -e POSTGRES_PASSWORD=dallinger -e POSTGRES_DB=dallinger -v dallinger_postgres:/var/lib/postgresql/data postgres:12
 
+If you have these already created you can remove the existing ones and recreate them. To remove the existing ones run:
+
+.. code-block:: shell
+
+    # Needed if you want to recreate containers
+    docker rm dallinger_redis
+    docker rm dallinger_postgres
+
+or you can start the containers you have:
+
+.. code-block:: shell
+
+    # Needed if you want to start stopped containers
+    docker start dallinger_redis dallinger_postgres
+
 Start adminer:
 
 .. code-block:: shell
 
-    docker run -d --name dallinger_adminer --network dallinger --link dallinger_postgres:db adminer
+    docker run -d -p 8080:8080 --name dallinger_adminer --network dallinger --link dallinger_postgres:db adminer
 
-Find the adminer ip:
-
-.. code-block:: shell
-
-    docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dallinger_adminer
-
-Connect to adminer by visiting http://<result-of-docker-inspect>:8080
-Select PostgreSQL from the dropdown, and enter `dallinger` as both username and password.
+Connect to adminer by visiting http://localhost:8080
+Select PostgreSQL from the dropdown, and enter `dallinger` as both username and password. You can leave the "database" field blank to get a list of existing databases.
 
 
 Run experiment from docker image

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -56,7 +56,7 @@ Create a file named `Dockerfile` with these contents (replace image name in the 
 .. code-block::
 
     # syntax = docker/dockerfile:1.2
-    FROM ghcr.io/dallinger/dallinger:9.1.0a1
+    FROM ghcr.io/dallinger/dallinger
 
     RUN mkdir /experiment
     COPY requirements.txt /experiment/requirements.txt

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -1,0 +1,59 @@
+It is possible to develop with dallinger using only docker as a prerequisite.
+This guide goes through the necessary steps to achieve this.
+
+Set up services
+===============
+
+Start services needed by dallinger:
+
+.. code-block:: shell
+
+    docker run -d --name dallinger_redis --network=dallinger -v dallinger_redis:/data redis redis-server --appendonly yes
+    docker run -d --name dallinger_postgres --network=dallinger -e POSTGRES_USER=dallinger -e POSTGRES_PASSWORD=dallinger -e POSTGRES_DB=dallinger -v dallinger_postgres:/var/lib/postgresql/data postgres:12
+
+Start adminer:
+
+.. code-block:: shell
+
+    docker run -d --name dallinger_adminer --network dallinger --link dallinger_postgres:db adminer
+
+Find the adminer ip:
+
+.. code-block:: shell
+
+    docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dallinger_adminer
+
+Connect to adminer by visiting http://<result-of-docker-inspect>:8080
+Select PostgreSQL from the dropdown, and enter `dallinger` as both username and password.
+
+
+Run experiment from docker image
+================================
+
+Identify the experment image you want to use. We'll use ghcr.io/dallinger/dallinger/bartlett1932:75a9580c in this example:
+
+.. code-block:: shell
+
+   EXPERIMENT_IMAGE=ghcr.io/dallinger/dallinger/bartlett1932:75a9580c
+
+Copy the contents of the experiment to a local directory to be able to work on them while running a container:
+
+.. code-block:: shell
+
+    docker run --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/dest ${EXPERIMENT_IMAGE} cp -ar /experiment /dest/experiment-code
+
+This will create a directory `experiment-code` in the current directory, containing all experiment related files.
+
+
+Start the development server with docker:
+
+.. code-block:: shell
+
+    docker run --name dallinger --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/dest -v ${PWD}/experiment-code:/experiment --network dallinger -p 5000:5000 -e FlASK_OPTIONS='-h 0.0.0.0' -e REDIS_URL=redis://dallinger_redis:6379 -e DATABASE_URL=postgresql://dallinger:dallinger@dallinger_postgres/dallinger ${EXPERIMENT_IMAGE} dallinger develop debug
+
+You can now access the running dallinger instance on http://localhost:5000/dashboard
+The admin password can be found in the develop `config.txt` file:
+
+.. code-block:: shell
+
+    grep dashboard_password experiment-code/develop/config.txt

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -64,8 +64,6 @@ Create a file named `Dockerfile` with these contents (replace image name in the 
 
     WORKDIR /experiment
 
-    RUN python3 -m pip install -e /dallinger[docker] && rm -rf /root/.cache
-
     # Some experiments might only list dallinger as dependency
     # If they do the grep command will exit non-0, the pip command will not run
     # but the whole `RUN` group will succeed thanks to the last `true` invocation.

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -85,11 +85,12 @@ Build a docker image for the experiment using Buildkit:
     EXPERIMENT_IMAGE=my-experiment
     DOCKER_BUILDKIT=1 docker build . -t ${EXPERIMENT_IMAGE}
 
-Start the development server with docker:
+Create an alias to start the development server with docker and run it:
 
 .. code-block:: shell
 
-    docker run --name dallinger --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/experiment --network dallinger -p 5000:5000 -e FLASK_OPTIONS='-h 0.0.0.0' -e REDIS_URL=redis://dallinger_redis:6379 -e DATABASE_URL=postgresql://dallinger:dallinger@dallinger_postgres/dallinger ${EXPERIMENT_IMAGE} dallinger develop debug
+    alias dallinger-dev-server='docker run --name dallinger --rm -ti -u $(id -u ${USER}):$(id -g ${USER}) -v ${PWD}:/experiment --network dallinger -p 5000:5000 -e FLASK_OPTIONS='-h 0.0.0.0' -e REDIS_URL=redis://dallinger_redis:6379 -e DATABASE_URL=postgresql://dallinger:dallinger@dallinger_postgres/dallinger ${EXPERIMENT_IMAGE} dallinger develop debug'
+    dallinger-dev-server
 
 You can now access the running dallinger instance on http://localhost:5000/dashboard
 The admin password can be found in the develop `config.txt` file:

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -107,7 +107,7 @@ We're going to use variations of the same command, so we create an alias for con
 
 .. code-block:: shell
 
-    alias docker-dallinger='docker run --rm -ti -v ~/.ssh:/home/${USER}/.ssh -v /etc/passwd:/etc/passwd -v /etc/shadow:/etc/shadow -v ~/.local/share/dallinger/:/home/${USER}/.local/share/dallinger/ -e HOME=/home/${USER} -e DALLINGER_NO_EGG_BUILD=1 -u $(id -u ${USER}):$(id -g ${USER}) -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
+    alias docker-dallinger='docker run --rm -ti -v /etc/group:/etc/group -v ~/.docker:/root/.docker -v ~/.local/share/dallinger/:/root/.local/share/dallinger/ -e HOME=/root -e DALLINGER_NO_EGG_BUILD=1 -v /var/run/docker.sock:/var/run/docker.sock -v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
 
 
 Then we can use the alias to run dallinger inside a container:
@@ -120,9 +120,9 @@ Create a remote server with
 
 .. code-block:: shell
 
-    docker-dallinger docker-ssh servers add
+    docker-dallinger docker-ssh servers add --host <your-server-name-or-ip>
 
-[STILL NOT WORKING] And deploy to it with
+And deploy to it with
 
 .. code-block:: shell
 

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -107,7 +107,7 @@ We're going to use variations of the same command, so we create an alias for con
 
 .. code-block:: shell
 
-    alias docker-dallinger='docker run --rm -ti -v ~/.ssh:/home/.ssh -v /etc/passwd:/etc/passwd -v /etc/shadow:/etc/shadow -v ~/.local/share/dallinger/:/home/.local/share/dallinger/ -e HOME=/home -e DALLINGER_NO_EGG_BUILD=1 -u $(id -u ${USER}):$(id -g ${USER}) -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
+    alias docker-dallinger='docker run --rm -ti -v ~/.ssh:/home/${USER}/.ssh -v /etc/passwd:/etc/passwd -v /etc/shadow:/etc/shadow -v ~/.local/share/dallinger/:/home/${USER}/.local/share/dallinger/ -e HOME=/home/${USER} -e DALLINGER_NO_EGG_BUILD=1 -u $(id -u ${USER}):$(id -g ${USER}) -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
 
 
 Then we can use the alias to run dallinger inside a container:


### PR DESCRIPTION
Allow users to run dallinger commands from the published dallinger docker image (at ghcr.io/dallinger/dallinger).
Tested with local development and `dallinger docker-ssh deploy`.

See #2584 