### PR TITLE
Remove 'extras' from constraints and requirements files

### DIFF
--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -11,8 +11,10 @@ pip-compile
 # Remove the line specifying dallinger as editable dependency
 sed -e "s/^-e.*//" -i *.txt
 
-# Remove the extras from constraints.txt
+# Remove the extras from constraints.txt, dev-requirements.txt, and requirements.txt
 sed -e 's/\[.*==/==/' -i constraints.txt
+sed -e 's/\[.*==/==/' -i dev-requirements.txt
+sed -e 's/\[.*==/==/' -i requirements.txt
 # It prevents this error:
 # Constraints are only allowed to take the form of a package name and a version specifier.
 # Other forms were originally permitted as an accident of the implementation, but were undocumented.

--- a/scripts/update_experiments_constraints.sh
+++ b/scripts/update_experiments_constraints.sh
@@ -19,6 +19,8 @@ for demo_name in $(ls demos/dlgr/demos/); do
         pip-compile temp-requirements.txt -o constraints.txt
         rm temp-requirements.txt
         echo '# generate from file with hash ' $(md5_cmd requirements.txt) >> constraints.txt
+        # Remove the extras from constraints.txt
+        sed -e 's/\[.*==/==/' -i constraints.txt
         cd -
     fi
 done


### PR DESCRIPTION
**CHANGELOG**

* Infrastructure: Remove 'extras' from constraints and requirements files.
