### PR TITLE
Show database reset button in dashboard only in debug mode

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -797,8 +797,7 @@ def database():
 @login_required
 def develop():
     """Dashboard for working with ``dallinger develop`` Flask server."""
-
-    return render_template("dashboard_develop.html")
+    return render_template("dashboard_develop.html", mode=get_config().get("mode"))
 
 
 @dashboard.route("/database/action/<route_name>", methods=["POST"])

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -28,8 +28,9 @@
 
     <div class="dev-tools-section">
         <button id="new-participant" class="btn btn-primary" onclick="handleNewParticipant()">New participant</button>
-
-        <button id="init-db" class="btn btn-danger" onclick="handleInitDB()">Reset database</button>
+        {% if mode == "debug" %}
+            <button id="init-db" class="btn btn-danger" onclick="handleInitDB()">Reset database</button>
+        {% endif %}
     </div>
 
     <div class="dev-tools-section">


### PR DESCRIPTION
Show database reset button in dashboard only in debug mode as it is too dangerous when deployed !
