### PR TITLE
Add hard version constraint for Werkzeug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,9 @@ setup_args = dict(
         "tzlocal",
         "ua-parser",
         "user-agents",
+        # Newer versions of Werkzeug are not compatible with the current
+        # Flask-Login release
+        "Werkzeug < 3.0.0",
     ],
     extras_require={
         "jupyter": [


### PR DESCRIPTION
Make sure `pip install Dallinger` or `pip install -e .` from a checkout don't break by downloading a Werkzeug that's too new.
