### PR TITLE
Run pip-compile in verbose mode

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -595,6 +595,7 @@ cp requirements.txt constraints.txt"""
                 [
                     "pip-compile",
                     "--resolver=backtracking",
+                    "-v",
                     str(tmpfile),
                     "-o",
                     "constraints.txt",


### PR DESCRIPTION
When running `dallinger generate-constraints`, run `pip-compile`  in verbose mode, so that you can debug slow running resolutions.