### PR TITLE
Docker compose logs

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -625,7 +625,7 @@ class Executor:
             else:
                 print("*** BEGIN docker-compose logs ***")
                 print(channel.recv(10**10).decode())
-                print("*** END docker-compose logs ***")
+                print("*** END docker-compose logs ***\n")
 
     def check_sudo(self):
         """Make sure the current user is authorized to invoke sudo without providing a password.

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -24,6 +24,7 @@
             <script src="{{ url_for('static', filename='scripts/store+json2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/fingerprintjs2/1.5.1/fingerprint2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/dallinger2.js') }}" type="text/javascript"> </script>
+            <script src="{{ url_for('static', filename='scripts/survey-jquery/survey-jquery.js') }}" type="text/javascript"> </script>
         {% endblock %}
         {% block scripts %}
             <script type="text/javascript">

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``/var/lib/dallinger/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger_file_systems/${experiment_id}``.
 
 
 Support for python dependencies in private repositories


### PR DESCRIPTION
! Warning ! This MR branches from #4524, which should be merged before examining the present MR.

In the context of Docker SSH commands, we sometimes see executor failures that look like this:

```
Error: exit code was not 0 (137)


Traceback (most recent call last):
  File "/Users/peter.harrison/.virtualenvs/psynet/bin/psynet", line 8, in <module>
    sys.exit(psynet())
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/peter.harrison/git/PsyNet/psynet/command_line.py", line 479, in deploy
    ctx.invoke(
  File "/Users/peter.harrison/.virtualenvs/psynet/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "/Users/peter.harrison/git/Dallinger/dallinger/command_line/docker_ssh.py", line 230, in wrapper
    return f(*args, **kwargs)
  File "/Users/peter.harrison/git/Dallinger/dallinger/command_line/docker_ssh.py", line 403, in deploy
    executor.run(
  File "/Users/peter.harrison/git/Dallinger/dallinger/command_line/docker_ssh.py", line 608, in run
    raise ExecuteException
dallinger.command_line.docker_ssh.ExecuteException
```

In such cases, more revealing error messages can often be found by examining the docker-compose logs, which can be done by running the following command: 

```
$ docker-compose logs

Attaching to test234234_worker_1, test234234_web_1, test234234_clock_1, test234234_redis_test234234_1
redis_test234234_1  | 1:C 29 Nov 2022 17:52:24.729 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
redis_test234234_1  | 1:C 29 Nov 2022 17:52:24.729 # Redis version=7.0.5, bits=64, commit=00000000, modified=0, pid=1, just started
redis_test234234_1  | 1:C 29 Nov 2022 17:52:24.729 # Configuration loaded
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.730 * Increased maximum number of open files to 10032 (it was originally set to 1024).
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.730 * monotonic clock: POSIX clock_gettime
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.730 * Running mode=standalone, port=6379.
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.730 # Server initialized
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.731 * Creating AOF base file appendonly.aof.1.base.rdb on server start
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.733 * Creating AOF incr file appendonly.aof.1.incr.aof on server start
redis_test234234_1  | 1:M 29 Nov 2022 17:52:24.733 * Ready to accept connections
clock_1             | Error retrieving experiment class
clock_1             | Could not import experiment.
clock_1             | Traceback (most recent call last):
clock_1             |   File "/usr/local/bin/dallinger_heroku_clock", line 8, in <module>
clock_1             |     sys.exit(main())
clock_1             |   File "/usr/local/lib/python3.8/dist-packages/dallinger_scripts/clock.py", line 4, in main
clock_1             |     launch()
clock_1             |   File "/usr/local/lib/python3.8/dist-packages/dallinger/heroku/clock.py", line 49, in launch
clock_1             |     config.load()
clock_1             |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 292, in load
clock_1             |     self.load_from_file(localConfig)
clock_1             |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 251, in load_from_file
clock_1             |     self.extend(data, cast_types=True, strict=True)
clock_1             |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 146, in extend
clock_1             |     raise KeyError("{} is not a valid configuration key".format(key))
clock_1             | KeyError: 'default_export_root is not a valid configuration key'
web_1               | Error retrieving experiment class
web_1               | Could not import experiment.
web_1               | Traceback (most recent call last):
web_1               |   File "/usr/local/bin/dallinger_heroku_web", line 8, in <module>
web_1               |     sys.exit(main())
web_1               |   File "/usr/local/lib/python3.8/dist-packages/dallinger_scripts/web.py", line 11, in main
web_1               |     launch()
web_1               |   File "/usr/local/lib/python3.8/dist-packages/dallinger/experiment_server/gunicorn.py", line 100, in launch
web_1               |     config.load()
web_1               |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 292, in load
web_1               |     self.load_from_file(localConfig)
web_1               |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 251, in load_from_file
web_1               |     self.extend(data, cast_types=True, strict=True)
web_1               |   File "/usr/local/lib/python3.8/dist-packages/dallinger/config.py", line 146, in extend
web_1               |     raise KeyError("{} is not a valid configuration key".format(key))
web_1               | KeyError: 'default_export_root is not a valid configuration key'
worker_1            | Traceback (most recent call last):
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/connection.py", line 559, in connect
worker_1            |     sock = self._connect()
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/connection.py", line 615, in _connect
worker_1            |     raise err
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/connection.py", line 603, in _connect
worker_1            |     sock.connect(socket_address)
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/gevent/_socketcommon.py", line 607, in connect
worker_1            |     raise _SocketError(err, strerror(err))
worker_1            | TimeoutError: [Errno 110] Connection timed out
worker_1            | 
worker_1            | During handling of the above exception, another exception occurred:
worker_1            | 
worker_1            | Traceback (most recent call last):
worker_1            |   File "src/gevent/greenlet.py", line 906, in gevent._gevent_cgreenlet.Greenlet.run
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/dallinger/heroku/rq_gevent_worker.py", line 102, in _work
worker_1            |     self.register_birth()
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/dallinger/heroku/rq_gevent_worker.py", line 53, in register_birth
worker_1            |     super(GeventWorker, self).register_birth()
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/rq/worker.py", line 286, in register_birth
worker_1            |     if self.connection.exists(self.key) and \
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/client.py", line 1581, in exists
worker_1            |     return self.execute_command('EXISTS', *names)
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/client.py", line 898, in execute_command
worker_1            |     conn = self.connection or pool.get_connection(command_name, **options)
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/connection.py", line 1379, in get_connection
worker_1            |     connection.connect()
worker_1            |   File "/usr/local/lib/python3.8/dist-packages/redis/connection.py", line 563, in connect
worker_1            |     raise ConnectionError(self._error_message(e))
worker_1            | redis.exceptions.ConnectionError: Error 110 connecting to redis_test234234:6379. Connection timed out.
worker_1            | 2022-11-29T17:57:40Z <Greenlet at 0x7fcf8c671040: <bound method GeventWorker._work of <dallinger.heroku.rq_gevent_worker.GeventWorker object at 0x7fcf8c67c670>>(False)> failed with ConnectionError
worker_1            | 
```

This pull request modifies the `Executor` class to automatically print these logs when a failure occurs.