### PR TITLE
Allow subclassing vectors

### DIFF
--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1373,6 +1373,11 @@ class Vector(Base, SharedMixin):
 
     __tablename__ = "vector"
 
+    #: A String giving the name of the class. Defaults to
+    #: ``vector``. This allows subclassing.
+    type = Column(String(50))
+    __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "vector"}
+
     #: the id of the Node at which the vector originates
     origin_id = Column(Integer, ForeignKey("node.id"), index=True)
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1377,8 +1377,8 @@ class Vector(Base, SharedMixin):
     #: ``vector``. This allows subclassing.
     #:
     #: Note: The type column was added in 9/2022, 7+ years after the Vector ORM class was introduced. To support
-    #: datasets which don't include this column we define a default value which will be used when object instances are
-    #: loaded.
+    #: importing datasets which don't include this column we define a default value which will be used when deploying
+    #: experiments from zip files.
     type = Column(String(50), default="vector", server_default="vector")
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "vector"}
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1375,7 +1375,7 @@ class Vector(Base, SharedMixin):
 
     #: A String giving the name of the class. Defaults to
     #: ``vector``. This allows subclassing.
-    type = Column(String(50))
+    type = Column(String(50), default="vector", server_default="vector")
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "vector"}
 
     #: the id of the Node at which the vector originates

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -1375,6 +1375,10 @@ class Vector(Base, SharedMixin):
 
     #: A String giving the name of the class. Defaults to
     #: ``vector``. This allows subclassing.
+    #:
+    #: Note: The type column was added in 9/2022, 7+ years after the Vector ORM class was introduced. To support
+    #: datasets which don't include this column we define a default value which will be used when object instances are
+    #: loaded.
     type = Column(String(50), default="vector", server_default="vector")
     __mapper_args__ = {"polymorphic_on": type, "polymorphic_identity": "vector"}
 


### PR DESCRIPTION
- Enables experimenters to subclass Vector objects in the same way that one might subclass Node objects, by adding a polymorphic identity on the `type` column.
- Have set the default value of the corresponding SQL column to `vector` so that we can maintain back-compatibility with data exports from before the addition of this column.

I have tested manually that this works.