### PR TITLE
Update to collate_experiment_files

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -694,10 +694,10 @@ def collate_experiment_files(config, experiment_path, destination, copy_func):
     # Order matters here, since the first files copied "win" if there's a
     # collision:
     ExperimentFileSource(experiment_path).apply_to(destination, copy_func=copy_func)
+    ExplicitFileSource(experiment_path).apply_to(destination, copy_func=copy_func)
     DallingerFileSource(config, dallinger_package_path()).apply_to(
         destination, copy_func=copy_func
     )
-    ExplicitFileSource(experiment_path).apply_to(destination, copy_func=copy_func)
 
 
 class FileSource(object):


### PR DESCRIPTION
The `collate_experiment_files` function is responsible for constructing the experiment directory that is eventually deployed. Due to an oversight, the original version was written in a way such that it was impossible to override built-in Dallinger resources using the `extra_files` hook; such cases were instead silently ignored. This has now been rectified. 