### PR TITLE
Faster monitor

### DIFF
--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -236,6 +236,9 @@ def get_mapped_class(table: Union[str, Table]):
     """
     Returns the single class that maps to the provided table.
     Throws an ``AssertionError`` if there is not exactly one such class.
+    This function is therefore only intended for tables that do not implement
+    polymorphic identities, i.e. they do not include a ``type`` column.
+    An example is the Notification table.
     """
     mappers = get_mapped_classes(table)
     assert len(mappers) == 1

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -164,10 +164,6 @@ def get_mapped_classes():
     and ``polymorphic_identity``, the string label with which the class is
     identified in the table's type column.
     """
-    from dallinger.experiment import Experiment
-
-    exp = Experiment(session)
-
     classes = {}
     for table in Base.metadata.tables.values():
         if "type" in table.columns:
@@ -184,7 +180,7 @@ def get_mapped_classes():
                 }
         else:
             if session.query(table.columns.id).count() > 0:
-                cls = exp.known_classes[table.name.capitalize()]
+                cls = get_mapper(table)
                 classes[cls.__name__] = {
                     "cls": cls,
                     "table": table.name,
@@ -210,6 +206,26 @@ def get_polymorphic_mappers(table: Union[str, Table]):
         for mapper in Base.registry.mappers
         if table_name in [table.name for table in mapper.tables]
     }
+
+
+def get_mappers(table: Union[str, Table]):
+    if isinstance(table, str):
+        table_name = table
+    else:
+        assert isinstance(table, Table)
+        table_name = table.name
+
+    return [
+        mapper.class_
+        for mapper in Base.registry.mappers
+        if table_name in [table.name for table in mapper.tables]
+    ]
+
+
+def get_mapper(table: Union[str, Table]):
+    mappers = get_mappers(table)
+    assert len(mappers) == 1
+    return mappers[0]
 
 
 def serialized(func):

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -183,7 +183,7 @@ def get_all_mapped_classes():
                 }
         else:
             if session.query(table.columns.id).count() > 0:
-                cls = get_mapper(table)
+                cls = get_mapped_class(table)
                 classes[cls.__name__] = {
                     "cls": cls,
                     "table": table.name,
@@ -226,7 +226,7 @@ def get_mapped_classes(table: Union[str, Table]):
     ]
 
 
-def get_mapper(table: Union[str, Table]):
+def get_mapped_class(table: Union[str, Table]):
     mappers = get_mapped_classes(table)
     assert len(mappers) == 1
     return mappers[0]

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -195,8 +195,9 @@ def get_mapped_classes():
 def get_polymorphic_mappers(table: Union[str, Table]):
     """
     Lists the different polymorphic mappings defined for a given table.
-    Returns a dictionary keyed by possible values of ``table.type``
-    with values corresponding to object classes.
+    Returns a dictionary of classes
+    where the dictionary keys correspond to polymorphic identities
+    (i.e. possible values of the table's ``type`` column).
     """
     if isinstance(table, str):
         table_name = table

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -196,6 +196,20 @@ def get_all_mapped_classes():
     return classes
 
 
+def get_mappers(table: Union[str, Table]):
+    if isinstance(table, str):
+        table_name = table
+    else:
+        assert isinstance(table, Table)
+        table_name = table.name
+
+    return [
+        mapper
+        for mapper in Base.registry.mappers
+        if table_name in [table.name for table in mapper.tables]
+    ]
+
+
 def get_polymorphic_mapping(table: Union[str, Table]):
     """
     Gets the polymorphic mapping for a given table.
@@ -204,33 +218,17 @@ def get_polymorphic_mapping(table: Union[str, Table]):
     (i.e. possible values of the table's ``type`` column)
     and the dictionary values correspond to classes.
     """
-    if isinstance(table, str):
-        table_name = table
-    else:
-        assert isinstance(table, Table)
-        table_name = table.name
-
-    return {
-        mapper.polymorphic_identity: mapper.class_
-        for mapper in Base.registry.mappers
-        if table_name in [table.name for table in mapper.tables]
-    }
+    return {mapper.polymorphic_identity: mapper.class_ for mapper in get_mappers(table)}
 
 
 def get_mapped_classes(table: Union[str, Table]):
     """
     Returns a list of classes that map to the provided table.
     """
-    if isinstance(table, str):
-        table_name = table
-    else:
-        assert isinstance(table, Table)
-        table_name = table.name
-
     return [
         mapper.class_
         for mapper in Base.registry.mappers
-        if table_name in [table.name for table in mapper.tables]
+        if mapper in get_mappers(table)
     ]
 
 

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -212,7 +212,7 @@ def get_polymorphic_mappers(table: Union[str, Table]):
     }
 
 
-def get_mappers(table: Union[str, Table]):
+def get_mapped_classes(table: Union[str, Table]):
     if isinstance(table, str):
         table_name = table
     else:
@@ -227,7 +227,7 @@ def get_mappers(table: Union[str, Table]):
 
 
 def get_mapper(table: Union[str, Table]):
-    mappers = get_mappers(table)
+    mappers = get_mapped_classes(table)
     assert len(mappers) == 1
     return mappers[0]
 

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -155,7 +155,7 @@ def init_db(drop_all=False, bind=engine):
     return session
 
 
-def get_mapped_classes():
+def get_all_mapped_classes():
     """
     Lists the different classes that are mapped with SQLAlchemy.
     Classes are only included if they have at least one row in the database.

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -173,9 +173,9 @@ def get_all_mapped_classes():
             observed_types = [
                 r.type for r in session.query(table.columns.type).distinct().all()
             ]
-            mappers = get_polymorphic_mappers(table)
+            mapping = get_polymorphic_mapping(table)
             for type_ in observed_types:
-                cls = mappers[type_]
+                cls = mapping[type_]
                 classes[cls.__name__] = {
                     "cls": cls,
                     "table": table.name,
@@ -192,7 +192,7 @@ def get_all_mapped_classes():
     return classes
 
 
-def get_polymorphic_mappers(table: Union[str, Table]):
+def get_polymorphic_mapping(table: Union[str, Table]):
     """
     Lists the different polymorphic mappings defined for a given table.
     Returns a dictionary of classes

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -170,6 +170,8 @@ def get_all_mapped_classes():
     classes = {}
     for table in Base.metadata.tables.values():
         if "type" in table.columns:
+            # Most Dallinger tables (e.g. Node, Network) have a type column that specifies which class
+            # is associated with that database row.
             observed_types = [
                 r.type for r in session.query(table.columns.type).distinct().all()
             ]
@@ -182,6 +184,8 @@ def get_all_mapped_classes():
                     "polymorphic_identity": type_,
                 }
         else:
+            # Some tables (e.g. Notification) don't have any such column, so we can assume
+            # that they have exactly one mapped class.
             if session.query(table.columns.id).count() > 0:
                 cls = get_mapped_class(table)
                 classes[cls.__name__] = {

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -157,12 +157,15 @@ def init_db(drop_all=False, bind=engine):
 
 def get_mapped_classes():
     """
-    Lists the different classes that are mapped to database rows.
-    Each class is represented by a dictionary with three values:
+    Lists the different classes that are mapped with SQLAlchemy.
+    Classes are only included if they have at least one row in the database.
+    Returns a dictionary, keyed by class names,
+    where each value is itself a dictionary with three values:
     ``cls``, the class itself;
     ``table``, the database table within which the class can be found,
     and ``polymorphic_identity``, the string label with which the class is
-    identified in the table's type column.
+    identified in the table's ``type`` column. The ``polymorphic_identity`` field
+    takes a value of ``None`` if the table does not use polymorphic inheritance.
     """
     classes = {}
     for table in Base.metadata.tables.values():

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -168,7 +168,7 @@ def get_mapped_classes():
 
     exp = Experiment(session)
 
-    classes = []
+    classes = {}
     for table in Base.metadata.tables.values():
         if "type" in table.columns:
             observed_types = [
@@ -177,16 +177,19 @@ def get_mapped_classes():
             mappers = get_polymorphic_mappers(table)
             for type_ in observed_types:
                 cls = mappers[type_]
-                classes.append(
-                    {"cls": cls, "table": table.name, "polymorphic_identity": type_}
-                )
+                classes[cls.__name__] = {
+                    "cls": cls,
+                    "table": table.name,
+                    "polymorphic_identity": type_,
+                }
         else:
             if session.query(table.columns.id).count() > 0:
                 cls = exp.known_classes[table.name.capitalize()]
-                classes.append(
-                    {"cls": cls, "table": table.name, "polymorphic_identity": None}
-                )
-    classes.sort(key=lambda x: x["cls"].__name__)
+                classes[cls.__name__] = {
+                    "cls": cls,
+                    "table": table.name,
+                    "polymorphic_identity": None,
+                }
     return classes
 
 

--- a/dallinger/db.py
+++ b/dallinger/db.py
@@ -194,10 +194,11 @@ def get_all_mapped_classes():
 
 def get_polymorphic_mapping(table: Union[str, Table]):
     """
-    Lists the different polymorphic mappings defined for a given table.
-    Returns a dictionary of classes
+    Gets the polymorphic mapping for a given table.
+    Returns a dictionary
     where the dictionary keys correspond to polymorphic identities
-    (i.e. possible values of the table's ``type`` column).
+    (i.e. possible values of the table's ``type`` column)
+    and the dictionary values correspond to classes.
     """
     if isinstance(table, str):
         table_name = table
@@ -213,6 +214,9 @@ def get_polymorphic_mapping(table: Union[str, Table]):
 
 
 def get_mapped_classes(table: Union[str, Table]):
+    """
+    Returns a list of classes that map to the provided table.
+    """
     if isinstance(table, str):
         table_name = table
     else:
@@ -227,6 +231,10 @@ def get_mapped_classes(table: Union[str, Table]):
 
 
 def get_mapped_class(table: Union[str, Table]):
+    """
+    Returns the single class that maps to the provided table.
+    Throws an ``AssertionError`` if there is not exactly one such class.
+    """
     mappers = get_mapped_classes(table)
     assert len(mappers) == 1
     return mappers[0]

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -986,8 +986,8 @@ class Experiment(object):
         transformations=False,
     ):
         results = {
-            "networks": self._summarize_table("network", network_roles, network_ids),
-            "nodes": self._summarize_table(
+            "networks": self.summarize_table("network", network_roles, network_ids),
+            "nodes": self.summarize_table(
                 "node",
                 network_roles,
                 network_ids,
@@ -995,19 +995,19 @@ class Experiment(object):
             ),
             "vectors": []
             if collapsed
-            else self._summarize_table("vector", network_roles, network_ids),
+            else self.summarize_table("vector", network_roles, network_ids),
             "infos": []
             if collapsed
-            else self._summarize_table("info", network_roles, network_ids),
-            "participants": [] if collapsed else self._summarize_table("participant"),
+            else self.summarize_table("info", network_roles, network_ids),
+            "participants": [] if collapsed else self.summarize_table("participant"),
             "trans": []
             if collapsed or not transformations
-            else self._summarize_table("transformation", network_roles, network_ids),
+            else self.summarize_table("transformation", network_roles, network_ids),
         }
 
         return results
 
-    def _summarize_table(
+    def summarize_table(
         self,
         table: Union[Table, str],
         network_roles: Optional[List] = None,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -36,7 +36,7 @@ from dallinger.data import (
     is_registered,
 )
 from dallinger.data import load as data_load
-from dallinger.db import Base, db_url, get_polymorphic_mappers, init_db
+from dallinger.db import Base, db_url, get_polymorphic_mapping, init_db
 from dallinger.heroku.tools import HerokuApp
 from dallinger.information import Gene, Meme, State
 from dallinger.models import Info, Network, Node, Participant, Transformation
@@ -1061,7 +1061,7 @@ class Experiment(object):
             cls = getattr(models, table.name.capitalize())
         else:
             assert "type" in table.columns
-            cls = get_polymorphic_mappers(table)[polymorphic_identity]
+            cls = get_polymorphic_mapping(table)[polymorphic_identity]
 
         if cls_filter is not None and not cls_filter(cls):
             return
@@ -1144,7 +1144,7 @@ class Experiment(object):
         if polymorphic_identity is None:
             cls = getattr(models, table.name.capitalize())
         else:
-            cls = get_polymorphic_mappers(table)[polymorphic_identity]
+            cls = get_polymorphic_mapping(table)[polymorphic_identity]
 
         for obj in cls.query.options(undefer("*")).order_by(cls.id).all():
             data = obj.__json__()

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -991,27 +991,40 @@ class Experiment(object):
         collapsed=False,
         transformations=False,
     ):
-        results = {
-            "networks": self.summarize_table("network", network_roles, network_ids),
-            "nodes": self.summarize_table(
-                "node",
-                network_roles,
-                network_ids,
-                cls_filter=(lambda cls: issubclass(cls, Source)) if collapsed else None,
-            ),
-            "vectors": []
-            if collapsed
-            else self.summarize_table("vector", network_roles, network_ids),
-            "infos": []
-            if collapsed
-            else self.summarize_table("info", network_roles, network_ids),
-            "participants": [] if collapsed else self.summarize_table("participant"),
-            "trans": []
-            if collapsed or not transformations
-            else self.summarize_table("transformation", network_roles, network_ids),
-        }
+        networks = (self.summarize_table("network", network_roles, network_ids),)
 
-        return results
+        nodes = self.summarize_table(
+            "node",
+            network_roles,
+            network_ids,
+            cls_filter=(lambda cls: issubclass(cls, Source)) if collapsed else None,
+        )
+
+        if collapsed:
+            vectors = []
+            infos = []
+            participants = []
+            trans = []
+        else:
+            vectors = self.summarize_table("vector", network_roles, network_ids)
+            infos = self.summarize_table("info", network_roles, network_ids)
+            participants = self.summarize_table("participant")
+
+            if transformations:
+                trans = self.summarize_table(
+                    "transformation", network_roles, network_ids
+                )
+            else:
+                trans = []
+
+        return {
+            "networks": networks,
+            "nodes": nodes,
+            "vectors": vectors,
+            "infos": infos,
+            "participants": participants,
+            "trans": trans,
+        }
 
     def summarize_table(
         self,

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -1111,10 +1111,7 @@ class Experiment(object):
             query = query.filter(Network.role.in_(network_roles))
 
         if network_ids is not None:
-            try:
-                query = query.filter(Network.id.in_(network_ids))
-            except Exception:
-                raise
+            query = query.filter(Network.id.in_(network_ids))
 
         if network_roles is not None or network_ids is not None:
             if "network_id" in table.columns:

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -1159,12 +1159,9 @@ class Experiment(object):
         if polymorphic_identity == "None":
             polymorphic_identity = None
 
-        if polymorphic_identity is None:
-            cls = get_mapped_class(table)
-        else:
-            cls = get_polymorphic_mapping(table)[polymorphic_identity]
+        objects = self.pull_table(table, polymorphic_identity=polymorphic_identity)
 
-        for obj in cls.query.options(undefer("*")).order_by(cls.id).all():
+        for obj in objects:
             data = obj.__json__()
             # Add participant worker_id to data, we normally leave it out of
             # JSON renderings

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -1029,16 +1029,21 @@ class Experiment(object):
     def summarize_table(
         self,
         table: Union[Table, str],
-        network_roles: Optional[
-            List
-        ] = None,  # Restrict to objects from networks with given roles
-        network_ids: Optional[
-            List
-        ] = None,  # Restrict to objects from networks with given ids
-        cls_filter: Optional[
-            callable
-        ] = None,  # Lambda function returning ``False`` for classes to exclude
+        network_roles: Optional[List] = None,
+        network_ids: Optional[List] = None,
+        cls_filter: Optional[callable] = None,
     ):
+        """
+        Summarizes a given database table.
+
+        :param table: Table to be summarized
+        :param network_roles: Optionally restrict output to objects from networks with these roles
+        :param network_ids: Optionally restrict output to objects from networks with these IDs
+        :param cls_filter: Optional lambda function that returns ``False`` for classes that should be excluded
+
+        Returns a list of JSON-style dictionaries produced by calling ``.__json__()`` on every object
+        retrieved from the table.
+        """
         objects = self.pull_table(
             table=table,
             polymorphic_identity=None,
@@ -1051,23 +1056,23 @@ class Experiment(object):
     def pull_table(
         self,
         table: Union[Table, str],
-        polymorphic_identity: Optional[
-            str
-        ] = None,  # Restrict to a given polymorphic identity (see ``type`` column)
-        network_roles: Optional[
-            List
-        ] = None,  # Restrict to objects from networks with given roles
-        network_ids: Optional[
-            List
-        ] = None,  # Restrict to objects from networks with given ids
-        cls_filter: Optional[
-            callable
-        ] = None,  # Lambda function returning ``False`` for classes to exclude
+        polymorphic_identity: Optional[str] = None,
+        network_roles: Optional[List] = None,
+        network_ids: Optional[List] = None,
+        cls_filter: Optional[callable] = None,
     ):
         """
         Downloads every object in the specified table.
-        For efficiency, the SQL queries are batched by the values of the polymorphic identity column 'type'
+        For efficiency, the SQL queries are batched by the values of the polymorphic identity column ``type``
         if it is present.
+
+        :param table: Table to be summarized
+        :param polymorphic_identity: Optionally restrict output to a given polymorphic identity (i.e. ``type`` value)
+        :param network_roles: Optionally restrict output to objects from networks with these roles
+        :param network_ids: Optionally restrict output to objects from networks with these IDs
+        :param cls_filter: Optional lambda function that returns ``False`` for classes that should be excluded
+
+        Returns a list of database-mapped objects.
         """
         if isinstance(table, str):
             table = Base.metadata.tables[table]

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -990,7 +990,7 @@ class Experiment(object):
             "nodes": self._summarize_table(
                 "node",
                 sql_filter,
-                cls_filter=lambda cls: issubclass(cls, Source) if collapsed else None,
+                cls_filter=(lambda cls: issubclass(cls, Source)) if collapsed else None,
             ),
             "vectors": [] if collapsed else self._summarize_table("vector", sql_filter),
             "infos": [] if collapsed else self._summarize_table("info", sql_filter),

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -991,7 +991,7 @@ class Experiment(object):
         collapsed=False,
         transformations=False,
     ):
-        networks = (self.summarize_table("network", network_roles, network_ids),)
+        networks = self.summarize_table("network", network_roles, network_ids)
 
         nodes = self.summarize_table(
             "node",

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -723,7 +723,9 @@ def database():
     title = "Database View"
     exp = Experiment(session)
 
-    label = request.args.get("label")
+    label = request.args.get("polymorphic_identity", None)
+    if label is None:
+        label = request.args.get("table", None).capitalize()
 
     if label:
         title = "Database View: {}s".format(label)

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -718,7 +718,7 @@ def prep_datatables_options(table_data):
 @dashboard.route("/database")
 @login_required
 def database():
-    from dallinger.db import get_polymorphic_mappers
+    from dallinger.db import get_polymorphic_mapping
     from dallinger.experiment_server.experiment_server import Experiment, session
 
     exp = Experiment(session)
@@ -734,7 +734,7 @@ def database():
 
     if polymorphic_identity is not None:
         assert table is not None
-        cls = get_polymorphic_mappers(table)[polymorphic_identity]
+        cls = get_polymorphic_mapping(table)[polymorphic_identity]
         label = cls.__name__
     else:
         label = table.capitalize()

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -28,7 +28,7 @@ from wtforms.validators import DataRequired, ValidationError
 import dallinger.db
 from dallinger import recruiters
 from dallinger.config import get_config
-from dallinger.db import get_mapped_classes
+from dallinger.db import get_all_mapped_classes
 from dallinger.heroku.tools import HerokuApp
 from dallinger.utils import deferred_route_decorator
 
@@ -215,7 +215,7 @@ BROWSEABLE_MODELS = [
 
 
 def database_children():
-    mapped_classes = list(get_mapped_classes().items())
+    mapped_classes = list(get_all_mapped_classes().items())
     mapped_classes.sort(key=lambda x: x[0])
     for cls_name, cls_info in mapped_classes:
         yield DashboardTab(

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -215,7 +215,7 @@ BROWSEABLE_MODELS = [
 
 
 def database_children():
-    mapped_classes = get_mapped_classes().items()
+    mapped_classes = list(get_mapped_classes().items())
     mapped_classes.sort(key=lambda x: x[0])
     for cls_name, cls_info in mapped_classes:
         yield DashboardTab(

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -202,18 +202,6 @@ class DashboardTabs(object):
         return iter(self.tabs)
 
 
-BROWSEABLE_MODELS = [
-    "Info",
-    "Network",
-    "Node",
-    "Participant",
-    "Question",
-    "Transformation",
-    "Transmission",
-    "Notification",
-]
-
-
 def database_children():
     mapped_classes = list(get_all_mapped_classes().items())
     mapped_classes.sort(key=lambda x: x[0])

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -718,17 +718,28 @@ def prep_datatables_options(table_data):
 @dashboard.route("/database")
 @login_required
 def database():
+    from dallinger.db import get_polymorphic_mappers
     from dallinger.experiment_server.experiment_server import Experiment, session
 
-    title = "Database View"
     exp = Experiment(session)
 
-    label = request.args.get("polymorphic_identity", None)
-    if label is None:
-        label = request.args.get("table", None).capitalize()
+    table = request.args.get("table", None)
+    polymorphic_identity = request.args.get("polymorphic_identity", None)
 
-    if label:
-        title = "Database View: {}s".format(label)
+    if polymorphic_identity == "None":
+        polymorphic_identity = None
+
+    if table is None and polymorphic_identity is None:
+        table = "participant"
+
+    if polymorphic_identity is not None:
+        assert table is not None
+        cls = get_polymorphic_mappers(table)[polymorphic_identity]
+        label = cls.__name__
+    else:
+        label = table.capitalize()
+
+    title = "Database View: {}".format(label)
     datatables_options = prep_datatables_options(
         exp.table_data(**request.args.to_dict())
     )

--- a/dallinger/frontend/templates/dashboard_monitor.html
+++ b/dallinger/frontend/templates/dashboard_monitor.html
@@ -17,7 +17,7 @@
                                 <option value="n_pending_infos">Number of pending infos</option>
                                 <option value="n_completed_infos">Number of completed infos</option>
                                 <option value="n_failed_infos">Number of failed infos</option>
-                                <option value="n_completed_nodes">Number of completed nodes</option>
+                                <option value="n_alive_nodes">Number of completed nodes</option>
                                 <option value="n_failed_nodes">Number of failed nodes</option>
                             </select>
                             <div class="input-group-append">

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -685,7 +685,7 @@ class TestDashboardDatabase(object):
         resp = webapp_admin.get("/dashboard/database?table=network")
 
         assert resp.status_code == 200
-        assert "<h1>Database View: Networks</h1>" in resp.data.decode("utf8")
+        assert "<h1>Database View: Network</h1>" in resp.data.decode("utf8")
 
     def test_table_data(self, a, db_session):
         from dallinger.experiment_server.experiment_server import Experiment

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -501,6 +501,7 @@ class TestDashboardNetworkInfo(object):
         info4 = a.info(origin=source2, contents="contents3")
         a.transformation(info_in=info1, info_out=info2)
         a.transformation(info_in=info3, info_out=info4)
+        db_session.commit()
         yield exp
 
     def test_network_structure(self, a, db_session):
@@ -681,7 +682,7 @@ class TestDashboardDatabase(object):
         assert webapp.get("/dashboard/database").status_code == 401
 
     def test_render(self, active_config, webapp_admin):
-        resp = webapp_admin.get("/dashboard/database?model_type=Network")
+        resp = webapp_admin.get("/dashboard/database?table=network")
 
         assert resp.status_code == 200
         assert "<h1>Database View: Networks</h1>" in resp.data.decode("utf8")
@@ -694,7 +695,7 @@ class TestDashboardDatabase(object):
 
         network = Network.query.all()[0]
 
-        table = exp.table_data(model_type=["Network"])
+        table = exp.table_data(table="network")
         assert len(table["data"]) == 1
         assert table["data"][0]["id"] == network.id
         assert table["data"][0]["role"] == network.role
@@ -708,7 +709,7 @@ class TestDashboardDatabase(object):
 
         source = a.source(network=network)
 
-        table = exp.table_data(model_type="Node")
+        table = exp.table_data(table="node")
         assert len(table["data"]) == 1
         assert table["data"][0]["id"] == source.id
         assert table["data"][0]["type"] == source.type
@@ -721,7 +722,7 @@ class TestDashboardDatabase(object):
             raise KeyError("'id' not in Node columns")
 
         p = a.participant()
-        table = exp.table_data(model_type="Participant")
+        table = exp.table_data(table="participant")
         assert len(table["data"]) == 1
         assert table["data"][0]["id"] == p.id
         assert table["data"][0]["type"] == p.type
@@ -882,7 +883,7 @@ class TestDashboardDatabase(object):
 
         webapp, renderer = mock_renderer
         p = a.participant()
-        webapp.get("/dashboard/database?model_type=Participant")
+        webapp.get("/dashboard/database?table=participant")
         renderer.assert_called_once()
         render_args = renderer.call_args[1]
         dt_options = json.loads(render_args["datatables_options"])
@@ -914,12 +915,12 @@ class TestDashboardDatabase(object):
     def test_actions_with_mturk(self, a, active_config, mock_renderer):
         webapp, renderer = mock_renderer
         active_config.extend({"mode": "live", "recruiter": "mturk"})
-        webapp.get("/dashboard/database?model_type=Participant")
+        webapp.get("/dashboard/database?table=participant")
         render_args = renderer.call_args[1]
         assert render_args["is_sandbox"] is False
 
         active_config.extend({"mode": "sandbox", "recruiter": "mturk"})
-        webapp.get("/dashboard/database?model_type=Participant")
+        webapp.get("/dashboard/database?table=participant")
         render_args = renderer.call_args[1]
         assert render_args["is_sandbox"] is True
 
@@ -933,7 +934,7 @@ class TestDashboardDatabase(object):
             actions.return_value = [
                 {"name": "special_action", "title": "Special Action"}
             ]
-            webapp.get("/dashboard/database?model_type=Participant")
+            webapp.get("/dashboard/database?table=participant")
             render_args = renderer.call_args[1]
             dt_options = json.loads(render_args["datatables_options"])
             actions = dt_options["buttons"][1]

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ import six
 from pytest import mark, raises
 
 from dallinger import models, nodes
-from dallinger.db import get_mapped_classes
+from dallinger.db import Base, get_mapped_classes, get_polymorphic_mappers
 from dallinger.information import Gene
 from dallinger.nodes import Agent, Source
 from dallinger.transformations import Mutation
@@ -810,3 +810,11 @@ class TestModels(object):
             "table": "node",
             "polymorphic_identity": "node",
         }
+
+    def test_get_polymorphic_mappers(self, db_session):
+        table = Base.metadata.tables["node"]
+        mappers = get_polymorphic_mappers(table)
+
+        assert mappers["generic_source"] == Source
+        assert mappers["agent"] == Agent
+        assert mappers["node"] == models.Node

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ import six
 from pytest import mark, raises
 
 from dallinger import models, nodes
-from dallinger.db import Base, get_mapped_classes, get_polymorphic_mappers
+from dallinger.db import Base, get_all_mapped_classes, get_polymorphic_mappers
 from dallinger.information import Gene
 from dallinger.nodes import Agent, Source
 from dallinger.transformations import Mutation
@@ -762,7 +762,7 @@ class TestModels(object):
         assert "unique_id" not in participant_json
         assert "worker_id" not in participant_json
 
-    def test_get_mapped_classes(self, db_session):
+    def test_get_all_mapped_classes(self, db_session):
         net = models.Network()
         participant = models.Participant(
             recruiter_id="hotair",
@@ -785,7 +785,7 @@ class TestModels(object):
         db_session.add(source)
         db_session.commit()
 
-        classes = get_mapped_classes()
+        classes = get_all_mapped_classes()
 
         assert classes["Participant"] == {
             "cls": models.Participant,

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -108,6 +108,11 @@ class TestModels(object):
             "property4": None,
             "property5": None,
             "details": {},
+            "n_alive_nodes": 3,
+            "n_failed_nodes": 0,
+            "n_completed_infos": 2,
+            "n_pending_infos": 0,
+            "n_failed_infos": 0,
             "object_type": "Network",
         }
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,7 @@ import six
 from pytest import mark, raises
 
 from dallinger import models, nodes
-from dallinger.db import Base, get_all_mapped_classes, get_polymorphic_mappers
+from dallinger.db import Base, get_all_mapped_classes, get_polymorphic_mapping
 from dallinger.information import Gene
 from dallinger.nodes import Agent, Source
 from dallinger.transformations import Mutation
@@ -811,9 +811,9 @@ class TestModels(object):
             "polymorphic_identity": "node",
         }
 
-    def test_get_polymorphic_mappers(self, db_session):
+    def test_get_polymorphic_mapping(self, db_session):
         table = Base.metadata.tables["node"]
-        mappers = get_polymorphic_mappers(table)
+        mappers = get_polymorphic_mapping(table)
 
         assert mappers["generic_source"] == Source
         assert mappers["agent"] == Agent


### PR DESCRIPTION
## Description

Enhanced efficiency in dashboard monitor data loading.

## Motivation and Context

Previously the dashboard could take a very long time to load when the database contained many custom object classes. In such cases we are now running about 1000 times faster.

## How Has This Been Tested?

I have added a few unit tests for new functions included in this merge request. The monitor already had good coverage with unit tests, and these are now passing, showing that existing functionality has been preserved. I have manually tested performance of the dashboard with a large experiment (2000 networks, PsyNet static_big demo, faster-exports branch), and have verified that performance is now much improved.