### PR TITLE
Release v10.1.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.2.0a1
+current_version = 10.1.2
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Change Log
 
+## [v10.1.2](https://github.com/dallinger/dallinger/tree/v10.1.2) (2024-07-02)
+
+#### Fixed
+- Removed `check-latest: true` from `setup-python` action in ci.yml.
+- Renamed `prolific.co` to `prolific.com` for API calls to `api.prolific.com` and for various other subdomains.
+- Fixed value for `recruiter` in the 'New participant' link in the dashboard's "Development" tab. It is now set dynamically, e.g. when deploying with Prolific as recruitment method `recruiter` is set to "prolific", whereas when debugging the same experiment locally, `recruiter` is assigned "hotair" as value.
+
+#### Updated
+- Infrastructure: Updated dependencies.
+
 ## [v10.1.1](https://github.com/dallinger/dallinger/tree/v10.1.1) (2024-05-09)
 
 #### Updated

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "10.2.0a1"
+__version__ = "10.1.2"

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -62,11 +62,11 @@ click==8.1.7
     #   nltk
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -76,7 +76,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -180,7 +180,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -198,11 +198,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -250,14 +250,14 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
 regex==2022.3.15
     # via nltk
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,11 +266,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -311,7 +311,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -330,7 +330,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -339,7 +339,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -353,7 +353,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -368,6 +368,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -394,7 +398,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/chatroom_ws/constraints.txt
+++ b/demos/dlgr/demos/chatroom_ws/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -62,11 +62,11 @@ click==8.1.7
     #   nltk
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -76,7 +76,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -180,7 +180,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -198,11 +198,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -250,14 +250,14 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
 regex==2022.3.15
     # via nltk
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,11 +266,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -311,7 +311,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -330,7 +330,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -339,7 +339,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -353,7 +353,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -368,6 +368,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -394,7 +398,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -23,11 +23,11 @@ blinker==1.8.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.34.100
+boto3==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.34.100
+botocore==1.34.137
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==1.5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,11 +61,11 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==42.0.7
+cryptography==42.0.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.1.1
+dallinger==10.1.2
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,7 +75,7 @@ executing==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==25.0.1
+faker==26.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -175,7 +175,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.0
+packaging==24.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -193,11 +193,11 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.43
+prompt-toolkit==3.0.47
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==5.9.8
+psutil==6.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,12 +245,12 @@ pytz==2024.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
-redis==5.0.4
+redis==5.0.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   rq
-requests==2.31.0
+requests==2.32.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,11 +259,11 @@ rq==1.16.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.1
+s3transfer==0.10.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.20.0
+selenium==4.22.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -304,7 +304,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==8.3.0
+tenacity==8.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -321,7 +321,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.25.0
+trio==0.25.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -330,7 +330,7 @@ trio-websocket==0.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,7 +344,7 @@ ua-parser==0.18.0
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
@@ -359,6 +359,10 @@ wcwidth==0.2.13
     # via
     #   -c ../../../../dev-requirements.txt
     #   prompt-toolkit
+websocket-client==1.8.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   selenium
 werkzeug==3.0.3
     # via
     #   -c ../../../../dev-requirements.txt
@@ -385,7 +389,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==6.3
+zope-interface==6.4.post2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==10.2.0a1
+Dallinger==10.1.2

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="10.2.0a1",
+    version="10.1.2",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "10.2.0a1"
+version = "10.1.2"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
#### Fixed
- Removed `check-latest: true` from `setup-python` action in ci.yml.
- Renamed `prolific.co` to `prolific.com` for API calls to `api.prolific.com` and for various other subdomains.
- Fixed value for `recruiter` in the 'New participant' link in the dashboard's "Development" tab. It is now set dynamically, e.g. when deploying with Prolific as recruitment method `recruiter` is set to "prolific", whereas when debugging the same experiment locally, `recruiter` is assigned "hotair" as value.

#### Updated
- Infrastructure: Updated dependencies.