### PR TITLE
Fix the display of participant IDs in the dashboard monitor

### DIFF
--- a/dallinger/frontend/static/scripts/network-monitor.js
+++ b/dallinger/frontend/static/scripts/network-monitor.js
@@ -353,7 +353,7 @@ var draw_network = function () {
             from = info.origin_id;
             from_node = list_of_nodes[from];
             node_viz = nodes[list_of_node_indx[from] - 1];
-            participant_id = from_node.participant_id || info.participant_id || null;
+            participant_id = info.participant_id || from_node.participant_id || null;
             if (participant_id === null) {
                 participant = {};
                 participant_id = 0;


### PR DESCRIPTION
Fixed a bug where participant IDs weren't always displaying properly in the dashboard network visualization. 

In particular, this edit concerns the labelling of edges between nodes and infos:

<img width="229" alt="image" src="https://github.com/Dallinger/Dallinger/assets/22684998/0c8aea66-26d0-43e9-98eb-a094a841d9b1">

I have updated the code that works out what participant ID to display. Originally it would look first at `node.participant_id`, then `info.participant_id`. I have now reversed the priority so that the more specific `info.participant_id` is prioritised if available.