### PR TITLE
Migrate /var/lib/dallinger -> ~/dallinger_file_systems

### DIFF
--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``/var/lib/dallinger/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger_file_systems/${experiment_id}``.
 
 
 Support for python dependencies in private repositories


### PR DESCRIPTION
Previously Dallinger Docker SSH deployment mounted `/var/lib/dallinger/{experiment_id}` as `/var/lib/dallinger` within the Docker image. The problem with this is that not all Docker installations are able to write to `/var/lib/dallinger/`; in particular, if Docker is installed via Snap then this fails. I have instead changed this behaviour so that the mount point is instead `~/dallinger_file_systems`. I think it's not a bad thing to have this within the user directory, anyway. I have updated the documentation accordingly.