### PR TITLE
Prolific development recruiter: 5pts

### DIFF
--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -27,6 +27,7 @@ from sqlalchemy.sql.expression import true
 from dallinger import db, experiment, models, recruiters
 from dallinger.config import get_config
 from dallinger.notifications import MessengerError, admin_notifier
+from dallinger.recruiters import ProlificRecruiter
 from dallinger.utils import generate_random_id
 
 from . import dashboard
@@ -510,7 +511,7 @@ def prepare_advertisement():
         redirect_params = entry_information.copy()
         del redirect_params["generate_tokens"]
 
-        if "prolific" in recruiter_name:
+        if isinstance(recruiter, ProlificRecruiter):
             entry_params = ("PROLIFIC_PID", "STUDY_ID", "SESSION_ID")
         else:
             entry_params = ("hitId", "assignmentId", "workerId")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -422,7 +422,6 @@ def launch():
     recruitment_details = None
     if _config().get("activate_recruiter_on_start"):
         try:
-            print(exp.recruiter)
             recruitment_details = exp.recruiter.open_recruitment(
                 n=exp.initial_recruitment_size
             )

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -422,6 +422,7 @@ def launch():
     recruitment_details = None
     if _config().get("activate_recruiter_on_start"):
         try:
+            print(exp.recruiter)
             recruitment_details = exp.recruiter.open_recruitment(
                 n=exp.initial_recruitment_size
             )
@@ -510,7 +511,7 @@ def prepare_advertisement():
         redirect_params = entry_information.copy()
         del redirect_params["generate_tokens"]
 
-        if recruiter_name == "prolific":
+        if "prolific" in recruiter_name:
             entry_params = ("PROLIFIC_PID", "STUDY_ID", "SESSION_ID")
         else:
             entry_params = ("hitId", "assignmentId", "workerId")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -500,9 +500,9 @@ def prepare_advertisement():
     if not browser.is_supported(request.user_agent.string):
         raise ExperimentError("browser_type_not_allowed")
 
+    recruiter = recruiters.from_config(config)
     recruiter_name = request.args.get("recruiter")
     if not recruiter_name:
-        recruiter = recruiters.from_config(config)
         recruiter_name = recruiter.nickname
 
     entry_information = request.args.to_dict()

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -301,24 +301,81 @@ class DevProlificService(ProlificService):
         self.referer_header = "referer_header"
 
     def approve_participant_session(self, session_id: str) -> dict:
-        """DEVELOPMENT ONLY: Mark an assignment as approved."""
-        return self._req(
+        self._req(
             method="POST",
-            endpoint="/submissions/dev-session-id/transition/",
+            endpoint=f"/submissions/{session_id}/transition/",
             json={"action": "APPROVE"},
         )
+        return True
+
+    def draft_study(
+        self,
+        completion_code: str,
+        completion_option: str,
+        description: str,
+        eligibility_requirements: List[dict],
+        estimated_completion_time: int,
+        external_study_url: str,
+        internal_name: str,
+        maximum_allowed_time: int,
+        name: str,
+        prolific_id_option: str,
+        reward: int,
+        total_available_places: int,
+        device_compatibility: Optional[List[str]] = None,
+        peripheral_requirements: Optional[List[str]] = None,
+    ) -> dict:
+        """Create a draft Study on Prolific, and return its properties."""
+
+        payload = {
+            "name": name,
+            "internal_name": internal_name,
+            "description": description,
+            "external_study_url": external_study_url,
+            "prolific_id_option": prolific_id_option,
+            "completion_code": completion_code,
+            "completion_option": completion_option,
+            "total_available_places": total_available_places,
+            "estimated_completion_time": estimated_completion_time,
+            "maximum_allowed_time": maximum_allowed_time,
+            "reward": reward,
+            "eligibility_requirements": eligibility_requirements,
+            "status": "UNPUBLISHED",
+        }
+
+        if device_compatibility is not None:
+            payload["device_compatibility"] = device_compatibility
+        if peripheral_requirements is not None:
+            payload["peripheral_requirements"] = peripheral_requirements
+
+        self._req(method="POST", endpoint="/studies/", json=payload)
+        return {"id": "prolific-user-id", "external_study_url": "external-study-url"}
+
+    def publish_study(self, study_id: str) -> dict:
+        self._req(
+            method="POST",
+            endpoint=f"/studies/{study_id}/transition/",
+            json={"action": "PUBLISH"},
+        )
+        return {"id": "prolific-user-id", "external_study_url": "external-study-url"}
+
+    def who_am_i(self) -> dict:
+        """For testing authorization, primarily, but does return all the
+        details for your user.
+        """
+        return {"id": "prolific-user-id"}
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
-        """Does NOT run the request/response cycle but instead writes to the log."""
+        """Does NOT make any requests but instead writes to the log."""
         url = f"{self.api_root}{endpoint}"
         summary = {
             "URL": url,
             "method": method,
             "args": kw,
         }
-        logger.warning(">>>>>>>>>>>>>>>>>>>>>>>>")
-        logger.warning(
-            f">>> Prolific API request would have been: {json.dumps(summary)} <<<"
+        logger.info("########## PROLIFIC API DEBUG LOG START ###########")
+        logger.info(
+            f"########## PROLIFIC API request would have been: {json.dumps(summary)} <<<"
         )
-        logger.warning(">>>>>>>>>>>>>>>>>>>>>>>>")
+        logger.info("########## PROLIFIC API DEBUG LOG END #############")
         return {}

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -349,9 +349,6 @@ class DevProlificService(ProlificService):
         return {"id": "prolific-user-id", "external_study_url": "external-study-url"}
 
     def who_am_i(self) -> dict:
-        """For testing authorization, primarily, but does return all the
-        details for your user.
-        """
         return {"id": "prolific-user-id"}
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
@@ -362,6 +359,9 @@ class DevProlificService(ProlificService):
             "method": method,
             "args": kw,
         }
-        logger.info("########## PROLIFIC API DEBUG LOG START ###########")
-        logger.info(f"PROLIFIC API request would have been: {json.dumps(summary)}")
-        logger.info("########## PROLIFIC API DEBUG LOG END #############")
+        self.debug_log(f"PROLIFIC API request would have been: {json.dumps(summary)}")
+
+    def debug_log(self, msg):
+        logger.info("########## PROLIFIC DEBUG LOG START ###########")
+        logger.info(msg)
+        logger.info("########## PROLIFIC DEBUG LOG END #############")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -291,7 +291,7 @@ class DevProlificService(ProlificService):
         from uuid import uuid4
 
         """Does NOT make any requests but instead writes to the log."""
-        self.debug_log_request(f"method = {method}, endpoint = {endpoint}, kw = {kw}")
+        self.debug_log_request(method=method, endpoint=endpoint, **kw)
 
         if endpoint.startswith("/studies/"):
             if method == "GET":
@@ -371,8 +371,13 @@ class DevProlificService(ProlificService):
 
         logger.error("Simulated Prolific API call could not be matched.")
 
-    def debug_log_request(self, request):
-        logger.warning(f"Simulated Prolific API request: {request}")
+    def debug_log_request(self, method, endpoint, **kw):
+        log_msg = (
+            f'Simulated Prolific API request: method="{method}", endpoint="{endpoint}"'
+        )
+        log_msg += f', json={kw["json"]}' if "json" in kw else ""
+        log_msg += f'\n{kw["message"]}' if "message" in kw else ""
+        logger.warning(log_msg)
 
     def debug_log_response(self, response):
         logger.warning(f"Simulated Prolific API response: {response}")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -298,8 +298,7 @@ class DevProlificService(ProlificService):
                 # method="GET", endpoint=f"/studies/{study_id}/"
                 if re.match(r"/studies/[a-z0-9]+/", endpoint):
                     response = {
-                        "id": "prolific-user-id",
-                        "external_study_url": "external-study-url",
+                        "total_available_places": 100,
                     }
                     return self.debug_log_response(response)
 

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -289,19 +289,21 @@ class DevProlificService(ProlificService):
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
         """Does NOT make any requests but instead writes to the log."""
-        self.debug_log(f"method = {method}, endpoint = {endpoint}, kw = {kw}")
+        self.debug_log_request(f"method = {method}, endpoint = {endpoint}, kw = {kw}")
 
         if endpoint.startswith("/studies/"):
             if method == "GET":
                 # method="GET", endpoint=f"/studies/{study_id}/"
                 if re.match(r"/studies/[a-z0-9]+/", endpoint):
-                    return {
+                    response = {
                         "id": "prolific-user-id",
                         "external_study_url": "external-study-url",
                     }
+                    return self.debug_log_response(response)
+
                 # method="GET", endpoint="/studies/"
                 elif endpoint == "/studies/":
-                    return {
+                    response = {
                         "results": [
                             {
                                 "title": "title",
@@ -312,54 +314,65 @@ class DevProlificService(ProlificService):
                             }
                         ]
                     }
+                    return self.debug_log_response(response)
 
             elif method == "POST":
                 # method="POST", endpoint="/studies/", json=payload
                 if endpoint == "/studies/":
-                    return {
+                    response = {
                         "id": "study-id",
                         "external_study_url": "external-study-url",
                     }
+                    return self.debug_log_response(response)
 
                 # method="POST", endpoint=f"/studies/{study_id}/transition/", json={"action": "PUBLISH"},
                 elif re.match(r"/studies/[a-z0-9]+/transition/", endpoint):
-                    return True
+                    return self.debug_log_response(True)
 
             elif method == "PATCH":
                 # method="PATCH", endpoint=f"/studies/{study_id}/", json={"total_available_places": new_total},
-                return {
+                response = {
                     "items": ["https://experiment-url-1", "https://experiment-url-2"],
                     "message": "More info about this particular recruiter's process",
                 }
+                return self.debug_log_response(response)
 
             # method="DELETE", endpoint=f"/studies/{study_id}"
             elif method == "DELETE":
-                return {"status_code": 204}
+                response = {"status_code": 204}
+                return self.debug_log_response(response)
 
         # method="POST", endpoint=f"/bulk-bonus-payments/{setup_response['id']}/pay/"
         elif endpoint.startswith("/bulk-bonus-payments/"):
-            return {"id": "id-from call-to-/bulk-bonus-payments/<id>/pay/"}
+            response = {"id": "id-from call-to-/bulk-bonus-payments/<id>/pay/"}
+            return self.debug_log_response(response)
 
         # method="POST", endpoint="/submissions/bonus-payments/", json=payload
         elif endpoint.startswith("/submissions/bonus-payments"):
-            return {"id": "id-from call-to-/submissions/bonus-payments"}
+            response = {"id": "id-from call-to-/submissions/bonus-payments"}
+            return self.debug_log_response(response)
 
         elif endpoint.startswith("/submissions/"):
             # method="POST", endpoint=f"/submissions/{session_id}/transition/", json={"action": "APPROVE"},
             if re.match(r"/submissions/[A-Za-z0-9]+/transition/", endpoint):
-                return True
+                return self.debug_log_response(True)
 
             # method="GET", endpoint=f"/submissions/{session_id}/"
             elif re.match(r"/submissions/[A-Za-z0-9]+/", endpoint):
-                return {
+                response = {
                     "id": "id",
                     "study_id": "study-id",
                     "participant": "participant",
                     "started_at": "started-at-timestamp",
                     "status": "AWAITING REVIEW",
                 }
+                return self.debug_log_response(response)
 
         logger.error("Simulated Prolific API call could not be matched.")
 
-    def debug_log(self, msg):
-        logger.warning(f"Simulated Prolific API call: {msg}")
+    def debug_log_request(self, request):
+        logger.warning(f"Simulated Prolific API request: {request}")
+
+    def debug_log_response(self, response):
+        logger.warning(f"Simulated Prolific API response: {response}")
+        return response

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -292,6 +292,7 @@ class DevProlificService(ProlificService):
 
         """Does NOT make any requests but instead writes to the log."""
         self.debug_log_request(method=method, endpoint=endpoint, **kw)
+        response = None
 
         if endpoint.startswith("/studies/"):
             if method == "GET":
@@ -300,7 +301,6 @@ class DevProlificService(ProlificService):
                     response = {
                         "total_available_places": 100,
                     }
-                    return self.debug_log_response(response)
 
                 # method="GET", endpoint="/studies/"
                 elif endpoint == "/studies/":
@@ -315,7 +315,6 @@ class DevProlificService(ProlificService):
                             }
                         ]
                     }
-                    return self.debug_log_response(response)
 
             elif method == "POST":
                 # method="POST", endpoint="/studies/", json=payload
@@ -324,11 +323,10 @@ class DevProlificService(ProlificService):
                         "id": "study-id",
                         "external_study_url": "external-study-url",
                     }
-                    return self.debug_log_response(response)
 
                 # method="POST", endpoint=f"/studies/{study_id}/transition/", json={"action": "PUBLISH"},
                 elif re.match(r"/studies/[a-z0-9]+/transition/", endpoint):
-                    return self.debug_log_response(True)
+                    response = True
 
             elif method == "PATCH":
                 # method="PATCH", endpoint=f"/studies/{study_id}/", json={"total_available_places": new_total},
@@ -336,27 +334,23 @@ class DevProlificService(ProlificService):
                     "items": ["https://experiment-url-1", "https://experiment-url-2"],
                     "message": "More info about this particular recruiter's process",
                 }
-                return self.debug_log_response(response)
 
             # method="DELETE", endpoint=f"/studies/{study_id}"
             elif method == "DELETE":
                 response = {"status_code": 204}
-                return self.debug_log_response(response)
 
         # method="POST", endpoint=f"/bulk-bonus-payments/{setup_response['id']}/pay/"
         elif endpoint.startswith("/bulk-bonus-payments/"):
             response = {"id": str(uuid4())}
-            return self.debug_log_response(response)
 
         # method="POST", endpoint="/submissions/bonus-payments/", json=payload
         elif endpoint.startswith("/submissions/bonus-payments"):
             response = {"id": str(uuid4())}
-            return self.debug_log_response(response)
 
         elif endpoint.startswith("/submissions/"):
             # method="POST", endpoint=f"/submissions/{session_id}/transition/", json={"action": "APPROVE"},
             if re.match(r"/submissions/[A-Za-z0-9]+/transition/", endpoint):
-                return self.debug_log_response(True)
+                response = True
 
             # method="GET", endpoint=f"/submissions/{session_id}/"
             elif re.match(r"/submissions/[A-Za-z0-9]+/", endpoint):
@@ -367,9 +361,11 @@ class DevProlificService(ProlificService):
                     "started_at": "started-at-timestamp",
                     "status": "AWAITING REVIEW",
                 }
-                return self.debug_log_response(response)
 
-        logger.error("Simulated Prolific API call could not be matched.")
+        if response is None:
+            raise RuntimeError("Simulated Prolific API call could not be matched.")
+        self.debug_log_response(response)
+        return response
 
     def debug_log_request(self, method, endpoint, **kw):
         log_msg = (
@@ -381,4 +377,3 @@ class DevProlificService(ProlificService):
 
     def debug_log_response(self, response):
         logger.warning(f"Simulated Prolific API response: {response}")
-        return response

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -291,7 +291,7 @@ class DevProlificService(ProlificService):
         from uuid import uuid4
 
         """Does NOT make any requests but instead writes to the log."""
-        self.debug_log_request(method=method, endpoint=endpoint, **kw)
+        self.log_request(method=method, endpoint=endpoint, **kw)
         response = None
 
         if endpoint.startswith("/studies/"):
@@ -364,10 +364,10 @@ class DevProlificService(ProlificService):
 
         if response is None:
             raise RuntimeError("Simulated Prolific API call could not be matched.")
-        self.debug_log_response(response)
+        self.log_response(response)
         return response
 
-    def debug_log_request(self, method, endpoint, **kw):
+    def log_request(self, method, endpoint, **kw):
         log_msg = (
             f'Simulated Prolific API request: method="{method}", endpoint="{endpoint}"'
         )
@@ -375,5 +375,5 @@ class DevProlificService(ProlificService):
         log_msg += f'\n{kw["message"]}' if "message" in kw else ""
         logger.warning(log_msg)
 
-    def debug_log_response(self, response):
+    def log_response(self, response):
         logger.warning(f"Simulated Prolific API response: {response}")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -286,9 +286,6 @@ class ProlificService:
 class DevProlificService(ProlificService):
     """Wrapper that mocks the Prolific REST API and instead of making requests it writes to the log."""
 
-    def __init__(self, api_token: str, api_version: str, referer_header: str):
-        super().__init__(api_token, api_version, referer_header)
-
     def approve_participant_session(self, session_id: str) -> dict:
         self._req(
             method="POST",

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -374,8 +374,5 @@ class DevProlificService(ProlificService):
             "args": kw,
         }
         logger.info("########## PROLIFIC API DEBUG LOG START ###########")
-        logger.info(
-            f"########## PROLIFIC API request would have been: {json.dumps(summary)} <<<"
-        )
+        logger.info(f"PROLIFIC API request would have been: {json.dumps(summary)} <<<")
         logger.info("########## PROLIFIC API DEBUG LOG END #############")
-        return {}

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -348,8 +348,17 @@ class DevProlificService(ProlificService):
         )
         return {"id": "prolific-user-id", "external_study_url": "external-study-url"}
 
-    def who_am_i(self) -> dict:
-        return {"id": "prolific-user-id"}
+    def pay_session_bonus(self, study_id: str, worker_id: str, amount: float) -> bool:
+        amount_str = "{:.2f}".format(amount)
+        payload = {
+            "study_id": study_id,
+            "csv_bonuses": f"{worker_id},{amount_str}",
+        }
+
+        self._req(method="POST", endpoint="/submissions/bonus-payments/", json=payload)
+        setup_response = {"id": "id-from call-to-/submissions/bonus-payments"}
+
+        self._req("POST", endpoint=f"/bulk-bonus-payments/{setup_response['id']}/pay/")
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
         """Does NOT make any requests but instead writes to the log."""
@@ -359,9 +368,7 @@ class DevProlificService(ProlificService):
             "method": method,
             "args": kw,
         }
-        self.debug_log(f"PROLIFIC API request would have been: {json.dumps(summary)}")
+        self.dev_log(json.dumps(summary))
 
-    def debug_log(self, msg):
-        logger.info("########## PROLIFIC DEBUG LOG START ###########")
-        logger.info(msg)
-        logger.info("########## PROLIFIC DEBUG LOG END #############")
+    def dev_log(self, msg):
+        logger.warning(f" >>> PROLIFIC DEV LOG <<< API request would have been: {msg}")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -284,7 +284,7 @@ class ProlificService:
 
 
 class DevProlificService(ProlificService):
-    """Wrapper that mocks the Prolific REST API and instead write to the log."""
+    """Wrapper that mocks the Prolific REST API and instead of making requests it writes to the log."""
 
     def __init__(self, api_token: str, api_version: str, referer_header: str):
         super().__init__(api_token, api_version, referer_header)
@@ -314,8 +314,6 @@ class DevProlificService(ProlificService):
         device_compatibility: Optional[List[str]] = None,
         peripheral_requirements: Optional[List[str]] = None,
     ) -> dict:
-        """Create a draft Study on Prolific, and return its properties."""
-
         payload = {
             "name": name,
             "internal_name": internal_name,
@@ -354,11 +352,10 @@ class DevProlificService(ProlificService):
             "study_id": study_id,
             "csv_bonuses": f"{worker_id},{amount_str}",
         }
-
         self._req(method="POST", endpoint="/submissions/bonus-payments/", json=payload)
         setup_response = {"id": "id-from call-to-/submissions/bonus-payments"}
-
         self._req("POST", endpoint=f"/bulk-bonus-payments/{setup_response['id']}/pay/")
+        return {"id": "id-from call-to-/bulk-bonus-payments/<id>/pay/"}
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
         """Does NOT make any requests but instead writes to the log."""

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -374,5 +374,5 @@ class DevProlificService(ProlificService):
             "args": kw,
         }
         logger.info("########## PROLIFIC API DEBUG LOG START ###########")
-        logger.info(f"PROLIFIC API request would have been: {json.dumps(summary)} <<<")
+        logger.info(f"PROLIFIC API request would have been: {json.dumps(summary)}")
         logger.info("########## PROLIFIC API DEBUG LOG END #############")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -284,21 +284,10 @@ class ProlificService:
 
 
 class DevProlificService(ProlificService):
-    """
-    Wrapper that mocks the Prolific REST API and instead write to the log.
-
-    params:
-        api_token: Prolific API token
-        api_version: Prolific API version
-        referer_header: Referer header to help Prolific identify our requests when troubleshooting
-    """
+    """Wrapper that mocks the Prolific REST API and instead write to the log."""
 
     def __init__(self, api_token: str, api_version: str, referer_header: str):
         super().__init__(api_token, api_version, referer_header)
-        self.api_token = "dev-api_token"
-        self.api_token_fragment = f"{api_token[:3]}...{api_token[-3:]}"
-        self.api_version = "api_version"
-        self.referer_header = "referer_header"
 
     def approve_participant_session(self, session_id: str) -> dict:
         self._req(

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -373,7 +373,7 @@ class DevProlificService(ProlificService):
         )
         log_msg += f', json={kw["json"]}' if "json" in kw else ""
         log_msg += f'\n{kw["message"]}' if "message" in kw else ""
-        logger.warning(log_msg)
+        logger.info(log_msg)
 
     def log_response(self, response):
-        logger.warning(f"Simulated Prolific API response: {response}")
+        logger.info(f"Simulated Prolific API response: {response}")

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -288,6 +288,8 @@ class DevProlificService(ProlificService):
     """Wrapper that mocks the Prolific REST API and instead of making requests it writes to the log."""
 
     def _req(self, method: str, endpoint: str, **kw) -> dict:
+        from uuid import uuid4
+
         """Does NOT make any requests but instead writes to the log."""
         self.debug_log_request(f"method = {method}, endpoint = {endpoint}, kw = {kw}")
 
@@ -344,12 +346,12 @@ class DevProlificService(ProlificService):
 
         # method="POST", endpoint=f"/bulk-bonus-payments/{setup_response['id']}/pay/"
         elif endpoint.startswith("/bulk-bonus-payments/"):
-            response = {"id": "id-from call-to-/bulk-bonus-payments/<id>/pay/"}
+            response = {"id": str(uuid4())}
             return self.debug_log_response(response)
 
         # method="POST", endpoint="/submissions/bonus-payments/", json=payload
         elif endpoint.startswith("/submissions/bonus-payments"):
-            response = {"id": "id-from call-to-/submissions/bonus-payments"}
+            response = {"id": str(uuid4())}
             return self.debug_log_response(response)
 
         elif endpoint.startswith("/submissions/"):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -324,8 +324,6 @@ def _prolific_service_from_config():
 def _dev_prolific_service_from_config():
     from dallinger.prolific import DevProlificService
 
-    config = get_config()
-    config.load()
     return DevProlificService(
         api_token="prolific-api-token",
         api_version="prolific-api-version",
@@ -630,10 +628,6 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     @property
     def external_submission_url(self):
-        """On experiment completion, participants are returned to
-        the Prolific site with a HIT (Study) specific link, which will
-        trigger payment of their base pay.
-        """
         self.prolificservice.debug_log(
             "PROLIFIC external submission URL would have been: "
             f"https://app.prolific.com/submissions/complete?cc={self.completion_code}\n"

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -623,7 +623,7 @@ class DevProlificRecruiter(ProlificRecruiter):
     nickname = "devprolific"
 
     def __init__(self, *args, **kwargs):
-        super().__init__()
+        super().__init__(*args, **kwargs)
         self.prolificservice = _dev_prolific_service_from_config()
 
     @property

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1791,7 +1791,8 @@ def from_config(config):
     # Special case 3: if we're not using bots and we're in debug mode,
     # if present, use the configured debug_recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
-        if config.get("recruiter", None) == "prolific":
+        recruiter = by_name(config.get("recruiter", None))
+        if isinstance(recruiter, ProlificRecruiter):
             return by_name("devprolific")
 
         return by_name(config.get("debug_recruiter", "HotAirRecruiter"))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -642,7 +642,7 @@ class DevProlificRecruiter(ProlificRecruiter):
         trigger payment of their base pay.
         """
         # TODO
-        return ""
+        return "http://127.0.0.1:5000/dashboard/develop"
 
 
 class CLIRecruiter(Recruiter):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -631,7 +631,8 @@ class DevProlificRecruiter(ProlificRecruiter):
             message="Exiting by sending browser to dashboard on localhost (external submission URL).\n",
         )
         response = "http://127.0.0.1:5000/dashboard/develop"
-        return self.prolificservice.debug_log_response(response)
+        self.prolificservice.debug_log_response(response)
+        return response
 
 
 class CLIRecruiter(Recruiter):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1791,7 +1791,6 @@ def from_config(config):
     # Special case 3: if we're not using bots and we're in debug mode,
     # if present, use the configured debug_recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
-        recruiter = by_name(config.get("recruiter", None))
         if isinstance(recruiter, ProlificRecruiter):
             return by_name("devprolific")
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -366,7 +366,7 @@ class ProlificRecruiter(Recruiter):
                 f"(ID {self.current_study_id}) is already running for this experiment"
             )
 
-        if self.study_domain is None and self.config.get("mode") != "debug":
+        if self.study_domain is None:
             raise ProlificRecruiterException(
                 "Can't run a Prolific Study from localhost"
             )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1791,7 +1791,7 @@ def from_config(config):
     # Special case 3: if we're not using bots and we're in debug mode,
     # if present, use the configured debug_recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
-        if config.get("recruiter") == "prolific":
+        if config.get("recruiter", None) == "prolific":
             return by_name("devprolific")
 
         return by_name(config.get("debug_recruiter", "HotAirRecruiter"))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -366,7 +366,10 @@ class ProlificRecruiter(Recruiter):
                 f"(ID {self.current_study_id}) is already running for this experiment"
             )
 
-        if self.study_domain is None:
+        if (
+            self.study_domain is None
+            and self.config.get("debug_recruiter") != "DevProlificRecruiter"
+        ):
             raise ProlificRecruiterException(
                 "Can't run a Prolific Study from localhost"
             )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -626,8 +626,9 @@ class DevProlificRecruiter(ProlificRecruiter):
     @property
     def external_submission_url(self):
         self.prolificservice.debug_log_request(
-            f"https://app.prolific.com/submissions/complete?cc={self.completion_code} (external submission URL)\n"
-            "Exiting by sending browser to dashboard on localhost.\n"
+            "GET",
+            f"https://app.prolific.com/submissions/complete?cc={self.completion_code}",
+            message="Exiting by sending browser to dashboard on localhost (external submission URL).\n",
         )
         response = "http://127.0.0.1:5000/dashboard/develop"
         return self.prolificservice.debug_log_response(response)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -324,7 +324,6 @@ def _prolific_service_from_config():
 def _dev_prolific_service_from_config():
     from dallinger.prolific import DevProlificService
 
-    logger.info("PROLIFIC RECRUITER LOG: Getting DevProlificService")
     config = get_config()
     config.load()
     return DevProlificService(
@@ -635,9 +634,9 @@ class DevProlificRecruiter(ProlificRecruiter):
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
-        logger.info(
-            "PROLIFIC DEBUG MODE: Exiting by sending browser to dashboard on localhost."
-        )
+        logger.info("########## PROLIFIC API DEBUG LOG START ###########")
+        logger.info("Exiting by sending browser to dashboard on localhost.")
+        logger.info("########## PROLIFIC API DEBUG LOG END #############")
         return "http://127.0.0.1:5000/dashboard/develop"
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -625,13 +625,13 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     @property
     def external_submission_url(self):
-        self.prolificservice.debug_log_request(
+        self.prolificservice.log_request(
             "GET",
             f"https://app.prolific.com/submissions/complete?cc={self.completion_code}",
             message="Exiting by sending browser to dashboard on localhost (external submission URL).\n",
         )
         response = "http://127.0.0.1:5000/dashboard/develop"
-        self.prolificservice.debug_log_response(response)
+        self.prolificservice.log_response(response)
         return response
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -72,11 +72,11 @@ class Recruiter(object):
         """Return a list of one or more initial recruitment URLs and an initial
         recruitment message:
         {
-            items: [
-                'https://experiment-url-1',
-                'https://experiment-url-2'
+            "items": [
+                "https://experiment-url-1",
+                "https://experiment-url-2"
             ],
-            message: 'More info about this particular recruiter's process'
+            "message": "More info about this particular recruiter's process"
         }
         """
         raise NotImplementedError
@@ -628,7 +628,7 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     @property
     def external_submission_url(self):
-        self.prolificservice.dev_log(
+        self.prolificservice.debug_log(
             f"https://app.prolific.com/submissions/complete?cc={self.completion_code} (external submission URL)\n"
             "Exiting by sending browser to dashboard on localhost.\n"
         )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -625,11 +625,12 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     @property
     def external_submission_url(self):
-        self.prolificservice.debug_log(
+        self.prolificservice.debug_log_request(
             f"https://app.prolific.com/submissions/complete?cc={self.completion_code} (external submission URL)\n"
             "Exiting by sending browser to dashboard on localhost.\n"
         )
-        return "http://127.0.0.1:5000/dashboard/develop"
+        response = "http://127.0.0.1:5000/dashboard/develop"
+        return self.prolificservice.debug_log_response(response)
 
 
 class CLIRecruiter(Recruiter):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -627,16 +627,7 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     def __init__(self, *args, **kwargs):
         super().__init__()
-        self.config = get_config()
-        if not self.config.ready:
-            self.config.load()
-        base_url = get_base_url()
-        self.ad_url = f"{base_url}/ad?recruiter={self.nickname}"
-        self.study_domain = os.getenv("HOST")
         self.prolificservice = _dev_prolific_service_from_config()
-        self.notifies_admin = admin_notifier(self.config)
-        self.mailer = get_mailer(self.config)
-        self.store = kwargs.get("store") or RedisStore()
 
     @property
     def external_submission_url(self):
@@ -644,7 +635,9 @@ class DevProlificRecruiter(ProlificRecruiter):
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
-        # TODO
+        logger.info(
+            "PROLIFIC DEBUG MODE: Exiting by sending browser to dashboard on localhost."
+        )
         return "http://127.0.0.1:5000/dashboard/develop"
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -634,9 +634,13 @@ class DevProlificRecruiter(ProlificRecruiter):
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
-        logger.info("########## PROLIFIC API DEBUG LOG START ###########")
-        logger.info("Exiting by sending browser to dashboard on localhost.")
-        logger.info("########## PROLIFIC API DEBUG LOG END #############")
+        logger.info(
+            "########## PROLIFIC API DEBUG LOG START ###########\n"
+            "PROLIFIC external submission URL would have been:\n"
+            f"https://app.prolific.com/submissions/complete?cc={self.completion_code}\n"
+            "Exiting by sending browser to dashboard on localhost.\n"
+            "########## PROLIFIC API DEBUG LOG END #############"
+        )
         return "http://127.0.0.1:5000/dashboard/develop"
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -604,6 +604,21 @@ class ProlificRecruiter(Recruiter):
         }
 
 
+class DevProlificRecruiter(ProlificRecruiter):
+    """A debug recruiter for [Prolific](https://app.prolific.com/)"""
+
+    nickname = "devprolific"
+
+    def open_recruitment(self, n: int = 1) -> dict:
+        """Mock a study for Prolific."""
+
+        logger.info("Opening Prolific recruitment debug session")
+        return {
+            "items": ["external-study-url"],
+            "message": "Mocked study for Prolific",
+        }
+
+
 class CLIRecruiter(Recruiter):
     """A recruiter which prints out /ad URLs to the console for direct
     assigment.

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -363,10 +363,7 @@ class ProlificRecruiter(Recruiter):
                 f"(ID {self.current_study_id}) is already running for this experiment"
             )
 
-        if (
-            self.study_domain is None
-            and self.config.get("debug_recruiter") != "DevProlificRecruiter"
-        ):
+        if self.study_domain is None and not isinstance(self, DevProlificRecruiter):
             raise ProlificRecruiterException(
                 "Can't run a Prolific Study from localhost"
             )

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -324,6 +324,7 @@ def _prolific_service_from_config():
 def _dev_prolific_service_from_config():
     from dallinger.prolific import DevProlificService
 
+    logger.info("PROLIFIC RECRUITER LOG: Getting DevProlificService")
     config = get_config()
     config.load()
     return DevProlificService(
@@ -365,7 +366,7 @@ class ProlificRecruiter(Recruiter):
                 f"(ID {self.current_study_id}) is already running for this experiment"
             )
 
-        if self.study_domain is None:
+        if self.study_domain is None and self.config.get("mode") != "debug":
             raise ProlificRecruiterException(
                 "Can't run a Prolific Study from localhost"
             )
@@ -634,21 +635,13 @@ class DevProlificRecruiter(ProlificRecruiter):
         self.mailer = get_mailer(self.config)
         self.store = kwargs.get("store") or RedisStore()
 
-    def open_recruitment(self, n: int = 1) -> dict:
-        """Mock a study for Prolific."""
-
-        logger.info("Opening Prolific recruitment debug session")
-        return {
-            "items": ["external-study-url"],
-            "message": "Mocked study for Prolific",
-        }
-
     @property
     def external_submission_url(self):
         """On experiment completion, participants are returned to
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
+        # TODO
         return ""
 
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1790,6 +1790,9 @@ def from_config(config):
     # Special case 3: if we're not using bots and we're in debug mode,
     # if present, use the configured debug_recruiter or else fallback to HotAirRecruiter:
     if debug_mode:
+        if config.get("recruiter") == "prolific":
+            return by_name("devprolific")
+
         return by_name(config.get("debug_recruiter", "HotAirRecruiter"))
 
     # Configured recruiter:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -634,12 +634,10 @@ class DevProlificRecruiter(ProlificRecruiter):
         the Prolific site with a HIT (Study) specific link, which will
         trigger payment of their base pay.
         """
-        logger.info(
-            "########## PROLIFIC API DEBUG LOG START ###########\n"
-            "PROLIFIC external submission URL would have been:\n"
+        self.prolificservice.debug_log(
+            "PROLIFIC external submission URL would have been: "
             f"https://app.prolific.com/submissions/complete?cc={self.completion_code}\n"
             "Exiting by sending browser to dashboard on localhost.\n"
-            "########## PROLIFIC API DEBUG LOG END #############"
         )
         return "http://127.0.0.1:5000/dashboard/develop"
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -628,9 +628,8 @@ class DevProlificRecruiter(ProlificRecruiter):
 
     @property
     def external_submission_url(self):
-        self.prolificservice.debug_log(
-            "PROLIFIC external submission URL would have been: "
-            f"https://app.prolific.com/submissions/complete?cc={self.completion_code}\n"
+        self.prolificservice.dev_log(
+            f"https://app.prolific.com/submissions/complete?cc={self.completion_code} (external submission URL)\n"
             "Exiting by sending browser to dashboard on localhost.\n"
         )
         return "http://127.0.0.1:5000/dashboard/develop"

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -327,8 +327,8 @@ def _dev_prolific_service_from_config():
     config = get_config()
     config.load()
     return DevProlificService(
-        api_token="prolific_api_token",
-        api_version="prolific_api_version",
+        api_token="prolific-api-token",
+        api_version="prolific-api-version",
         referer_header=f"https://github.com/Dallinger/Dallinger/v{__version__}",
     )
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -394,7 +394,10 @@ def prolificservice(prolific_config, fake_parsed_prolific_study):
 @pytest.mark.usefixtures("prolific_config")
 class TestProlificRecruiter(object):
     @pytest.fixture
-    def recruiter(self, mailer, notifies_admin, prolificservice, hit_id_store):
+    def recruiter(
+        self, mailer, notifies_admin, prolificservice, hit_id_store, active_config
+    ):
+        active_config.extend({"debug_recruiter": ""})
         from dallinger.recruiters import ProlificRecruiter
 
         with mock.patch.multiple(
@@ -420,9 +423,6 @@ class TestProlificRecruiter(object):
         with pytest.raises(ProlificRecruiterException):
             recruiter.open_recruitment()
 
-    @pytest.mark.skip(
-        reason="TODO: We want to call open_recruitment for DevProlificRecruiter"
-    )
     def test_open_recruitment_raises_if_running_on_localhost(self, recruiter):
         from dallinger.recruiters import ProlificRecruiterException
 

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -420,6 +420,9 @@ class TestProlificRecruiter(object):
         with pytest.raises(ProlificRecruiterException):
             recruiter.open_recruitment()
 
+    @pytest.mark.skip(
+        reason="TODO: We want to call open_recruitment for DevProlificRecruiter"
+    )
     def test_open_recruitment_raises_if_running_on_localhost(self, recruiter):
         from dallinger.recruiters import ProlificRecruiterException
 


### PR DESCRIPTION
@pmcharrison writes:

> We wish to add a subclass of `ProlificRecruiter` called `DevProlificRecruiter` which can be used to debug and test Prolific  experiments locally (currently when you run in debug mode the experiment defaults to `HotAirRecruiter`, so recruiter-specific code doesn't get run). Every time a communication with the API would happen, we should print to the logs the content of the call, but not actually try to make the call.
>
> @fmhoeger has already made some progress on this but has had health issues recently and has not been able to finish it. We were wondering whether someone would be able to continue and finish it.

### Added
- Added `DevProlificRecruiter` and `DevProlificService` for Prolific development


Depends on https://github.com/Dallinger/Dallinger/pull/6408