### PR TITLE
Introduce config variable 'lock_table_when_creating_participant'

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -71,6 +71,7 @@ default_keys = (
     ("keywords", six.text_type, []),
     ("language", six.text_type, []),
     ("lifetime", int, []),
+    ("lock_table_when_creating_participant", bool, []),
     ("logfile", six.text_type, []),
     ("loglevel", int, []),
     ("mode", six.text_type, []),

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -20,6 +20,7 @@ replay = False
 mode = debug
 enable_global_experiment_registry = False
 language = en
+lock_table_when_creating_participant = True
 
 [Recruiter]
 activate_recruiter_on_start = True

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -796,7 +796,10 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         config.load()
 
     if config.get("lock_table_when_creating_participant"):
-        # Lock the table, triggering multiple simultaneous accesses to fail
+        # Historically we have locked the participant table when creating participants
+        # to avoid database inconsistency problems. However some experimenters have experienced
+        # some deadlocking problems associated with this locking, so we have made
+        # it an opt-out behavior.
         try:
             session.connection().execute(
                 "LOCK TABLE participant IN EXCLUSIVE MODE NOWAIT"

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -159,6 +159,7 @@ def stub_config():
         "id": "TEST_EXPERIMENT_UID",  # This is a significant value; change with caution.
         "keywords": "kw1, kw2, kw3",
         "lifetime": 1,
+        "lock_table_when_creating_participant": True,
         "logfile": "-",
         "loglevel": 0,
         "mode": "debug",


### PR DESCRIPTION
The `create_participant` route ordinarily begins by locking the Participant table (see `experiment_server.py`):

```py
try:
    session.connection().execute(
        "LOCK TABLE participant IN EXCLUSIVE MODE NOWAIT"
    )
except exc.OperationalError as e:
    e.orig = TransactionRollbackError()
    raise e
```

If this command happens to run at the same time as another server process that interacts with the participant table, it is possible for a deadlock to occur. In such cases the entire server process freezes. This could lead to timeouts in participant requests.

Another approach would be to rewrite experiment code to avoid such deadlocks. In theory one should be able to introduce other locks on the experiment side to avoid such deadlocks occurring. However it is hard to get this right in SQLAlchemy and we have not yet managed to fix the problem that way.

This PR introduces a config variable 'lock_table_when_creating_participant' that defaults to True, preserving the previous behaviour, but can be optionally set to False, in which case Dallinger will no longer lock the database table. This seems to fix the problems that we have been experiencing but we would like to keep an eye on this to see what the long-term implications are.