### PR TITLE
Allow customization of Configuration class

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -183,11 +183,6 @@ class Configuration(object):
 
     def get(self, key, default=marker):
         if not self.ready:
-            import pydevd_pycharm
-
-            pydevd_pycharm.settrace(
-                "localhost", port=12345, stdoutToServer=True, stderrToServer=True
-            )
             raise RuntimeError("Config not loaded")
         for layer in self.data:
             try:

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -8,6 +8,7 @@ import os
 import sys
 from collections import deque
 from contextlib import contextmanager
+from functools import cache
 from pathlib import Path
 
 import six
@@ -338,16 +339,17 @@ class Configuration(object):
         self.extend(exp_klass.config_defaults(), strict=True)
 
 
-config = None
-
-
+@cache
 def get_config():
-    global config
+    from dallinger.experiment import load
 
-    if config is None:
-        config = Configuration()
-        for registration in default_keys:
-            config.register(*registration)
+    exp_klass = load()
+
+    config_class = exp_klass.config_class()
+    config = config_class()
+
+    for registration in default_keys:
+        config.register(*registration)
 
     return config
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -8,7 +8,6 @@ import os
 import sys
 from collections import deque
 from contextlib import contextmanager
-from functools import cache
 from pathlib import Path
 
 import six
@@ -184,6 +183,11 @@ class Configuration(object):
 
     def get(self, key, default=marker):
         if not self.ready:
+            import pydevd_pycharm
+
+            pydevd_pycharm.settrace(
+                "localhost", port=12345, stdoutToServer=True, stderrToServer=True
+            )
             raise RuntimeError("Config not loaded")
         for layer in self.data:
             try:
@@ -273,7 +277,8 @@ class Configuration(object):
     def load_defaults(self):
         """Load default configuration values"""
         # Apply extra parameters before loading the configs
-        if self.experiment_available():
+        if experiment_available():
+            # In practice, experiment_available should only return False in tests
             self.register_extra_parameters()
 
         global_config_name = ".dallingerconfig"
@@ -288,11 +293,8 @@ class Configuration(object):
         for config_file in [global_defaults_file, local_defaults_file, global_config]:
             self.load_from_file(config_file)
 
-        if self.experiment_available():
+        if experiment_available():
             self.load_experiment_config_defaults()
-
-    def experiment_available(self):
-        return Path("experiment.py").exists()
 
     def load(self):
         self.load_defaults()
@@ -339,17 +341,25 @@ class Configuration(object):
         self.extend(exp_klass.config_defaults(), strict=True)
 
 
-@cache
+config = None
+
+
 def get_config():
-    from dallinger.experiment import load
+    global config
 
-    exp_klass = load()
+    if config is None:
+        if experiment_available():
+            from dallinger.experiment import load
 
-    config_class = exp_klass.config_class()
-    config = config_class()
+            exp_klass = load()
+            config_class = exp_klass.config_class()
+        else:
+            config_class = Configuration
 
-    for registration in default_keys:
-        config.register(*registration)
+        config = config_class()
+
+        for registration in default_keys:
+            config.register(*registration)
 
     return config
 
@@ -377,3 +387,7 @@ def initialize_experiment_package(path):
     package.__package__ = "dallinger_experiment"
     package.__name__ = "dallinger_experiment"
     sys.path.pop(0)
+
+
+def experiment_available():
+    return Path("experiment.py").exists()

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -174,6 +174,16 @@ class Experiment(object):
             self.widget = module.ExperimentWidget(self)
 
     @classmethod
+    def config_class(cls):
+        """
+        Override this method in order to define a custom Configuration class
+        for dealing with config variables (see e.g. config.txt).
+        """
+        from .config import Configuration
+
+        return Configuration
+
+    @classmethod
     def extra_parameters(cls):
         """Override this classmethod to register new config variables. It is
         called during config load. See

--- a/dallinger/registration.py
+++ b/dallinger/registration.py
@@ -8,12 +8,12 @@ import requests
 from dallinger.config import get_config
 
 logger = logging.getLogger(__file__)
-config = get_config()
 root = "https://api.osf.io/v2"
 
 
 def register(dlgr_id, snapshot=None):
     """Register the experiment using configured services."""
+    config = get_config()
     try:
         config.get("osf_access_token")
     except KeyError:
@@ -25,6 +25,7 @@ def register(dlgr_id, snapshot=None):
 
 def _create_osf_project(dlgr_id, description=None):
     """Create a project on the OSF."""
+    config = get_config()
 
     if not description:
         description = "Experiment {} registered by Dallinger.".format(dlgr_id)
@@ -49,6 +50,7 @@ def _create_osf_project(dlgr_id, description=None):
 
 def _upload_assets_to_OSF(dlgr_id, osf_id, provider="osfstorage"):
     """Upload experimental assets to the OSF."""
+    config = get_config()
     root = "https://files.osf.io/v1"
     snapshot_filename = "{}-code.zip".format(dlgr_id)
     snapshot_path = os.path.join("snapshots", snapshot_filename)

--- a/tests/test_bots.py
+++ b/tests/test_bots.py
@@ -4,10 +4,6 @@ import mock
 import pytest
 from selenium import webdriver
 
-from dallinger.config import get_config
-
-config = get_config()
-
 
 class TestBots(object):
     def test_create_bot(self, active_config):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -5,9 +5,6 @@ import mock
 import pytest
 
 from dallinger import models
-from dallinger.config import get_config
-
-config = get_config()
 
 
 @pytest.mark.usefixtures("experiment_dir")


### PR DESCRIPTION
## Added
- Added `Experiment.config_class`, a hook for customizing the Configuration class.

## Testing
Have tested manually by defining a custom config class in experiment.py and using it to customise config variable treatment.