### PR TITLE
Fix app-id not set in Docker deployment

### DIFF
--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -139,7 +139,8 @@ def push(use_existing: bool, **kwargs) -> str:
 
     config = get_config()
     config.load()
-    _, tmp = setup_experiment(log=log, debug=True, local_checks=False)
+    app_name = kwargs.get("app_name", None)
+    _, tmp = setup_experiment(log=log, debug=True, local_checks=False, app=app_name)
     image_name_with_tag = build_image(
         tmp,
         config.get("docker_image_base_name"),
@@ -325,7 +326,7 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     build_image(tmp, Path(os.getcwd()).name, Output(), force_build=True)
 
     # Push the built image to get the registry sha256
-    image_name = push.callback(use_existing=True)
+    image_name = push.callback(use_existing=True, app_name=app)
 
     # Log in to Heroku if we aren't already.
     log("Making sure that you are logged in to Heroku.")

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -224,7 +224,10 @@ def build_and_push_image(f):
                 )
                 raise click.Abort
         _, tmp_dir = setup_experiment(
-            Output().log, exp_config=config.as_dict(), local_checks=False
+            Output().log,
+            exp_config=config.as_dict(),
+            local_checks=False,
+            app=kwargs.get("app_name", None),
         )
         build_image(tmp_dir, config.get("docker_image_base_name"), out=Output())
         image_name = push.callback(use_existing=True)

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -223,14 +223,15 @@ def build_and_push_image(f):
                     f"Could not find image {image_name} specified in experiment config as `docker_image_name`"
                 )
                 raise click.Abort
+        app_name = kwargs.get("app_name", None)
         _, tmp_dir = setup_experiment(
             Output().log,
             exp_config=config.as_dict(),
             local_checks=False,
-            app=kwargs.get("app_name", None),
+            app=app_name,
         )
         build_image(tmp_dir, config.get("docker_image_base_name"), out=Output())
-        image_name = push.callback(use_existing=True)
+        image_name = push.callback(use_existing=True, app_name=app_name)
         return f(image_name, *args, **kwargs)
 
     return wrapper


### PR DESCRIPTION
Fixed a bug where app name / ID was not set appropriately in config during Docker deployment. Now when you docker-ssh deploy with a specified `--app` argument this is saved as expected in `config.heroku_app_id`.

(As an aside, the name heroku_app_id is not ideal and we should consider updating it one day)

## How Has This Been Tested?

Tested by manually deploying experiments.