### PR TITLE
Also allow base pay to be 0 in the case of Prolific.

### DIFF
--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -208,7 +208,7 @@ def verify_config(verbose=True):
 
         if base_pay < 0:
             log(
-                "✗ base_payment must be positive value in config.txt.",
+                "✗ base_payment must be greater than or equal to zero in config.txt.",
                 chevrons=False,
                 verbose=verbose,
             )

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -206,7 +206,7 @@ def verify_config(verbose=True):
     else:
         dollarFormat = "{:.2f}".format(base_pay)
 
-        if base_pay <= 0:
+        if base_pay < 0:
             log(
                 "✗ base_payment must be positive value in config.txt.",
                 chevrons=False,


### PR DESCRIPTION
The concept of base pay is mturk specific. It is not required in Prolific, so you should be able to set it to 0.