### PR TITLE
Update for latest Flask version

### DIFF
--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 export FLASK_APP="app.py"
-export FLASK_ENV="development"
+export FLASK_DEBUG=1
 
 # --eager-loading is required because we're patching IO with gevent.monkey.patch_all()
 # See somewhat indirect reference:

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -7,4 +7,4 @@ export FLASK_ENV="development"
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
 echo "Starting flask..."
 echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
-flask run --eager-loading "$@"
+flask run "$@"


### PR DESCRIPTION
Addresses #4290.

- Removes the not-supported `eager-loading` option from the `flask run` command.
- Replaces the deprecated `FLASK_ENV` command with `FLASK_DEBUG`.