### PR TITLE
Propagate config dashboard credentials to Docker

### DIFF
--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -203,7 +203,8 @@ def deploy_image(image_name, mode, config_options):
     """Deploy Heroku app using a docker image and MTurk."""
     config = get_config()
     config.load()
-    dashboard_password = secrets.token_urlsafe(8)
+    dashboard_user = config.get("dashboard_user", "admin")
+    dashboard_password = config.get("dashboard_password", secrets.token_urlsafe(8))
     dallinger_uid = str(uuid.uuid4())
     config_dict = {
         "AWS_ACCESS_KEY_ID": config.get("aws_access_key_id"),
@@ -215,6 +216,7 @@ def deploy_image(image_name, mode, config_options):
         "smtp_password": config.get("smtp_password"),
         "whimsical": config.get("whimsical"),
         "FLASK_SECRET_KEY": secrets.token_urlsafe(16),
+        "dashboard_user": dashboard_user,
         "dashboard_password": dashboard_password,
         "mode": mode,
         "CREATOR": netrc.netrc().hosts["api.heroku.com"][0],

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -3,6 +3,7 @@ import io
 import json
 import logging
 import os
+import secrets
 import select
 import socket
 import sys
@@ -307,7 +308,9 @@ def deploy(
         experiment_id = get_experiment_id_from_archive(archive_path)
     else:
         experiment_id = f"dlgr-{experiment_uuid[:8]}"
-    dashboard_password = token_urlsafe(8)
+
+    dashboard_user = config.get("dashboard_user", "admin")
+    dashboard_password = config.get("dashboard_password", secrets.token_urlsafe(8))
 
     cfg = config.as_dict()
     for key in "aws_access_key_id", "aws_secret_access_key":
@@ -323,6 +326,7 @@ def deploy(
             "smtp_password": config.get("smtp_password"),
             "prolific_api_token": config["prolific_api_token"],
             "auto_recruit": config["auto_recruit"],
+            "dashboard_user": dashboard_user,
             "dashboard_password": dashboard_password,
             "mode": mode,
             "CREATOR": f"{USER}@{HOSTNAME}",


### PR DESCRIPTION
Fixed a bug where config dashboard credentials weren't being propagated to Docker deployments.

## How Has This Been Tested?

Tested by manual deployment
