### PR TITLE
Add dashboard_password to local_config_defaults.txt

### DIFF
--- a/dallinger/default_configs/local_config_defaults.txt
+++ b/dallinger/default_configs/local_config_defaults.txt
@@ -14,3 +14,4 @@ loglevel = 0
 threads = auto
 whimsical = true
 dashboard_user = admin
+dashboard_password = dallinger


### PR DESCRIPTION
Add `dashboard_password` to local_config_defaults.txt to allow doing `config.dashboard_password` from within tests.
