### PR TITLE
Update docker_ssh.py

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -476,7 +476,7 @@ def remove_redis_volumes(app_name, executor):
             executor.run(f"docker volume rm '{redis_volume_name}'")
         except ExecuteException:
             err = stdout.getvalue()
-            if "No such volume" not in err:
+            if "no such volume" not in err.lower():
                 raise ExecuteException(err)
 
 


### PR DESCRIPTION
As part of the Docker-SSH deployment logic there is a moment where the process deletes any pre-existing Redis volumes for the app. It does this by calling the appropriate Docker command and catching and ignoring any 'no such volumes' error:

```py
def remove_redis_volumes(app_name, executor):
    redis_volume_name = f"{app_name}_dallinger_{app_name}_redis_data"
    stdout = io.StringIO()
    with redirect_stdout(stdout):
        try:
            executor.run(f"docker volume rm '{redis_volume_name}'")
        except ExecuteException:
            err = stdout.getvalue()
            if "No such volume" not in err:
                raise ExecuteException(err)
```

This worked on my server but it has been reported that another server experienced this error:

```py
Error response from daemon: get cb-test-ssh_dallinger_cb-test-ssh_redis_data: no such volume
```

It seems like the casing of this error message is inconsistent between Docker versions, stopping it from being caught properly. I've therefore updated the error catching logic to standardise the case before catching the error.