### PR TITLE
Use dynamic recruiter value when clicking 'New participant' link in the dashboard

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -797,7 +797,11 @@ def database():
 @login_required
 def develop():
     """Dashboard for working with ``dallinger develop`` Flask server."""
-    return render_template("dashboard_develop.html", mode=get_config().get("mode"))
+    return render_template(
+        "dashboard_develop.html",
+        mode=get_config().get("mode"),
+        recruiter=recruiters.from_config(get_config()).nickname,
+    )
 
 
 @dashboard.route("/database/action/<route_name>", methods=["POST"])

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -51,7 +51,7 @@
         }
 
         function handleNewParticipant() {
-            let url = "/ad?generate_tokens=true&recruiter=hotair&source=dashboard";
+            let url = "/ad?generate_tokens=true&recruiter={{ recruiter }}&source=dashboard";
             log("Recruiting new participant...");
             window.open(url, "_blank").focus();
         }

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -381,9 +381,9 @@ class ProlificRecruiter(Recruiter):
         """Map Prolific Study URL params to our internal keys."""
 
         participant_data = {
-            "hit_id": entry_information["STUDY_ID"],
-            "worker_id": entry_information["PROLIFIC_PID"],
-            "assignment_id": entry_information["SESSION_ID"],
+            "hit_id": entry_information.pop("STUDY_ID", None),
+            "worker_id": entry_information.pop("PROLIFIC_PID", None),
+            "assignment_id": entry_information.pop("SESSION_ID", None),
             "entry_information": entry_information,
         }
 


### PR DESCRIPTION
The value for `recruiter` in the 'New participant' link in the dashboard's "Development" tab is hardcoded as "hotair". Instead, the value should be set dynamically, e.g. when deploying with Prolific as recruitment method `recruiter` should be set to "prolific". However, when debugging the same experiment locally `recruiter` should use "hotair" as the value assigned.
