### PR TITLE
Hotfix ssh deploy

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -304,7 +304,7 @@ def deploy(
     app_yml = f"~/dallinger/{app_name}/docker-compose.yml"
     executor.run(
         f"if [ -f {app_yml} ]; then docker compose -f {app_yml} down --remove-orphans; fi",
-        _raise=False,
+        raise_=False,
     )
 
     print("Removing any pre-existing Redis volumes.")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -54,9 +54,12 @@ app = Flask("Experiment_Server")
 
 
 @app.before_request
-def check_for_protected_routes():
+def _load_config():
     _config()
-    
+
+
+@app.before_request
+def check_for_protected_routes():
     if current_user.is_authenticated:
         return
 
@@ -70,11 +73,6 @@ def check_for_protected_routes():
         raise PermissionError(
             f'Unauthorized call to protected route "{active_rule}": {request}'
         )
-
-
-@app.before_request
-def _prep_config():
-    _config()
 
 
 def _config():

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -55,6 +55,8 @@ app = Flask("Experiment_Server")
 
 @app.before_request
 def check_for_protected_routes():
+    _config()
+    
     if current_user.is_authenticated:
         return
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -70,6 +70,7 @@ def check_for_protected_routes():
         )
 
 
+@app.before_request
 def _config():
     app.secret_key = app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
     config = get_config()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -71,6 +71,10 @@ def check_for_protected_routes():
 
 
 @app.before_request
+def _prep_config():
+    _config()
+
+
 def _config():
     app.secret_key = app.config["SECRET_KEY"] = os.environ.get("FLASK_SECRET_KEY")
     config = get_config()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -883,7 +883,14 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
     if overrecruited:
         participant.status = "overrecruited"
 
-    result = {"participant": participant.__json__()}
+    result = {
+        "participant": {
+            **participant.__json__(),
+            # Add some extra information that is useful for initializing dallinger.identity
+            "unique_id": participant.unique_id,
+            "worker_id": participant.worker_id,
+        }
+    }
 
     # Queue notification to others in waiting room
     if exp.quorum:

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -447,6 +447,10 @@ var dallinger = (function () {
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;
+          dlgr.identity.assignmentId = resp.participant.assignment_id;
+          dlgr.identity.uniqueId = resp.participant.unique_id;
+          dlgr.identity.workerId = resp.participant.worker_id;
+          dlgr.identity.hitId = resp.participant.hit_id;
           if (! resp.quorum) {  // We're not using a waiting room.
             deferred.resolve();
             return;

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -437,14 +437,13 @@ var dallinger = (function () {
             "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
             (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;
     }
-    debugger
+
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();
     } else {
       $(function () {
         $('.btn-success').prop('disabled', true);
         dlgr.post(url, data).done(function (resp) {
-          debugger
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -390,7 +390,18 @@ var dallinger = (function () {
     }).done(function () {
       deferred.resolve();
       dlgr.allowExit();
-      if (window.opener && !window.opener.location.pathname.startsWith("/dashboard")) {
+
+      let openedFromDashboard;
+      try {
+        openedFromDashboard = window.opener && !window.opener.location.pathname.startsWith("/dashboard")
+      } catch (error) {
+        // If the parent window was from a different origin (e.g. Prolific) then we see an error like this:
+        // Uncaught DOMException: Blocked a frame with origin XXX from accessing a cross-origin frame.
+        // We catch and ignore this error.
+        openedFromDashboard = false;
+      }
+
+      if (window.opener && !openedFromDashboard) {
         // If the parent window is still around, redirect it to the exit route
         // and close the secondary window (this one) that held the main experiment:
         window.opener.location = exitRoute;

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -437,13 +437,14 @@ var dallinger = (function () {
             "/" + dlgr.identity.assignmentId + "/" + dlgr.identity.mode + "?fingerprint_hash=" +
             (dlgr.identity.fingerprintHash) + '&recruiter=' + dlgr.identity.recruiter;
     }
-
+    debugger
     if (dlgr.identity.participantId !== undefined && dlgr.identity.participantId !== 'undefined') {
       deferred.resolve();
     } else {
       $(function () {
         $('.btn-success').prop('disabled', true);
         dlgr.post(url, data).done(function (resp) {
+          debugger
           console.log(resp);
           $('.btn-success').prop('disabled', false);
           dlgr.identity.participantId = resp.participant.id;


### PR DESCRIPTION
Fixed several bugs that were manifesting on SSH deployments, some of which were specific to Prolific.

- Fixed wrong signature for `executor.run()` call in `docker_ssh.py`.
- Ensured that `config` is loaded before every Flask request; previously config was not loading in advance of the serving of static files and this was causing server errors.
- Fixed a bug in parent window closing which was preventing Prolific experiments from completing.
- Ensured that all fields in `dallinger.identity` are set properly when calling `dallinger.createParticipant`.

I have tested this by debugging an experiment locally and by sandboxing with Docker SSH to Prolific. Note that PsyNet experiments need the hotfix https://gitlab.com/PsyNetDev/PsyNet/-/merge_requests/509 before they can deploy properly.

This fix is quite urgent, and I think we should create a release when it's merged.