### PR TITLE
Issues/5726 prolific double submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,36 +3,44 @@
 ## [v10.1.3](https://github.com/dallinger/dallinger/tree/v10.1.3) (2024-07-04)
 
 #### Fixed
+
 - Fixed a new bug whereby participants could not begin the experiment in Prolific.
 
 ## [v10.1.2](https://github.com/dallinger/dallinger/tree/v10.1.2) (2024-07-02)
 
 #### Fixed
+
 - Removed `check-latest: true` from `setup-python` action in ci.yml.
 - Renamed `prolific.co` to `prolific.com` for API calls to `api.prolific.com` and for various other subdomains.
 - Fixed value for `recruiter` in the 'New participant' link in the dashboard's "Development" tab. It is now set dynamically, e.g. when deploying with Prolific as recruitment method `recruiter` is set to "prolific", whereas when debugging the same experiment locally, `recruiter` is assigned "hotair" as value.
 
 #### Updated
+
 - Infrastructure: Updated dependencies.
 
 ## [v10.1.1](https://github.com/dallinger/dallinger/tree/v10.1.1) (2024-05-09)
 
 #### Updated
+
 - Infrastructure: Updated Docker images to Debian bookworm
 
 ## [v10.1.0](https://github.com/dallinger/dallinger/tree/v10.1.0) (2024-05-08)
 
 #### Added
+
 - Added check to prevent underscores in `app` names. Allowed characters are `a-z`, `0-9` , and `-`.
 - Added logic for customizing `Recruiter` classes.
 
 #### Fixed
+
 - Fixed `SyntaxWarning: invalid escape sequence '\*'` in Python 3.12.
 
 #### Changed
+
 - The database reset button in the dashboard is now only displayed in debug mode.
 
 #### Updated
+
 - Infrastructure: Updated dependencies
   - Removed `mock` package; updated tests.
   - Removed pinning for `pytest`; updated tests.
@@ -40,25 +48,31 @@
 ## [v10.0.1](https://github.com/dallinger/dallinger/tree/v10.0.1) (2024-03-04)
 
 #### Added
+
 - Implemented `Experiment.get_status`, a customizable method that reports the current status of the experiment.
 - Implemented `Experiment.before_request` and `Experiment.after_request`, customizable hooks for running code before and after HTTP requests.
 
 #### Fixed
+
 - Fixed Chrome and ChromeDriver download link in Dockerfile.
 - Fixed dallinger requirement in demos and updated demos' constraints.
 
 #### Removed
+
 - Removed unused numpy and pandas dependencies.
 
 #### Updated
+
 - Infrastructure: Updated dependencies; pin pytest == 8.0.0.
 
 ## [v10.0.0](https://github.com/dallinger/dallinger/tree/v10.0.0) (2024-02-15)
 
 #### Breaking
+
 - Removed support for Python 3.8.
 
 #### Added
+
 - Added support for Python 3.12.
   - Remove version pinning for numpy, pandas, pre-commit, sphinx, and sphinx-related packages.
   - CI: Added Python 3.12 to GitHub workflow matrix and run Full tox tests for both Python 3.11 and 3.12.
@@ -69,10 +83,12 @@
 - Added Dozzle service to `dallinger docker-ssh` deployments.
 
 #### Changed
+
 - Revised logging text for Prolific.
 - Improve `handle_launch_data` error reporting and use it also for docker-ssh deployments.
 
 #### Updated
+
 - Infrastructure: Updated dependencies; pin ipython < 8.19.
 
 ## [v9.12.0](https://github.com/dallinger/dallinger/tree/v9.12.0) (2024-01-03)
@@ -158,8 +174,8 @@
   - Save `uniqueId` in `dlgr.identity` JavaScript object
   - Increase `unique_id` database column string size to 150
 - Infrastructure:
-   - Added Python 3.11 to list of supported programming languages
-   - Added Python 3.11 to CI workflow and updated Dockerfile to use Python 3.11
+  - Added Python 3.11 to list of supported programming languages
+  - Added Python 3.11 to CI workflow and updated Dockerfile to use Python 3.11
 - Infrastructure: Updated dependencies; require ipython < 8.13.
 
 ## [v9.7.0](https://github.com/dallinger/dallinger/tree/v9.7.0) (2023-04-27)
@@ -200,8 +216,8 @@
 - Enhancements to Prolific recruitment:
   - Extended `dallinger hits [--recruiter=prolific|mturk] [--sandbox]` to work with Prolific as well.
   - Addition of two new command line tools:
-    - `dallinger hit-details --hit_id  XYZ [--recruiter=prolific|mturk] [--sandbox]` which pastes all the HIT details in the console window.
-    - `dallinger copy-qualifications --hit_id  XYZ [--recruiter=prolific|mturk] [--sandbox]` which copies the requirements to participate in an experiment (e.g country or the number of completed tasks) from an existing HIT and saves it into a JSON file.
+    - `dallinger hit-details --hit_id XYZ [--recruiter=prolific|mturk] [--sandbox]` which pastes all the HIT details in the console window.
+    - `dallinger copy-qualifications --hit_id XYZ [--recruiter=prolific|mturk] [--sandbox]` which copies the requirements to participate in an experiment (e.g country or the number of completed tasks) from an existing HIT and saves it into a JSON file.
 - Enhancement: Added `Experiment.config_class`, a hook for customizing the Configuration class.
 - Infrastructure: Update dependencies.
 - Infrastructure: Upgrade to Docker Compose v2.
@@ -254,6 +270,7 @@
 - Infrastructure: Update dependencies
 
 ## [v9.3.0](https://github.com/dallinger/dallinger/tree/v9.3.0) (2022-12-16)
+
 - Enhancement: Docker quality of life improvements
   - Major
     - Disabled the behavior where the built image name is written to config.txt. This behavior was inconsistent with the other Dallinger deployment patterns, because it meant that if you deployed once, changed code in experiment.py, then redeployed, then the experiment would launch in the former version unless you remembered to delete the image name from config.txt.
@@ -621,7 +638,7 @@
   variable `heroku_python_version`. If not overriddent the default version of 3.6.10 will
   be used.
 - If files in the custom experiment directory are excluded by Git (by a local or global
-  .gitignore file, $GIT_DIR/info/exclude, etc.), they will not be copied for use in deployment
+  .gitignore file, \$GIT_DIR/info/exclude, etc.), they will not be copied for use in deployment
   or `dallinger debug` runs. They will also be excluded from file size checks performed
   automatically during `debug` and deployment, and by `dallinger verify`.
 - Add `failed` parameter to the add info route. This requires that all custom `Info` classes respect a `failed` keyword argument.

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -177,6 +177,27 @@ def verify_experiment_module(verbose):
         )
         ok = False
 
+    # Check for overrides of methods with name changes:
+    api_breakages = {
+        # "old name": "new name"
+        "on_assignment_submitted_to_recruiter": "on_recruiter_submission_complete",
+    }
+    try:
+        exp_class = exps[0][1]
+    except IndexError:
+        pass
+    else:
+        for old, new in api_breakages.items():
+            if hasattr(exp_class, old):
+                log(
+                    "✗ experiment.py overrides a method that has been renamed!\n"
+                    "\tOld name: {}\n\tNew name: {}\n"
+                    "Please rename your method accordingly.".format(old, new),
+                    chevrons=False,
+                    verbose=verbose,
+                )
+                ok = False
+
     return ok
 
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -720,6 +720,12 @@ class Experiment(object):
         # Check that the participant has completed task submission with
         # their recruiter:
         if participant.status != "submitted":
+            self.log(
+                "Called with unexpected participant status! "
+                "participant ID: {}, status: {}, recruiter: {}".format(
+                    participant.id, participant.status, participant.recruiter.nickname
+                )
+            )
             return
 
         config = get_config()

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -792,6 +792,11 @@ class Experiment(object):
             return
 
         if participant.status == "overrecruited":
+            logger.info(
+                "Skipping qualification assignment for overrecruited participant {}.".format(
+                    participant.id
+                )
+            )
             return
 
         quals = self.calculate_qualifications(participant)

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -720,7 +720,7 @@ class Experiment(object):
         # Check that the participant has completed task submission with
         # their recruiter:
         if participant.status != "submitted":
-            self.log(
+            logger.warning(
                 "Called with unexpected participant status! "
                 "participant ID: {}, status: {}, recruiter: {}".format(
                     participant.id, participant.status, participant.recruiter.nickname
@@ -753,16 +753,26 @@ class Experiment(object):
         # If they pass the data check, we might pay a bonus
         bonus = self.bonus(participant=participant)
         has_already_received_bonus = participant.bonus is not None
-        if not has_already_received_bonus and bonus >= min_real_bonus:
-            self.log("Bonus = {}: paying bonus".format(bonus))
+        if has_already_received_bonus:
+            self.log(
+                "Bonus of {} will NOT be paid, since participant {} "
+                "has already received a bonus of {}".format(
+                    bonus, participant.id, participant.bonus
+                )
+            )
+        elif bonus < min_real_bonus:
+            self.log(
+                "Bonus of {} will NOT be paid to participant {} as it is "
+                "less than {}.".format(bonus, participant.id, min_real_bonus)
+            )
+        else:
+            self.log("Paying bonus of {} to {}".format(bonus, participant.id))
             participant.recruiter.reward_bonus(
                 participant,
                 bonus,
                 self.bonus_reason(),
             )
             participant.bonus = bonus
-        else:
-            self.log("Bonus = {}: NOT paying bonus".format(bonus))
 
         # Attention Check
         if self.attention_check(participant=participant):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -724,8 +724,11 @@ class Experiment(object):
         config = get_config()
         min_real_bonus = 0.01
 
-        participant.status = "submitted"
-        participant.end_time = event["timestamp"]
+        # Usually, end_time will be set when the participant first exits
+        # the experiment via /worker_complete, but in case that hasn't
+        # happened, we set it here:
+        if participant.end_time is None:
+            participant.end_time = event["timestamp"]
         participant.base_pay = config.get("base_payment")
         participant.recruiter.approve_hit(participant.assignment_id)
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -709,13 +709,12 @@ class Experiment(object):
         """
         return True
 
-    def on_assignment_submitted_to_recruiter(self, participant, event):
-        """Working title. Called when assignment has been submitted
-        to the recruitment platform (may be Dallinger itself) by the
-        participant.
+    def on_recruiter_submission_complete(self, participant, event):
+        """Called after assignment submission has been processed by
+        the recruitment platform (may be Dallinger itself).
 
         :param participant (Participant): the ``Participant`` who has
-        submitted a HIT via their recruiter
+        submitted an assignment via their recruiter
         :param event: (dict): Info about the triggering event
         """
         eligible_statuses = ("working", "overrecruited", "returned", "abandoned")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1754,14 +1754,12 @@ def _worker_complete(participant_id):
         return  # Provide idempotence
 
     participant.end_time = datetime.now()
-    # NB: commit releases lock.
-    session.commit()
 
-    # First, notify experiment that participant has been marked complete. This
-    # is done first so that the experiment can request qualification assignment
-    # before the worker completes the HIT when using a recruiter like MTurk,
-    # where execution of the `worker_events.RecruiterSubmissionComplete` command
-    # is deferred until they've submitted the HIT on the MTurk platform.
+    # Immediately notify experiment that participant has been marked complete.
+    # This is done first so that the experiment can request qualification
+    # assignment before the worker submits their task on asynchronous
+    # recruitment platforms like MTurk. This prevents them from possibly being
+    # offered another task which they may no longer be qualified for.
     exp = Experiment(session)
     exp.participant_task_completed(participant)
 
@@ -1770,18 +1768,17 @@ def _worker_complete(participant_id):
     # and will optionally return an event type to request immediate
     # further processing
     event_type = participant.recruiter.on_task_completion(participant)
+    # NB: commit releases lock.
     session.commit()
 
-    if event_type is None:
-        return
-
-    # Currently we execute this function synchronously, regardless of the
-    # event type:
-    worker_function(
-        event_type=event_type,
-        assignment_id=participant.assignment_id,
-        participant_id=participant_id,
-    )
+    if event_type is not None:
+        # Currently we execute this function synchronously, regardless of the
+        # event type:
+        worker_function(
+            event_type=event_type,
+            assignment_id=participant.assignment_id,
+            participant_id=participant_id,
+        )
 
 
 @app.route("/worker_failed", methods=["GET"])

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1744,7 +1744,7 @@ def _worker_complete(participant_id):
     # this here, rather than in the worker function, means that
     # the experiment can request qualification assignment before the
     # worker completes the HIT when using a recruiter like MTurk, where
-    # execution of the `worker_events.AssignmentSubmitted` command is
+    # execution of the `worker_events.RecruiterSubmissionComplete` command is
     # deferred until they've submitted the HIT on the MTurk platform.
     exp = Experiment(session)
     exp.participant_task_completed(participant)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -657,6 +657,7 @@ def summary():
     # to counter missed messages at the end of the waiting room
     nonfailed_count = models.Participant.query.filter(
         (models.Participant.status == "working")
+        | (models.Participant.status == "recruiter_submission_started")
         | (models.Participant.status == "overrecruited")
         | (models.Participant.status == "submitted")
         | (models.Participant.status == "approved")
@@ -823,6 +824,11 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
     if not config.ready:
         config.load()
 
+    recruiter_name = request.args.get("recruiter")
+    fingerprint_hash = request.args.get("fingerprint_hash") or request.form.get(
+        "fingerprint_hash"
+    )
+
     if config.get("lock_table_when_creating_participant"):
         # Historically we have locked the participant table when creating participants
         # to avoid database inconsistency problems. However some experimenters have experienced
@@ -841,9 +847,6 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         msg = "/participant POST: required values were 'undefined'"
         return error_response(error_type=msg, status=403)
 
-    fingerprint_hash = request.args.get("fingerprint_hash") or request.form.get(
-        "fingerprint_hash"
-    )
     fingerprint_found = False
     if fingerprint_hash:
         try:
@@ -877,24 +880,23 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
 
     if duplicate:
         msg = """
-            AWS has reused assignment_id while existing participant is
+            {} has reused assignment_id while existing participant is
             working. Replacing older participant {}.
         """
-        app.logger.warning(msg.format(duplicate.id))
+        app.logger.warning(msg.format(recruiter_name, duplicate.id))
         q.enqueue(worker_function, "AssignmentReassigned", None, duplicate.id)
 
     # Count working or beyond participants.
     nonfailed_count = (
         models.Participant.query.filter(
             (models.Participant.status == "working")
+            | (models.Participant.status == "recruiter_submission_started")
             | (models.Participant.status == "overrecruited")
             | (models.Participant.status == "submitted")
             | (models.Participant.status == "approved")
         ).count()
         + 1
     )
-
-    recruiter_name = request.args.get("recruiter")
 
     # Create the new participant.
     exp = Experiment(session)
@@ -1730,14 +1732,25 @@ def worker_complete():
 
 
 def _worker_complete(participant_id):
-    participant = models.Participant.query.get(participant_id)
+    # Lock the participant row, then check and update status to avoid double-submits:
+    participant = (
+        models.Participant.query.populate_existing()
+        .with_for_update()
+        .get(participant_id)
+    )
     if participant is None:
         raise KeyError()
 
-    if participant.end_time is not None:  # Provide idempotence
-        return
+    if participant.status not in {"working", "overrecruited"}:
+        return  # Provide idempotence
 
     participant.end_time = datetime.now()
+    # Recruiter will mark participant with a different status depending
+    # on whether asynchronous submission is necessary (Mturk, Prolific),
+    # and will optionally return an event type to request immediate
+    # further processing
+    event_type = participant.recruiter.on_task_completion(participant)
+    # NB: commit releases lock
     session.commit()
 
     # Notify experiment that participant has been marked complete. Doing
@@ -1748,9 +1761,6 @@ def _worker_complete(participant_id):
     # deferred until they've submitted the HIT on the MTurk platform.
     exp = Experiment(session)
     exp.participant_task_completed(participant)
-
-    # Does the recruiter want us to execute some command on worker completion?
-    event_type = participant.recruiter.on_completion_event()
 
     if event_type is None:
         return

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1740,7 +1740,8 @@ def worker_complete():
 
 
 def _worker_complete(participant_id):
-    # Lock the participant row, then check and update status to avoid double-submits:
+    # Lock the participant row, then check and update status to avoid
+    # double-submits:
     participant = (
         models.Participant.query.populate_existing()
         .with_for_update()
@@ -1749,26 +1750,27 @@ def _worker_complete(participant_id):
     if participant is None:
         raise KeyError()
 
-    if participant.status not in {"working", "overrecruited"}:
+    if participant.end_time is not None:
         return  # Provide idempotence
 
     participant.end_time = datetime.now()
+    # NB: commit releases lock.
+    session.commit()
+
+    # First, notify experiment that participant has been marked complete. This
+    # is done first so that the experiment can request qualification assignment
+    # before the worker completes the HIT when using a recruiter like MTurk,
+    # where execution of the `worker_events.RecruiterSubmissionComplete` command
+    # is deferred until they've submitted the HIT on the MTurk platform.
+    exp = Experiment(session)
+    exp.participant_task_completed(participant)
+
     # Recruiter will mark participant with a different status depending
     # on whether asynchronous submission is necessary (Mturk, Prolific),
     # and will optionally return an event type to request immediate
     # further processing
     event_type = participant.recruiter.on_task_completion(participant)
-    # NB: commit releases lock
     session.commit()
-
-    # Notify experiment that participant has been marked complete. Doing
-    # this here, rather than in the worker function, means that
-    # the experiment can request qualification assignment before the
-    # worker completes the HIT when using a recruiter like MTurk, where
-    # execution of the `worker_events.RecruiterSubmissionComplete` command is
-    # deferred until they've submitted the HIT on the MTurk platform.
-    exp = Experiment(session)
-    exp.participant_task_completed(participant)
 
     if event_type is None:
         return

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1714,7 +1714,15 @@ def check_for_duplicate_assignments(participant):
 @app.route("/worker_complete", methods=["POST"])
 @db.scoped_session_decorator
 def worker_complete():
-    """Complete worker."""
+    """Called when a participant completes their task.
+
+    1. Loads participant row, with a lock
+    2. Checks participant status, to avoid double-submits
+    3. Updates end_time and status of participant
+    4. Asks recruiter if an event should be run
+    5. Calls exp.participant_task_completed(participant)
+    6. Runs any event requested by recruiter (synchronously)
+    """
     participant_id = request.values.get("participant_id")
     if not participant_id:
         return error_response(

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1744,7 +1744,7 @@ def _worker_complete(participant_id):
     # double-submits:
     participant = (
         models.Participant.query.populate_existing()
-        .with_for_update()
+        .with_for_update(of=models.Participant)
         .get(participant_id)
     )
     if participant is None:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -1718,10 +1718,10 @@ def worker_complete():
 
     1. Loads participant row, with a lock
     2. Checks participant status, to avoid double-submits
-    3. Updates end_time and status of participant
-    4. Asks recruiter if an event should be run
-    5. Calls exp.participant_task_completed(participant)
-    6. Runs any event requested by recruiter (synchronously)
+    3. Updates end_time of participant
+    4. Calls exp.participant_task_completed(participant)
+    5. Asks recruiter for new participant status and possible action to run
+    6. Runs any action requested by recruiter (synchronously)
     """
     participant_id = request.values.get("participant_id")
     if not participant_id:
@@ -1750,8 +1750,9 @@ def _worker_complete(participant_id):
     if participant is None:
         raise KeyError()
 
+    # Provide idempotence
     if participant.end_time is not None:
-        return  # Provide idempotence
+        return
 
     participant.end_time = datetime.now()
 
@@ -1763,19 +1764,19 @@ def _worker_complete(participant_id):
     exp = Experiment(session)
     exp.participant_task_completed(participant)
 
-    # Recruiter will mark participant with a different status depending
-    # on whether asynchronous submission is necessary (Mturk, Prolific),
-    # and will optionally return an event type to request immediate
-    # further processing
-    event_type = participant.recruiter.on_task_completion(participant)
+    # The recruiter tells us which status to assign the participant,
+    # and synchronous recruiters also return the name of an event
+    # command to run immediately (and synchronously)
+    status_and_action = participant.recruiter.on_task_completion()
+    participant.status = status_and_action["new_status"]
     # NB: commit releases lock.
     session.commit()
 
-    if event_type is not None:
+    if "action" in status_and_action:
         # Currently we execute this function synchronously, regardless of the
         # event type:
         worker_function(
-            event_type=event_type,
+            event_type=status_and_action["action"],
             assignment_id=participant.assignment_id,
             participant_id=participant_id,
         )

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -113,8 +113,8 @@ def worker_function(
         if participants:
             participant = max(participants, key=attrgetter("creation_time"))
 
-    # TODO: could this just be a separate function, instead of a very standalone
-    # path  through worker_function? Avoid the commit below would allow
+    # TODO: should this just be a separate function, instead of a very standalone
+    # path through worker_function? Avoiding the commit below would allow
     # us to lock the participant row for the full execution time.
     if event_type == "TrackingEvent":
         if not node and not participant:

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -259,7 +259,7 @@ class AssignmentReturned(WorkerEvent):
 
 class AssignmentSubmitted(WorkerEvent):
     def __call__(self):
-        self.experiment.on_assignment_submitted_to_recruiter(
+        self.experiment.on_recruiter_submission_complete(
             participant=self.participant, event=self.data
         )
 

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -114,8 +114,7 @@ def worker_function(
             participant = max(participants, key=attrgetter("creation_time"))
 
     # TODO: should this just be a separate function, instead of a very standalone
-    # path through worker_function? Avoiding the commit below would allow
-    # us to lock the participant row for the full execution time.
+    # path through worker_function?
     if event_type == "TrackingEvent":
         if not node and not participant:
             exp.log(

--- a/dallinger/frontend/templates/exit_recruiter_prolific.html
+++ b/dallinger/frontend/templates/exit_recruiter_prolific.html
@@ -51,7 +51,7 @@
 {% block scripts %}
 <script type="text/javascript">
     // The values our custom exit handler needs in order
-    // to to create an AssignmentSubmitted notification:
+    // to to create an RecruiterSubmissionComplete notification:
     const participantInfo = {
       assignmentId: "{{ assignment_id}}",
       participantId: "{{ participant_id }}",

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -241,7 +241,8 @@ class Participant(Base, SharedMixin):
     #:
     #:    - ``working`` - participant is working
     #:    - ``overrecruited`` - number of recruited participants exceed number required for the experiment, so this participant will not be used
-    #:    - ``submitted`` - participant has submitted their work
+    #:    - ``recruiter_submission_started`` - participant has submitted their assignment to their recruiter, but the recruiter is still processing it
+    #:    - ``submitted`` - participant's assignment submission processing has been completed by their recruiter
     #:    - ``approved`` - their work has been approved and they have been paid
     #:    - ``rejected`` - their work has been rejected
     #:    - ``returned`` - they returned the hit before finishing
@@ -258,6 +259,7 @@ class Participant(Base, SharedMixin):
         Enum(
             "working",
             "overrecruited",
+            "recruiter_submission_started",
             "submitted",
             "approved",
             "rejected",

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -242,7 +242,7 @@ class Participant(Base, SharedMixin):
     #:    - ``working`` - participant is working
     #:    - ``overrecruited`` - number of recruited participants exceed number required for the experiment, so this participant will not be used
     #:    - ``recruiter_submission_started`` - participant has submitted their assignment to their recruiter, but the recruiter is still processing it
-    #:    - ``submitted`` - participant's assignment submission processing has been completed by their recruiterl
+    #:    - ``submitted`` - participant's assignment submission processing has been completed by their recruiter
     #:    - ``approved`` - their work has been approved and they have been paid
     #:    - ``rejected`` - their work has been rejected
     #:    - ``returned`` - they returned the hit before finishing

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -242,7 +242,7 @@ class Participant(Base, SharedMixin):
     #:    - ``working`` - participant is working
     #:    - ``overrecruited`` - number of recruited participants exceed number required for the experiment, so this participant will not be used
     #:    - ``recruiter_submission_started`` - participant has submitted their assignment to their recruiter, but the recruiter is still processing it
-    #:    - ``submitted`` - participant's assignment submission processing has been completed by their recruiter
+    #:    - ``submitted`` - participant's assignment submission processing has been completed by their recruiterl
     #:    - ``approved`` - their work has been approved and they have been paid
     #:    - ``rejected`` - their work has been rejected
     #:    - ``returned`` - they returned the hit before finishing

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -286,7 +286,9 @@ def prolific_submission_listener():
 
     # Lock the participant row, then check and update status to avoid double-submits:
     participant = (
-        Participant.query.populate_existing().with_for_update().get(participant_id)
+        Participant.query.populate_existing()
+        .with_for_update(of=Participant)
+        .get(participant_id)
     )
     if participant is not None and participant.status != "submitted":
         participant.status = "submitted"

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -155,11 +155,12 @@ class Recruiter(object):
 
     def on_completion_event(self):
         """Return the name of the appropriate WorkerEvent command to run
-        when a participant completes an experiment.
+        when a participant's recruiter finishes processing their assignment
+        submission.
 
         If no event should be processed, return None.
         """
-        return "AssignmentSubmitted"
+        return "RecruiterSubmissionComplete"
 
     def load_service(self, sandbox):
         """Load the appropriate service for this recruiter."""
@@ -273,7 +274,7 @@ def prolific_submission_listener():
 
     When the participant submits their assignment/study to Prolific,
     we are then ready to handle experiment completion task (approval, bonus)
-    via the `AssignmentSubmitted` async worker function.
+    via the `RecruiterSubmissionComplete` async worker function.
     """
     identity_info = flask.request.form.to_dict()
     logger.warning(
@@ -484,7 +485,12 @@ class ProlificRecruiter(Recruiter):
 
     def _handle_exit_form_submission(self, assignment_id: str, participant_id: str):
         q = _get_queue()
-        q.enqueue(worker_function, "AssignmentSubmitted", assignment_id, participant_id)
+        q.enqueue(
+            worker_function,
+            "RecruiterSubmissionComplete",
+            assignment_id,
+            participant_id,
+        )
 
     def load_service(self, sandbox):
         return _prolific_service_from_config()
@@ -1320,7 +1326,10 @@ class MTurkRecruiter(Recruiter):
     def _resend_submitted_rest_notification_for(self, participant):
         q = _get_queue()
         q.enqueue(
-            worker_function, "AssignmentSubmitted", participant.assignment_id, None
+            worker_function,
+            "RecruiterSubmissionComplete",
+            participant.assignment_id,
+            None,
         )
 
     def _send_notification_missing_rest_notification_for(self, participant):
@@ -1538,7 +1547,7 @@ class BotRecruiter(Recruiter):
         logger.info("Bots don't get bonuses. Sorry, bots.")
 
     def on_completion_event(self):
-        return "BotAssignmentSubmitted"
+        return "BotRecruiterSubmissionComplete"
 
     def _get_bot_factory(self):
         # Must be imported at run-time

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -153,14 +153,16 @@ class Recruiter(object):
         """
         return None
 
-    def on_completion_event(self):
+    def on_task_completion(self, participant):
         """Return the name of the appropriate WorkerEvent command to run
         when a participant's recruiter finishes processing their assignment
         submission.
 
+        May also update participant status.
+
         If no event should be processed, return None.
         """
-        return "RecruiterSubmissionComplete"
+        raise NotImplementedError
 
     def load_service(self, sandbox):
         """Load the appropriate service for this recruiter."""
@@ -275,6 +277,9 @@ def prolific_submission_listener():
     When the participant submits their assignment/study to Prolific,
     we are then ready to handle experiment completion task (approval, bonus)
     via the `RecruiterSubmissionComplete` async worker function.
+
+    We are forced to take a small leap of faith that their redirect to the
+    Prolific submission page happens successfully.
     """
     identity_info = flask.request.form.to_dict()
     logger.warning(
@@ -283,14 +288,22 @@ def prolific_submission_listener():
     assignment_id = identity_info.get("assignmentId")
     participant_id = identity_info.get("participantId")
 
-    # participant = Participant.query.get(participant_id)
-    # participant.status = "the new status"
-    # session.commit()
-
-    recruiter = ProlificRecruiter()
-    recruiter._handle_exit_form_submission(
-        assignment_id=assignment_id, participant_id=participant_id
+    # Lock the participant row, then check and update status to avoid double-submits:
+    participant = (
+        Participant.query.populate_existing().with_for_update().get(participant_id)
     )
+    if participant is not None and participant.status != "submitted":
+        participant.status = "submitted"
+        session.commit()  # NB: commit releases lock
+        q = _get_queue()
+        # Here we assume the participant has submitted on Prolific by now
+        # and we express this by firing off the corresponding event:
+        q.enqueue(
+            worker_function,
+            "RecruiterSubmissionComplete",
+            assignment_id,
+            participant_id,
+        )
 
     return success_response()
 
@@ -458,13 +471,14 @@ class ProlificRecruiter(Recruiter):
         except ProlificServiceException as ex:
             logger.exception(str(ex))
 
-    def on_completion_event(self):
+    def on_task_completion(self, participant):
         """We cannot perform post-submission actions (approval, bonus payment)
         until after the participant has submitted their study via the Prolific
         UI, which we redirect them to from the exit page. This means that we
         can't do anything when the questionnaire is submitted, so we return None
         to signal this.
         """
+        participant.status = "recruiter_submission_started"
         return None
 
     @property
@@ -486,15 +500,6 @@ class ProlificRecruiter(Recruiter):
 
     def _record_current_study_id(self, study_id):
         self.store.set(self.study_id_storage_key, study_id)
-
-    def _handle_exit_form_submission(self, assignment_id: str, participant_id: str):
-        q = _get_queue()
-        q.enqueue(
-            worker_function,
-            "RecruiterSubmissionComplete",
-            assignment_id,
-            participant_id,
-        )
 
     def load_service(self, sandbox):
         return _prolific_service_from_config()
@@ -610,6 +615,13 @@ class CLIRecruiter(Recruiter):
     def __init__(self):
         super(CLIRecruiter, self).__init__()
         self.config = get_config()
+
+    def on_task_completion(self, participant):
+        """In our case, the task submission is implicitly complete, since we
+        have nothing to do.
+        """
+        participant.status = "submitted"
+        return "RecruiterSubmissionComplete"
 
     def exit_response(self, experiment, participant):
         """Delegate to the experiment for possible values to show to the
@@ -731,6 +743,13 @@ class SimulatedRecruiter(Recruiter):
     """A recruiter that recruits simulated participants."""
 
     nickname = "sim"
+
+    def on_task_completion(self, participant):
+        """In our case, the task submission is implicitly complete, since we
+        have nothing to do.
+        """
+        participant.status = "submitted"
+        return "RecruiterSubmissionComplete"
 
     def open_recruitment(self, n=1):
         """Open recruitment."""
@@ -1230,10 +1249,11 @@ class MTurkRecruiter(Recruiter):
                 "on MTurk and can no longer submit the questionnaire"
             )
 
-    def on_completion_event(self):
+    def on_task_completion(self, participant):
         """MTurk will send its own notification when the worker
         completes the HIT on that service.
         """
+        participant.status = "recruiter_submission_started"
         return None
 
     def reward_bonus(self, participant, amount, reason):
@@ -1312,13 +1332,43 @@ class MTurkRecruiter(Recruiter):
     def _confirm_sns_subscription(self, token, topic):
         self.mturkservice.confirm_subscription(token=token, topic=topic)
 
+    def _translate_event_type(mturk_event_type):
+        # If a translation exists, return it, otherwise return what we were given
+        mturk_to_dallinger = {"AssignmentSubmitted": "RecruiterSubmissionComplete"}
+
+        return mturk_to_dallinger.get(mturk_event_type, mturk_event_type)
+
     def _report_event_notification(self, events):
+        # Historically (and regrettably) we have adopted MTurk's event names
+        # internally. The one (new) exception to this is MTurk's "AssigmentSubmitted",
+        # which is now represented internally as "RecruiterSubmissionComplete"
+        #
+        # Note: this is an entry-point, so it's a reasonable place to commit a
+        # transaction before passing off the async worker task.
         q = _get_queue()
         for event in events:
-            event_type = event.get("EventType")
+            mturk_type = event.get("EventType")
             assignment_id = event.get("AssignmentId")
+
+            if mturk_type == "AssignmentSubmitted":
+                participant = (
+                    Participant.query.filter_by(assignment_id=assignment_id)
+                    .order_by(Participant.creation_time.desc())
+                    .first()
+                )
+                if participant is None:
+                    logger.error(
+                        "Recieved an AssignmentSubmitted notification from MTurk for assignment ID {}, "
+                        "which is not related to any participant.".format(assignment_id)
+                    )
+                    return
+
+                participant.status = "submitted"
+                session.commit()
+
+            dlgr_event_type = self._translate_event_type(mturk_type)
             participant_id = None
-            q.enqueue(worker_function, event_type, assignment_id, participant_id)
+            q.enqueue(worker_function, dlgr_event_type, assignment_id, participant_id)
 
     def _mturk_status_for(self, participant):
         try:
@@ -1557,7 +1607,8 @@ class BotRecruiter(Recruiter):
         """Logging only. These are bots."""
         logger.info("Bots don't get bonuses. Sorry, bots.")
 
-    def on_completion_event(self):
+    def on_task_completion(self, participant):
+        participant.status = "submitted"
         return "BotRecruiterSubmissionComplete"
 
     def _get_bot_factory(self):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1360,7 +1360,7 @@ class MTurkRecruiter(Recruiter):
                 )
                 if participant is None:
                     logger.error(
-                        "Recieved an AssignmentSubmitted notification from MTurk for assignment ID {}, "
+                        "Received an AssignmentSubmitted notification from MTurk for assignment ID {}, "
                         "which is not related to any participant.".format(assignment_id)
                     )
                     return
@@ -1438,7 +1438,7 @@ class MTurkRecruiter(Recruiter):
                 try:
                     self.mturkservice.get_qualification_type_by_name(new["name"])
                 except QualificationNotFoundException:
-                    logger.warn(
+                    logger.warning(
                         "Did not find qualification {}. Trying again...".format(
                             new["name"]
                         )
@@ -1451,7 +1451,7 @@ class MTurkRecruiter(Recruiter):
 
         unavailable = [q for q in result["new_qualifications"] if not q["available"]]
         if unavailable:
-            logger.warn(
+            logger.warning(
                 "After several attempts, some qualifications are still not ready "
                 "for assignment: {}".format(", ".join(unavailable))
             )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -22,7 +22,7 @@ from dallinger.db import redis_conn, session
 from dallinger.experiment_server.utils import crossdomain, success_response
 from dallinger.experiment_server.worker_events import worker_function
 from dallinger.heroku import tools as heroku_tools
-from dallinger.models import Recruitment
+from dallinger.models import Participant, Recruitment
 from dallinger.mturk import (
     DuplicateQualificationNameError,
     MTurkQualificationRequirements,
@@ -282,6 +282,10 @@ def prolific_submission_listener():
     )
     assignment_id = identity_info.get("assignmentId")
     participant_id = identity_info.get("participantId")
+
+    # participant = Participant.query.get(participant_id)
+    # participant.status = "the new status"
+    # session.commit()
 
     recruiter = ProlificRecruiter()
     recruiter._handle_exit_form_submission(
@@ -965,7 +969,14 @@ class RedisStore(object):
 
 
 def _run_mturk_qualification_assignment(worker_id, qualifications):
-    """Provides a way to run qualification assignment asynchronously."""
+    """Provides a way to run qualification assignment asynchronously.
+
+    TODO: could be made general:
+        1. pass in recruiter nickname
+        2. instantiate recruiter
+        3. recruiter._assign_experiment_qualifications(worker_id, qualifications)
+
+    """
     recruiter = MTurkRecruiter()
     recruiter._assign_experiment_qualifications(worker_id, qualifications)
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -153,14 +153,10 @@ class Recruiter(object):
         """
         return None
 
-    def on_task_completion(self, participant):
-        """Return the name of the appropriate WorkerEvent command to run
-        when a participant's recruiter finishes processing their assignment
-        submission.
-
-        May also update participant status.
-
-        If no event should be processed, return None.
+    def on_task_completion(self):
+        """Return the new status to assign the particpant, and optionally,
+        the name of the appropriate WorkerEvent command to run when a
+        participant first completes their assignment.
         """
         raise NotImplementedError
 
@@ -471,15 +467,16 @@ class ProlificRecruiter(Recruiter):
         except ProlificServiceException as ex:
             logger.exception(str(ex))
 
-    def on_task_completion(self, participant):
+    def on_task_completion(self):
         """We cannot perform post-submission actions (approval, bonus payment)
         until after the participant has submitted their study via the Prolific
         UI, which we redirect them to from the exit page. This means that we
         can't do anything when the questionnaire is submitted, so we return None
         to signal this.
         """
-        participant.status = "recruiter_submission_started"
-        return None
+        return {
+            "new_status": "recruiter_submission_started",
+        }
 
     @property
     def current_study_id(self):
@@ -616,12 +613,14 @@ class CLIRecruiter(Recruiter):
         super(CLIRecruiter, self).__init__()
         self.config = get_config()
 
-    def on_task_completion(self, participant):
+    def on_task_completion(self):
         """In our case, the task submission is implicitly complete, since we
         have nothing to do.
         """
-        participant.status = "submitted"
-        return "RecruiterSubmissionComplete"
+        return {
+            "new_status": "submitted",
+            "action": "RecruiterSubmissionComplete",
+        }
 
     def exit_response(self, experiment, participant):
         """Delegate to the experiment for possible values to show to the
@@ -744,12 +743,14 @@ class SimulatedRecruiter(Recruiter):
 
     nickname = "sim"
 
-    def on_task_completion(self, participant):
+    def on_task_completion(self):
         """In our case, the task submission is implicitly complete, since we
         have nothing to do.
         """
-        participant.status = "submitted"
-        return "RecruiterSubmissionComplete"
+        return {
+            "new_status": "submitted",
+            "action": "RecruiterSubmissionComplete",
+        }
 
     def open_recruitment(self, n=1):
         """Open recruitment."""
@@ -1249,12 +1250,13 @@ class MTurkRecruiter(Recruiter):
                 "on MTurk and can no longer submit the questionnaire"
             )
 
-    def on_task_completion(self, participant):
+    def on_task_completion(self):
         """MTurk will send its own notification when the worker
         completes the HIT on that service.
         """
-        participant.status = "recruiter_submission_started"
-        return None
+        return {
+            "new_status": "recruiter_submission_started",
+        }
 
     def reward_bonus(self, participant, amount, reason):
         """Reward the Turker for a specified assignment with a bonus."""
@@ -1367,8 +1369,7 @@ class MTurkRecruiter(Recruiter):
                 session.commit()
 
             dlgr_event_type = self._translate_event_type(mturk_type)
-            participant_id = None
-            q.enqueue(worker_function, dlgr_event_type, assignment_id, participant_id)
+            q.enqueue(worker_function, dlgr_event_type, assignment_id, participant.id)
 
     def _mturk_status_for(self, participant):
         try:
@@ -1607,9 +1608,11 @@ class BotRecruiter(Recruiter):
         """Logging only. These are bots."""
         logger.info("Bots don't get bonuses. Sorry, bots.")
 
-    def on_task_completion(self, participant):
-        participant.status = "submitted"
-        return "BotRecruiterSubmissionComplete"
+    def on_task_completion(self):
+        return {
+            "new_status": "submitted",
+            "action": "BotRecruiterSubmissionComplete",
+        }
 
     def _get_bot_factory(self):
         # Must be imported at run-time

--- a/docs/diagrams/task_completion_and_submission.md
+++ b/docs/diagrams/task_completion_and_submission.md
@@ -52,7 +52,7 @@ rec->>wf: __call__("AssignmentSubmitted", args...)
 wf->>nt: (add Note to DB)
 note over wf: COMMIT
 wf->>sub: __call__()
-sub->>ex: on_assignment_submitted_to_recruiter(participant)
+sub->>ex: on_recruiter_submission_complete(participant)
 note over ex: Most of what follows becomes potentially private to the Experiment:
 ex->>part: end_time
 ex->>part: status="submitted"

--- a/docs/diagrams/task_completion_and_submission.md
+++ b/docs/diagrams/task_completion_and_submission.md
@@ -4,7 +4,7 @@ A mermaid syntax diagram of task completion and subsequent triggered execution p
 
 ```mermaid
 sequenceDiagram
-title Dallinger AssignmentSubmitted (Recruiter owns worker_function call)
+title Dallinger Assignment Submission
 
 actor hw as HIT win
 actor ew as EXP win
@@ -16,7 +16,7 @@ participant ex as Experiment
 participant rec as Recruiter
 participant wf as worker_function
 participant nt as Notification
-participant sub as AssignmentSubmitted
+participant sub as RecruiterSubmissionComplete
 
 
 ew->>d2: submitQuestionnaire()
@@ -34,21 +34,21 @@ d2-->>hw: location=/recruiter-exit
 hw->>es: /recruiter-exit
 es->>rec: exit_response(experiment=exp, participant=participant)
 alt synchronous recruiters
-rec->>wf: __call__("AssignmentSubmitted", args...)
+rec->>wf: __call__("RecruiterSubmissionComplete", args...)
 rec-->>es: <rendered template specific to Recruiter>
 es-->>hw: <rendered template specific to Recruiter>
 else asynchronous recruiters
 rec-->>es: <rendered template specific to Recruiter>
 es-->>hw: <rendered template specific to Recruiter>
 hw->>rec: /prolific-submission-listener (Recruiter-specific route)
-rec->>wf: ASYNC __call__("AssignmentSubmitted", args...) (see below)
+rec->>wf: ASYNC __call__("RecruiterSubmissionComplete", args...) (see below)
 
 rec-->>d2: HTTP Response
 d2->>hw: location=prolificStudySubmissionURL
 end
 
 note over rec: Later, resuming call from Recruiter...
-rec->>wf: __call__("AssignmentSubmitted", args...)
+rec->>wf: __call__("RecruiterSubmissionComplete", args...)
 wf->>nt: (add Note to DB)
 note over wf: COMMIT
 wf->>sub: __call__()

--- a/docs/diagrams/task_completion_and_submission.md
+++ b/docs/diagrams/task_completion_and_submission.md
@@ -25,15 +25,13 @@ es-->>d2: HTTP Response
 d2->>d2: submitAssignment()
 d2->>es: /worker_complete POST
 es->>part: end_time
-es->>rec: on_completion_event(participant)
-rec->>part: status=["submitted"|"recruiter_submission_started"]
-rec-->>es: event type string or None
-note over es: COMMIT
 es->>ex: participant_task_completed()
 ex->>rec: assign_experiment_qualifications()
-
-
-opt event type not None (synchronous recruiters)
+es->>rec: on_task_completion()
+rec-->>es: {"new_status": (status), "action": (event name)}
+es->>part: status
+note over es: COMMIT
+opt "action" requested by recruiter (synchronous recruiters)
 es->>wf: __call__("RecruiterSubmissionComplete", args...)
 end
 
@@ -66,7 +64,6 @@ note over ex: Most of what follows becomes potentially private to the Experiment
 opt if not set already
 ex->>part: end_time
 end
-ex->>part: status="submitted"
 
 ex->>rec: approve_hit(assignment_id)
 ex->>part: base_pay
@@ -79,7 +76,7 @@ ex->>ex: bonus
 ex-->>ex: $2.99
 ex->>part: bonus=2.99
 ex->>ex: bonus_reason()
-ex-->>ex: \"Great work"
+ex-->>ex: "Great work"
 ex->>rec: award_bonus()
 else sad path
 ex->>part: status="bad_data"

--- a/docs/diagrams/task_completion_and_submission.md
+++ b/docs/diagrams/task_completion_and_submission.md
@@ -1,0 +1,94 @@
+# Dallinger Task Submission and Completion
+
+A mermaid syntax diagram of task completion and subsequent triggered execution paths.
+
+```mermaid
+sequenceDiagram
+title Dallinger AssignmentSubmitted (Recruiter owns worker_function call)
+
+actor hw as HIT win
+actor ew as EXP win
+participant d2 as dallinger2
+participant es as experiment_server
+participant part as Participant
+
+participant ex as Experiment
+participant rec as Recruiter
+participant wf as worker_function
+participant nt as Notification
+participant sub as AssignmentSubmitted
+
+
+ew->>d2: submitQuestionnaire()
+d2->>es: /question/<participant ID>
+es-->>d2: HTTP Response
+d2->>d2: submitAssignment()
+d2->>es: /worker_complete
+es->>part: end_time
+note over es: COMMIT
+es->>ex: participant_task_complete()
+ex->>rec: assign_experiment_qualifications()
+
+es-->>d2: HTTP Response
+d2-->>hw: location=/recruiter-exit
+hw->>es: /recruiter-exit
+es->>rec: exit_response(experiment=exp, participant=participant)
+alt synchronous recruiters
+rec->>wf: __call__("AssignmentSubmitted", args...)
+rec-->>es: <rendered template specific to Recruiter>
+es-->>hw: <rendered template specific to Recruiter>
+else asynchronous recruiters
+rec-->>es: <rendered template specific to Recruiter>
+es-->>hw: <rendered template specific to Recruiter>
+hw->>rec: /prolific-submission-listener (Recruiter-specific route)
+rec->>wf: ASYNC __call__("AssignmentSubmitted", args...) (see below)
+
+rec-->>d2: HTTP Response
+d2->>hw: location=prolificStudySubmissionURL
+end
+
+note over rec: Later, resuming call from Recruiter...
+rec->>wf: __call__("AssignmentSubmitted", args...)
+wf->>nt: (add Note to DB)
+note over wf: COMMIT
+wf->>sub: __call__()
+sub->>ex: on_assignment_submitted_to_recruiter(participant)
+note over ex: Most of what follows becomes potentially private to the Experiment:
+ex->>part: end_time
+ex->>part: status="submitted"
+
+ex->>rec: approve_hit(assignment_id)
+ex->>part: base_pay
+
+
+ex->>ex: data_check()
+ex-->>ex: bool
+alt happy path
+ex->>ex: bonus
+ex-->>ex: $2.99
+ex->>part: bonus=2.99
+ex->>ex: bonus_reason()
+ex-->>ex: \"Great work"
+ex->>rec: award_bonus()
+else sad path
+ex->>part: status="bad_data"
+ex->>ex: data_check_failed()
+ex->>rec: recruit(n=1)
+end
+
+
+ex->>ex: attention_check()
+ex-->>ex: bool
+alt happy path
+ex->>part: status="approved"
+ex->>ex: submission_successful()
+ex->>ex: recruit()
+
+else sad path
+ex->>part: status="did_not_attend"
+ex->>rec: close_recruitment() ??
+ex->>ex: attention_check_failed()
+ex->>rec: recruit(n=1)
+end
+note over wf: COMMIT
+```

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -798,7 +798,10 @@ class Testhandle_launch_data(object):
 
         log.reset_mock()
         handler("https://nonexistent.example.com/", log, attempts=1)
-        assert "Name or service not known" in log.call_args_list[0][0][0]
+        assert (
+            "Error accessing https://nonexistent.example.com/"
+            in log.call_args_list[0][0][0]
+        )
 
     def test_non_json_response_error(self, handler):
         log = mock.Mock()

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -135,6 +135,7 @@ class TestExperimentBaseClass(object):
         self, a, active_config, exp
     ):
         participant = a.participant()
+        participant.status = "submitted"
         exp.bonus = mock.Mock(return_value=0.01)
         end_time = datetime(2000, 1, 1)
 
@@ -168,10 +169,11 @@ class TestExperimentBaseClass(object):
             },
         )
 
-        assert participant.bonus == 0
+        assert participant.bonus is None
 
-    def test_on_recruiter_submission_complete__sets_end_time(self, a, exp):
+    def test_on_recruiter_submission_complete__sets_end_time_if_not_set(self, a, exp):
         participant = a.participant()
+        participant.status = "submitted"
         end_time = datetime(2000, 1, 1)
 
         exp.on_recruiter_submission_complete(
@@ -226,6 +228,7 @@ class TestExperimentBaseClass(object):
 
     def test_on_recruiter_submission_complete__failed_data_check(self, a, exp):
         participant = a.participant()
+        participant.status = "submitted"
         exp.data_check = mock.Mock(return_value=False)
         end_time = datetime(2000, 1, 1)
 
@@ -243,6 +246,7 @@ class TestExperimentBaseClass(object):
 
     def test_on_recruiter_submission_complete__failed_attention_check(self, a, exp):
         participant = a.participant()
+        participant.status = "submitted"
         exp.attention_check = mock.Mock(return_value=False)
         end_time = datetime(2000, 1, 1)
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -131,14 +131,14 @@ class TestExperimentBaseClass(object):
             exp.normalize_entry_information({"foo": "bar"})
             normalizer.assert_called_once_with({"foo": "bar"})
 
-    def test_on_assignment_submitted_to_recruiter__approves_and_records_base_payment(
+    def test_on_recruiter_submission_complete__approves_and_records_base_payment(
         self, a, active_config, exp
     ):
         participant = a.participant()
         exp.bonus = mock.Mock(return_value=0.01)
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",
@@ -152,13 +152,13 @@ class TestExperimentBaseClass(object):
         assert participant.status == "approved"
         assert participant.bonus == 0.01
 
-    def test_on_assignment_submitted_to_recruiter__pays_no_bonus_if_less_than_one_cent(
+    def test_on_recruiter_submission_complete__pays_no_bonus_if_less_than_one_cent(
         self, a, exp
     ):
         participant = a.participant()
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",
@@ -170,11 +170,11 @@ class TestExperimentBaseClass(object):
 
         assert participant.bonus == 0
 
-    def test_on_assignment_submitted_to_recruiter__sets_end_time(self, a, exp):
+    def test_on_recruiter_submission_complete__sets_end_time(self, a, exp):
         participant = a.participant()
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",
@@ -186,14 +186,14 @@ class TestExperimentBaseClass(object):
 
         assert participant.end_time == end_time
 
-    def test_on_assignment_submitted_to_recruiter__noop_if_already_approved_worker(
+    def test_on_recruiter_submission_complete__noop_if_already_approved_worker(
         self, a, exp
     ):
         participant = a.participant()
         participant.status = "approved"
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",
@@ -205,12 +205,12 @@ class TestExperimentBaseClass(object):
 
         assert participant.base_pay is None
 
-    def test_on_assignment_submitted_to_recruiter__failed_data_check(self, a, exp):
+    def test_on_recruiter_submission_complete__failed_data_check(self, a, exp):
         participant = a.participant()
         exp.data_check = mock.Mock(return_value=False)
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",
@@ -222,12 +222,12 @@ class TestExperimentBaseClass(object):
 
         assert participant.status == "bad_data"
 
-    def test_on_assignment_submitted_to_recruiter__failed_attention_check(self, a, exp):
+    def test_on_recruiter_submission_complete__failed_attention_check(self, a, exp):
         participant = a.participant()
         exp.attention_check = mock.Mock(return_value=False)
         end_time = datetime(2000, 1, 1)
 
-        exp.on_assignment_submitted_to_recruiter(
+        exp.on_recruiter_submission_complete(
             participant=participant,
             event={
                 "event_type": "AssignmentSubmitted",

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -141,7 +141,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,
@@ -161,7 +161,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,
@@ -177,7 +177,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,
@@ -196,7 +196,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,
@@ -213,7 +213,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,
@@ -230,7 +230,7 @@ class TestExperimentBaseClass(object):
         exp.on_recruiter_submission_complete(
             participant=participant,
             event={
-                "event_type": "AssignmentSubmitted",
+                "event_type": "RecruiterSubmissionComplete",
                 "participant_id": participant.id,
                 "assignment_id": participant.assignment_id,
                 "timestamp": end_time,

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -186,6 +186,25 @@ class TestExperimentBaseClass(object):
 
         assert participant.end_time == end_time
 
+    def test_on_recruiter_submission_complete__wont_overwrite_end_time(self, a, exp):
+        participant = a.participant()
+        participant.status = "submitted"
+        old_time = datetime(2000, 1, 1)
+        new_time = datetime(2000, 2, 2)
+        participant.end_time = old_time
+
+        exp.on_recruiter_submission_complete(
+            participant=participant,
+            event={
+                "event_type": "RecruiterSubmissionComplete",
+                "participant_id": participant.id,
+                "assignment_id": participant.assignment_id,
+                "timestamp": new_time,
+            },
+        )
+
+        assert participant.end_time == old_time
+
     def test_on_recruiter_submission_complete__noop_if_already_approved_worker(
         self, a, exp
     ):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1844,9 +1844,9 @@ class TestAssignmentSubmitted(object):
 
         return AssignmentSubmitted(**standard_args)
 
-    def test_calls_on_assignment_submitted_to_recruiter(self, runner):
+    def test_calls_on_recruiter_submission_complete(self, runner):
         runner()
-        runner.experiment.on_assignment_submitted_to_recruiter.assert_called_once()
+        runner.experiment.on_recruiter_submission_complete.assert_called_once()
 
 
 class TestBotAssignmentSubmitted(object):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -198,7 +198,7 @@ class TestCLIRecruiter(object):
         assert "mode=new_mode" in result["items"][0]
 
     def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "AssignmentSubmitted"
+        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
 
 
 @pytest.mark.usefixtures("active_config")
@@ -250,7 +250,7 @@ class TestHotAirRecruiter(object):
         assert "mode=debug" in result["items"][0]
 
     def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "AssignmentSubmitted"
+        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
 
 
 class TestSimulatedRecruiter(object):
@@ -273,7 +273,7 @@ class TestSimulatedRecruiter(object):
         assert recruiter.open_recruitment(n=3)["items"] == []
 
     def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "AssignmentSubmitted"
+        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
 
     def test_close_recruitment(self, recruiter):
         assert recruiter.close_recruitment() is None
@@ -322,7 +322,7 @@ class TestBotRecruiter(object):
         recruiter.reward_bonus(a.participant(), 0.01, "You're great!")
 
     def test_returns_specific_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "BotAssignmentSubmitted"
+        assert recruiter.on_completion_event() == "BotRecruiterSubmissionComplete"
 
     def test_notify_duration_exceeded_rejects_participants(self, a, recruiter):
         bot = a.participant(recruiter_id="bots")
@@ -515,7 +515,10 @@ class TestProlificRecruiter(object):
 
         assert response.status_code == 200
         queue.enqueue.assert_called_once_with(
-            mock.ANY, "AssignmentSubmitted", "some assignment ID", "some participant ID"
+            mock.ANY,
+            "RecruiterSubmissionComplete",
+            "some assignment ID",
+            "some participant ID",
         ),
 
     def test_clean_qualification_attributes(self, recruiter):
@@ -1185,7 +1188,10 @@ class TestMTurkRecruiter(object):
         recruiter.notify_duration_exceeded(participants, datetime.now())
 
         queue.enqueue.assert_called_once_with(
-            worker_function, "AssignmentSubmitted", participants[0].assignment_id, None
+            worker_function,
+            "RecruiterSubmissionComplete",
+            participants[0].assignment_id,
+            None,
         )
         recruiter.notifies_admin.send.assert_called_once()
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -197,10 +197,11 @@ class TestCLIRecruiter(object):
         result = recruiter.open_recruitment()
         assert "mode=new_mode" in result["items"][0]
 
-    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
-        assert p.status == "submitted"
+    def test_on_task_completion__returns_event_type_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "submitted",
+            "action": "RecruiterSubmissionComplete",
+        }
 
 
 @pytest.mark.usefixtures("active_config")
@@ -251,10 +252,11 @@ class TestHotAirRecruiter(object):
         result = recruiter.open_recruitment()
         assert "mode=debug" in result["items"][0]
 
-    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
-        assert p.status == "submitted"
+    def test_on_task_completion__returns_event_type_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "submitted",
+            "action": "RecruiterSubmissionComplete",
+        }
 
 
 class TestSimulatedRecruiter(object):
@@ -276,10 +278,11 @@ class TestSimulatedRecruiter(object):
     def test_open_recruitment_multiple_returns_empty_result(self, recruiter):
         assert recruiter.open_recruitment(n=3)["items"] == []
 
-    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
-        assert p.status == "submitted"
+    def test_on_task_completion__returns_event_type_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "submitted",
+            "action": "RecruiterSubmissionComplete",
+        }
 
     def test_close_recruitment(self, recruiter):
         assert recruiter.close_recruitment() is None
@@ -327,10 +330,11 @@ class TestBotRecruiter(object):
     def test_reward_bonus(self, a, recruiter):
         recruiter.reward_bonus(a.participant(), 0.01, "You're great!")
 
-    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) == "BotRecruiterSubmissionComplete"
-        assert p.status == "submitted"
+    def test_on_task_completion__returns_event_type_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "submitted",
+            "action": "BotRecruiterSubmissionComplete",
+        }
 
     def test_notify_duration_exceeded_rejects_participants(self, a, recruiter):
         bot = a.participant(recruiter_id="bots")
@@ -441,10 +445,10 @@ class TestProlificRecruiter(object):
             "entry_information": prolific_format,
         }
 
-    def test_suppresses_assignment_submitted(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) is None
-        assert p.status == "recruiter_submission_started"
+    def test_on_task_completion__returns_no_event_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "recruiter_submission_started",
+        }
 
     @pytest.mark.usefixtures("experiment_dir_merged")
     def test_exit_page_includes_submission_prolific_button(self, a, webapp, recruiter):
@@ -1003,10 +1007,10 @@ class TestMTurkRecruiter(object):
         with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment()
 
-    def test_suppresses_assignment_submitted(self, a, recruiter):
-        p = a.participant()
-        assert recruiter.on_task_completion(p) is None
-        assert p.status == "recruiter_submission_started"
+    def test_on_task_completion__returns_no_event_and_new_status(self, recruiter):
+        assert recruiter.on_task_completion() == {
+            "new_status": "recruiter_submission_started",
+        }
 
     def test_current_hit_id_with_active_experiment(self, recruiter, fake_parsed_hit):
         recruiter.open_recruitment()

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -197,8 +197,10 @@ class TestCLIRecruiter(object):
         result = recruiter.open_recruitment()
         assert "mode=new_mode" in result["items"][0]
 
-    def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
+    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
+        assert p.status == "submitted"
 
 
 @pytest.mark.usefixtures("active_config")
@@ -249,8 +251,10 @@ class TestHotAirRecruiter(object):
         result = recruiter.open_recruitment()
         assert "mode=debug" in result["items"][0]
 
-    def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
+    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
+        assert p.status == "submitted"
 
 
 class TestSimulatedRecruiter(object):
@@ -272,8 +276,10 @@ class TestSimulatedRecruiter(object):
     def test_open_recruitment_multiple_returns_empty_result(self, recruiter):
         assert recruiter.open_recruitment(n=3)["items"] == []
 
-    def test_returns_standard_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "RecruiterSubmissionComplete"
+    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) == "RecruiterSubmissionComplete"
+        assert p.status == "submitted"
 
     def test_close_recruitment(self, recruiter):
         assert recruiter.close_recruitment() is None
@@ -321,8 +327,10 @@ class TestBotRecruiter(object):
     def test_reward_bonus(self, a, recruiter):
         recruiter.reward_bonus(a.participant(), 0.01, "You're great!")
 
-    def test_returns_specific_submission_event_type(self, recruiter):
-        assert recruiter.on_completion_event() == "BotRecruiterSubmissionComplete"
+    def test_on_task_completion__returns_event_type_and_sets_status(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) == "BotRecruiterSubmissionComplete"
+        assert p.status == "submitted"
 
     def test_notify_duration_exceeded_rejects_participants(self, a, recruiter):
         bot = a.participant(recruiter_id="bots")
@@ -433,8 +441,10 @@ class TestProlificRecruiter(object):
             "entry_information": prolific_format,
         }
 
-    def test_defers_assignment_submission_via_null_on_completion_event(self, recruiter):
-        assert recruiter.on_completion_event() is None
+    def test_suppresses_assignment_submitted(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) is None
+        assert p.status == "recruiter_submission_started"
 
     @pytest.mark.usefixtures("experiment_dir_merged")
     def test_exit_page_includes_submission_prolific_button(self, a, webapp, recruiter):
@@ -500,12 +510,14 @@ class TestProlificRecruiter(object):
             study_id="abcdefghijklmnopqrstuvwx", number_to_add=1
         )
 
-    def test_submission_listener_enqueues_assignment_submitted_notification(
-        self, queue, webapp
+    def test_submission_listener_updates_status_and_enqueues_notification(
+        self, a, queue, webapp, db_session
     ):
+        participant = a.participant(assignment_id="some assignment ID")
+        participant_id = participant.id
         exit_form_submission = {
-            "assignmentId": "some assignment ID",
-            "participantId": "some participant ID",
+            "assignmentId": participant.assignment_id,
+            "participantId": f"{participant_id}",
             "somethingElse": "blah... whatever",
         }
 
@@ -513,13 +525,36 @@ class TestProlificRecruiter(object):
             "/prolific-submission-listener", data=exit_form_submission
         )
 
+        participant = db_session.merge(participant)
         assert response.status_code == 200
+        assert participant.status == "submitted"
         queue.enqueue.assert_called_once_with(
             mock.ANY,
             "RecruiterSubmissionComplete",
             "some assignment ID",
-            "some participant ID",
-        ),
+            f"{participant_id}",
+        )
+
+    def test_submission_listener_prevents_double_processing(self, a, queue, webapp):
+        participant = a.participant(assignment_id="some assignment ID")
+        participant_id = participant.id
+        exit_form_submission = {
+            "assignmentId": "some assignment ID",
+            "participantId": f"{participant_id}",
+            "somethingElse": "blah... whatever",
+        }
+
+        # Call twice
+        webapp.post("/prolific-submission-listener", data=exit_form_submission)
+        webapp.post("/prolific-submission-listener", data=exit_form_submission)
+
+        # Just one job added to queue
+        queue.enqueue.assert_called_once_with(
+            mock.ANY,
+            "RecruiterSubmissionComplete",
+            "some assignment ID",
+            f"{participant_id}",
+        )
 
     def test_clean_qualification_attributes(self, recruiter):
         json_path = os.path.join(
@@ -968,8 +1003,10 @@ class TestMTurkRecruiter(object):
         with pytest.raises(MTurkRecruiterException):
             recruiter.open_recruitment()
 
-    def test_supresses_assignment_submitted(self, recruiter):
-        assert recruiter.on_completion_event() is None
+    def test_suppresses_assignment_submitted(self, a, recruiter):
+        p = a.participant()
+        assert recruiter.on_task_completion(p) is None
+        assert p.status == "recruiter_submission_started"
 
     def test_current_hit_id_with_active_experiment(self, recruiter, fake_parsed_hit):
         recruiter.open_recruitment()

--- a/tests/test_sockets.py
+++ b/tests/test_sockets.py
@@ -282,7 +282,7 @@ class TestChatEndpoint:
         #    ``TestChannel.test_subscribe_sends_control_message``
         # 2. A websocket connected message on the control channel sent before
         #    entering the receive loop in `client.publish()`
-        # 3. The plain text message recieved from `ws.recieve()` on the
+        # 3. The plain text message received from `ws.receive()` on the
         #    `special` channel.
 
         assert sockets.redis_conn.publish.call_count == 3


### PR DESCRIPTION

## Description
Addresses the double submission problem in the `ProlificRecruiter` documented in https://github.com/Dallinger/Dallinger/issues/5726, and other changes for improved clarity.

### Changes
1. Introduce a new participant status, "recruiter_submission_started", to reflect the state between the participant completing the experiment task, and the time when their recruiter has finished processing their submission, in cases where there is a separate, asynchronous submission step on the recruitment platform, like with MTurk and Prolific
2. Rename the "AssignmentSubmitted" event/command to "RecruiterSubmissionComplete", to better reflect when it is executed (not upon submission to the recruiter, but upon _completion_ of the submission with the recruiter)
3. When a Prolific participant clicks the button to return to Prolific and submit their task, lock the participant DB row, check to make sure they have not already taken this action. If they have, ignore the submission. If they have not, mark them as "submitted" and enqueue a "RecruiterSubmissionComplete" asynchronous command. When we perform the participant status check, we now lock the database row to prevent double-submission slipping past.
4. Adds a [Mermaid](https://docs.mermaidchart.com/mermaid/intro) syntax diagram of the task submission process to the Dallinger docs

### Optional changes
This PR makes changes to the Experiment and Recruiter interfaces because it changes method names:
1. `Experiment.on_assignment_submitted_to_recruiter()` is changed to `Experiment.on_recruiter_submission_complete()`
2. `Recruiter.on_completion_event()` is changed to `Recruiter.on_task_completion()`

These changes were made to better represent when and how the methods are invoked, but they are not strictly necessary, and we could revert to using the current names.

### Changes not made
We currently don't actually check whether a participant has submitted their task with Prolific before declaring that they've done so. This seems to work OK in practice, but we could probably do something more ambitious, like polling Prolific in an asynchronous process to check for when their status moves from "ACTIVE" to "AWAITING REVIEW". This would have two benefits:
1. the behavior would not be "fake" (and hence confusing), and would be more consistent with MTurk
2. we would no longer have to loop/poll when attempting approve the task later, since we would know the task was already in the appropriate state on Prolific

## Motivation and Context
Related bug: https://github.com/Dallinger/Dallinger/issues/5726


## How Has This Been Tested?
Automated tests only

