### PR TITLE
Change default dallinger_develop_directory

### DIFF
--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -4,7 +4,7 @@ aws_secret_access_key = YourSecretAccessKey
 aws_region = us-east-1
 
 [Development]
-dallinger_develop_directory = ~/dallinger_develop
+dallinger_develop_directory = /tmp/dallinger_develop
 
 [Email Access]
 smtp_host = smtp.gmail.com:587


### PR DESCRIPTION
The default `dallinger_develop_directory` was originally `~/dallinger_develop_directory`. This proved to have two problems:

- If the path contained a period, then `dallinger develop` commands would fail due to Python importing weirdness.
- `dallinger develop` would fail if run in a Docker container because the home directory would expand to root and then have permissions problems.

A better default seems to be `/tmp/dallinger_develop_directory`, which is available on both MacOS and Linux, and poses no such issues.