### PR TITLE
Migrate to new Heroku Postgres/Redis plans

### DIFF
--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -231,7 +231,7 @@ def deploy_image(image, mode, config_options):
 
     print(f"Heroku app {app.name} created. Installing add-ons")
 
-    app.install_addon(f"heroku-postgresql:{config.get('database_size', 'hobby-dev')}")
+    app.install_addon(f"heroku-postgresql:{config.get('database_size', 'standard-0')}")
     # redistogo is significantly faster to start than heroku-redis
     app.install_addon("redistogo:nano")
     app.install_addon("papertrail")

--- a/demos/dlgr/demos/bartlett1932/config.txt
+++ b/demos/dlgr/demos/bartlett1932/config.txt
@@ -20,13 +20,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/chatroom/config.txt
+++ b/demos/dlgr/demos/chatroom/config.txt
@@ -21,12 +21,12 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false

--- a/demos/dlgr/demos/concentration/config.txt
+++ b/demos/dlgr/demos/concentration/config.txt
@@ -19,13 +19,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/function_learning/config.txt
+++ b/demos/dlgr/demos/function_learning/config.txt
@@ -18,12 +18,12 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false

--- a/demos/dlgr/demos/iterated_drawing/config.txt
+++ b/demos/dlgr/demos/iterated_drawing/config.txt
@@ -18,13 +18,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/mcmcp/config.txt
+++ b/demos/dlgr/demos/mcmcp/config.txt
@@ -18,12 +18,12 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = true

--- a/demos/dlgr/demos/rogers/config.txt
+++ b/demos/dlgr/demos/rogers/config.txt
@@ -28,12 +28,12 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false

--- a/demos/dlgr/demos/sheep_market/config.txt
+++ b/demos/dlgr/demos/sheep_market/config.txt
@@ -18,13 +18,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/snake/config.txt
+++ b/demos/dlgr/demos/snake/config.txt
@@ -19,13 +19,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/twentyfortyeight/config.txt
+++ b/demos/dlgr/demos/twentyfortyeight/config.txt
@@ -19,13 +19,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/demos/dlgr/demos/vox_populi/config.txt
+++ b/demos/dlgr/demos/vox_populi/config.txt
@@ -18,13 +18,13 @@ browser_exclude_rule = MSIE, mobile, tablet
 
 [Database]
 database_url = postgresql://postgres@localhost/dallinger
-database_size = hobby-dev
+database_size = standard-0
 
 [Server]
 dyno_type = hobby
 num_dynos_web = 1
 num_dynos_worker = 1
-redis_size = hobby-dev
+redis_size = premium-0
 host = 0.0.0.0
 clock_on = false
 logfile = -

--- a/docs/source/demos_on_heroku.rst
+++ b/docs/source/demos_on_heroku.rst
@@ -10,8 +10,8 @@ More information on account verification can be found `here <https://devcenter.h
 If you wish to only make use of Heroku's free tier offerings, set the following in the demo's config.txt file:
 ::
 
-    database_size = hobby-dev
-    redis_size = hobby-dev
+    database_size = standard-0
+    redis_size = premium-0
 
 
 You can read more about Heroku's `Postgres Plans <https://devcenter.heroku.com/articles/heroku-postgres-plans/>`__ and

--- a/tox.ini
+++ b/tox.ini
@@ -31,7 +31,7 @@ passenv =
     PROLIFIC_RESEARCHER_API_TOKEN
     mturk_worker_id
     threads
-whitelist_externals =
+allowlist_externals =
     find
 
 [testenv:fast]
@@ -102,7 +102,7 @@ deps =
     flake8
 
 [testenv:docs]
-whitelist_externals =
+allowlist_externals =
     make
     yarn
 commands =


### PR DESCRIPTION
Replace all occurrences of `hobby-dev` with `standard-0` for Postgres and with `premium-0` for Redis.
For reference see

https://devcenter.heroku.com/articles/heroku-postgres-plans
https://elements.heroku.com/addons/heroku-redis

See also issue #4632 