### PR TITLE
Eliminate unnecessary 'is not a valid configuration key' errors

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -144,7 +144,6 @@ class Configuration(object):
                 # This key hasn't been registered, we ignore it
                 if strict:
                     raise KeyError("{} is not a valid configuration key".format(key))
-                logger.debug("{} is not a valid configuration key".format(key))
                 continue
             expected_type = self.types.get(key)
             if cast_types:


### PR DESCRIPTION
Originally when calling `Config.load_from_environment` an error message would be logged for each environment variable that does not correspond to a Dallinger configuration key:

```
raise KeyError("{} is not a valid configuration key".format(key))
```

This is clearly undesirable behavior because environmental variables will often include keys that don't correspond to Dallinger configuration keys. I have fixed this behavior by modifying the code such that `Config.extend` only throws this error if `strict=True`.