### PR TITLE
Fix paramiko import

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -676,7 +676,7 @@ class Executor:
 
         Adapted from paramiko "interactive.py" demo.
         """
-        from paramiko.py3compat import u
+        from paramiko.util import u
 
         chan = self.client.get_transport().open_session()
         chan.exec_command(cmd)


### PR DESCRIPTION
## Bugfix
- Fixed import of `u` function for paramiko version >= 3