### PR TITLE
Misc Docker deployment fixes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/pycqa/isort
-  rev: 5.11.4
+  rev: 5.12.0
   hooks:
     - id: isort
       args: ["--profile", "black", "--filter-files"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [master](https://github.com/dallinger/dallinger/tree/master) (xxxx-xx-xx)
 
+- Fixed: Docker image caching problems with SSH deployment.
+- Fixed: Redis server contamination when deploying multiple apps with the same name via SSH.
+
 ## [v9.4.0](https://github.com/dallinger/dallinger/tree/v9.4.0) (2023-01-26)
 
 - Enhancement: Refactored `advertisement` method to prepare the advertisement in a separate function `prepare_advertisement`. This allows wrappers around Dallinger, e.g. PsyNet, to use other rendering functions than the one used in Flask. For example, this is important if you want to add custom Jinja2 filters or add translations.

--- a/constraints.txt
+++ b/constraints.txt
@@ -47,9 +47,9 @@ black==22.12.0
     # via dallinger
 bleach==6.0.0
     # via nbconvert
-boto3==1.26.58
+boto3==1.26.60
     # via dallinger
-botocore==1.29.58
+botocore==1.29.60
     # via
     #   boto3
     #   s3transfer
@@ -173,7 +173,7 @@ gevent==22.10.2
     #   gevent-websocket
 gevent-websocket==0.10.1
     # via flask-sockets
-greenlet==2.0.1
+greenlet==2.0.2
     # via
     #   dallinger
     #   gevent
@@ -184,7 +184,7 @@ h11==0.14.0
     # via wsproto
 heroku3==5.2.0
     # via dallinger
-identify==2.5.15
+identify==2.5.17
     # via pre-commit
 idna==3.4
     # via
@@ -195,7 +195,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.20.2
+ipykernel==6.21.0
     # via
     #   ipywidgets
     #   jupyter
@@ -217,7 +217,7 @@ ipywidgets==8.0.4
     # via
     #   dallinger
     #   jupyter
-isort==5.11.4
+isort==5.12.0
     # via dallinger
 itsdangerous==2.1.2
     # via
@@ -244,7 +244,7 @@ jsonschema==3.2.0
     #   nbformat
 jupyter==1.0.0
     # via dallinger
-jupyter-client==8.0.1
+jupyter-client==8.0.2
     # via
     #   ipykernel
     #   jupyter-console
@@ -255,8 +255,9 @@ jupyter-client==8.0.1
     #   qtconsole
 jupyter-console==6.4.4
     # via jupyter
-jupyter-core==5.1.5
+jupyter-core==5.2.0
     # via
+    #   ipykernel
     #   jupyter-client
     #   jupyter-server
     #   nbclassic
@@ -319,7 +320,6 @@ nbformat==5.7.3
     #   notebook
 nest-asyncio==1.5.6
     # via
-    #   ipykernel
     #   nbclassic
     #   notebook
 nodeenv==1.7.0
@@ -332,7 +332,7 @@ numpy==1.24.1
     # via pandas
 odfpy==1.4.1
     # via tablib
-openpyxl==3.0.10
+openpyxl==3.1.0
     # via tablib
 outcome==1.2.0
     # via trio
@@ -370,7 +370,7 @@ pexpect==4.8.0
     #   ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via dallinger
 platformdirs==2.6.2
     # via
@@ -382,7 +382,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==3.0.1
+pre-commit==3.0.2
     # via dallinger
 prometheus-client==0.16.0
     # via
@@ -597,9 +597,9 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tox==4.4.2
+tox==4.4.3
     # via dallinger
-traitlets==5.8.1
+traitlets==5.9.0
     # via
     #   comm
     #   ipykernel

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -1,4 +1,5 @@
 import hashlib
+import io
 import json
 import logging
 import os
@@ -6,7 +7,7 @@ import select
 import socket
 import sys
 import zipfile
-from contextlib import contextmanager
+from contextlib import contextmanager, redirect_stdout
 from email.utils import parseaddr
 from functools import wraps
 from getpass import getuser
@@ -320,9 +321,13 @@ def deploy(
         BytesIO(CADDYFILE.format(host=dns_host, tls=tls).encode()),
         "dallinger/Caddyfile",
     )
-    executor.run("docker-compose -f ~/dallinger/docker-compose.yml up -d")
-    print("Launched http and postgresql servers. Starting experiment")
+    print("Removing any pre-existing Redis volumes.")
+    remove_redis_volumes(app_name, executor)
 
+    print("Launching http and postgresql servers.")
+    executor.run("docker-compose -f ~/dallinger/docker-compose.yml up -d")
+
+    print("Starting experiment.")
     experiment_uuid = str(uuid4())
     if app_name:
         experiment_id = app_name
@@ -461,6 +466,18 @@ def get_experiment_id_from_archive(archive_path):
     with zipfile.ZipFile(archive_path) as archive:
         with archive.open("experiment_id.md") as fh:
             return fh.read().decode("utf-8")
+
+
+def remove_redis_volumes(app_name, executor):
+    redis_volume_name = f"{app_name}_dallinger_{app_name}_redis_data"
+    stdout = io.StringIO()
+    with redirect_stdout(stdout):
+        try:
+            executor.run(f"docker volume rm '{redis_volume_name}'")
+        except ExecuteException:
+            err = stdout.getvalue()
+            if "No such container" not in err:
+                raise ExecuteException(err)
 
 
 @docker_ssh.command()

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -476,7 +476,7 @@ def remove_redis_volumes(app_name, executor):
             executor.run(f"docker volume rm '{redis_volume_name}'")
         except ExecuteException:
             err = stdout.getvalue()
-            if "No such container" not in err:
+            if "No such volume" not in err:
                 raise ExecuteException(err)
 
 

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -265,6 +265,13 @@ def build_image(
     tmp_dir, base_image_name, out, needs_chrome=False, force_build=False
 ) -> str:
     """Build the docker image for the experiment and return its name."""
+    # The logic for when to reuse previous builds needs discussion. Previously a build was only invalidated
+    # when requirements.txt or prepare_docker_image.sh was changed. As a result, changes to experiment.py
+    # would not be propagated to the build. This error was not seen in Heroku deployment because
+    # the invocation used force_build=True, but it would manifest in SSH deployment.
+    # We've now set force_build = True here as a temporary fix, but if everyone agrees, we should
+    # disable this check entirely and allow Docker to manage its own cache.
+    force_build = True
     tag = get_experiment_image_tag(tmp_dir)
     image_name = f"{base_image_name}:{tag}"
     base_image_name = get_base_image(tmp_dir, needs_chrome)

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -304,9 +304,7 @@ def build_image(
         )
     else:
         dockerfile_text = rf"""# syntax=docker/dockerfile:1
-        # FROM {base_image_name}\
-        # TODO - revert to above version when making Dallinger release
-        FROM ghcr.io/dallinger/dallinger:9.4.0
+        FROM {base_image_name}
         #
         RUN mkdir /experiment
         WORKDIR /experiment

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -262,16 +262,12 @@ def get_experiment_image_tag(experiment_tmp_path: str) -> str:
 
 
 def build_image(
-    tmp_dir, base_image_name, out, needs_chrome=False, force_build=False
+    tmp_dir, base_image_name, out, needs_chrome=False, force_build=True
 ) -> str:
-    """Build the docker image for the experiment and return its name."""
-    # The logic for when to reuse previous builds needs discussion. Previously a build was only invalidated
-    # when requirements.txt or prepare_docker_image.sh was changed. As a result, changes to experiment.py
-    # would not be propagated to the build. This error was not seen in Heroku deployment because
-    # the invocation used force_build=True, but it would manifest in SSH deployment.
-    # We've now set force_build = True here as a temporary fix, but if everyone agrees, we should
-    # disable this check entirely and allow Docker to manage its own cache.
-    force_build = True
+    """Build the docker image for the experiment and return its name.
+    If force_build=False, then the image will only be rebuilt if requirements.txt or prepare_docker_image.sh
+    have changed.
+    """
     tag = get_experiment_image_tag(tmp_dir)
     image_name = f"{base_image_name}:{tag}"
     base_image_name = get_base_image(tmp_dir, needs_chrome)

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -326,7 +326,7 @@ def build_image(
             ./prepare_docker_image.sh
         # We rely on the already installed dallinger: the docker image tag has been chosen
         # based on the contents of this file. This makes sure dallinger stays installed from
-        # /dallinger, and that it doesn't waste space with two copies in two different layers.\
+        # /dallinger, and that it doesn't waste space with two copies in two different layers.
         #
         # Some experiments might only list dallinger as dependency
         # If they do the grep command will exit non-0, the pip command will not run

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -47,9 +47,9 @@ black==22.12.0
     # via dallinger
 bleach==6.0.0
     # via nbconvert
-boto3==1.26.58
+boto3==1.26.60
     # via dallinger
-botocore==1.29.58
+botocore==1.29.60
     # via
     #   boto3
     #   s3transfer
@@ -173,7 +173,7 @@ gevent==22.10.2
     #   gevent-websocket
 gevent-websocket==0.10.1
     # via flask-sockets
-greenlet==2.0.1
+greenlet==2.0.2
     # via
     #   dallinger
     #   gevent
@@ -184,7 +184,7 @@ h11==0.14.0
     # via wsproto
 heroku3==5.2.0
     # via dallinger
-identify==2.5.15
+identify==2.5.17
     # via pre-commit
 idna==3.4
     # via
@@ -195,7 +195,7 @@ imagesize==1.4.1
     # via sphinx
 iniconfig==2.0.0
     # via pytest
-ipykernel==6.20.2
+ipykernel==6.21.0
     # via
     #   ipywidgets
     #   jupyter
@@ -217,7 +217,7 @@ ipywidgets==8.0.4
     # via
     #   dallinger
     #   jupyter
-isort==5.11.4
+isort==5.12.0
     # via dallinger
 itsdangerous==2.1.2
     # via
@@ -244,7 +244,7 @@ jsonschema[format-nongpl]==3.2.0
     #   nbformat
 jupyter==1.0.0
     # via dallinger
-jupyter-client==8.0.1
+jupyter-client==8.0.2
     # via
     #   ipykernel
     #   jupyter-console
@@ -255,8 +255,9 @@ jupyter-client==8.0.1
     #   qtconsole
 jupyter-console==6.4.4
     # via jupyter
-jupyter-core==5.1.5
+jupyter-core==5.2.0
     # via
+    #   ipykernel
     #   jupyter-client
     #   jupyter-server
     #   nbclassic
@@ -319,7 +320,6 @@ nbformat==5.7.3
     #   notebook
 nest-asyncio==1.5.6
     # via
-    #   ipykernel
     #   nbclassic
     #   notebook
 nodeenv==1.7.0
@@ -332,7 +332,7 @@ numpy==1.24.1
     # via pandas
 odfpy==1.4.1
     # via tablib
-openpyxl==3.0.10
+openpyxl==3.1.0
     # via tablib
 outcome==1.2.0
     # via trio
@@ -370,7 +370,7 @@ pexpect==4.8.0
     #   ipython
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via dallinger
 platformdirs==2.6.2
     # via
@@ -382,7 +382,7 @@ pluggy==1.0.0
     # via
     #   pytest
     #   tox
-pre-commit==3.0.1
+pre-commit==3.0.2
     # via dallinger
 prometheus-client==0.16.0
     # via
@@ -597,9 +597,9 @@ tornado==6.2
     #   nbclassic
     #   notebook
     #   terminado
-tox==4.4.2
+tox==4.4.3
     # via dallinger
-traitlets==5.8.1
+traitlets==5.9.0
     # via
     #   comm
     #   ipykernel

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,9 +18,9 @@ attrs==22.2.0
     # via
     #   outcome
     #   trio
-boto3==1.26.58
+boto3==1.26.60
     # via dallinger
-botocore==1.29.58
+botocore==1.29.60
     # via
     #   boto3
     #   s3transfer
@@ -70,7 +70,7 @@ gevent==22.10.2
     #   gevent-websocket
 gevent-websocket==0.10.1
     # via flask-sockets
-greenlet==2.0.1
+greenlet==2.0.2
     # via
     #   dallinger
     #   gevent
@@ -108,7 +108,7 @@ packaging==23.0
     # via build
 pexpect==4.8.0
     # via dallinger
-pip-tools==6.12.1
+pip-tools==6.12.2
     # via dallinger
 psutil==5.9.4
     # via dallinger


### PR DESCRIPTION
After discussing with Silvio, have agreed the following fixes for docker-ssh deployment.

- [x] Default to `force_build=True` when building experiment Docker images for safety. Sometimes the build wasn't happening when it needed to, and this caused outdated Docker images to be applied.
- [x] Reorder the default Dockerfile commands so that experiment directory gets copied last. This improves the caching logic and speeds build.
- [x] When deploying an app with docker ssh, we should delete any pre-existing redis volumes with the same name (the general form is`my-exp_dallinger_my-exp_redis_data`). We `docker rm` these volumes, but don’t throw an error if none exist. This fixes an error where the Redis state from a previous deployment would persist over to a subsequent deployment with the same app ID.