### PR TITLE
Prolific improvements

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -204,8 +204,6 @@ def debug(verbose, bot, proxy, no_browsers=False, exp_config=None):
     debugger.run()
 
 
-
-
 def prelaunch_db_bootstrapper(zip_path, log):
     def bootstrap_db(heroku_app, config):
         # Pre-populate the database if an archive was given
@@ -508,7 +506,10 @@ def get_recruiter(recruiter_name):
     elif recruiter_name == "prolific":
         return ProlificRecruiter(is_dummy=True)
     else:
-        raise NotImplementedError(f"Invalid recruiter, please choose from {available_recruiters}")
+        raise NotImplementedError(
+            f"Invalid recruiter, please choose from {available_recruiters}"
+        )
+
 
 @dallinger.command()
 @click.option("--app", default=None, help="Experiment id")
@@ -520,12 +521,12 @@ def get_recruiter(recruiter_name):
 )
 @click.option("--recruiter", default="mturk", help="Experiment id")
 def hits(app, sandbox, recruiter):
-    """List all HITs for the recruiter account or for a specific experiment id.
-    """
+    """List all HITs for the recruiter account or for a specific experiment id."""
     if app is not None:
         verify_id(None, "--app", app)
 
     get_recruiter(recruiter).hits(app, sandbox)
+
 
 @dallinger.command()
 @click.option("--hit_id", default=None, help="MTurk HIT ID")
@@ -539,7 +540,8 @@ def hits(app, sandbox, recruiter):
 def hit_details(hit_id, sandbox, recruiter):
     """Print the details for a specific HIT is for a recruiter."""
     details = get_recruiter(recruiter).hit_details(hit_id, sandbox)
-    print(json.dumps(details, indent=4))
+    print(json.dumps(details, indent=4, default=str))
+
 
 @dallinger.command()
 @click.option("--hit_id", default=None, help="MTurk HIT ID")
@@ -550,20 +552,29 @@ def hit_details(hit_id, sandbox, recruiter):
     help="Look for HITs in the MTurk sandbox rather than the live/production environment",
 )
 @click.option("--recruiter", default="mturk", help="Experiment id")
-@click.option("--qualification_path", default=None, help="Filename/path for the qualification file")
+@click.option(
+    "--qualification_path",
+    default=None,
+    help="Filename/path for the qualification file",
+)
 def copy_qualifications(hit_id, sandbox, recruiter, qualification_path):
     """Copy qualifications from an existing HIT ID."""
     recruiter = get_recruiter(recruiter)
     if qualification_path is None:
         qualification_path = recruiter.default_qualification_name
-    assert qualification_path.endswith(".json"), "Qualification path must be a json file"
+    assert qualification_path.endswith(
+        ".json"
+    ), "Qualification path must be a json file"
     if exists(qualification_path):
-        overwrite = query_yes_no(f"Overwrite existing qualification file: {qualification_path}?")
+        overwrite = query_yes_no(
+            f"Overwrite existing qualification file: {qualification_path}?"
+        )
         if not overwrite:
             raise Exception(f"Qualification file already exists: {qualification_path}.")
     qualifications = recruiter.get_qualifications(hit_id, sandbox)
     with open(qualification_path, "w") as f:
         json.dump(qualifications, f, indent=4)
+
 
 @dallinger.command()
 @click.option("--hit_id", default=None, help="MTurk HIT ID")

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -589,6 +589,9 @@ class MTurkService(object):
     def get_hit(self, hit_id):
         return self._translate_hit(self.mturk.get_hit(HITId=hit_id)["HIT"])
 
+    def get_study(self, hit_id):
+        return self.mturk.get_hit(HITId=hit_id)["HIT"]
+
     def get_hits(self, hit_filter=lambda x: True):
         done = False
         next_token = None

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -108,10 +108,13 @@ class ProlificService:
         del args["self"]
         del args["mode"]
         draft = self.draft_study(**args)
-        if mode == "sandbox":
-            return draft
+        study_id = draft["id"]
+        if mode == "live":
+            logger.info(f"Publishing experiment {study_id} on Prolific...")
+            return self.publish_study(study_id)
         else:
-            return self.publish_study(draft["id"])
+            logger.info(f"Sandboxing experiment {study_id} in Prolific (saved as draft, not public)...")
+            return draft
 
     def draft_study(
         self,

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -106,6 +106,7 @@ class ProlificService:
         """
         args = locals()
         del args["self"]
+        del args["mode"]
         draft = self.draft_study(**args)
         if mode == "sandbox":
             return draft

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -3,6 +3,7 @@ import logging
 import requests
 import tenacity
 from typing import List, Optional
+from dateutil import parser
 
 logger = logging.getLogger(__file__)
 
@@ -16,12 +17,13 @@ class ProlificServiceException(Exception):
 class ProlificService:
     """Wrapper for Prolific REST API"""
 
-    def __init__(self, api_token: str, api_version: str, referer_header: str):
+    def __init__(self, api_token: str, api_version: str, referer_header: str, sandbox: bool):
         self.api_token = api_token
         # For error logging:
         self.api_token_fragment = f"{api_token[:3]}...{api_token[-3:]}"
         self.api_version = api_version
         self.referer_header = referer_header
+        self.sandbox = sandbox
 
     @property
     def api_root(self):
@@ -157,6 +159,21 @@ class ProlificService:
             payload["peripheral_requirements"] = peripheral_requirements
 
         return self._req(method="POST", endpoint="/studies/", json=payload)
+
+    def get_hits(self):
+        """Get a list of all HITs in the account."""
+        response = self._req(method="GET", endpoint="/studies/")
+        return [
+            {
+                "id": hit["id"],
+                "title": hit["name"],
+                "annotation": hit.get("internal_name", ""),
+                "status": hit["status"],
+                "created": parser.parse(hit["date_created"]),
+                "expiration": '',  # Not available in Prolific in list view
+                "description": '',  # Not available in Prolific in list view
+            } for hit in response["results"]
+        ]
 
     def get_study(self, study_id: str) -> dict:
         """Fetch details of an existing Study"""

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -95,6 +95,7 @@ class ProlificService:
         prolific_id_option: str,
         reward: int,
         total_available_places: int,
+        mode: str,
         device_compatibility: Optional[List[str]] = None,
         peripheral_requirements: Optional[List[str]] = None,
     ) -> dict:
@@ -106,7 +107,10 @@ class ProlificService:
         args = locals()
         del args["self"]
         draft = self.draft_study(**args)
-        return self.publish_study(draft["id"])
+        if mode == "sandbox":
+            return draft
+        else:
+            return self.publish_study(draft["id"])
 
     def draft_study(
         self,

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -133,19 +133,19 @@ class ProlificService:
         """Create a draft Study on Prolific, and return its properties."""
 
         payload = {
+            "name": name,
+            "internal_name": internal_name,
+            "description": description,
+            "external_study_url": external_study_url,
+            "prolific_id_option": prolific_id_option,
             "completion_code": completion_code,
             "completion_option": completion_option,
-            "description": description,
-            "eligibility_requirements": eligibility_requirements,
-            "estimated_completion_time": estimated_completion_time,
-            "external_study_url": external_study_url,
-            "internal_name": internal_name,
-            "maximum_allowed_time": maximum_allowed_time,
-            "name": name,
-            "prolific_id_option": prolific_id_option,
-            "reward": reward,
-            "status": "UNPUBLISHED",
             "total_available_places": total_available_places,
+            "estimated_completion_time": estimated_completion_time,
+            "maximum_allowed_time": maximum_allowed_time,
+            "reward": reward,
+            "eligibility_requirements": eligibility_requirements,
+            "status": "UNPUBLISHED",
         }
 
         if device_compatibility is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -271,6 +271,7 @@ class ProlificRecruiter(Recruiter):
             "prolific_id_option": "url_parameters",
             "reward": self.config.get("prolific_reward_cents"),
             "total_available_places": n,
+            "mode": self.config.get("mode")
         }
         # Merge in any explicit configuration untouched:
         if self.config.get("prolific_recruitment_config", None) is not None:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -265,9 +265,7 @@ class ProlificRecruiter(Recruiter):
                 "prolific_maximum_allowed_minutes",
                 3 * self.config.get("prolific_estimated_completion_minutes") + 2,
             ),
-            "name": "{} ({})".format(
-                self.config.get("title"), heroku_tools.app_name(self.config.get("id"))
-            ),
+            "name": self.config.get("title"),
             "prolific_id_option": "url_parameters",
             "reward": self.config.get("prolific_reward_cents"),
             "total_available_places": n,

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -677,6 +677,35 @@ def assemble_experiment_temp_dir(log, config, for_remote=False):
             requirements_path.write_text(new_constraints_text)
     return dst
 
+def query_yes_no(question, default="yes"):
+    """Ask a yes/no question via raw_input() and return their answer.
+
+    "question" is a string that is presented to the user.
+    "default" is the presumed answer if the user just hits <Enter>.
+        It must be "yes" (the default), "no" or None (meaning
+        an answer is required of the user).
+
+    The "answer" return value is True for "yes" or False for "no".
+    """
+    valid = {"yes": True, "y": True, "ye": True, "no": False, "n": False}
+    if default is None:
+        prompt = " [y/n] "
+    elif default == "yes":
+        prompt = " [Y/n] "
+    elif default == "no":
+        prompt = " [y/N] "
+    else:
+        raise ValueError("invalid default answer: '%s'" % default)
+
+    while True:
+        sys.stdout.write(question + prompt)
+        choice = input().lower()
+        if default is not None and choice == "":
+            return valid[default]
+        elif choice in valid:
+            return valid[choice]
+        else:
+            sys.stdout.write("Please respond with 'yes' or 'no' " "(or 'y' or 'n').\n")
 
 def copy_file(from_path, to_path):
     """Actually copy a file from one location to another."""

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -269,6 +269,15 @@ Prolific Recruitment
             ]
         }
 
+
+    You can also specify the devices you expect the participants to have, e.g.::
+        {
+            "eligibility_requirements": […],
+            "device_compatibility": ["desktop"],
+            "peripheral_requirements": ["audio", "microphone"]
+        }
+    Supported devices are ``desktop``, ``tablet``, and ``mobile``. Supported peripherals are ``audio``, ``camera``, ``download`` (download additional software to run the experiment), and ``microphone``.
+
     You would then include this file in your overall configuration by adding the following
     to your config.txt file::
 


### PR DESCRIPTION
- Extended `dallinger hits [--recruiter=prolific|mturk] [--sandbox]` to work with Prolific as well
- Addition of two new command line tools:
   - `dallinger hit-details --hit_id  XYZ [--recruiter=prolific|mturk] [--sandbox]` which pastes all the HIT details in the console window.
   - `dallinger copy-qualifications --hit_id  XYZ [--recruiter=prolific|mturk] [--sandbox]` which copies the requirements to participate in an experiment (e.g country or the number of completed tasks) from an existing HIT and saves it into a JSON file.