### PR TITLE
Preserve .dallingerconfig when using env fixture

### DIFF
--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -98,7 +98,7 @@ def env():
             try:
                 shutil.copyfile(
                     os.path.join(original_home, ".dallingerconfig"),
-                    os.path.join(fake_home, ".dallingerconfig")
+                    os.path.join(fake_home, ".dallingerconfig"),
                 )
             except FileNotFoundError:
                 pass

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -98,7 +98,7 @@ def env():
             try:
                 shutil.copyfile(
                     os.path.join(original_home, ".dallingerconfig"),
-                    os.path.join(fake_home, ".dallingerconfig"),
+                    os.path.join(fake_home, ".dallingerconfig")
                 )
             except FileNotFoundError:
                 pass

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -85,7 +85,7 @@ def env():
     # Heroku requires a home directory to start up
     # We create a fake one using tempfile and set it into the
     # environment to handle sandboxes on CI servers
-    original_home = os.getenv("HOME")
+    original_home = os.path.expanduser("~")
     with mock.patch("os.environ", os.environ.copy()) as environ_patched:
         running_on_ci = environ_patched.get("CI", False)
         have_home_dir = environ_patched.get("HOME", False)

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -85,6 +85,7 @@ def env():
     # Heroku requires a home directory to start up
     # We create a fake one using tempfile and set it into the
     # environment to handle sandboxes on CI servers
+    original_home = os.getenv("HOME")
     with mock.patch("os.environ", os.environ.copy()) as environ_patched:
         running_on_ci = environ_patched.get("CI", False)
         have_home_dir = environ_patched.get("HOME", False)
@@ -94,6 +95,13 @@ def env():
         else:
             fake_home = tempfile.mkdtemp()
             environ_patched.update({"HOME": fake_home})
+            try:
+                shutil.copyfile(
+                    os.path.join(original_home, ".dallingerconfig"),
+                    os.path.join(fake_home, ".dallingerconfig"),
+                )
+            except FileNotFoundError:
+                pass
             yield environ_patched
             shutil.rmtree(fake_home, ignore_errors=True)
 


### PR DESCRIPTION
When running on CI, the `env` test fixture previously created a sandbox home directory, but did not copy over the `.dallingerconfig` from the original directory. This is problematic as otherwise this config file would be a useful way to specify global configurations for automated tests that spawn debug experiments. Dallinger hasn't encountered this problem before because its CI tests don't spawn debug experiments, but we've run into this problem now with PsyNet, which does. This PR fixes the issue. I have tested it through our PsyNet CI tests, which rely on this functionality.