### PR TITLE
Rename prolific.co -> prolific.com

### DIFF
--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -35,7 +35,7 @@ class ProlificService:
     @property
     def api_root(self):
         """The root URL for API calls."""
-        return f"https://api.prolific.co/api/{self.api_version}"
+        return f"https://api.prolific.com/api/{self.api_version}"
 
     def add_participants_to_study(self, study_id: int, number_to_add: int) -> dict:
         """Add additional slots to a running Study."""

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -306,7 +306,7 @@ def _prolific_service_from_config():
 
 
 class ProlificRecruiter(Recruiter):
-    """A recruiter for [Prolific](https://app.prolific.co/)"""
+    """A recruiter for [Prolific](https://app.prolific.com/)"""
 
     nickname = "prolific"
 
@@ -424,7 +424,9 @@ class ProlificRecruiter(Recruiter):
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
-        return f"https://app.prolific.co/submissions/complete?cc={self.completion_code}"
+        return (
+            f"https://app.prolific.com/submissions/complete?cc={self.completion_code}"
+        )
 
     def exit_response(self, experiment, participant):
         """Return our custom particpant exit template.
@@ -498,7 +500,7 @@ class ProlificRecruiter(Recruiter):
             "question": "In what country do you currently reside?",
             "description": "",
             "title": "Current Country of Residence",
-            "help_text": "Please note that Prolific is currently only available for participants who live in OECD countries. <a href='https://researcher-help.prolific.co/hc/en-gb/articles/360009220833-Who-are-the-people-in-your-participant-pool' target='_blank'>Read more about this</a>",
+            "help_text": "Please note that Prolific is currently only available for participants who live in OECD countries. <a href='https://researcher-help.prolific.com/hc/en-gb/articles/360009220833-Who-are-the-people-in-your-participant-pool' target='_blank'>Read more about this</a>",
             "participant_help_text": "",
             "researcher_help_text": "",
             "is_new": false,

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -242,7 +242,7 @@ Prolific Recruitment
         - ``peripheral_requirements``
         - ``eligibility_requirements``
 
-    See the `Prolific API Documentation <https://docs.prolific.co/docs/api-docs/public/#tag/Studies/paths/~1api~1v1~1studies~1/post>`__
+    See the `Prolific API Documentation <https://docs.prolific.com/docs/api-docs/public/#tag/Studies/paths/~1api~1v1~1studies~1/post>`__
     for details.
 
     Configuration can also be stored in a separate JSON file, and included by using the

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -73,7 +73,7 @@ def test_all_methods_give_informative_error_messages(subject):
     with pytest.raises(ProlificServiceException) as ex_info:
         subject.who_am_i()
 
-    assert ex_info.match('"URL": "https://api.prolific.co/api/junk/users/me/"')
+    assert ex_info.match('"URL": "https://api.prolific.com/api/junk/users/me/"')
 
 
 @pytest.mark.usefixtures("check_prolific")
@@ -91,7 +91,7 @@ def test_requests_are_logged(subject):
         subject.who_am_i()
 
     logger.warning.assert_called_once_with(
-        'Prolific API request: {"URL": "https://api.prolific.co/api/v1/users/me/", "method": "GET", "args": {}}'
+        'Prolific API request: {"URL": "https://api.prolific.com/api/v1/users/me/", "method": "GET", "args": {}}'
     )
 
 


### PR DESCRIPTION
#### CHANGELOG

* Rename `prolific.co` to `prolific.com` for API calls to `api.prolific.com` and for various other subdomains.
