### PR TITLE
Fix unpublished doc pages

### DIFF
--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -88,6 +88,7 @@ Create a file named `Dockerfile` with these contents (replace image name in the 
 Build a docker image for the experiment using Buildkit:
 
 .. code-block:: shell
+
     EXPERIMENT_IMAGE=my-experiment
     DOCKER_BUILDKIT=1 docker build . -t ${EXPERIMENT_IMAGE}
 
@@ -112,6 +113,7 @@ Deploy the experiment image using ssh
 We're going to use variations of the same command, so we create an alias for convenience.
 
 .. code-block:: shell
+
     # On Linux you can use:
     alias docker-dallinger='docker run --rm -ti -v /etc/group:/etc/group -v ~/.docker:/root/.docker -v ~/.local/share/dallinger/:/root/.local/share/dallinger/ -e HOME=/root -e DALLINGER_NO_EGG_BUILD=1 -v /var/run/docker.sock:/var/run/docker.sock -v $(readlink -f $SSH_AUTH_SOCK):/ssh-agent -e SSH_AUTH_SOCK=/ssh-agent -v ${PWD}:/experiment  ${EXPERIMENT_IMAGE} dallinger'
 

--- a/docs/source/docker_only.rst
+++ b/docs/source/docker_only.rst
@@ -1,8 +1,14 @@
+Docker-only installation
+========================
+
 It is possible to develop with dallinger using only docker as a prerequisite.
-This guide goes through the necessary steps to achieve this.
+This means you do not need to follow most of the steps detailed in the Installation instructions.
+Instead, you just need to install Docker, and create a ``.dallingerconfig`` file containing
+the information requested in the Installation instructions.
+Once these steps are complete, you can move forward following these instructions:
 
 Set up services
-===============
+---------------
 
 Create the dallinger docker network (if not present already):
 
@@ -43,7 +49,7 @@ Select PostgreSQL from the dropdown, and enter `dallinger` as both username and 
 
 
 Run experiment from docker image
-================================
+--------------------------------
 
 Enter the experiment directory:
 
@@ -101,7 +107,7 @@ The admin password can be found in the develop `config.txt` file:
 
 
 Deploy the experiment image using ssh
-=====================================
+-------------------------------------
 
 We're going to use variations of the same command, so we create an alias for convenience.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -57,6 +57,7 @@ Several demos demonstrate Dallinger in action:
     :maxdepth: 1
 
     demo_index
+    demos_on_heroku
 
 
 Experiment Author Documentation
@@ -71,9 +72,8 @@ designing new experiments for others to use.
 
     developing_dallinger_setup_guide
     creating_an_experiment
+    required_experiment_files
     networks
-    docker_support
-    docker_tutorial
     the_experiment_class
     classes
     web_api
@@ -86,6 +86,25 @@ designing new experiments for others to use.
     recruitment
     scheduled_tasks
     private_repo
+
+Alternative Environments Documentation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We are currently experimenting with several other development and deployment environments
+for Dallinger, such as Docker and Vagrant. These potentially offer various advantages,
+such as better cross-platform compatibility, enhanced reproducibility, and so on.
+The following documentation topics describe some of these approaches. However,
+this work is still experimental and so the documentation is not complete yet.
+
+.. toctree::
+    :caption: Alternative Environments
+    :maxdepth: 1
+
+    docker_tutorial
+    docker_support
+    docker_only
+    vagrant_setup
+
 
 Core Contribution Documentation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
There were several documentation pages that weren't being indexed by Sphinx and hence weren't being published to the documentation website, including the new Docker documentation. I have addressed this now.