### PR TITLE
Add better logging for Prolific JSONDecodeError

### DIFF
--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -242,7 +242,9 @@ class ProlificService:
         try:
             parsed = response.json()
         except requests.exceptions.JSONDecodeError as err:
-            raise ProlificServiceException(f"Failed to parse the following JSON response from Prolific: {err.doc}")
+            raise ProlificServiceException(
+                f"Failed to parse the following JSON response from Prolific: {err.doc}"
+            )
 
         if "error" in parsed:
             error = {

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -239,7 +239,11 @@ class ProlificService:
         if method == "DELETE" and response.ok:
             return {"status_code": response.status_code}
 
-        parsed = response.json()
+        try:
+            parsed = response.json()
+        except requests.exceptions.JSONDecodeError as err:
+            raise ProlificServiceException(f"Failed to parse the following JSON response from Prolific: {err.doc}")
+
         if "error" in parsed:
             error = {
                 "method": method,


### PR DESCRIPTION
If the Prolific API returned a JSON response that could not be decoded as valid JSON, Dallinger would throw an error but would not say what the invalid JSON string was. Now this JSON string is printed as part of the error messsage.