### PR TITLE
Remove numpy and pandas dependencies as they are not used by Dallinger

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,6 @@ dependencies = [
     "heroku3",
     "ipython < 8.19",
     "localconfig",
-    "numpy",
-    "pandas",
     "pexpect",
     "pip",
     "pip-tools",


### PR DESCRIPTION
Currently numpy and pandas are listed in pyproject.toml despite not being used by Dallinger. This makes the Docker image unnecessarily heavy. This PR removes them.