### PR TITLE
Bugfix in handle_launch_data

### DIFF
--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -522,7 +522,7 @@ def deploy(
     else:
         print("Launching experiment")
         launch_data = handle_launch_data(
-            "https://{experiment_id}.{dns_host}/launch", print
+            f"https://{experiment_id}.{dns_host}/launch", print
         )
         print(launch_data.get("recruitment_msg"))
 


### PR DESCRIPTION
There was a missing `f` in an f-string that was causing deployments to fail.
