### PR TITLE
Fix bug in dlgr.submitAssignment

### DIFF
--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -393,7 +393,7 @@ var dallinger = (function () {
 
       let openedFromDashboard;
       try {
-        openedFromDashboard = window.opener && !window.opener.location.pathname.startsWith("/dashboard")
+        openedFromDashboard = window.opener && window.opener.location.pathname.startsWith("/dashboard");
       } catch (error) {
         // If the parent window was from a different origin (e.g. Prolific) then we see an error like this:
         // Uncaught DOMException: Blocked a frame with origin XXX from accessing a cross-origin frame.


### PR DESCRIPTION
Fixed a bug in `dlgr.submitAssignment` that was causing MTurk HIT submission to fail. This bug was introduced in v.9.7.0 when fixing another bug (where the dashboard tab was closed on `dlgr.submitAssignment`). The bug meant that `externalSubmit` was being called in the popup window, not the MTurk iframe, causing submission to fail.

## How Has This Been Tested?
I tested this by completing a HIT on MTurk Sandbox, but it would be good if @fmhoeger verifies that this fixes the problem.