### PR TITLE
Fix missing commit in clock.py

### DIFF
--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from apscheduler.schedulers.blocking import BlockingScheduler
 
 import dallinger
-from dallinger import recruiters
+from dallinger import db, recruiters
 from dallinger.experiment import EXPERIMENT_TASK_REGISTRATIONS
 from dallinger.models import Participant
 from dallinger.utils import ParticipationTime
@@ -41,6 +41,7 @@ def check_db_for_missing_notifications():
     reference_time = datetime.now()
 
     run_check(participants, config, reference_time)
+    db.session.commit()
 
 
 def launch():


### PR DESCRIPTION
The following scheduled task was defined in clock.py:

```py
@scheduler.scheduled_job("interval", minutes=0.5)
def check_db_for_missing_notifications():
    """Check the database for missing notifications."""
    config = dallinger.config.get_config()
    participants = Participant.query.filter_by(status="working").all()
    reference_time = datetime.now()

    run_check(participants, config, reference_time)
```

The `Participant.query` command would start a Postgres transaction, but this transaction would never be terminated. This would cause errors if the server process had to be restarted, because there would never be a moment at which the connection could be gracefully terminated. I have now added a `db.session.commit()` at the end of this function to avoid this problem.
