### PR TITLE
Print link to experiment dashboard in console

### DIFF
--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -116,7 +116,9 @@ def _browser(route=None, port=5000):
     config.load()
     url_factory = valid_routes.get(route)
     if url_factory is not None:
-        open_browser(url_factory(config, port))
+        url = url_factory(config, port)
+        logger.info("Experiment dashboard: %s", url)
+        open_browser(url)
     else:
         click.echo(
             "Supported routes are:\n\t{}".format("\n\t".join(valid_routes.keys()))


### PR DESCRIPTION
`dallinger develop debug` would automatically open the browser to the dashboard. However this behaviour doesn't work when the command is launched within a Docker container. I've therefore added a feature whereby a link to the dashboard (prepopulated with login credentials) is automatically printed to the console so that the experimenter can easily login in this case.