### PR TITLE
Add docker_ssh_volumes config option to specify additional volumes

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -103,6 +103,7 @@ default_keys = (
     ("worker_multiplier", float, []),
     ("docker_image_base_name", six.text_type, [], ""),
     ("docker_image_name", six.text_type, [], ""),
+    ("docker_ssh_volumes", six.text_type, [], ""),
 )
 
 

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -30,6 +30,11 @@ services:
       - dallinger
     volumes:
       - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+    {%- if config.get("docker_ssh_volumes", "") %}
+    {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
+      - {{ volume | string() | tojson }}
+    {%- endfor %}
+    {%- endif %}
 
   web:
     image: {{ experiment_image }}
@@ -46,6 +51,11 @@ services:
           - {{ experiment_id }}_web
     volumes:
       - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+    {%- if config.get("docker_ssh_volumes", "") %}
+    {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
+      - {{ volume | string() | tojson }}
+    {%- endfor %}
+    {%- endif %}
 
 {%- if config["clock_on"] %}
   clock:

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -448,7 +448,12 @@ Docker Deployment Configuration
 ``docker_image_name``
     The docker image name to use for this experiment.
 
-    If present, the code in the current directory will not be used.
+    If present, the code in the current directory will not be used when deploying.
     The specified image will be used instead.
 
     Example: ``ghcr.io/dallinger/dallinger/bartlett1932@sha256:ad3c7b376e23798438c18aae6e0136eb97f5627ddde6baafe1958d40274fa478``
+
+``docker_ssh_volumes``
+    Additional list of volumes to mount when deploying using docker-ssh.
+
+    Example: ``/host/path:/container_path,/another-path:/another-container-path``


### PR DESCRIPTION
## Description
See #4266

## Motivation and Context
When deploying using `dallinger docker-ssh deploy` it's useful to be able to specify additional volumes to mount.
This PR adds the `docker_ssh_volumes` config variable to let users specify a list of volumes to mount

## How Has This Been Tested?
Manual testing.