### PR TITLE
Misc Docker quality of life improvements

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -241,7 +241,7 @@ def _deploy_in_mode(mode, verbose, log, app=None, archive=None):
     config.load()
     config.extend({"mode": mode, "logfile": "-"})
 
-    deploy_sandbox_shared_setup(
+    return deploy_sandbox_shared_setup(
         log=log, verbose=verbose, app=app, prelaunch_actions=prelaunch
     )
 

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -289,7 +289,9 @@ def sandbox(verbose, app, archive):
 @report_idle_after(21600)
 def deploy(verbose, app, archive):
     """Deploy app using Heroku to MTurk."""
-    _deploy_in_mode(mode="live", verbose=verbose, log=log, app=app, archive=archive)
+    return _deploy_in_mode(
+        mode="live", verbose=verbose, log=log, app=app, archive=archive
+    )
 
 
 @dallinger.command()

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -275,7 +275,9 @@ def fail_on_unsupported_urls(f):
 @report_idle_after(21600)
 def sandbox(verbose, app, archive):
     """Deploy app using Heroku to the MTurk Sandbox."""
-    _deploy_in_mode(mode="sandbox", verbose=verbose, log=log, app=app, archive=archive)
+    return _deploy_in_mode(
+        mode="sandbox", verbose=verbose, log=log, app=app, archive=archive
+    )
 
 
 @dallinger.command()

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -105,7 +105,7 @@ def remove_services_data():
 @require_exp_directory
 def sandbox(verbose, app):
     """Deploy app using Heroku to the MTurk Sandbox."""
-    _deploy_in_mode(mode="sandbox", verbose=verbose, log=log, app=app)
+    return _deploy_in_mode(mode="sandbox", verbose=verbose, log=log, app=app)
 
 
 @docker.command()
@@ -114,7 +114,7 @@ def sandbox(verbose, app):
 @require_exp_directory
 def deploy(verbose, app):
     """Deploy app using Heroku to MTurk."""
-    _deploy_in_mode(mode="live", verbose=verbose, log=log, app=app)
+    return _deploy_in_mode(mode="live", verbose=verbose, log=log, app=app)
 
 
 @docker.command()
@@ -301,7 +301,7 @@ def _deploy_in_mode(mode, verbose, log, app=None):
     config.load()
     config.extend({"mode": mode, "logfile": "-"})
 
-    deploy_heroku_docker(log=log, verbose=verbose, app=app)
+    return deploy_heroku_docker(log=log, verbose=verbose, app=app)
 
 
 def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
@@ -451,6 +451,8 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,
+        "dashboard_user": result["dashboard_user"],
+        "dashboard_password": result["dashboard_password"],
         "dashboard_url": "{}/dashboard/".format(heroku_app.url),
         # "recruitment_msg": launch_data.get("recruitment_msg", None),
     }

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -199,7 +199,7 @@ REGISTRY_UNAUTHORIZED_HELP_TEXT = [
 @click.option("--live", "mode", flag_value="live", help="Deploy to the real MTurk")
 @click.option("--image", required=True, help="Name of the docker image to deploy")
 @click.option("--config", "-c", "config_options", nargs=2, multiple=True)
-def deploy_image(image, mode, config_options):
+def deploy_image(image_name, mode, config_options):
     """Deploy Heroku app using a docker image and MTurk."""
     config = get_config()
     config.load()
@@ -238,12 +238,12 @@ def deploy_image(image, mode, config_options):
     # Prepare the git repo to push to Heroku
     tmp = tempfile.mkdtemp()
     os.chdir(tmp)
-    Path("Dockerfile").write_text(f"FROM {image}")
+    Path("Dockerfile").write_text(f"FROM {image_name}")
     Path("heroku.yml").write_text(HEROKU_YML)
     git = GitClient()
     git.init()
     git.add("--all")
-    git.commit(f"Deploying image {image}")
+    git.commit(f"Deploying image {image_name}")
 
     # Launch the Heroku app.
     print("Pushing code to Heroku...")

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -1,6 +1,7 @@
 import codecs
 import netrc
 import os
+import re
 import secrets
 import subprocess
 import tempfile
@@ -457,6 +458,25 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
         # "recruitment_msg": launch_data.get("recruitment_msg", None),
     }
     return result
+
+
+def add_image_name(config_path: str, image_name: str):
+    """Alters the text file at `config_path` to set the contents
+    of the variable `docker_image_name` to the passed `image_name`.
+    If a line is already present it will be replaced.
+    If it's not it will be added next to the line with the `docker_image_base_name` variable.
+    """
+    config = Path(config_path)
+    new_line = f"docker_image_name = {image_name}"
+    old_text = config.read_text()
+    if re.search("^docker_image_name =", old_text, re.M):
+        text = re.sub("docker_image_name = .*", new_line, old_text)
+    elif re.search("^docker_image_base_name =", old_text, re.M):
+        text = re.sub("(docker_image_base_name = .*)", r"\g<1>\n" + new_line, old_text)
+    else:
+        text = "".join((old_text, "\n" + new_line))
+
+    config.write_text(text)
 
 
 def heroku_addons_cmd(app_name):

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -647,7 +647,7 @@ class Executor:
     def reload_caddy(self):
         self.run(
             "docker-compose -f ~/dallinger/docker-compose.yml exec -T httpserver "
-            "caddy reload -config /etc/caddy/Caddyfile"
+            "caddy reload --config /etc/caddy/Caddyfile"
         )
 
     def run_and_echo(self, cmd):  # pragma: no cover

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -295,7 +295,7 @@ def build_and_push_image(f):
 @click.option("--config", "-c", "config_options", nargs=2, multiple=True)
 @build_and_push_image
 def deploy(
-    image, mode, server, dns_host, app_name, config_options, archive_path
+    image_name, mode, server, dns_host, app_name, config_options, archive_path
 ):  # pragma: no cover
     """Deploy a dallnger experiment docker image to a server using ssh."""
     config = get_config()
@@ -351,7 +351,7 @@ def deploy(
             "CREATOR": f"{USER}@{HOSTNAME}",
             "DALLINGER_UID": experiment_uuid,
             "ADMIN_USER": "admin",
-            "docker_image_name": image,
+            "docker_image_name": image_name,
         }
     )
     cfg.update(config_options)
@@ -361,7 +361,7 @@ def deploy(
     sftp.putfo(
         BytesIO(
             get_docker_compose_yml(
-                cfg, experiment_id, image, postgresql_password
+                cfg, experiment_id, image_name, postgresql_password
             ).encode()
         ),
         f"dallinger/{experiment_id}/docker-compose.yml",
@@ -439,7 +439,7 @@ def deploy(
     log_command = f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f"
 
     deployment_infos = [
-        f"Deployed Docker image name: {image}",
+        f"Deployed Docker image name: {image_name}",
         "To display the logs for this experiment you can run:",
         log_command,
         f"You can now log in to the console at {dashboard_link} (user = {dashboard_user}, password = {dashboard_password})",

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -19,6 +19,7 @@ import sys
 import socket
 import zipfile
 
+import paramiko.ssh_exception
 from jinja2 import Template
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
@@ -117,7 +118,15 @@ def remove(host):
 
 
 def prepare_server(host, user):
-    executor = Executor(host, user)
+    try:
+        executor = Executor(host, user)
+    except paramiko.ssh_exception.AuthenticationException as exc:
+        if user is None:
+            raise paramiko.ssh_exception.AuthenticationException(
+                "Failed to authenticate to the server. Do you need to specify a user?"
+            ) from exc
+        raise
+
     print("Checking docker presence")
     try:
         executor.run("docker ps")

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -432,6 +432,7 @@ def deploy(
     print(response.json()["recruitment_msg"])
 
     deployment_infos = [
+        f"Deployed Docker image name: {image}",
         "To display the logs for this experiment you can run:",
         f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f",
         f"You can now log in to the console at https://{experiment_id}.{dns_host}/dashboard as user {cfg['ADMIN_USER']} using password {cfg['dashboard_password']}",

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -625,7 +625,7 @@ class Executor:
             else:
                 print("*** BEGIN docker-compose logs ***")
                 print(channel.recv(10**10).decode())
-                print("*** END docker-compose logs ***")
+                print("*** END docker-compose logs ***\n")
 
     def check_sudo(self):
         """Make sure the current user is authorized to invoke sudo without providing a password.

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -434,11 +434,12 @@ def deploy(
     dashboard_user = cfg["ADMIN_USER"]
     dashboard_password = cfg["dashboard_password"]
     dashboard_link = f"https://{dashboard_user}:{dashboard_password}@{experiment_id}.{dns_host}/dashboard"
+    log_command = f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f"
 
     deployment_infos = [
         f"Deployed Docker image name: {image}",
         "To display the logs for this experiment you can run:",
-        f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f",
+        log_command,
         f"You can now log in to the console at {dashboard_link} (user = {dashboard_user}, password = {dashboard_password})",
     ]
     for line in deployment_infos:
@@ -446,6 +447,13 @@ def deploy(
     with open(f"deployment-info_{experiment_id}.txt", "w") as f:
         for line in deployment_infos:
             f.write(f"{line}\n")
+
+    return {
+        "dashboard_user": dashboard_user,
+        "dashboard_password": dashboard_password,
+        "dashboard_link": dashboard_link,
+        "log_command": log_command,
+    }
 
 
 def get_experiment_id_from_archive(archive_path):

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -504,7 +504,7 @@ def stats(server):
     help="Don't scrub PII (Personally Identifiable Information) - if not specified PII will be scrubbed",
 )
 @server_option
-def export(server, app, local, no_scrub):
+def export(app, local, no_scrub, server):
     """Export database to a local file."""
     server_info = CONFIGURED_HOSTS[server]
     with remote_postgres(server_info, app) as db_uri:

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -21,7 +21,6 @@ from typing import Dict
 from uuid import uuid4
 
 import click
-import paramiko.ssh_exception
 import requests
 from jinja2 import Template
 from requests.adapters import HTTPAdapter
@@ -116,6 +115,8 @@ def remove(host):
 
 
 def prepare_server(host, user):
+    import paramiko.ssh_exception
+
     try:
         executor = Executor(host, user)
     except paramiko.ssh_exception.AuthenticationException as exc:

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -475,6 +475,7 @@ def apps(server):
     apps = executor.run("ls ~/dallinger/caddy.d")
     for app in apps.split():
         print(app)
+    return apps
 
 
 @docker_ssh.command()

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -431,11 +431,15 @@ def deploy(
     )
     print(response.json()["recruitment_msg"])
 
+    dashboard_user = cfg["ADMIN_USER"]
+    dashboard_password = cfg["dashboard_password"]
+    dashboard_link = f"https://{dashboard_user}:{dashboard_password}@{experiment_id}.{dns_host}/dashboard"
+
     deployment_infos = [
         f"Deployed Docker image name: {image}",
         "To display the logs for this experiment you can run:",
         f"ssh {ssh_user}@{ssh_host} docker-compose -f '~/dallinger/{experiment_id}/docker-compose.yml' logs -f",
-        f"You can now log in to the console at https://{experiment_id}.{dns_host}/dashboard as user {cfg['ADMIN_USER']} using password {cfg['dashboard_password']}",
+        f"You can now log in to the console at {dashboard_link} (user = {dashboard_user}, password = {dashboard_password})",
     ]
     for line in deployment_infos:
         print(line)

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -166,6 +166,11 @@ def copy_docker_config(host, user):
                     "mv ~/.docker/config.json  ~/.docker/config.json.$(date +%d-%m-%Y-%H:%M.bak)"
                 ).split()
         sftp = get_sftp(host, user=user)
+        try:
+            # Create the .docker directory if it doesn't exist
+            sftp.mkdir(".docker")
+        except IOError:
+            pass
         sftp.putfo(BytesIO(local_file_contents), ".docker/config.json")
 
 

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -11,6 +11,7 @@ from email.utils import parseaddr
 from functools import wraps
 from getpass import getuser
 from io import BytesIO
+from pathlib import Path
 from secrets import token_urlsafe
 from shlex import quote
 from socket import gethostbyname_ex
@@ -444,7 +445,10 @@ def deploy(
     ]
     for line in deployment_infos:
         print(line)
-    with open(f"deployment-info_{experiment_id}.txt", "w") as f:
+
+    deploy_log_path = Path("deploy_logs") / f"{experiment_id}.txt"
+    deploy_log_path.parent.mkdir(exist_ok=True)
+    with open(deploy_log_path, "w") as f:
         for line in deployment_infos:
             f.write(f"{line}\n")
 

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -647,7 +647,6 @@ class Executor:
             channel.exec_command(
                 f'docker-compose -f "$HOME/dallinger/{self.app}/docker-compose.yml" logs'
             )
-            # channel.exec_command(f'cd "$HOME/dallinger/{self.app}" && docker-compose logs')
             status = channel.recv_exit_status()
             if status != 0:
                 print("docker-compose logs failed to run.")

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -104,7 +104,7 @@ default_keys = (
     ("worker_multiplier", float, []),
     ("docker_image_base_name", six.text_type, [], ""),
     ("docker_image_name", six.text_type, [], ""),
-    ("docker_ssh_volumes", six.text_type, [], ""),
+    ("docker_volumes", six.text_type, [], ""),
 )
 
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -297,7 +297,7 @@ class Configuration(object):
         if self.get("docker_image_base_name", None) is None:
             raise ValueError(
                 "docker_image_base_name must be specified in config.txt before you can "
-                "launch an experiment using Docker. For example, you might write the following: \n\n"
+                "launch an experiment using Docker. For example, you might write the following: \n"
                 "docker_image_base_name = registry.gitlab.developers.cam.ac.uk/mus/cms/psynet-experiment-images"
             )
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -295,7 +295,11 @@ class Configuration(object):
         self.ready = True
 
         if self.get("docker_image_base_name", None) is None:
-            self.set("docker_image_base_name", Path(os.getcwd()).name)
+            raise ValueError(
+                "docker_image_base_name must be specified in config.txt before you can "
+                "launch an experiment using Docker. For example, you might write the following: \n\n"
+                "docker_image_base_name = registry.gitlab.developers.cam.ac.uk/mus/cms/psynet-experiment-images"
+            )
 
     def register_extra_parameters(self):
         initialize_experiment_package(os.getcwd())

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -289,7 +289,7 @@ class Configuration(object):
             self.load_from_file(config_file)
 
     def experiment_available(self):
-        return "dallinger_experiment" in sys.modules or Path("experiment.py").exists()
+        return Path("experiment.py").exists()
 
     def load(self):
         self.load_defaults()

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -194,7 +194,10 @@ class Configuration(object):
             except KeyError:
                 continue
         if default is marker:
-            raise KeyError(key)
+            raise KeyError(
+                f"The following config parameter was not set: {key}. Consider setting it in "
+                "config.txt or in ~/.dallingerconfig."
+            )
         return default
 
     def __getitem__(self, key):
@@ -270,7 +273,8 @@ class Configuration(object):
     def load_defaults(self):
         """Load default configuration values"""
         # Apply extra parameters before loading the configs
-        self.register_extra_parameters()
+        if self.experiment_available():
+            self.register_extra_parameters()
 
         global_config_name = ".dallingerconfig"
         global_config = os.path.expanduser(os.path.join("~/", global_config_name))
@@ -283,6 +287,9 @@ class Configuration(object):
         # Load the configuration, with local parameters overriding global ones.
         for config_file in [global_defaults_file, local_defaults_file, global_config]:
             self.load_from_file(config_file)
+
+    def experiment_available(self):
+        return "dallinger_experiment" in sys.modules or Path("experiment.py").exists()
 
     def load(self):
         self.load_defaults()

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -294,13 +294,6 @@ class Configuration(object):
         self.load_from_environment()
         self.ready = True
 
-        if self.get("docker_image_base_name", None) is None:
-            raise ValueError(
-                "docker_image_base_name must be specified in config.txt or ~/.dallingerconfig before you can "
-                "launch an experiment using Docker. For example, you might write the following: \n"
-                "docker_image_base_name = registry.gitlab.developers.cam.ac.uk/mus/cms/psynet-experiment-images"
-            )
-
     def register_extra_parameters(self):
         initialize_experiment_package(os.getcwd())
         extra_parameters = None

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -296,7 +296,7 @@ class Configuration(object):
 
         if self.get("docker_image_base_name", None) is None:
             raise ValueError(
-                "docker_image_base_name must be specified in config.txt before you can "
+                "docker_image_base_name must be specified in config.txt or ~/.dallingerconfig before you can "
                 "launch an experiment using Docker. For example, you might write the following: \n"
                 "docker_image_base_name = registry.gitlab.developers.cam.ac.uk/mus/cms/psynet-experiment-images"
             )

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -33,7 +33,6 @@ chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 [Heroku]
 clock_on = False
-heroku_python_version = 3.10
 sentry = False
 redis_size = premium-0
 worker_multiplier = 1.5

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -33,7 +33,7 @@ chrome-path = /Applications/Google Chrome.app/Contents/MacOS/Google Chrome
 
 [Heroku]
 clock_on = False
-heroku_python_version = 3.10.2
+heroku_python_version = 3.10
 sentry = False
 redis_size = premium-0
 worker_multiplier = 1.5

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -440,7 +440,9 @@ class DebugDeployment(HerokuLocalDeployment):
 
     def display_dashboard_access_details(self, url):
         config = get_config()
-        self.out.log("Experiment dashboard: {}".format(url))
+        self.out.log(
+            "Experiment dashboard: {} (open this in Google Chrome)".format(url)
+        )
         self.out.log(
             "Dashboard user: {} password: {}".format(
                 config.get("dashboard_user"),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -442,9 +442,7 @@ class DebugDeployment(HerokuLocalDeployment):
 
     def display_dashboard_access_details(self, url):
         config = get_config()
-        self.out.log(
-            "Experiment dashboard: {} (open this in Google Chrome)".format(url)
-        )
+        self.out.log("Experiment dashboard: {}".format(url))
         self.out.log(
             "Dashboard user: {} password: {}".format(
                 config.get("dashboard_user"),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -224,6 +224,8 @@ def deploy_sandbox_shared_setup(
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,
         "dashboard_url": "{}/dashboard/".format(heroku_app.url),
+        "dashboard_user": config.get("dashboard_user"),
+        "dashboard_password": config.get("dashboard_password"),
         "recruitment_msg": launch_data.get("recruitment_msg", None),
     }
 

--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -45,6 +45,11 @@ services:
 {%- for volumestr in volumes %}
       - "{{ volumestr }}"
 {%- endfor %}
+{%- if config.get("docker_volumes", "") %}
+{%- for volume in config.get("docker_volumes", "").split(",") %}
+      - {{ volume | string() | tojson }}
+{%- endfor %}
+{%- endif %}
     environment: &commonenv
 {%- if needs_chrome %}
       HOST: web # Tell the worker where we expect the web service to be
@@ -70,6 +75,11 @@ services:
 {%- for volumestr in volumes %}
       - "{{ volumestr }}"
 {%- endfor %}
+{%- if config.get("docker_volumes", "") %}
+{%- for volume in config.get("docker_volumes", "").split(",") %}
+      - {{ volume | string() | tojson }}
+{%- endfor %}
+{%- endif %}
     environment:
       <<: *commonenv
       PORT: 5000

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - /var/lib/dallinger/{{ experiment_id }}:/var/lib/dallinger
+      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_ssh_volumes", "") %}
     {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - "${HOME}/dallinger_file_systems/{{ experiment_id }}":/var/lib/dallinger
+      - ${HOME}/dallinger_file_systems/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_volumes", "") %}
     {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_volumes", "") %}
     {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -29,7 +29,7 @@ services:
     networks:
       - dallinger
     volumes:
-      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_volumes", "") %}
     {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -50,7 +50,7 @@ services:
         aliases:
           - {{ experiment_id }}_web
     volumes:
-      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if config.get("docker_volumes", "") %}
     {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
@@ -72,7 +72,7 @@ services:
         aliases:
           - {{ experiment_id }}_clock
     volumes:
-      - ${HOME}/dallinger-experiment-data/{{ experiment_id }}:/var/lib/dallinger
+      - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
 
 volumes:

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -30,8 +30,8 @@ services:
       - dallinger
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
-    {%- if config.get("docker_ssh_volumes", "") %}
-    {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
+    {%- if config.get("docker_volumes", "") %}
+    {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
     {%- endfor %}
     {%- endif %}
@@ -51,8 +51,8 @@ services:
           - {{ experiment_id }}_web
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
-    {%- if config.get("docker_ssh_volumes", "") %}
-    {%- for volume in config.get("docker_ssh_volumes", "").split(",") %}
+    {%- if config.get("docker_volumes", "") %}
+    {%- for volume in config.get("docker_volumes", "").split(",") %}
       - {{ volume | string() | tojson }}
     {%- endfor %}
     {%- endif %}

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -213,6 +213,13 @@ class Experiment(object):
         """
         return []
 
+    def on_launch(self):
+        """This function is called upon experiment launch. Unlike
+        the background tasks, this function is blocking: recruitment
+        won't start until the function has returned.
+        """
+        pass
+
     @cached_property
     def recruiter(self):
         """Reference to a Recruiter, the Dallinger class that recruits

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -392,6 +392,16 @@ def launch():
         )
 
     try:
+        exp.on_launch()
+    except Exception as e:
+        return error_response(
+            error_text="An error occurred when calling on_launch(), check experiment server log "
+            "for details: {}".format(str(e)),
+            status=500,
+            simple=True,
+        )
+
+    try:
         recruitment_details = exp.recruiter.open_recruitment(
             n=exp.initial_recruitment_size
         )

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -24,7 +24,6 @@
             <script src="{{ url_for('static', filename='scripts/store+json2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/fingerprintjs2/1.5.1/fingerprint2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/dallinger2.js') }}" type="text/javascript"> </script>
-            <script src="{{ url_for('static', filename='scripts/survey-jquery/survey-jquery.js') }}" type="text/javascript"> </script>
         {% endblock %}
         {% block scripts %}
             <script type="text/javascript">

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -24,6 +24,7 @@
             <script src="{{ url_for('static', filename='scripts/store+json2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/fingerprintjs2/1.5.1/fingerprint2.min.js') }}" type="text/javascript"></script>
             <script src="{{ url_for('static', filename='scripts/dallinger2.js') }}" type="text/javascript"> </script>
+            <script src="{{ url_for('static', filename='scripts/survey-jquery/survey-jquery.js') }}" type="text/javascript"> </script>
         {% endblock %}
         {% block scripts %}
             <script type="text/javascript">

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -645,9 +645,10 @@ def assemble_experiment_temp_dir(log, config, for_remote=False):
         file.write(exp_id)
 
     # Write out a runtime.txt file based on configuration
-    pyversion = config.get("heroku_python_version")
-    with open(os.path.join(dst, "runtime.txt"), "w") as file:
-        file.write("python-{}".format(pyversion))
+    pyversion = config.get("heroku_python_version", None)
+    if pyversion:
+        with open(os.path.join(dst, "runtime.txt"), "w") as file:
+            file.write("python-{}".format(pyversion))
 
     requirements_path = Path(dst) / "requirements.txt"
     # Overwrite the requirements.txt file with the contents of the constraints.txt file

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -458,7 +458,7 @@ Docker Deployment Configuration
 
     Example: ``ghcr.io/dallinger/dallinger/bartlett1932@sha256:ad3c7b376e23798438c18aae6e0136eb97f5627ddde6baafe1958d40274fa478``
 
-``docker_ssh_volumes``
-    Additional list of volumes to mount when deploying using docker-ssh.
+``docker_volumes``
+    Additional list of volumes to mount when deploying using docker.
 
     Example: ``/host/path:/container_path,/another-path:/another-container-path``

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``/var/lib/dallinger/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger_file_systems/${experiment_id}``.
 
 
 Support for python dependencies in private repositories

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``~/dallinger-data/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger-experiment-data/${experiment_id}``.
 
 
 Support for python dependencies in private repositories

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``~/dallinger_file_systems/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger-data/${experiment_id}``.
 
 
 Support for python dependencies in private repositories

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -236,7 +236,7 @@ To stop an experiment and remove its containers from the server, run:
 .. note::
 
       When deploying to a server using docker, the experiment can save files to the directory ``/var/lib/dallinger``.
-      This directory will be visible on the server as ``~/dallinger-experiment-data/${experiment_id}``.
+      This directory will be visible on the server as ``~/dallinger-data/${experiment_id}``.
 
 
 Support for python dependencies in private repositories

--- a/tests/experiment/experiment.py
+++ b/tests/experiment/experiment.py
@@ -1,5 +1,0 @@
-from dallinger.experiment import Experiment
-
-
-class Exp(Experiment):
-    pass

--- a/tests/experiment/experiment.py
+++ b/tests/experiment/experiment.py
@@ -1,0 +1,5 @@
+from dallinger.experiment import Experiment
+
+
+class Exp(Experiment):
+    pass

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -202,11 +202,6 @@ worldwide = false
         config.ready = True
         assert config.get("num_participants") == 1
 
-    def test_docker_image_default(self, experiment_dir):
-        config = get_config()
-        config.load()
-        assert config.get("docker_image_base_name") == "experiment"
-
 
 @pytest.mark.usefixtures("experiment_dir_merged")
 class TestConfigurationIntegrationTests(object):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
 import os
-import sys
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -224,17 +223,6 @@ class TestConfigurationIntegrationTests(object):
         config._reset(register_defaults=True)
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
-
-    def test_custom_experiment_module_set_and_retained(
-        self, reset_config, experiment_dir
-    ):
-        config = get_config()
-        config.register_extra_parameters()
-        assert sys.modules["dallinger_experiment"] is not None
-        exp_module = sys.modules["dallinger_experiment"]
-        config.clear()
-        config.register_extra_parameters()
-        assert sys.modules["dallinger_experiment"] is exp_module
 
     def test_write_omits_sensitive_keys_if_filter_sensitive(self, in_tempdir):
         config = get_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 import os
+import sys
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -223,6 +224,17 @@ class TestConfigurationIntegrationTests(object):
         config._reset(register_defaults=True)
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
+
+    def test_custom_experiment_module_set_and_retained(
+        self, reset_config, experiment_dir
+    ):
+        config = get_config()
+        config.register_extra_parameters()
+        assert sys.modules["dallinger_experiment"] is not None
+        exp_module = sys.modules["dallinger_experiment"]
+        config.clear()
+        config.register_extra_parameters()
+        assert sys.modules["dallinger_experiment"] is exp_module
 
     def test_write_omits_sensitive_keys_if_filter_sensitive(self, in_tempdir):
         config = get_config()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,8 +1,6 @@
 from __future__ import unicode_literals
 
-import mock
 import os
-import sys
 from tempfile import NamedTemporaryFile
 
 import pytest
@@ -225,16 +223,6 @@ class TestConfigurationIntegrationTests(object):
         config._reset(register_defaults=True)
         config.register_extra_parameters()
         config.load_from_file(LOCAL_CONFIG)
-
-    def test_custom_experiment_module_set_and_retained(self, reset_config):
-        config = get_config()
-        config.register_extra_parameters()
-        assert sys.modules["dallinger_experiment"] is not None
-        exp_module = mock.Mock()
-        with mock.patch.dict("sys.modules", dallinger_experiment=exp_module):
-            config.clear()
-            config.register_extra_parameters()
-            assert sys.modules["dallinger_experiment"] is exp_module
 
     def test_write_omits_sensitive_keys_if_filter_sensitive(self, in_tempdir):
         config = get_config()

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -623,7 +623,9 @@ class TestDeploySandboxSharedSetupNoExternalCalls(object):
         assert result == {
             "app_home": "fake-web-url",
             "app_name": "dlgr-fake-uid",
+            "dashboard_password": "DUMBPASSWORD",
             "dashboard_url": "fake-web-url/dashboard/",
+            "dashboard_user": "admin",
             "recruitment_msg": "fake\nrecruitment\nlist",
         }
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import yaml
 
 
@@ -36,6 +37,30 @@ def test_get_docker_compose_yml_env_vars_escaping():
     assert (
         result["services"]["worker"]["environment"]["foo"]
         == r'" a quote and a \ backslash '
+    )
+
+
+def test_add_image_name(tempdir):
+    from dallinger.command_line.docker import add_image_name
+
+    file = Path(tempdir) / "test.txt"
+
+    file.write_text("")
+    add_image_name(str(file), "foobar")
+    assert "docker_image_name = foobar" in file.read_text()
+
+    file.write_text("\ndocker_image_name = old_image_name\n")
+    add_image_name(str(file), "new_image_name")
+    assert "old_image_name" not in file.read_text()
+    assert "docker_image_name = new_image_name" in file.read_text()
+
+    file.write_text(
+        "foo = bar\ndocker_image_base_name = the_base_image_name\nbar = foo"
+    )
+    add_image_name(str(file), "foobar_image")
+    assert (
+        file.read_text()
+        == "foo = bar\ndocker_image_base_name = the_base_image_name\ndocker_image_name = foobar_image\nbar = foo"
     )
 
 

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 import yaml
 
 
@@ -37,30 +36,6 @@ def test_get_docker_compose_yml_env_vars_escaping():
     assert (
         result["services"]["worker"]["environment"]["foo"]
         == r'" a quote and a \ backslash '
-    )
-
-
-def test_add_image_name(tempdir):
-    from dallinger.command_line.docker import add_image_name
-
-    file = Path(tempdir) / "test.txt"
-
-    file.write_text("")
-    add_image_name(str(file), "foobar")
-    assert "docker_image_name = foobar" in file.read_text()
-
-    file.write_text("\ndocker_image_name = old_image_name\n")
-    add_image_name(str(file), "new_image_name")
-    assert "old_image_name" not in file.read_text()
-    assert "docker_image_name = new_image_name" in file.read_text()
-
-    file.write_text(
-        "foo = bar\ndocker_image_base_name = the_base_image_name\nbar = foo"
-    )
-    add_image_name(str(file), "foobar_image")
-    assert (
-        file.read_text()
-        == "foo = bar\ndocker_image_base_name = the_base_image_name\ndocker_image_name = foobar_image\nbar = foo"
     )
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,6 @@
 envlist =
      style,tests
 
-[testenv]
-allowlist_externals = find
-
 [testenv:tests]
 extras =
     data

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,9 @@
 envlist =
      style,tests
 
+[testenv]
+allowlist_externals = find
+
 [testenv:tests]
 extras =
     data

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
     PROLIFIC_RESEARCHER_API_TOKEN
     mturk_worker_id
     threads
-whitelist_externals =
+allowlist_externals =
     find
 
 [testenv:fast]
@@ -102,7 +102,7 @@ deps =
     flake8
 
 [testenv:docs]
-whitelist_externals =
+allowlist_externals =
     make
     yarn
 commands =


### PR DESCRIPTION
I have put a load of inline comments to help explain the various changes. Here is a summary of what has been done:

# Major

- Disabled the behavior where the built image name is written to config.txt. This behavior was inconsistent with the other Dallinger deployment patterns, because it meant that if you deployed once, changed code in experiment.py, then redeployed, then the experiment would launch in the former version unless you remembered to delete the image name from config.txt.
- Heroku deployments were failing because the default `heroku_python_version` had been discontinued by Heroku. We have experienced similar problems in the past and have always had to update Dallinger. Now we have changed the behaviour such that, if `heroku_python_version` is not specified in the experiment config, then it will use the default Python runtime currently in use by Heroku.

# Minor

- Propagate more information from deployment-related functions (e.g. dashboard credentials) so that they can be used by wrapper functions.
- Print more information (e.g. dashboard credentials) in deployment-related functions.
- Better debugging logs for docker-ssh deployments.
- Move deployment info logs from `deployment-info_{experiment_id}.txt` to `deploy_logs/*` to avoid clutter.
- Move default `dallinger_develop_directory` to `/tmp/dallinger_develop` because the original location was not writable by default on Docker.
- Minor bugfixes in docker-ssh deployment/export.
- Rename config variable `docker_ssh_volumes` -> `docker_volumes` because it's relevant also when we're doing docker locally. 
- Some minor renaming of internal variables for consistency.