### PR TITLE
WIP: Expose MAX_LAUNCH_ATTEMPTS as environment variable

### DIFF
--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -1,3 +1,5 @@
+import os
+
 import click
 import logging
 import subprocess
@@ -92,7 +94,8 @@ def launch_app_and_open_dashboard(port):
 
 def _launch_app(port):
     url = BASE_URL.format(port) + "launch"
-    _handle_launch_data(url, error=log, delay=1.0)
+    max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 6))
+    _handle_launch_data(url, error=log, delay=1.0, attempts=max_launch_attempts)
 
 
 def _open_dashboard(port):

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -285,7 +285,10 @@ def deploy_image(image_name, mode, config_options):
 
     print("Launching experiment")
     app_url = f"https://{app_hostname}"
-    launch_data = _handle_launch_data(f"{app_url}/launch", print)
+    max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 30))
+    launch_data = _handle_launch_data(
+        f"{app_url}/launch", print, attempts=max_launch_attempts
+    )
     print(launch_data.get("recruitment_msg"))
 
     print(
@@ -420,7 +423,10 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
     log("Calling {}".format(launch_url), chevrons=False)
-    launch_data = _handle_launch_data(launch_url, error=log)
+    max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 6))
+    launch_data = _handle_launch_data(
+        launch_url, error=log, attempts=max_launch_attempts
+    )
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -428,7 +428,8 @@ def deploy(
     executor.reload_caddy()
 
     print("Launching experiment")
-    response = get_retrying_http_client().post(
+    max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 30))
+    response = get_retrying_http_client(max_launch_attempts).post(
         f"https://{experiment_id}.{dns_host}/launch", verify=HAS_TLS
     )
     print(response.json()["recruitment_msg"])
@@ -589,9 +590,9 @@ def get_docker_compose_yml(
     )
 
 
-def get_retrying_http_client():
+def get_retrying_http_client(max_attempts=30):
     retry_strategy = Retry(
-        total=30,
+        total=max_attempts,
         backoff_factor=0.2,
         status_forcelist=[429, 500, 502, 503, 504],
         method_whitelist=["POST"],

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -219,7 +219,10 @@ def deploy_sandbox_shared_setup(
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
     log("Calling {}".format(launch_url), chevrons=False)
-    launch_data = _handle_launch_data(launch_url, error=log)
+    max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 6))
+    launch_data = _handle_launch_data(
+        launch_url, error=log, attempts=max_launch_attempts
+    )
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,
@@ -550,7 +553,12 @@ class LoaderDeployment(HerokuLocalDeployment):
         if self.exp_config.get("replay"):
             self.out.log("Launching the experiment...")
             time.sleep(4)
-            _handle_launch_data("{}/launch".format(base_url), error=self.out.error)
+            max_launch_attempts = int(os.getenv("MAX_LAUNCH_ATTEMPTS", 6))
+            _handle_launch_data(
+                "{}/launch".format(base_url),
+                error=self.out.error,
+                attempts=max_launch_attempts,
+            )
             heroku.monitor(listener=self.notify)
 
         # Just run until interrupted:


### PR DESCRIPTION
By default when calling the `/launch` route to launch an experiment Dallinger will retry up to a hard-coded number of times (either 6 or 30, depending on the deployment method. I've now exposed this parameter as an environment variable called MAX_LAUNCH_ATTEMPTS. I'm not sure whether this is useful yet though...