### PR TITLE
Fix bug in Docker SSH 'removing any pre-existing app with the same name'

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -303,7 +303,8 @@ def deploy(
     print("Removing any pre-existing app with the same name.")
     app_yml = f"~/dallinger/{app_name}/docker-compose.yml"
     executor.run(
-        f"if [ -f {app_yml} ]; then docker compose -f {app_yml} down --remove-orphans; fi"
+        f"if [ -f {app_yml} ]; then docker compose -f {app_yml} down --remove-orphans; fi",
+        _raise=False,
     )
 
     print("Removing any pre-existing Redis volumes.")


### PR DESCRIPTION
When Docker-SSH deploys and an app currently exists with that name, there is currently code for stopping any pre-existing app. This code uses `docker compose down`, but this command throws an error like this:

```
Error response from daemon: error while removing network: network dallinger id 4fd314c36d2e3baf56d450156c189ea078522bed75a7824ba8108a403e47971c has active endpoints
```

Following the implementation in `dallinger docker-ssh destroy`, we can safely ignore this error because we don't want/need to remove this network. So, we just pass `_raise=False` to stop these errors from breaking the command.