### PR TITLE
Fix remote_postgres for docker compose v2

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -525,7 +525,7 @@ def remote_postgres(server_info, app):
         # on the remote docker container. First we need to find the IP of the
         # container running docker
         postgresql_remote_ip = executor.run(
-            "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dallinger_postgresql_1"
+            "docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dallinger-postgresql-1"
         ).strip()
         # Now we start the tunnel
         tunnel = SSHTunnelForwarder(


### PR DESCRIPTION
## Description

- Fixed `remote_postgres` for compatibility with docker compose v2. This was necessary because docker compose v2 uses slightly different container names by default, using hyphens as separators rather than underscores.

## How Has This Been Tested?

Tested locally by running an experiment export.