### PR TITLE
Remove --resolver=backtracking for pip-tools>=7.0.0

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -595,7 +595,6 @@ cp requirements.txt constraints.txt"""
             check_output(
                 [
                     "pip-compile",
-                    "--resolver=backtracking",
                     "-v",
                     str(tmpfile),
                     "-o",

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -4,9 +4,9 @@ cd $dir/..
 set -xe
 rm -f requirements.txt dev-requirements.txt constraints.txt
 export CUSTOM_COMPILE_COMMAND=./scripts/update_dependencies.sh
-pip-compile --resolver=backtracking constraints.in
-pip-compile --resolver=backtracking dev-requirements.in
-pip-compile --resolver=backtracking
+pip-compile constraints.in
+pip-compile dev-requirements.in
+pip-compile
 
 # Remove the line specifying dallinger as editable dependency
 sed -e "s/^-e.*//" -i *.txt

--- a/scripts/update_experiments_constraints.sh
+++ b/scripts/update_experiments_constraints.sh
@@ -16,7 +16,7 @@ for demo_name in $(ls demos/dlgr/demos/); do
         echo Compiling ${demo_name}
         echo "-c ../../../../dev-requirements.txt
 -r requirements.txt" > temp-requirements.txt
-        pip-compile --resolver=backtracking temp-requirements.txt -o constraints.txt
+        pip-compile temp-requirements.txt -o constraints.txt
         rm temp-requirements.txt
         echo '# generate from file with hash ' $(md5_cmd requirements.txt) >> constraints.txt
         # Remove the extras from constraints.txt


### PR DESCRIPTION
With pip-tools version 7.0.0 `--resolver=backtracking` became the default setting, so it can be removed from `pip-compile` commands.

CHANGELOG for pip-tools 7.0.0: https://github.com/jazzband/pip-tools/releases/tag/7.0.0

See issue https://github.com/Dallinger/Dallinger/issues/4919 for reference.