### PR TITLE
Prolific improvements

### DIFF
--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -108,10 +108,13 @@ class ProlificService:
         del args["self"]
         del args["mode"]
         draft = self.draft_study(**args)
-        if mode == "sandbox":
-            return draft
+        study_id = draft["id"]
+        if mode == "live":
+            logger.info(f"Publishing experiment {study_id} on Prolific...")
+            return self.publish_study(study_id)
         else:
-            return self.publish_study(draft["id"])
+            logger.info(f"Sandboxing experiment {study_id} in Prolific (saved as draft, not public)...")
+            return draft
 
     def draft_study(
         self,

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -106,6 +106,7 @@ class ProlificService:
         """
         args = locals()
         del args["self"]
+        del args["mode"]
         draft = self.draft_study(**args)
         if mode == "sandbox":
             return draft

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -95,6 +95,7 @@ class ProlificService:
         prolific_id_option: str,
         reward: int,
         total_available_places: int,
+        mode: str,
         device_compatibility: Optional[List[str]] = None,
         peripheral_requirements: Optional[List[str]] = None,
     ) -> dict:
@@ -106,7 +107,10 @@ class ProlificService:
         args = locals()
         del args["self"]
         draft = self.draft_study(**args)
-        return self.publish_study(draft["id"])
+        if mode == "sandbox":
+            return draft
+        else:
+            return self.publish_study(draft["id"])
 
     def draft_study(
         self,

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -133,19 +133,19 @@ class ProlificService:
         """Create a draft Study on Prolific, and return its properties."""
 
         payload = {
+            "name": name,
+            "internal_name": internal_name,
+            "description": description,
+            "external_study_url": external_study_url,
+            "prolific_id_option": prolific_id_option,
             "completion_code": completion_code,
             "completion_option": completion_option,
-            "description": description,
-            "eligibility_requirements": eligibility_requirements,
-            "estimated_completion_time": estimated_completion_time,
-            "external_study_url": external_study_url,
-            "internal_name": internal_name,
-            "maximum_allowed_time": maximum_allowed_time,
-            "name": name,
-            "prolific_id_option": prolific_id_option,
-            "reward": reward,
-            "status": "UNPUBLISHED",
             "total_available_places": total_available_places,
+            "estimated_completion_time": estimated_completion_time,
+            "maximum_allowed_time": maximum_allowed_time,
+            "reward": reward,
+            "eligibility_requirements": eligibility_requirements,
+            "status": "UNPUBLISHED",
         }
 
         if device_compatibility is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -271,6 +271,7 @@ class ProlificRecruiter(Recruiter):
             "prolific_id_option": "url_parameters",
             "reward": self.config.get("prolific_reward_cents"),
             "total_available_places": n,
+            "mode": self.config.get("mode")
         }
         # Merge in any explicit configuration untouched:
         if self.config.get("prolific_recruitment_config", None) is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -265,9 +265,7 @@ class ProlificRecruiter(Recruiter):
                 "prolific_maximum_allowed_minutes",
                 3 * self.config.get("prolific_estimated_completion_minutes") + 2,
             ),
-            "name": "{} ({})".format(
-                self.config.get("title"), heroku_tools.app_name(self.config.get("id"))
-            ),
+            "name": self.config.get("title"),
             "prolific_id_option": "url_parameters",
             "reward": self.config.get("prolific_reward_cents"),
             "total_available_places": n,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -269,6 +269,15 @@ Prolific Recruitment
             ]
         }
 
+
+    You can also specify the devices you expect the participants to have, e.g.::
+        {
+            "eligibility_requirements": […],
+            "device_compatibility": ["desktop"],
+            "peripheral_requirements": ["audio", "microphone"]
+        }
+    Supported devices are ``desktop``, ``tablet``, and ``mobile``. Supported peripherals are ``audio``, ``camera``, ``download`` (download additional software to run the experiment), and ``microphone``.
+
     You would then include this file in your overall configuration by adding the following
     to your config.txt file::
 


### PR DESCRIPTION
This issue proposes some improvements on deploying and sandboxing experiments to Prolific.

## Fixes
- Currently, when `mode` is set to `"sandbox"` in config.txt, it publishes the survey on Prolific. I added a fix which does not publish the survey when sandboxing.

## Improvements
- Extend the Prolific documentation showing how to select specific devices (e.g., desktop only) or additional hardware (e.g., microphone).
- Only use the app hash in the internal title and not in the public title as this is not informative to participants.
- Explicitly log whether the experiment is sandboxed or deployed to Prolific.