### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     needs: check_mturk_changes
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     services:
       redis:
         image: redis
@@ -113,7 +113,7 @@ jobs:
         run: |
           tox ${{ needs.check_mturk_changes.outputs.needs_mturk_tests == 'true' && '-- --mturkfull' || ''}}
           npm run test --coverage
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == 3.10 || matrix.python-version == 3.11
       - name: Run Fast Tests Only
         env:
           DATABASE_URL: postgresql://dallinger:dallinger@localhost/dallinger
@@ -125,10 +125,10 @@ jobs:
         run: |
           tox -e fast
           npm run test --coverage
-        if: matrix.python-version != 3.10
+        if: matrix.python-version != 3.10 && matrix.python-version != 3.11
       - name: Codecov.io check
         uses: codecov/codecov-action@v3
-        if: matrix.python-version == 3.10
+        if: matrix.python-version == 3.11
 
   docker:
     runs-on: ubuntu-latest
@@ -174,10 +174,10 @@ jobs:
         run: docker run --rm ghcr.io/dallinger/dallinger:${{ steps.vars.outputs.version }} python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
       - name: Make sure dallinger script entry point is working with dallinger source mounted as volume
         run: docker run -v $PWD/dallinger:/dallinger/dallinger --rm ghcr.io/dallinger/dallinger:${{ steps.vars.outputs.version }} python3 -c "from pkg_resources import load_entry_point; load_entry_point('dallinger', 'console_scripts', 'dallinger_heroku_worker')"
-      - name: Set up Python 3.10
+      - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.11"
       - name: Cache pip
         uses: actions/cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           tox ${{ needs.check_mturk_changes.outputs.needs_mturk_tests == 'true' && '-- --mturkfull' || ''}}
           npm run test --coverage
-        if: matrix.python-version == 3.10 || matrix.python-version == 3.11
+        if: matrix.python-version == 3.11
       - name: Run Fast Tests Only
         env:
           DATABASE_URL: postgresql://dallinger:dallinger@localhost/dallinger
@@ -125,7 +125,7 @@ jobs:
         run: |
           tox -e fast
           npm run test --coverage
-        if: matrix.python-version != 3.10 && matrix.python-version != 3.11
+        if: matrix.python-version != 3.11
       - name: Codecov.io check
         uses: codecov/codecov-action@v3
         if: matrix.python-version == 3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 ###################### Image with build tools to compile wheels ###############
-FROM python:3.10-bullseye as wheels
+FROM python:3.11-bullseye as wheels
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL Description="Dallinger base docker image" Version="1.0"
@@ -22,7 +22,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 
 ###################### Dallinger base image ###################################
-FROM python:3.10-bullseye as dallinger
+FROM python:3.11-bullseye as dallinger
 ENV DEBIAN_FRONTEND=noninteractive
 LABEL org.opencontainers.image.source https://github.com/Dallinger/Dallinger
 

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -350,4 +350,3 @@ zope-interface==6.0
 # pip
 # setuptools
 # generate from file with hash  d0bfb8e6474319a7832980a687befbb2
-# generate from file with hash  d0bfb8e6474319a7832980a687befbb2

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -350,3 +350,4 @@ zope-interface==6.0
 # pip
 # setuptools
 # generate from file with hash  d0bfb8e6474319a7832980a687befbb2
+# generate from file with hash  d0bfb8e6474319a7832980a687befbb2

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup_args = dict(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Framework :: Pytest",
     ],
     include_package_data=True,

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1136,7 +1136,10 @@ class TestConstraints(object):
             constraints_file = Path(tmp_path) / "constraints.txt"
             # If not present a `constraints.txt` file will be generated
             assert constraints_file.exists()
-            assert "toml" in constraints_file.read_text()
+            if sys.version_info >= (3, 11):
+                assert "toml" not in constraints_file.read_text()
+            else:
+                assert "toml" in constraints_file.read_text()
 
             # An existing file will be left untouched
             constraints_file.write_text("foobar")


### PR DESCRIPTION
# CHANGELOG

- Infrastructure:
  - Added Python 3.11 to list of supported programming languages and to CI workflow
  - Updated `Dockerfile` to use Python 3.11
