### PR TITLE
Improve handle_launch_data error reporting and use it also for docker-ssh deployments

### DIFF
--- a/dallinger/command_line/develop.py
+++ b/dallinger/command_line/develop.py
@@ -13,7 +13,7 @@ from dallinger.command_line.utils import (
 )
 from dallinger.config import get_config
 from dallinger.db import redis_conn
-from dallinger.deployment import DevelopmentDeployment, _handle_launch_data
+from dallinger.deployment import DevelopmentDeployment, handle_launch_data
 from dallinger.utils import develop_target_path, open_browser
 
 BASE_URL = "http://127.0.0.1:{}/"
@@ -87,7 +87,7 @@ def launch_app_and_open_dashboard(port):
 
 def _launch_app(port):
     url = BASE_URL.format(port) + "launch"
-    _handle_launch_data(url, error=log, delay=1.0)
+    handle_launch_data(url, error=log, delay=1.0)
 
 
 def _open_dashboard(port):

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -24,7 +24,7 @@ from dallinger.command_line.utils import (
     verify_id,
 )
 from dallinger.config import get_config
-from dallinger.deployment import _handle_launch_data
+from dallinger.deployment import handle_launch_data
 from dallinger.heroku.tools import HerokuApp
 from dallinger.utils import GitClient, abspath_from_egg, setup_experiment
 
@@ -290,7 +290,7 @@ def deploy_image(image_name, mode, config_options):
 
     print("Launching experiment")
     app_url = f"https://{app_hostname}"
-    launch_data = _handle_launch_data(f"{app_url}/launch", print)
+    launch_data = handle_launch_data(f"{app_url}/launch", print)
     print(launch_data.get("recruitment_msg"))
 
     print(
@@ -427,7 +427,7 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
     log("Calling {}".format(launch_url), chevrons=False)
-    launch_data = _handle_launch_data(launch_url, error=log)
+    launch_data = handle_launch_data(launch_url, error=log)
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -33,7 +33,7 @@ from dallinger.command_line.utils import Output
 from dallinger.config import get_config
 from dallinger.data import bootstrap_db_from_zip, export_db_uri
 from dallinger.db import create_db_engine
-from dallinger.deployment import setup_experiment
+from dallinger.deployment import handle_launch_data, setup_experiment
 from dallinger.utils import abspath_from_egg, check_output
 
 # A couple of constants to colour console output
@@ -515,10 +515,10 @@ def deploy(
         print("Skipping experiment launch logic because we are in update mode.")
     else:
         print("Launching experiment")
-        response = get_retrying_http_client().post(
-            f"https://{experiment_id}.{dns_host}/launch", verify=HAS_TLS
+        launch_data = handle_launch_data(
+            "https://{experiment_id}.{dns_host}/launch", print
         )
-        print(response.json()["recruitment_msg"])
+        print(launch_data.get("recruitment_msg"))
 
     dashboard_user = cfg["ADMIN_USER"]
     dashboard_password = cfg["dashboard_password"]

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -56,12 +56,12 @@ def handle_launch_data(url, error, delay=DEFAULT_DELAY, attempts=MAX_ATTEMPTS):
                 request_happened = False
                 error(
                     f"Error parsing response from {url}, "
-                    f"check logs for details.\n{launch_request.text}"
+                    f"check server logs for details.\n{launch_request.text}"
                 )
             except ValueError as err:
                 error(
                     f"Error parsing response from {url}, "
-                    f"check logs for details.\n{err}\n{launch_request.text}"
+                    f"check server logs for details.\n{err}\n{launch_request.text}"
                 )
                 raise
 
@@ -87,7 +87,7 @@ def handle_launch_data(url, error, delay=DEFAULT_DELAY, attempts=MAX_ATTEMPTS):
             )
         time.sleep(delay)
 
-    error("Experiment launch failed, check logs for details.")
+    error("Experiment launch failed, check server logs for details.")
     if launch_data and launch_data.get("message"):
         error(launch_data["message"])
     if launch_request is not None:

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -26,37 +26,44 @@ from dallinger.utils import (
     setup_experiment,
 )
 
-INITIAL_DELAY = 1
+DEFAULT_DELAY = 1
 BACKOFF_FACTOR = 2
 MAX_ATTEMPTS = 6
 
 
-def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):
+def handle_launch_data(url, error, delay=DEFAULT_DELAY, attempts=MAX_ATTEMPTS):
+    """Sends a POST request to te given `url`, retrying it with exponential backoff.
+    The passed `error` function is invoked to give feedback as each error occurs,
+    possibly multiple times.
+    """
     launch_data = None
     launch_request = None
     for remaining_attempt in sorted(range(attempts), reverse=True):  # [3, 2, 1, 0]
-        time.sleep(delay)
         try:
             launch_request = requests.post(url)
             request_happened = True
-        except requests.exceptions.RequestException:
+        except requests.exceptions.RequestException as err:
             request_happened = False
-            error(f"Error accessing {url}")
+            error(f"Error accessing {url}:\n{err}")
 
-        try:
-            if request_happened:
+        if request_happened:
+            try:
                 launch_data = launch_request.json()
-        except ValueError:
-            error(
-                "Error parsing response from {}, "
-                "check web dyno logs for details: {}".format(url, launch_request.text)
-            )
-            raise
-        except json.decoder.JSONDecodeError:
-            # The Heroku backend did not return JSON. It means our dallinger instance
-            # was not (yet) running at the time of the request.
-            # We treat this similarly to a RequestException: we'll try again after waiting.
-            request_happened = False
+            except json.decoder.JSONDecodeError:
+                # The backend did not return JSON. It means our dallinger instance
+                # was not (yet) running at the time of the request.
+                # We treat this similarly to a RequestException: we'll try again after waiting.
+                request_happened = False
+                error(
+                    f"Error parsing response from {url}, "
+                    f"check logs for details.\n{launch_request.text}"
+                )
+            except ValueError as err:
+                error(
+                    f"Error parsing response from {url}, "
+                    f"check logs for details.\n{err}\n{launch_request.text}"
+                )
+                raise
 
         # Early return if successful
         if request_happened and launch_request.ok:
@@ -78,8 +85,9 @@ def _handle_launch_data(url, error, delay=INITIAL_DELAY, attempts=MAX_ATTEMPTS):
                     next_attempt_count, attempts, delay
                 )
             )
+        time.sleep(delay)
 
-    error("Experiment launch failed, check web dyno logs for details.")
+    error("Experiment launch failed, check logs for details.")
     if launch_data and launch_data.get("message"):
         error(launch_data["message"])
     if launch_request is not None:
@@ -216,7 +224,7 @@ def deploy_sandbox_shared_setup(
     log("Launching the experiment on the remote server and starting recruitment...")
     launch_url = "{}/launch".format(heroku_app.url)
     log("Calling {}".format(launch_url), chevrons=False)
-    launch_data = _handle_launch_data(launch_url, error=log)
+    launch_data = handle_launch_data(launch_url, error=log)
     result = {
         "app_name": heroku_app.name,
         "app_home": heroku_app.url,
@@ -390,7 +398,7 @@ class DebugDeployment(HerokuLocalDeployment):
         self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
         self.out.log("Launching the experiment...")
         try:
-            result = _handle_launch_data(
+            result = handle_launch_data(
                 "{}/launch".format(base_url), error=self.out.error, attempts=1
             )
         except Exception:
@@ -545,7 +553,7 @@ class LoaderDeployment(HerokuLocalDeployment):
         if self.exp_config.get("replay"):
             self.out.log("Launching the experiment...")
             time.sleep(4)
-            _handle_launch_data("{}/launch".format(base_url), error=self.out.error)
+            handle_launch_data("{}/launch".format(base_url), error=self.out.error)
             heroku.monitor(listener=self.notify)
 
         # Just run until interrupted:

--- a/docs/source/troubleshooting.rst
+++ b/docs/source/troubleshooting.rst
@@ -51,7 +51,7 @@ Common Sandbox Error
 
     ❯❯ Launching the experiment on MTurk...
 
-    ❯❯ Error parsing response from /launch, check web dyno logs for details: <!DOCTYPE html>
+    ❯❯ Error parsing response from /launch, check logs for details: <!DOCTYPE html>
         <html>
           <head>
             <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -95,8 +95,8 @@ Common Sandbox Error
       File "/Users/user/Dallinger/dallinger/command_line.py", line 550, in _deploy_in_mode
         deploy_sandbox_shared_setup(verbose=verbose, app=app)
       File "/Users/user/Dallinger/dallinger/command_line.py", line 518, in deploy_sandbox_shared_setup
-        launch_data = _handle_launch_data('{}/launch'.format(heroku_app.url))
-      File "/Users/user/Dallinger/dallinger/command_line.py", line 386, in _handle_launch_data
+        launch_data = handle_launch_data('{}/launch'.format(heroku_app.url))
+      File "/Users/user/Dallinger/dallinger/command_line.py", line 386, in handle_launch_data
         launch_data = launch_request.json()
       File "/Users/user/.virtualenvs/dallinger/lib/python3.6/site-packages/requests/models.py", line 892, in json
         return complexjson.loads(self.text, **kwargs)

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import mock
 import pexpect
 import pytest
+import requests
 import six
 from pytest import raises
 from six.moves import configparser
@@ -57,7 +58,7 @@ def faster(tempdir, active_config):
 
 @pytest.fixture
 def launch():
-    with mock.patch("dallinger.deployment._handle_launch_data") as hld:
+    with mock.patch("dallinger.deployment.handle_launch_data") as hld:
         hld.return_value = {"recruitment_msg": "fake\nrecruitment\nlist"}
         yield hld
 
@@ -734,13 +735,12 @@ class TestDeploySandboxSharedSetupFullSystem(object):
 
 
 @pytest.mark.usefixtures("bartlett_dir")
-@pytest.mark.slow
-class Test_handle_launch_data(object):
+class Testhandle_launch_data(object):
     @pytest.fixture
     def handler(self):
-        from dallinger.deployment import _handle_launch_data
+        from dallinger.deployment import handle_launch_data
 
-        return _handle_launch_data
+        return handle_launch_data
 
     def test_success(self, handler):
         log = mock.Mock()
@@ -751,19 +751,17 @@ class Test_handle_launch_data(object):
             mock_post.return_value = result
             assert handler("/some-launch-url", error=log) == {"message": "msg!"}
 
-    def test_failure(self, handler):
-        from requests.exceptions import HTTPError
-
+    def test_failure_mock(self, handler):
         log = mock.Mock()
         with mock.patch("dallinger.deployment.requests.post") as mock_post:
             mock_post.return_value = mock.Mock(
                 ok=False,
                 json=mock.Mock(return_value={"message": "msg!"}),
-                raise_for_status=mock.Mock(side_effect=HTTPError),
+                raise_for_status=mock.Mock(side_effect=requests.exceptions.HTTPError),
                 status_code=500,
                 text="Failure",
             )
-            with pytest.raises(HTTPError):
+            with pytest.raises(requests.exceptions.HTTPError):
                 handler("/some-launch-url", error=log, delay=0.05, attempts=3)
 
         log.assert_has_calls(
@@ -777,10 +775,30 @@ class Test_handle_launch_data(object):
                     "Experiment launch failed. Trying again (attempt 3 of 3) in 0.2 seconds ..."
                 ),
                 mock.call("Error accessing /some-launch-url (500):\nFailure"),
-                mock.call("Experiment launch failed, check web dyno logs for details."),
+                mock.call("Experiment launch failed, check logs for details."),
                 mock.call("msg!"),
             ]
         )
+
+    def test_failure_real(self, handler):
+        log = mock.Mock()
+
+        try:
+            handler("https://httpbin.org/status/500", log, attempts=1)
+        except requests.exceptions.HTTPError:
+            pass
+        log.assert_has_calls(
+            [
+                mock.call(
+                    "Error parsing response from https://httpbin.org/status/500, check logs for details.\n"
+                ),
+                mock.call("Experiment launch failed, check logs for details."),
+            ]
+        )
+
+        log.reset_mock()
+        handler("https://nonexistent.example.com/", log, attempts=1)
+        assert "Name or service not known" in log.call_args_list[0][0][0]
 
     def test_non_json_response_error(self, handler):
         log = mock.Mock()
@@ -792,7 +810,7 @@ class Test_handle_launch_data(object):
                 handler("/some-launch-url", error=log)
 
         log.assert_called_once_with(
-            "Error parsing response from /some-launch-url, check web dyno logs for details: "
+            "Error parsing response from /some-launch-url, check logs for details.\n\n"
             "Big, unexpected problem."
         )
 
@@ -923,14 +941,14 @@ class TestDebugServer(object):
                 pass
 
     def test_failure(self, debugger):
-        from requests.exceptions import HTTPError
-
         with mock.patch("dallinger.deployment.HerokuLocalDeployment.WRAPPER_CLASS"):
             with mock.patch("dallinger.deployment.requests.post") as mock_post:
                 mock_post.return_value = mock.Mock(
                     ok=False,
                     json=mock.Mock(return_value={"message": "msg!"}),
-                    raise_for_status=mock.Mock(side_effect=HTTPError),
+                    raise_for_status=mock.Mock(
+                        side_effect=requests.exceptions.HTTPError
+                    ),
                     status_code=500,
                     text="Failure",
                 )
@@ -942,7 +960,7 @@ class TestDebugServer(object):
                 mock.call(
                     "Error accessing http://localhost:5000/launch (500):\nFailure"
                 ),
-                mock.call("Experiment launch failed, check web dyno logs for details."),
+                mock.call("Experiment launch failed, check logs for details."),
                 mock.call("msg!"),
             ]
         )

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -775,7 +775,7 @@ class Testhandle_launch_data(object):
                     "Experiment launch failed. Trying again (attempt 3 of 3) in 0.2 seconds ..."
                 ),
                 mock.call("Error accessing /some-launch-url (500):\nFailure"),
-                mock.call("Experiment launch failed, check logs for details."),
+                mock.call("Experiment launch failed, check server logs for details."),
                 mock.call("msg!"),
             ]
         )
@@ -790,9 +790,9 @@ class Testhandle_launch_data(object):
         log.assert_has_calls(
             [
                 mock.call(
-                    "Error parsing response from https://httpbin.org/status/500, check logs for details.\n"
+                    "Error parsing response from https://httpbin.org/status/500, check server logs for details.\n"
                 ),
-                mock.call("Experiment launch failed, check logs for details."),
+                mock.call("Experiment launch failed, check server logs for details."),
             ]
         )
 
@@ -810,7 +810,7 @@ class Testhandle_launch_data(object):
                 handler("/some-launch-url", error=log)
 
         log.assert_called_once_with(
-            "Error parsing response from /some-launch-url, check logs for details.\n\n"
+            "Error parsing response from /some-launch-url, check server logs for details.\n\n"
             "Big, unexpected problem."
         )
 
@@ -960,7 +960,7 @@ class TestDebugServer(object):
                 mock.call(
                     "Error accessing http://localhost:5000/launch (500):\nFailure"
                 ),
-                mock.call("Experiment launch failed, check logs for details."),
+                mock.call("Experiment launch failed, check server logs for details."),
                 mock.call("msg!"),
             ]
         )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
The `dallinger docker-ssh deploy` is very scarce in details when the http request to `/launch` the experiment fails. The heroku deployment gives more details.
This PR makes `dallinger docker-ssh deploy` use the same code to do the request, improving the error handling. It also adds a test for failures (to make sure helpful messages are emitted) and changes the logic of the `handle_launch_data` function to be more explicit (for instance when a request returns a non-json body.


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
See #5124 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
A unit test has been added.