### PR TITLE
Stop catching experiment import errors in register_extra_parameters

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -305,10 +305,7 @@ class Configuration(object):
         # This will run any experiment specific parameter registrations
         from dallinger.experiment import load
 
-        try:
-            exp_klass = load()
-        except ImportError:
-            exp_klass = None
+        exp_klass = load()
         exp_params = getattr(exp_klass, "extra_parameters", None)
         if exp_params is not None and not self._experiment_params_loaded:
             exp_params()


### PR DESCRIPTION
There is a function in Dallinger called `register_extra_parameters` which is responsible for defining extra config parameters with reference to experiment.py. The original function would try to import the local experiment class, but silently catch any import errors raised and continue with execution. If that experiment class defined an extra config parameter, this definition would be missed, and so Dallinger would throw a subsequent error once it sees this unrecognised parameter in `config.txt`. The resulting error message confuses the user, as it suggests that there is a problem with config parameter registration, whereas the real problem is an import error in experiment.py.

The following example comes from an experiment.py which tries to import a non-existent package:

``` 
import abc123
```

```
>>> from dallinger.config import get_config
>>> config = get_config()
>>> config.load()
ERROR:/Users/peter.harrison/git/Dallinger/dallinger/experiment.py:Error retrieving experiment class
ERROR:/Users/peter.harrison/git/Dallinger/dallinger/experiment.py:Could not import experiment.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/peter.harrison/git/Dallinger/dallinger/config.py", line 288, in load
    self.load_defaults()
  File "/Users/peter.harrison/git/Dallinger/dallinger/config.py", line 285, in load_defaults
    self.load_from_file(config_file)
  File "/Users/peter.harrison/git/Dallinger/dallinger/config.py", line 251, in load_from_file
    self.extend(data, cast_types=True, strict=True)
  File "/Users/peter.harrison/git/Dallinger/dallinger/config.py", line 146, in extend
    raise KeyError("{} is not a valid configuration key".format(key))
KeyError: 'default_export_root is not a valid configuration key'
```

This merge request updates the logic so that import errors are no longer silently ignored at this stage, but are instead reported appropriately.