### PR TITLE
Improvements to 'unique ID' storage

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -80,6 +80,8 @@ var dallinger = (function () {
    *
    * ``assignmentId``  - MTurk Assignment Id
    *
+   * ``uniqueId``      - MTurk Worker Id and Assignment Id
+   *
    * ``mode``          - Dallinger experiment mode
    *
    * ``participantId`` - Dallinger participant Id
@@ -95,6 +97,8 @@ var dallinger = (function () {
     set workerId(value) {  dlgr.storage.set('worker_id', value); },
     get assignmentId() { return  dlgr.storage.get('assignment_id'); },
     set assignmentId(value) {  dlgr.storage.set('assignment_id', value); },
+    get uniqueId() { return  dlgr.storage.get('unique_id'); },
+    set uniqueId(value) {  dlgr.storage.set('unique_id', value); },
     get mode() { return  dlgr.storage.get('mode'); },
     set mode(value) {  dlgr.storage.set('mode', value); },
     get participantId() { return dlgr.storage.get('participant_id'); },
@@ -109,6 +113,7 @@ var dallinger = (function () {
       this.hitId = dlgr.getUrlParameter('hitId');
       this.workerId = dlgr.getUrlParameter('workerId');
       this.assignmentId = dlgr.getUrlParameter('assignmentId');
+      this.uniqueId = dlgr.getUrlParameter('workerId') + ":" + dlgr.getUrlParameter('assignmentId');
       this.mode = dlgr.getUrlParameter('mode');
       // Store all url parameters as entry information.
       // This won't work in IE, but should work in Edge.

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -101,7 +101,7 @@ describe('identity', function () {
 
   beforeEach(function () {
     window.history.pushState({}, 'Test Title',
-      'test.html?recruiter=hotair&hitId=HHH&assignmentId=AAA&workerId=WWW&uniqueId=WWW:AAA&mode=debug'
+      'test.html?recruiter=hotair&hitId=HHH&assignmentId=AAA&workerId=WWW&mode=debug'
     );
 
     dlgr = require('./dallinger2').dallinger;

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -101,7 +101,7 @@ describe('identity', function () {
 
   beforeEach(function () {
     window.history.pushState({}, 'Test Title',
-      'test.html?recruiter=hotair&hitId=HHH&assignmentId=AAA&workerId=WWW&mode=debug'
+      'test.html?recruiter=hotair&hitId=HHH&assignmentId=AAA&workerId=WWW&uniqueId=WWW:AAA&mode=debug'
     );
 
     dlgr = require('./dallinger2').dallinger;
@@ -112,6 +112,7 @@ describe('identity', function () {
     expect(dlgr.identity.assignmentId).toBe('AAA');
     expect(dlgr.identity.hitId).toBe('HHH');
     expect(dlgr.identity.workerId).toBe('WWW');
+    expect(dlgr.identity.uniqueId).toBe('WWW:AAA');
     expect(dlgr.identity.mode).toBe('debug');
   });
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -213,7 +213,7 @@ class Participant(Base, SharedMixin):
 
     #: A String, a concatenation of :attr:`~dallinger.models.Participant.worker_id`
     #: and :attr:`~dallinger.models.Participant.assignment_id`
-    unique_id = Column(String(75), nullable=False, index=True)
+    unique_id = Column(String(150), nullable=False, index=True)
 
     #: A String, the id of the hit the participant is working on
     hit_id = Column(String(50), nullable=False)


### PR DESCRIPTION
* Save `uniqueId` in `dlgr.identity` JavaScript object
* Increase `unique_id` database column string size to 150