### PR TITLE
Reinstate auto_recruit check in ProlificRecruiter.recruit()

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -382,6 +382,10 @@ class ProlificRecruiter(Recruiter):
 
     def recruit(self, n: int = 1):
         """Recruit `n` new participants to an existing Prolific Study"""
+        if not self.config.get("auto_recruit"):
+            logger.info("auto_recruit is False: recruitment suppressed")
+            return
+
         return self.prolificservice.add_participants_to_study(
             study_id=self.current_study_id, number_to_add=n
         )


### PR DESCRIPTION
## Fixed
- Fixed regression where `auto_recruit` checks had been accidentally deleted from Prolific.

## How Has This Been Tested?
Will test this by deploying an experiment.