### PR TITLE
Better num retries in Docker-SSH deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Enhancement: Refactored `advertisement` method to prepare the advertisement in a separate function `prepare_advertisement`. This allows wrappers around Dallinger, e.g. PsyNet, to use other rendering functions than the one used in Flask. For example, this is important if you want to add custom Jinja2 filters or add translations.
 - Enhancement: Add a new customizable `config_defaults` method on the `Experiment class` that allows the user to specify custom default values for config variables.
 - Infrastructure: Added `isort` to the list of pre-commit hooks to sort imports alphabetically, and automatically separated into sections and by type.
+- Changed: Reduced the number of retries in the launch call of docker-ssh deployment, so that the command fails earlier with feedback.
 
 ## [v9.3.1](https://github.com/dallinger/dallinger/tree/v9.3.1) (2023-01-17)
 

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -587,7 +587,7 @@ def get_docker_compose_yml(
 
 def get_retrying_http_client():
     retry_strategy = Retry(
-        total=30,
+        total=6,
         backoff_factor=0.2,
         status_forcelist=[429, 500, 502, 503, 504],
         method_whitelist=["POST"],


### PR DESCRIPTION
Reduced the number of retries in the launch call of docker-ssh deployment, so that the command fails earlier with feedback.
Previously it was 30, meaning that the command would freeze silently for something like a minute before delivering the error message. Now it's set to 5, meaning that it fails within 10 seconds or so.