### PR TITLE
Add check for dependencies using `pkg_resources`

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -19,7 +19,6 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unicodedata import normalize
 
-import pkg_resources
 import requests
 from faker import Faker
 from flask import request
@@ -28,6 +27,11 @@ from dallinger import db
 from dallinger.compat import is_command
 from dallinger.config import get_config
 from dallinger.version import __version__
+
+try:
+    from pip._vendor import pkg_resources
+except ImportError:
+    pkg_resources = None
 
 fake = Faker()
 
@@ -402,7 +406,7 @@ def check_experiment_dependencies(requirements_file):
         if find_spec(dep) is None:
             try:
                 pkg_resources.get_distribution(dep)
-            except pkg_resources.DistributionNotFound:
+            except (pkg_resources.DistributionNotFound, AttributeError):
                 raise ValueError(
                     f"Please install the '{dep}' package to run this experiment."
                 )

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 from unicodedata import normalize
 
+import pkg_resources
 import requests
 from faker import Faker
 from flask import request
@@ -399,9 +400,12 @@ def check_experiment_dependencies(requirements_file):
 
     for dep in dependencies:
         if find_spec(dep) is None:
-            raise ValueError(
-                f"Please install the '{dep}' package to run this experiment."
-            )
+            try:
+                pkg_resources.get_distribution(dep)
+            except pkg_resources.DistributionNotFound:
+                raise ValueError(
+                    f"Please install the '{dep}' package to run this experiment."
+                )
 
 
 def develop_target_path(config):


### PR DESCRIPTION
## Description

When checking for installed experiment dependencies Dallinger uses `importlib.util.find_spec`, but packages whose install name differs from their import name (e.g. `PyYAML` which is imported as `yaml`) aren't found by that check. This change falls back on `pkg_resources.get_distribution` to check the package name when the `find_spec` check fails.

## Motivation and Context

We want GridUniverse to use some YAML configuration and depending on PyYAML caused an issue in `dallinger.uitls.check_experiment_dependencies`. This fixes that import and is likely needed for other libraries as well. The two checks are a bit redundant, and the new check would probably suffice on its own, but there doesn't seem to be any harm in checking both.
