### PR TITLE
Better error catching in init_db

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -147,7 +147,7 @@ def init_db(drop_all=False, bind=engine):
         Base.metadata.create_all(bind=bind)
     except OperationalError as err:
         msg = 'password authentication failed for user "dallinger"'
-        if hasattr(err, "message") and msg in err.message:
+        if msg in str(err):
             sys.stderr.write(db_user_warning)
         raise
 

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -147,7 +147,7 @@ def init_db(drop_all=False, bind=engine):
         Base.metadata.create_all(bind=bind)
     except OperationalError as err:
         msg = 'password authentication failed for user "dallinger"'
-        if msg in err.message:
+        if hasattr(err, "message") and msg in err.message:
             sys.stderr.write(db_user_warning)
         raise
 


### PR DESCRIPTION
The error catching logic in init_db was failing with current versions of SQLAlchemy and has now been fixed.