### PR TITLE
Revise 'Study now published on Prolific' -> 'Study created on Prolific'

### DIFF
--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -366,7 +366,7 @@ class ProlificRecruiter(Recruiter):
 
         return {
             "items": [study_info["external_study_url"]],
-            "message": "Study now published on Prolific",
+            "message": "Study created on Prolific",
         }
 
     def normalize_entry_information(self, entry_information: dict):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -389,7 +389,7 @@ class TestProlificRecruiter(object):
 
     def test_open_recruitment_with_valid_request(self, recruiter):
         result = recruiter.open_recruitment(n=5)
-        assert result["message"] == "Study now published on Prolific"
+        assert result["message"] == "Study created on Prolific"
 
     def test_open_recruitment_raises_if_study_already_in_progress(self, recruiter):
         from dallinger.recruiters import ProlificRecruiterException


### PR DESCRIPTION
## Description

I revised the logging text

> Study now published on Prolific

to the more accurate

> Study created on Prolific

The former was a bit misleading for cases where there is no initial recruitment of participants
