### PR TITLE
Add EC2 provisioning support to Dallinger commandline

### DIFF
--- a/constraints.in
+++ b/constraints.in
@@ -1,1 +1,1 @@
--e .[jupyter,data,dev,docker]
+-e .[jupyter,data,dev,docker,ec2]

--- a/constraints.txt
+++ b/constraints.txt
@@ -14,6 +14,8 @@ anyio==4.4.0
     # via
     #   httpx
     #   jupyter-server
+appnope==0.1.4
+    # via ipykernel
 apscheduler==3.10.4
     # via dallinger
 argon2-cffi==23.1.0
@@ -160,7 +162,6 @@ greenlet==3.0.3
     # via
     #   dallinger
     #   gevent
-    #   sqlalchemy
 gunicorn==22.0.0
     # via dallinger
 h11==0.14.0
@@ -601,6 +602,8 @@ tornado==6.4.1
     #   notebook
     #   terminado
 tox==4.15.1
+    # via dallinger
+tqdm==4.66.4
     # via dallinger
 traitlets==5.14.3
     # via

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -28,6 +28,7 @@ from dallinger import data, db
 from dallinger.command_line.develop import develop
 from dallinger.command_line.docker import docker
 from dallinger.command_line.docker_ssh import docker_ssh
+from dallinger.command_line.ec2 import ec2
 from dallinger.command_line.utils import (
     Output,
     header,
@@ -128,6 +129,7 @@ def dallinger():
 dallinger.add_command(develop)
 dallinger.add_command(docker)
 dallinger.add_command(docker_ssh)
+dallinger.add_command(ec2)
 
 
 @dallinger.command()

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -28,7 +28,6 @@ from dallinger import data, db
 from dallinger.command_line.develop import develop
 from dallinger.command_line.docker import docker
 from dallinger.command_line.docker_ssh import docker_ssh
-from dallinger.command_line.ec2 import ec2
 from dallinger.command_line.utils import (
     Output,
     header,
@@ -129,7 +128,17 @@ def dallinger():
 dallinger.add_command(develop)
 dallinger.add_command(docker)
 dallinger.add_command(docker_ssh)
-dallinger.add_command(ec2)
+
+try:
+    from dallinger.command_line.ec2 import ec2
+
+    dallinger.add_command(ec2)
+except ImportError:
+    log(
+        "Could not import EC2 support. "
+        "Install dallinger with the ec2 extra to use EC2 related commands."
+    )
+    pass
 
 
 @dallinger.command()

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -1,0 +1,233 @@
+import os
+
+import click
+
+from .lib.ec2 import (
+    _get_instance_id_from,
+    _get_instance_row_from,
+    get_instances,
+    increase_storage,
+    list_instance_types,
+    list_instances,
+    list_regions,
+    provision,
+    restart,
+    start,
+    stop,
+    teardown,
+)
+from .utils import user_confirms
+
+
+def get_instance_config():
+    from dallinger.config import get_config
+
+    config = get_config()
+    if not config.ready:
+        config.load()
+    return {
+        "pem": config.get("ec2_default_pem", "dallinger"),
+        "security_group_name": config.get("ec2_default_security_group", "dallinger"),
+    }
+
+
+# EC2 on demand provisioning
+@click.group("ec2")
+@click.pass_context
+def ec2(ctx):
+    pass
+
+
+@ec2.group("ssh")
+@click.pass_context
+def ssh(ctx):
+    pass
+
+
+@ssh.command("web")
+@click.option("--app", required=True, help="App name")
+@click.option("--dns", required=True, help="Server name")
+def ssh__web(app, dns):
+    command = f"ssh {dns} -t 'docker exec -it {app}-web-1 bash'"
+    os.system(command)
+
+
+@ec2.group("list")
+@click.pass_context
+def list(ctx):
+    pass
+
+
+@list.command("instances")
+@click.option("--region", default=None, help="Region name")
+@click.option("--running", is_flag=True, help="List running instances")
+@click.option("--stopped", is_flag=True, help="List stopped instances")
+@click.option("--terminated", is_flag=True, help="List terminated instances")
+@click.option("--pem", default=None, help="Name of the PEM file to use")
+@click.pass_context
+def list__instances(ctx, region, running, stopped, terminated, pem):
+    filtered_states = []
+    if running:
+        filtered_states.append("running")
+    if stopped:
+        filtered_states.append("stopped")
+    if terminated:
+        filtered_states.append("terminated")
+    list_instances(region, filtered_states=filtered_states, pem=pem)
+
+
+@list.command("regions")
+@click.pass_context
+def list__regions(ctx):
+    list_regions()
+
+
+@list.command("instance_types")
+@click.option("--region", default=None, help="Region name")
+@click.pass_context
+def list__instance_types(ctx, region):
+    list_instance_types(region)
+
+
+@ec2.command("provision")
+@click.option("--name", required=True, help="Instance name")
+@click.option("--region", default=None, help="Region name")
+@click.option("--type", default="m5.xlarge", help="Instance type")
+@click.option("--storage", default=32, type=int, help="Storage in GB; default is 32 GB")
+@click.option(
+    "--pem", default="dallinger", help="PEM file name; default is dallinger.pem"
+)
+@click.option(
+    "--image_name",
+    default="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230516",
+    help="Image name; default is Ubuntu 22.04",
+)
+@click.option(
+    "--security_group_name",
+    default="dallinger",
+    help="Security group name; default is dallinger",
+)
+@click.option(
+    "--dns-host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    default=None,
+)
+@click.pass_context
+def ec2__provision(
+    ctx, name, region, type, storage, pem, image_name, security_group_name, dns_host
+):
+    try:
+        from dallinger import db, experiment
+
+        config = get_instance_config()
+        exp_klass = experiment.load()
+        exp = exp_klass(db.session)
+
+        asset_storage = getattr(exp, "asset_storage", None)
+        if asset_storage is not None:
+            asset_storage = asset_storage.__class__.__name__
+
+        if asset_storage and not asset_storage == "S3Storage":
+            if not user_confirms(
+                f"Your asset storage is {asset_storage} which is not recommended for experiments which use assets. "
+                f"For experiments with assets we recommend using S3Storage instead. "
+                f"Are you sure you want to provision an EC2 instance?"
+            ):
+                exit()
+    except ImportError:
+        if not user_confirms(
+            "You are not inside an experiment folder. This is not recommended. "
+            "Are you sure you want to provision an EC2 instance?"
+        ):
+            exit()
+
+    pem = config.get("pem", pem)
+    security_group_name = config.get("security_group_name", security_group_name)
+
+    provision(
+        instance_name=name,
+        region_name=region,
+        instance_type=type,
+        storage_in_gb=storage,
+        key_name=pem,
+        image_name=image_name,
+        security_group_name=security_group_name,
+        dns_host=dns_host,
+    )
+
+
+@ec2.command("increase-storage")
+@click.option("--dns", default=None, help="Public DNS name")
+@click.option("--name", default=None, help="Instance ID")
+@click.option("--region", default=None, help="Region name")
+@click.option("--storage", required=True, type=int, help="Storage in GB")
+@click.pass_context
+def ec2__increase_storage(ctx, dns, name, region, storage):
+    instance_row = _get_instance_row_from(
+        region_name=region, instance_name=name, public_dns_name=dns
+    )
+    instance_id = instance_row["instance_id"]
+    instance_name = instance_row["name"]
+    increase_storage(instance_id, instance_name, storage, region_name=region)
+
+
+@ec2.command("stop")
+@click.option("--dns", default=None, help="Public DNS name")
+@click.option("--name", default=None, help="Instance ID")
+@click.option("--region", default=None, help="Region name")
+@click.pass_context
+def ec2__stop(ctx, dns, name, region):
+    instance_id = _get_instance_id_from(
+        region_name=region, instance_name=name, public_dns_name=dns
+    )
+    stop(region, instance_id)
+
+
+@ec2.command("start")
+@click.option("--dns", default=None, help="Public DNS name")
+@click.option("--name", default=None, help="Instance ID")
+@click.option("--region", default=None, help="Region name")
+@click.pass_context
+def ec2__start(ctx, dns, name, region):
+    instance_id = _get_instance_id_from(
+        region_name=region,
+        instance_name=name,
+        public_dns_name=dns,
+        filter_by="state == 'stopped'",
+    )
+    start(region, instance_id)
+
+
+@ec2.command("restart")
+@click.option("--dns", default=None, help="Public DNS name")
+@click.option("--name", default=None, help="Instance ID")
+@click.option("--region", default=None, help="Region name")
+@click.pass_context
+def ec2__restart(ctx, dns, name, region):
+    instance_id = _get_instance_id_from(
+        region_name=region, instance_name=name, public_dns_name=dns
+    )
+    restart(region, instance_id)
+
+
+@ec2.command("teardown")
+@click.option("--dns", default=None, help="Public DNS name")
+@click.option("--name", default=None, help="Instance ID")
+@click.option("--region", default=None, help="Region name")
+@click.option(
+    "--dns-host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    default=None,
+)
+@click.pass_context
+def ec2__teardown(ctx, dns, name, region, dns_host):
+    instance_id = _get_instance_id_from(
+        region_name=region, instance_name=name, public_dns_name=dns
+    )
+    if dns is None:
+        dns = (
+            get_instances(region)
+            .query(f"instance_id == '{instance_id}'")
+            .iloc[0]["public_dns_name"]
+        )
+    teardown(region, instance_id, dns, dns_host)

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -398,7 +398,9 @@ def increase_storage(
     return host, user, ip_address, executor
 
 
-def filter_zone_ids(zone_name, route_53=get_53_client()):
+def filter_zone_ids(zone_name, route_53=None):
+    if route_53 is None:
+        route_53 = get_53_client()
     return [
         item.get("Id")
         for item in route_53.list_hosted_zones_by_name()["HostedZones"]
@@ -414,7 +416,9 @@ def get_subdomain(dns_host):
     return dns_host.split(".")[0]
 
 
-def remove_dns_records(zone_id, dns_host, route_53=get_53_client(), confirm=False):
+def remove_dns_records(zone_id, dns_host, route_53=None, confirm=False):
+    if route_53 is None:
+        route_53 = get_53_client()
     records = route_53.list_resource_record_sets(HostedZoneId=zone_id)
     filtered_records = [
         record for record in records["ResourceRecordSets"] if dns_host in record["Name"]
@@ -442,7 +446,10 @@ def remove_dns_records(zone_id, dns_host, route_53=get_53_client(), confirm=Fals
         print(f"Removed DNS record {dns_host}")
 
 
-def create_dns_record(dns_host, user, host, route_53=get_53_client()):
+def create_dns_record(dns_host, user, host, route_53=None):
+    if route_53 is None:
+        route_53 = get_53_client()
+
     filtered_hosts = filter_zone_ids(get_domain(dns_host), route_53)
     hosted_zone_id = filtered_hosts[0]
     response = route_53.change_resource_record_sets(

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -1,0 +1,690 @@
+import base64
+import logging
+import os.path
+import struct
+import subprocess
+import time
+from typing import Callable
+
+import boto3
+import click
+import pandas as pd
+import paramiko
+from botocore.exceptions import ClientError
+from paramiko.util import deflate_long
+from tqdm import tqdm
+from yaspin import yaspin
+
+from ..config import remove_host as dallinger_remove_host
+from ..config import store_host as dallinger_store_host
+from ..docker_ssh import Executor
+from ..docker_ssh import prepare_server as dallinger_prepare_server
+
+logger = logging.getLogger(__name__)
+
+
+def get_keys(region_name=None):
+    from dallinger.config import get_config
+
+    config = get_config()
+    if not config.ready:
+        config.load()
+    keys = {}
+    # If keys are not set let boto get them from ~/.aws/config or other standard places
+    if config.get("aws_access_key_id"):
+        keys = {
+            "aws_access_key_id": config.get("aws_access_key_id"),
+            "aws_secret_access_key": config.get("aws_secret_access_key"),
+            "region_name": region_name or config.get("aws_region", "us-east-1"),
+        }
+    return keys
+
+
+def url_to_country_city(url):
+    # Lookup the country and city of an IP address
+    # https://stackoverflow.com/questions/38099968/how-to-get-country-name-from-ip-address-in-python
+    import json
+
+    import requests
+
+    response = requests.get(f"http://ip-api.com/json/{url}")
+    js = json.loads(response.text)
+    return {
+        "country": js["country"],
+        "city": js["city"],
+    }
+
+
+def get_ec2_client(region_name=None):
+    return boto3.client("ec2", **get_keys(region_name))
+
+
+def get_53_client():
+    return boto3.client("route53", **get_keys())
+
+
+def list_regions():
+    logger.info("Getting regions...")
+    regions = get_ec2_client().describe_regions()["Regions"]
+    region_metadata = []
+    for region in regions:
+        region_metadata.append(
+            {
+                "region_name": region["RegionName"],
+                "endpoint": region["Endpoint"],
+                **url_to_country_city(region["Endpoint"]),
+            }
+        )
+
+    print(pd.DataFrame(region_metadata).to_markdown())
+
+
+def get_instances(region_name=None):
+    reservations = get_ec2_client(region_name).describe_instances()["Reservations"]
+    instances = []
+    for reservation in reservations:
+        for instance in reservation["Instances"]:
+            instances.append(
+                {
+                    "name": instance["Tags"][0]["Value"],
+                    "instance_id": instance["InstanceId"],
+                    "instance_type": instance["InstanceType"],
+                    "availability_zone": instance["Placement"]["AvailabilityZone"],
+                    "state": instance["State"]["Name"],
+                    "public_dns_name": instance["PublicDnsName"],
+                    # 'public_ip_address': instance['PublicIpAddress'],
+                    "pem": instance["KeyName"],
+                }
+            )
+
+    return pd.DataFrame(instances)
+
+
+def get_all_instances(region_name=None):
+    if region_name is None:
+        logger.warning("Listing instances in all regions...")
+        instance_dfs = []
+        all_regions = get_ec2_client().describe_regions()["Regions"]
+        pb = tqdm(all_regions, total=len(all_regions))
+        for region in pb:
+            pb.set_description("Retrieving instances in " + region["RegionName"])
+            instance_dfs.append(get_instances(region["RegionName"]))
+        instance_df = pd.concat(instance_dfs)
+    else:
+        instance_df = get_instances(region_name)
+    return instance_df
+
+
+def list_instances(region_name=None, filtered_states=[], pem=None):
+    logger.info("Getting instances...")
+    # Get all instances for the specified region
+    instance_df = get_all_instances(region_name)
+    # Filter instances based on state and pem
+    if len(filtered_states) > 0:
+        instance_df = instance_df.query("state in @filtered_states")
+    if pem is not None:
+        instance_df = instance_df.query("pem == @pem")
+    print(instance_df.to_markdown())
+
+
+def get_instance_types(region_name=None):
+    ec2 = get_ec2_client(region_name)
+    pb = tqdm()
+    response = ec2.describe_instance_types()
+    instance_types = response["InstanceTypes"]
+    pb.update(len(instance_types))
+    while "NextToken" in response:
+        response = ec2.describe_instance_types(NextToken=response["NextToken"])
+        instance_types += response["InstanceTypes"]
+        pb.update(len(instance_types))
+
+    instance_type_metadata = []
+    for instance_type in instance_types:
+        memory_in_gb = instance_type["MemoryInfo"]["SizeInMiB"] / 1024
+        if instance_type["InstanceStorageSupported"]:
+            storage_in_gb = instance_type["InstanceStorageInfo"]["TotalSizeInGB"]
+        else:
+            storage_in_gb = 0
+        instance_type_metadata.append(
+            {
+                "instance_type": instance_type["InstanceType"],
+                "vcpu": instance_type["VCpuInfo"]["DefaultVCpus"],
+                "memory": f"{memory_in_gb} GB",
+                "storage": f"{storage_in_gb} GB",
+                "network_performance": instance_type["NetworkInfo"][
+                    "NetworkPerformance"
+                ],
+            }
+        )
+    return pd.DataFrame(instance_type_metadata)
+
+
+def list_instance_types(region_name=None):
+    print("Getting all instance types...")
+    instance_type_df = get_instance_types(region_name)
+    print(instance_type_df.to_markdown())
+
+
+def list_recent_ubuntu_images(region_name=None):
+    logger.info("Getting recent Ubuntu images...")
+    response = get_ec2_client(region_name).describe_images(
+        IncludeDeprecated=False,
+    )
+    image_ids = []
+    for image in response["Images"]:
+        image_ids.append(
+            {
+                "image_id": image["ImageId"],
+                "name": image["Name"],
+                "creation_date": image["CreationDate"],
+            }
+        )
+    print(pd.DataFrame(image_ids).to_markdown())
+
+
+def get_security_group_id(security_group_name, region_name=None):
+    try:
+        response = get_ec2_client(region_name).describe_security_groups(
+            GroupNames=[security_group_name]
+        )
+        return response["SecurityGroups"][0]["GroupId"]
+    except Exception:
+        print(
+            f"Security group {security_group_name} not found in region {region_name}. Creating..."
+        )
+        response = get_ec2_client(region_name).create_security_group(
+            Description="Default security group for dallinger docker to EC2",
+            GroupName=security_group_name,
+        )
+        group_id = response["GroupId"]
+
+        IpPermissions = [
+            {
+                "FromPort": port,
+                "IpProtocol": "tcp",
+                "IpRanges": [{"CidrIp": "0.0.0.0/0"}],
+                "Ipv6Ranges": [],
+                "PrefixListIds": [],
+                "ToPort": port,
+                "UserIdGroupPairs": [],
+            }
+            for port in [80, 22, 443, 5000]
+        ]
+
+        # Add inbound rules
+        get_ec2_client(region_name).authorize_security_group_ingress(
+            GroupId=group_id,
+            IpPermissions=IpPermissions,
+        )
+        return group_id
+
+
+def get_pem_path(key_name):
+    return os.path.join(os.path.expanduser("~"), f"{key_name}.pem")
+
+
+def register_key_pair(ec2, key_name):
+    pem_loc = get_pem_path(key_name)
+    key = paramiko.RSAKey.from_private_key_file(pem_loc)
+
+    output = b""
+    parts = [
+        b"ssh-rsa",
+        deflate_long(key.public_numbers.e),
+        deflate_long(key.public_numbers.n),
+    ]
+    for part in parts:
+        output += struct.pack(">I", len(part)) + part
+    public_key = b"ssh-rsa " + base64.b64encode(output) + b"\n"
+    ec2.import_key_pair(KeyName=key_name, PublicKeyMaterial=public_key)
+
+
+def add_key_to_ssh_agent(key_name):
+    pem_loc = get_pem_path(key_name)
+    subprocess.run(["ssh-add", pem_loc])
+
+
+def wait_for_instance(instance_name, host, user="ubuntu", n_tries=10):
+    for i in range(n_tries):
+        try:
+            executor = Executor(host, user)
+            return executor
+        except Exception:
+            time.sleep((i + 1) * 30)
+            print(f"Failed to connect to {instance_name}. Retrying...")
+    raise Exception(f"Failed to connect to {instance_name}.")
+
+
+def get_image_id(ec2, image_name):
+    response = ec2.describe_images(
+        IncludeDeprecated=False,
+        Filters=[
+            {
+                "Name": "name",
+                "Values": [image_name],
+            },
+        ],
+    )
+    assert len(response["Images"]) == 1
+    return response["Images"][0]["ImageId"]
+
+
+def setup_ssh_keys(ec2, key_name, region_name=None):
+    try:
+        ec2.describe_key_pairs(KeyNames=[key_name])
+    except ClientError:
+        print(f"Key pair {key_name} not found in region {region_name}. Creating...")
+        register_key_pair(ec2, key_name)
+
+    add_key_to_ssh_agent(key_name)
+
+
+def boot_instance(ec2, image_id, instance_type, key_name, instance_name, region_name):
+    response = ec2.run_instances(
+        ImageId=image_id,
+        InstanceType=instance_type,
+        KeyName=key_name,
+        MaxCount=1,
+        MinCount=1,
+        TagSpecifications=[
+            {
+                "ResourceType": "instance",
+                "Tags": [
+                    {
+                        "Key": "Name",
+                        "Value": instance_name,
+                    },
+                ],
+            },
+        ],
+    )
+    instance = response["Instances"][0]
+    instance_id = instance["InstanceId"]
+
+    print(f"Waiting for {instance_name} to be ready...")
+    waiter = get_ec2_client(region_name).get_waiter("instance_running")
+    waiter.wait(InstanceIds=[instance_id])
+    print(f"{instance_name} is ready!")
+    return instance_id
+
+
+def set_security_group(
+    ec2, instance_id, instance_name, security_group_id, security_group_name
+):
+    print(f"Associating security group {security_group_name} with {instance_name}...")
+    ec2.modify_instance_attribute(
+        Groups=[security_group_id],
+        InstanceId=instance_id,
+    )
+
+
+def get_volume_size(ec2, volume_id):
+    response = ec2.describe_volumes(VolumeIds=[volume_id])
+    return response["Volumes"][0]["Size"]
+
+
+def increase_storage(
+    instance_id, instance_name, storage_in_gb, ec2=None, region_name=None
+):
+    if ec2 is None:
+        assert region_name is not None
+        ec2 = get_ec2_client(region_name)
+    # Set sufficient storage
+    print(f"Increasing storage of {instance_name} to {storage_in_gb} GB...")
+
+    # get volume id
+    response = ec2.describe_instances(InstanceIds=[instance_id])
+    instance = response["Reservations"][0]["Instances"][0]
+    volume_id = instance["BlockDeviceMappings"][0]["Ebs"]["VolumeId"]
+
+    # Get volume size
+    volume_size = get_volume_size(ec2, volume_id)
+
+    assert (
+        volume_size < storage_in_gb
+    ), f"Volume size {volume_size} GB is already greater than {storage_in_gb} GB"
+
+    # increase volume size
+    ec2.modify_volume(
+        VolumeId=volume_id,
+        Size=storage_in_gb,
+    )
+
+    print(f"Waiting for {instance_name} to be ready...")
+    waiter = ec2.get_waiter("volume_in_use")
+    waiter.wait(VolumeIds=[volume_id])
+    print(f"{instance_name} is ready!")
+
+    # Extend partition
+    host, user, ip_address = (
+        instance["PublicDnsName"],
+        "ubuntu",
+        instance["PublicIpAddress"],
+    )
+    executor = wait_for_instance(instance_name, host, user)
+
+    volume_partition_list = [
+        line for line in executor.run("lsblk -o name -n").split("\n") if line != ""
+    ]
+    volume_to_partitions = {}
+    for volume_or_partition in volume_partition_list:
+        if not any([volume_or_partition.__contains__(arrow) for arrow in ["└─", "├─"]]):
+            volume_to_partitions[volume_or_partition] = []
+        else:
+            partition = volume_or_partition
+            for volume in volume_to_partitions.keys():
+                if volume_or_partition.__contains__(volume):
+                    partition = volume + partition.split(volume)[1]
+                    volume_to_partitions[volume].append(partition)
+                    break
+    selected_volumes = [
+        volume
+        for volume, partitions in volume_to_partitions.items()
+        if len(partitions) > 0
+    ]
+    assert len(selected_volumes) == 1
+    selected_volume = selected_volumes[0]
+    selected_partition = volume_to_partitions[selected_volume][0]
+
+    print(executor.run("df -h"))
+    print(executor.run("lsblk"))
+    time.sleep(20)
+    executor.run(f"sudo growpart /dev/{selected_volume} 1")
+
+    time.sleep(10)
+    executor.run(f"sudo resize2fs /dev/{selected_partition}")
+
+    print(executor.run("df -h"))
+    return host, user, ip_address, executor
+
+
+def filter_zone_ids(zone_name, route_53=get_53_client()):
+    return [
+        item.get("Id")
+        for item in route_53.list_hosted_zones_by_name()["HostedZones"]
+        if zone_name in item.get("Name", "")
+    ]
+
+
+def get_domain(dns_host):
+    return ".".join(dns_host.split(".")[-2:])
+
+
+def get_subdomain(dns_host):
+    return dns_host.split(".")[0]
+
+
+def remove_dns_records(zone_id, dns_host, route_53=get_53_client(), confirm=False):
+    records = route_53.list_resource_record_sets(HostedZoneId=zone_id)
+    filtered_records = [
+        record for record in records["ResourceRecordSets"] if dns_host in record["Name"]
+    ]
+
+    if len(filtered_records) > 0:
+        used_host = filtered_records[0]["ResourceRecords"][0]["Value"]
+        msg = f"""
+                DNS host {dns_host} is already used by instance {used_host}. Make sure no experiments are running under this
+                domain, OTHERWISE THIS WILL BREAK THEM. Are you sure you want to overwrite the DNS record and use it for
+                this server?
+                """
+        if confirm and not click.confirm(msg):
+            print("Aborting...")
+            return
+
+        # delete the existing records
+        for record in filtered_records:
+            route_53.change_resource_record_sets(
+                HostedZoneId=zone_id,
+                ChangeBatch={
+                    "Changes": [{"Action": "DELETE", "ResourceRecordSet": record}]
+                },
+            )
+        print(f"Removed DNS record {dns_host}")
+
+
+def create_dns_record(dns_host, user, host, route_53=get_53_client()):
+    filtered_hosts = filter_zone_ids(get_domain(dns_host), route_53)
+    hosted_zone_id = filtered_hosts[0]
+    response = route_53.change_resource_record_sets(
+        HostedZoneId=hosted_zone_id,
+        ChangeBatch={
+            "Changes": [
+                {
+                    "Action": "CREATE",
+                    "ResourceRecordSet": {
+                        "Type": "CNAME",
+                        "Name": dns_host,
+                        "TTL": 300,
+                        "ResourceRecords": [{"Value": host}],
+                    },
+                }
+            ]
+        },
+    )
+
+    assert (
+        response["ResponseMetadata"]["HTTPStatusCode"] == 200
+    ), "Failed to set up DNS record"
+
+    with yaspin(
+        text="Waiting for DNS record to be set up (can take up to two minutes)..."
+    ):
+        change_id = response["ChangeInfo"]["Id"]
+        n_tries = 24
+        wait = 5
+        timeout = n_tries * wait
+        for _ in range(n_tries):
+            response = route_53.get_change(Id=change_id)
+            if response["ChangeInfo"]["Status"] == "INSYNC":
+                break
+            time.sleep(wait)
+        else:
+            raise Exception(f"DNS record setup timed out after {timeout} seconds.")
+
+    is_wild_card = dns_host.startswith("*.")
+    full_domain = dns_host.replace("*.", "")
+    test_host = f"test.{full_domain}" if is_wild_card else dns_host
+
+    dns_executor = Executor(test_host, user)
+    print("DNS record set up!")
+    return dns_executor
+
+
+def prepare_instance(
+    instance_name: str,
+    region_name: str,
+    instance_type: str,
+    storage_in_gb: int,
+    key_name: str,
+    image_name: str,
+    security_group_name: str,
+    dns_host: str = None,
+    callback: Callable[[str, str, str, Executor], None] = None,
+):
+    instance_df = get_all_instances(region_name)
+    assert (
+        len(instance_df) == 0
+        or len(instance_df.query(f"name == '{instance_name}' and state=='running'"))
+        == 0
+    ), f"Instance {instance_name} already exists!"
+
+    if dns_host is not None:
+        route_53 = get_53_client()
+        assert (
+            len(dns_host.split(".")) == 3
+        ), "DNS host must be in the format subdomain.domain.tld"
+        domain = get_domain(dns_host)
+
+        msg = f"""
+        Hosted zone {domain} not found in Route 53.
+        To set it up, you need a DNS record for your experiment server.
+        On the AWS online console, navigate to the Route 53 service.
+        On the Dashboard you can register a domain name. Note that different domain names
+        come with different costs, and that registering a domain name can take from a few minutes to several hours.
+        Before proceeding with the next steps, please wait until the AWS console tells you that the registration
+        is complete.
+        """
+        filtered_ids = filter_zone_ids(domain, route_53)
+        assert len(filtered_ids) == 1, msg
+
+        remove_dns_records(filtered_ids[0], dns_host, route_53, confirm=True)
+
+        with open(os.path.expanduser("~/.ssh/known_hosts"), "r") as f:
+            known_hosts = f.readlines()
+            known_hosts = [
+                line for line in known_hosts if not line.startswith(dns_host)
+            ]
+
+        with open(os.path.expanduser("~/.ssh/known_hosts"), "w") as f:
+            f.writelines(known_hosts)
+
+    start = time.time()
+    ec2 = get_ec2_client(region_name)
+    security_group_id = get_security_group_id(security_group_name, region_name)
+    print(f"Provisioning {instance_name} on {region_name}...")
+    image_id = get_image_id(ec2, image_name)
+
+    setup_ssh_keys(ec2, key_name, region_name)
+
+    instance_id = boot_instance(
+        ec2, image_id, instance_type, key_name, instance_name, region_name
+    )
+
+    set_security_group(
+        ec2, instance_id, instance_name, security_group_id, security_group_name
+    )
+
+    host, user, ip_address, executor = increase_storage(
+        instance_id, instance_name, storage_in_gb, ec2
+    )
+    if callback is not None:
+        callback(host, user, ip_address, executor, dns_host)
+
+    duration = time.time() - start
+    print(
+        f"Provisioning complete! Time taken: {duration}. {instance_name} is ready at {host}"
+    )
+
+
+def prepare_docker_experiment_setup(host, user, ip_address, executor, dns_host=None):
+    from dallinger.config import get_config
+
+    config = get_config()
+    if not config.ready:
+        config.load()
+    assert config.get("dashboard_user") and config.get(
+        "dashboard_password"
+    ), "dashboard_user and dashboard_password must be set in ~/.dallingerconfig"
+
+    dallinger_prepare_server(host, user)
+
+    if dns_host is not None:
+        create_dns_record(dns_host, user, host)
+        create_dns_record("*." + dns_host, user, host)
+
+    dallinger_store_host(dict(host=host, user=user))
+    dallinger_store_host(dict(host=dns_host, user=user))
+    print("Host registered in dallinger")
+
+
+def provision(
+    instance_name: str,
+    region_name: str,
+    instance_type: str,
+    storage_in_gb: int,
+    key_name: str,
+    image_name: str,
+    security_group_name: str,
+    dns_host: str = None,
+):
+    prepare_instance(
+        instance_name,
+        region_name,
+        instance_type,
+        storage_in_gb,
+        key_name,
+        image_name,
+        security_group_name,
+        dns_host,
+        callback=prepare_docker_experiment_setup,
+    )
+
+
+def _get_instance_row_from(
+    region_name,
+    instance_name=None,
+    public_dns_name=None,
+    filter_by="state == 'running'",
+):
+    instances_df = get_instances(region_name)
+    if filter_by is not None:
+        instances_df = instances_df.query(filter_by)
+
+    assert (
+        sum([var is None for var in [instance_name, public_dns_name]]) == 1
+    ), "Provide either instance_name or public_dns"
+    if instance_name is not None:
+        selected_instances = instances_df.query(f"name == '{instance_name}'")
+    else:
+        selected_instances = instances_df.query(
+            f"public_dns_name == '{public_dns_name}'"
+        )
+    if len(selected_instances) == 0:
+        raise Exception("No instances found")
+    elif len(selected_instances) > 1:
+        raise Exception("Multiple running instances found")
+    else:
+        return selected_instances.iloc[0]
+
+
+def _get_instance_id_from(
+    region_name,
+    instance_name=None,
+    public_dns_name=None,
+    filter_by="state == 'running'",
+):
+    return _get_instance_row_from(
+        region_name, instance_name, public_dns_name, filter_by
+    )["instance_id"]
+
+
+def get_instance_id_from_url(region_name, public_dns_name):
+    return _get_instance_id_from(region_name, public_dns_name=public_dns_name)
+
+
+def get_instance_id_from_name(region_name, instance_name):
+    return _get_instance_id_from(region_name, instance_name=instance_name)
+
+
+def restart(region_name, instance_id):
+    logger.info(f"Restarting {instance_id}...")
+    get_ec2_client(region_name).reboot_instances(InstanceIds=[instance_id])
+    logger.info(f"Restarting of {instance_id} complete!")
+
+
+def start(region_name, instance_id):
+    logger.info(f"Starting {instance_id}...")
+    get_ec2_client(region_name).start_instances(InstanceIds=[instance_id])
+    logger.info(f"Starting of {instance_id} complete!")
+
+
+def stop(region_name, instance_id):
+    logger.warning(
+        f"Instance {instance_id} will be stopped. You will still be charged for the storage."
+    )
+    logger.info(f"Stopping {instance_id}...")
+    get_ec2_client(region_name).stop_instances(InstanceIds=[instance_id])
+    logger.info(f"Stopping of {instance_id} complete!")
+
+
+def teardown(region_name, instance_id, public_dns_name, dns_host):
+    logger.info(f"Terminating {instance_id} ({public_dns_name})...")
+    get_ec2_client(region_name).terminate_instances(InstanceIds=[instance_id])
+    dallinger_remove_host(public_dns_name)
+
+    if dns_host is not None:
+        route_53 = get_53_client()
+        filtered_ids = filter_zone_ids(get_domain(dns_host), route_53)
+        remove_dns_records(filtered_ids[0], dns_host, route_53)
+        dallinger_remove_host(dns_host)
+    logger.info(f"Termination of {instance_id} complete!")

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -296,3 +296,12 @@ def verify_id(ctx, param, app):
             "The --app parameter contains invalid characters. The only characters allowed are: a-z, 0-9, and '-'."
         )
     return app
+
+
+# Ported from PsyNet
+def user_confirms(question, default=False):
+    """
+    Like click.confirm but safe for using within our wrapped Docker commands.
+    """
+    print(question + " Enter 'y' for yes, 'n' for no.")
+    return click.confirm("", default=default)

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -58,6 +58,8 @@ default_keys = (
     ("dyno_type", six.text_type, []),
     ("dyno_type_web", six.text_type, []),
     ("dyno_type_worker", six.text_type, []),
+    ("ec2_default_pem", six.text_type, []),
+    ("ec2_default_security_group", six.text_type, []),
     ("enable_global_experiment_registry", bool, []),
     ("EXPERIMENT_CLASS_NAME", six.text_type, []),
     ("group_name", six.text_type, []),

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -2,6 +2,8 @@
 aws_access_key_id = YourAccessKeyId
 aws_secret_access_key = YourSecretAccessKey
 aws_region = us-east-1
+ec2_default_pem = dallinger
+ec2_default_security_group = dallinger
 
 [Development]
 dallinger_develop_directory = /tmp/dallinger_develop

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -1,1 +1,1 @@
--e .[data,dev,jupyter,docker]
+-e .[data,dev,jupyter,docker,ec2]

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -14,6 +14,8 @@ anyio==4.4.0
     # via
     #   httpx
     #   jupyter-server
+appnope==0.1.4
+    # via ipykernel
 apscheduler==3.10.4
     # via dallinger
 argon2-cffi==23.1.0
@@ -160,7 +162,6 @@ greenlet==3.0.3
     # via
     #   dallinger
     #   gevent
-    #   sqlalchemy
 gunicorn==22.0.0
     # via dallinger
 h11==0.14.0
@@ -601,6 +602,8 @@ tornado==6.4.1
     #   notebook
     #   terminado
 tox==4.15.1
+    # via dallinger
+tqdm==4.66.4
     # via dallinger
 traitlets==5.14.3
     # via

--- a/docs/source/ec2_deployment.rst
+++ b/docs/source/ec2_deployment.rst
@@ -1,0 +1,172 @@
+Using EC2 for Docker Based Deployments
+======================================
+
+The ``dallinger`` commandline tool has some helpers for managing EC2 instances
+to help facilitate using docker to deploy experiments on those instances (see
+:doc:`docker_support`).
+
+
+Initial Setup
+-------------
+
+Route53 DNS
+~~~~~~~~~~~
+
+In order to use EC2 provisioning, you must have a domain created in AWS Route53
+managed using the same credentials you use for your experiment (see:
+:doc:`aws_etc_keys`). The examples below assume that you have setup a domain
+``my-experiments.org`` in Route53.
+
+EC2 Security Group
+~~~~~~~~~~~~~~~~~~
+
+By default the ``dallinger ec2`` commands will provision instances with the
+security group ``dallinger``. If that group does not exist, one will be created
+with appropriate ingress rules. You can use an existing security group by
+specifying the ``--security_group_name`` option on the commandline, or by
+setting the ``ec2_default_security_group`` value in your `~/.dallingerconfig`
+file.
+
+EC2 SSH Key Pair (PEM File)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default the ``dallinger ec2`` commands will use an SSH key pair named
+``dallinger`` to create instances. If that key pair does not exist, one will be
+created and added to your SSH keychain. You can use an existing SSH key pair by
+specifying the ``--pem`` option on the commandline, or by setting the
+``ec2_default_pem`` value in your `~/.dallingerconfig` file.
+
+AWS Region
+----------
+
+Except where noted, when ``--region`` is not specified then the
+config value set in ``aws_region`` in e.g. ``~/.dallingerconfig`` will be used.
+
+
+Provisioning an EC2 server instance
+-----------------------------------
+
+**Note**: If you decide to deploy to an EC2 instance, you need to "hire" the server
+(Provisioning). Once you do that -- the clock is ticking and you will be charged
+hourly until you release it (Teardown).
+
+To provision an on-demand EC2 instance::
+
+    dallinger ec2 provision --name <server_name> --region <region> --dns-host <subdomain>.my-experiments.org --type <type> --pem <pem> --security_group_name <security_group>
+
+Pick an instance name which is easy to recognize, for example
+‘tapping_deployment_batch_2’ is good but ‘melody123’ would be bad::
+
+    dallinger ec2 provision --name tapping_deployment_batch_2 --region <region> --dns-host <subdomain>.my-experiments.org --type <type>
+
+For example, if you want to collect data in Paris your command will include the
+region name for Paris, like this::
+
+    dallinger ec2 provision --name tapping_deployment_batch_2 --region eu-west-3 --dns-host <subdomain>.my-experiments.org --type <type>
+
+Subdomain name should target your identity so it could be your own name. For
+example::
+
+    dallinger ec2 provision --name tapping_deployment_batch_2 --region eu-west-3 --dns-host elif.my-experiments.org --type <type>
+
+You should use a different instance type according to your need. m7i.large is
+recommended for debugging and m7i.xlarge is for deploying. For example::
+
+    dallinger ec2 provision --name tapping_deployment_batch_2 --region eu-west-3 --dns-host elif.my-experiments.org -
+
+You can configure different amounts of storage or different instance types::
+
+    dallinger ec2 provision --name <server_name> --region <region> --storage 100 --type m5.2xlarge
+
+
+Increasing Storage on An Instance
+---------------------------------
+
+You can increase the storage on a running instance by server name::
+
+    dallinger ec2 increase-storage --name <server_name> --region <region> --storage 200
+
+Or by DNS name::
+
+    dallinger ec2 increase-storage --dns <subdomain>.my-experiments.org --region <region> --storage 200
+
+
+Stopping and Starting
+---------------------
+
+You can temporarily stop a running instance to prevent it from incurring hourly
+costs (while retaining it's stored data)::
+
+    dallinger ec2 stop --name <server_name> --region <region>
+    dallinger ec2 stop --dns <subdomain>.my-experiments.org --region <region>
+
+Similarly you can start a stopped instance::
+
+    dallinger ec2 start --name <server_name> --region <region>
+    dallinger ec2 start --dns <subdomain>.my-experiments.org --region <region>
+
+Or restart a running instance::
+
+    dallinger ec2 restart --name <server_name> --region <region>
+    dallinger ec2 restart --dns <subdomain>.my-experiments.org --region <region>
+
+
+Teardown an EC2 Instance
+------------------------
+
+**Important**: don't forget to export your data before you tear down the server.
+If you don't all data is lost and there is NO way to retrieve them. Before you
+teardown the instance make sure:
+
+    * The experiment is stopped on the recruiter, e.g. in Prolific the experiment should be STOPPED and thus not active
+    * Make sure you exported your data and run export.py to make sure your data is not faulty
+
+To teardown an on-demand EC2 instance ny server name::
+
+    dallinger ec2 teardown --name <server_name> --region <region>
+
+Or by DNS name::
+
+    dallinger ec2 teardown --dns <subdomain>.my-experiments.org --region <region>
+
+
+Listing Available Regions and Instance Types
+--------------------------------------------
+
+You can list the available EC2 regions using::
+
+    dallinger ec2 list regions
+
+Different instance types may be available in different regions, you can list the
+available instance types for a region using::
+
+    dallinger ec2 list instance_types --region <region>
+
+
+Listing Existing Instances
+--------------------------
+
+Dallinger provides some tools for introspecting your current EC2 resources. You can list all instances::
+
+    dallinger ec2 list instances --region <region>
+
+Or filter based on instance state::
+
+    dallinger ec2 list instances --region <region> --running
+    dallinger ec2 list instances --region <region> --stopped --terminated
+
+Additionally you can filter based on instance PEM key name::
+
+    dallinger ec2 list instances --region <region> --running --pem my-pem
+
+**Note**: If ``--region`` is not explicitly specified instances in all regions will be listed.
+
+
+Connecting to a Container Running an Experiment
+-----------------------------------------------
+
+You can make an SSH connection to the docker container running the a specific
+experiment using the server DNS name and the experiment app name with the
+following command::
+
+    dallinger ssh web --dns <subdomain>.my-experiments.org --app <subdomain>.my-experiments.org

--- a/docs/source/ec2_deployment.rst
+++ b/docs/source/ec2_deployment.rst
@@ -103,7 +103,7 @@ Stopping and Starting
 ---------------------
 
 You can temporarily stop a running instance to prevent it from incurring hourly
-costs (while retaining it's stored data)::
+costs (while retaining its stored data)::
 
     dallinger ec2 stop --name <server_name> --region <region>
     dallinger ec2 stop --dns <subdomain>.my-experiments.org --region <region>

--- a/docs/source/ec2_deployment.rst
+++ b/docs/source/ec2_deployment.rst
@@ -12,10 +12,18 @@ Initial Setup
 Route53 DNS
 ~~~~~~~~~~~
 
-In order to use EC2 provisioning, you must have a domain created in AWS Route53
-managed using the same credentials you use for your experiment (see:
-:doc:`aws_etc_keys`). The examples below assume that you have setup a domain
-``my-experiments.org`` in Route53.
+
+If your lab is doing this for the first time, you probably need to acquire a
+domain name for your experiment server. This is the parent URL that will be used
+to host your experiments. If your lab already has a domain name, you can skip
+this step. On the AWS online console, navigate to the Route 53 service. On the
+Dashboard you can register a domain name. Note that different domain names come
+with different costs, and that registering a domain name can take from a few
+minutes to several hours. Before proceeding with the next steps, please wait
+until the AWS console tells you that the registration is complete.
+
+The examples below assume that you have setup a domain ``my-experiments.org`` in
+Route53.
 
 EC2 Security Group
 ~~~~~~~~~~~~~~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -112,6 +112,7 @@ this work is still experimental and so the documentation is not complete yet.
     docker_support
     docker_only
     vagrant_setup
+    ec2_deployment
 
 
 Core Contribution Documentation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,12 @@ docker = [
     "paramiko",
     "sshtunnel",
 ]
+ec2 = [
+    "pandas",
+    "paramiko",
+    "tqdm",
+    "yaspin",
+]
 jupyter = [
     "ipywidgets",
     "jupyter",

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,6 @@ greenlet==3.0.3
     # via
     #   dallinger
     #   gevent
-    #   sqlalchemy
 gunicorn==22.0.0
     # via dallinger
 h11==0.14.0

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 compat=""
 if [[ "$OSTYPE" == "darwin"* ]]; then
     compat=" "
@@ -7,7 +7,7 @@ fi
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd $dir/..
 set -xe
-rm -f requirements.txt dev-requirements.txt constraints.txt
+# rm -f requirements.txt dev-requirements.txt constraints.txt
 export CUSTOM_COMPILE_COMMAND=./scripts/update_dependencies.sh
 pip-compile constraints.in
 pip-compile dev-requirements.in


### PR DESCRIPTION
This code is derived from @polvanrijn's work on the CAP package. Refs #6588

## Description
Implements and documents various command line extensions related to EC2 instance provisioning. A couple of notes for those already using these commands via the `cap` package:

* I've changed the default security group name from `cap` to `dallinger`, but you can override that in your dallinger config using the `ec2_default_security_group` variable.
* I've changed the default SSH key pair id (PEM file) from `cap` to `dallinger`, but you can override that in your dallinger config using the `ec2_default_pem` variable.
* I've updated the commands to not require a `--region` specification, the `aws_region` config will be used by default if a `--region` is not specified. The exception is the `ec2 list instances` command which will still list instances in all regions when `--region` is not specified.

## Motivation and Context
See #6588

## How Has This Been Tested?
Manual commandline testing. My ability to test provisioning and teardown was limited by some local issues I'm having with experiment deploys, but all other methods were tested.

