### PR TITLE
Fix indentation for Docker volumes in docker-compose.yml.j2

### DIFF
--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -46,7 +46,7 @@ services:
 {%- endfor %}
 {%- if config.get("docker_volumes", "") %}
 {%- for volume in config.get("docker_volumes", "").split(",") %}
-    - {{ volume | string() }}
+      - {{ volume | string() }}
 {%- endfor %}
 {%- endif %}
     environment: &commonenv
@@ -76,7 +76,7 @@ services:
 {%- endfor %}
 {%- if config.get("docker_volumes", "") %}
 {%- for volume in config.get("docker_volumes", "").split(",") %}
-    - {{ volume | string() }}
+      - {{ volume | string() }}
 {%- endfor %}
 {%- endif %}
     environment:


### PR DESCRIPTION
Fix indentation bug writing Docker volumes in `docker-compose.yml.j2` introduced in commit https://github.com/Dallinger/Dallinger/commit/d316719ac3c91a0e46a9e4a5b23a850c72b9aafe