### PR TITLE
5418 chromedriver fails to download in ci docker job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,6 @@ RUN --mount=type=cache,target=/chromedownload \
     rm -rf /var/lib/apt/lists/*
 
 RUN OUR_CHROME_VERSION=$(google-chrome --version |sed "s/Google Chrome //") && \
-    chrome-for-testing/${OUR_CHROME_VERSION}/linux64/chrome-linux64.zip) && \
     echo Installing chromedriver $OUR_CHROME_VERSION && \
     busybox wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${OUR_CHROME_VERSION}/linux64/chromedriver-linux64.zip -O /tmp/chromedriver_linux64.zip && \
     busybox unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,7 +83,7 @@ RUN --mount=type=cache,target=/chromedownload \
     apt install -y --no-install-recommends /chromedownload/google-chrome-stable_current_amd64.deb && \
     rm -rf /var/lib/apt/lists/*
 
-RUN OUR_CHROME_VERSION=$(google-chrome --version |sed "s/Google Chrome //") && \
+RUN OUR_CHROME_VERSION=$(google-chrome --version |sed "s/Google Chrome //;s/ //") && \
     echo Installing chromedriver $OUR_CHROME_VERSION && \
     busybox wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${OUR_CHROME_VERSION}/linux64/chromedriver-linux64.zip -O /tmp/chromedriver_linux64.zip && \
     busybox unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -83,10 +83,9 @@ RUN --mount=type=cache,target=/chromedownload \
     apt install -y --no-install-recommends /chromedownload/google-chrome-stable_current_amd64.deb && \
     rm -rf /var/lib/apt/lists/*
 
-RUN OUR_CHROME_VERSION=$(google-chrome --version |sed "s/Google Chrome //;s/ //;s/\.[^.]*$//") && \
-    echo Finding the chromedriver version to install for chrome $OUR_CHROME_VERSION && \
-    CHROMEDRIVER_VERSION=$(busybox wget -O - https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${OUR_CHROME_VERSION}) && \
-    echo Installing chromedriver $CHROMEDRIVER_VERSION && \
-    busybox wget https://chromedriver.storage.googleapis.com/${CHROMEDRIVER_VERSION}/chromedriver_linux64.zip -O /tmp/chromedriver_linux64.zip && \
+RUN OUR_CHROME_VERSION=$(google-chrome --version |sed "s/Google Chrome //") && \
+    chrome-for-testing/${OUR_CHROME_VERSION}/linux64/chrome-linux64.zip) && \
+    echo Installing chromedriver $OUR_CHROME_VERSION && \
+    busybox wget https://edgedl.me.gvt1.com/edgedl/chrome/chrome-for-testing/${OUR_CHROME_VERSION}/linux64/chromedriver-linux64.zip -O /tmp/chromedriver_linux64.zip && \
     busybox unzip /tmp/chromedriver_linux64.zip -d /usr/local/bin/ && \
     rm /tmp/chromedriver_linux64.zip


### PR DESCRIPTION
* The download URL for Chromedriver changed as of version 115. This PR fixes the recent issue where the CI docker job fails due to a wrong chromedriver download URL.