### PR TITLE
Refactoring of `advertisement()`

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -10,7 +10,6 @@ import re
 from flask import (
     abort,
     Flask,
-    redirect,
     render_template,
     request,
     Response,
@@ -33,7 +32,6 @@ from dallinger.config import get_config
 from dallinger import recruiters
 from dallinger.notifications import admin_notifier
 from dallinger.notifications import MessengerError
-from dallinger.utils import generate_random_id
 
 from . import dashboard
 from .replay import ReplayBackend
@@ -41,11 +39,11 @@ from .worker_events import worker_function
 from .utils import (
     crossdomain,
     nocache,
-    ValidatesBrowser,
     error_page,
     error_response,
     success_response,
     ExperimentError,
+    prepare_advertisement
 )
 
 
@@ -482,65 +480,17 @@ def advertisement():
         The user will be redirected to this view with random recruiter
         arguments set.
     """
-    config = _config()
 
-    # Browser rule validation, if configured:
-    browser = ValidatesBrowser(config)
-    if not browser.is_supported(request.user_agent.string):
-        raise ExperimentError("browser_type_not_allowed")
-
-    entry_information = request.args.to_dict()
-
-    if entry_information.get("generate_tokens", None) in ("1", "true", "yes"):
-        redirect_params = entry_information.copy()
-        del redirect_params["generate_tokens"]
-        for entry_param in ("hitId", "assignmentId", "workerId"):
-            if not redirect_params.get(entry_param):
-                redirect_params[entry_param] = generate_random_id()
-        return redirect(url_for("advertisement", **redirect_params))
-
-    app_id = config.get("id", "unknown")
-    exp = Experiment(session)
-    entry_data = exp.normalize_entry_information(entry_information)
-
-    hit_id = entry_data.get("hit_id")
-    assignment_id = entry_data.get("assignment_id")
-    worker_id = entry_data.get("worker_id")
-
-    if not (hit_id and assignment_id):
-        raise ExperimentError("hit_assign_worker_id_not_set_by_recruiter")
-
-    if worker_id is not None:
-        # Check if this workerId has completed the task before
-        already_participated = (
-            models.Participant.query.filter(
-                models.Participant.worker_id == worker_id
-            ).first()
-            is not None
-        )
-
-        if already_participated:
-            raise ExperimentError("already_did_exp_hit")
-
-    recruiter_name = request.args.get("recruiter")
-    if recruiter_name:
-        recruiter = recruiters.by_name(recruiter_name)
+    is_redirect, kw = prepare_advertisement()
+    if is_redirect:
+        return kw["redirect"]
     else:
-        recruiter = recruiters.from_config(config)
-        recruiter_name = recruiter.nickname
-
-    # Participant has not yet agreed to the consent. They might not
-    # even have accepted the HIT.
-    return render_template(
-        "ad.html",
-        recruiter=recruiter_name,
-        hitid=hit_id,
-        assignmentid=assignment_id,
-        workerid=worker_id,
-        mode=config.get("mode"),
-        app_id=app_id,
-        query_string=request.query_string.decode(),
-    )
+        # Participant has not yet agreed to the consent. They might not
+        # even have accepted the HIT.
+        return render_template(
+            "ad.html",
+            **kw
+        )
 
 
 @app.route("/recruiter-exit", methods=["GET"])

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -10,7 +10,6 @@ from flask import render_template
 from flask import Response
 from functools import update_wrapper
 from json import dumps
-
 from dallinger.config import get_config
 
 logger = logging.getLogger(__name__)
@@ -79,8 +78,6 @@ def nocache(func):
         return resp
 
     return update_wrapper(new_func, func)
-
-
 
 
 class ExperimentError(Exception):

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -8,10 +8,16 @@ from flask import request
 from flask import current_app
 from flask import render_template
 from flask import Response
+from flask import redirect
+from flask import url_for
 from functools import update_wrapper
 from json import dumps
-from dallinger.config import get_config
 
+from dallinger import db
+from dallinger.config import get_config
+from dallinger.utils import generate_random_id
+from dallinger import models
+from dallinger import recruiters
 
 logger = logging.getLogger(__name__)
 
@@ -79,6 +85,67 @@ def nocache(func):
         return resp
 
     return update_wrapper(new_func, func)
+
+
+def prepare_advertisement():
+    from dallinger.experiment_server.experiment_server import Experiment
+    session = db.session
+    config = _config()
+    mode = config.get("mode")
+
+    # Browser rule validation, if configured:
+    browser = ValidatesBrowser(config)
+    if not browser.is_supported(request.user_agent.string):
+        raise ExperimentError("browser_type_not_allowed")
+
+    entry_information = request.args.to_dict()
+
+    if entry_information.get("generate_tokens", None) in ("1", "true", "yes"):
+        redirect_params = entry_information.copy()
+        del redirect_params["generate_tokens"]
+        for entry_param in ("hitId", "assignmentId", "workerId"):
+            if not redirect_params.get(entry_param):
+                redirect_params[entry_param] = generate_random_id()
+        return True, {'redirect': redirect(url_for("advertisement", **redirect_params))}
+
+    app_id = config.get("id", "unknown")
+    exp = Experiment(session)
+    entry_data = exp.normalize_entry_information(entry_information)
+
+    hit_id = entry_data.get("hit_id")
+    assignment_id = entry_data.get("assignment_id")
+    worker_id = entry_data.get("worker_id")
+
+    if not (hit_id and assignment_id):
+        raise ExperimentError("hit_assign_worker_id_not_set_by_recruiter")
+
+    if worker_id is not None:
+        # Check if this workerId has completed the task before
+        already_participated = (
+                models.Participant.query.filter(
+                    models.Participant.worker_id == worker_id
+                ).first()
+                is not None
+        )
+
+        if already_participated:
+            raise ExperimentError("already_did_exp_hit")
+
+    recruiter_name = request.args.get("recruiter")
+    if not recruiter_name:
+        recruiter = recruiters.from_config(config)
+        recruiter_name = recruiter.nickname
+
+    kwargs = {
+        'recruiter': recruiter_name,
+        'hitid': hit_id,
+        'assignmentid': assignment_id,
+        'workerid': worker_id,
+        'mode': mode,
+        'app_id': app_id,
+        'query_string': request.query_string.decode()
+    }
+    return False, kwargs
 
 
 class ExperimentError(Exception):


### PR DESCRIPTION
Refactoring of `advertisement()` to prepare the advertisement in a separate function. This allows wrappers around dallinger, e.g. PsyNet, to use other rendering functions than the one used in Flask. This is for example important, if you want to add custom Jinja filters or add translations.