### PR TITLE
Fix small spelling errors in documentation

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -243,7 +243,7 @@ class Recruiter(object):
 
 
 def alphanumeric_code(seed: str, length: int = 8):
-    """Return and alphanumeric string of specified length based on a
+    """Return an alphanumeric string of specified length based on a
     seed value, so the same result will always be returned for a given
     seed.
     """

--- a/demos/dlgr/demos/rogers/models.py
+++ b/demos/dlgr/demos/rogers/models.py
@@ -166,7 +166,7 @@ class RogersEnvironment(Source):
         return State
 
     def _contents(self):
-        """Contents of created infos is either propirtion or 1-proportion by default."""
+        """Contents of created infos is either proportion or 1-proportion by default."""
         if random.random() < 0.5:
             return self.proportion
         else:


### PR DESCRIPTION
This fix addresses a couple of small typos in docstrings.

Background: I'm doing a research study on function comments that may be incorrect. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!