### PR TITLE
Limit worker CPU usage

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -106,6 +106,7 @@ default_keys = (
     ("docker_image_base_name", six.text_type, [], ""),
     ("docker_image_name", six.text_type, [], ""),
     ("docker_volumes", six.text_type, [], ""),
+    ("worker_cpu_shares", int, [], ""),
 )
 
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -106,7 +106,7 @@ default_keys = (
     ("docker_image_base_name", six.text_type, [], ""),
     ("docker_image_name", six.text_type, [], ""),
     ("docker_volumes", six.text_type, [], ""),
-    ("worker_cpu_shares", int, [], ""),
+    ("docker_worker_cpu_shares", int, [], ""),
 )
 
 

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -21,6 +21,7 @@ mode = debug
 enable_global_experiment_registry = False
 language = en
 lock_table_when_creating_participant = True
+worker_cpu_shares = 1024
 
 [Recruiter]
 activate_recruiter_on_start = True

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -21,7 +21,7 @@ mode = debug
 enable_global_experiment_registry = False
 language = en
 lock_table_when_creating_participant = True
-worker_cpu_shares = 1024
+docker_worker_cpu_shares = 1024
 
 [Recruiter]
 activate_recruiter_on_start = True

--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -29,7 +29,7 @@ services:
   worker:
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
-    cpu_shares: {{ config["worker_cpu_shares"] }}
+    cpu_shares: {{ config["docker_worker_cpu_shares"] }}
     depends_on:
       postgresql:
         condition: service_healthy

--- a/dallinger/docker/docker-compose.yml.j2
+++ b/dallinger/docker/docker-compose.yml.j2
@@ -29,6 +29,7 @@ services:
   worker:
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
+    cpu_shares: {{ config["worker_cpu_shares"] }}
     depends_on:
       postgresql:
         condition: service_healthy

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -46,9 +46,7 @@ services:
   worker_{{ number + 1 }}:
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
-    {%- if config["worker_cpu_shares"] %}
     cpu_shares: {{ config["worker_cpu_shares"] }}
-    {%- endif %}
     depends_on:
       <<: *commondepends
     user: "${UID}:${GID}"

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -46,6 +46,9 @@ services:
   worker_{{ number + 1 }}:
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
+    {%- if config["worker_cpu_shares"] %}
+    cpu_shares: {{ config["worker_cpu_shares"] }}
+    {%- endif %}
     depends_on:
       <<: *commondepends
     user: "${UID}:${GID}"

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -46,7 +46,7 @@ services:
   worker_{{ number + 1 }}:
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
-    cpu_shares: {{ config["worker_cpu_shares"] }}
+    cpu_shares: {{ config["docker_worker_cpu_shares"] }}
     depends_on:
       <<: *commondepends
     user: "${UID}:${GID}"

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -479,3 +479,8 @@ Docker Deployment Configuration
     Additional list of volumes to mount when deploying using docker.
 
     Example: ``/host/path:/container_path,/another-path:/another-container-path``
+
+``docker_worker_cpu_shares``
+    An integer value which specify `Docker --cpu-shares option <https://docs.docker.com/config/containers/resource_constraints/#configure-the-default-cfs-scheduler>`_ for worker containers.
+
+    Defaults to ``1024``, lower this value to limit worker containers CPU usage when CPU cycles are constrained.


### PR DESCRIPTION
This PR address issue #6336 .

## Description

This PR adds a new `worker_cpu_shares` configuration variable which limits the worker CPU usage when resources are constrained.
This make use of the docker `--cpu-shares` option:

`Set this flag to a value greater or less than the default of 1024 to increase or reduce the container's weight, and give it access to a greater or lesser proportion of the host machine's CPU cycles. This is only enforced when CPU cycles are constrained. When plenty of CPU cycles are available, all containers use as much CPU as they need. In that way, this is a soft limit. --cpu-shares doesn't prevent containers from being scheduled in Swarm mode. It prioritizes container CPU resources for the available CPU cycles. It doesn't guarantee or reserve any specific CPU access.`

## Motivation and Context

In Docker deployment, worker processes can compete with web and clock processes for resources. This is dangerous, as a backlog of worker tasks can cause the web/clock processes to slow down unacceptably.

## How Has This Been Tested?

Tested locally by running `dallinger docker debug` from a demo experiment folder and checking the generated `docker-compose.yml` in the project temporary folder includes the correct value for the `cpu_shares`  option.
