### PR TITLE
Ec2 bugfixes

### DIFF
--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -128,7 +128,7 @@ def ec2__provision(
         security_group_name = config.get("security_group_name", security_group_name)
     from .utils import check_valid_subdomain
 
-    check_valid_subdomain("name", dns_host)
+    check_valid_subdomain("name", name)
 
     provision(
         instance_name=name,

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -109,7 +109,7 @@ def list__instance_types(ctx, region):
 @click.option(
     "--security_group_name",
     default=None,
-    help="Security group name; default is dallinger",
+    help="Security group name; default is security_group_name from the config; fallback is dallinger",
 )
 @click.option(
     "--dns-host",

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -221,4 +221,4 @@ def ec2__teardown(ctx, dns, name, region, dns_host):
             .query(f"instance_id == '{instance_id}'")
             .iloc[0]["public_dns_name"]
         )
-    teardown(region, instance_id, dns, dns_host)
+    teardown(region, instance_id, dns, dns_host, name)

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -100,7 +100,11 @@ def list__instance_types(ctx, region):
 @click.option("--region", default=None, help="Region name")
 @click.option("--type", default="m5.xlarge", help="Instance type")
 @click.option("--storage", default=32, type=int, help="Storage in GB; default is 32 GB")
-@click.option("--pem", default=None, help="PEM file name; default is dallinger.pem")
+@click.option(
+    "--pem",
+    default=None,
+    help="Path to PEM file; if not specified, defaults to the `pem` config variable, whose default value is 'dallinger.pem'",
+)
 @click.option(
     "--image_name",
     default="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230516",
@@ -109,7 +113,7 @@ def list__instance_types(ctx, region):
 @click.option(
     "--security_group_name",
     default=None,
-    help="Security group name; default is security_group_name from the config; fallback is dallinger",
+    help="Security group name; if not specified, defaults to the `security_group_name` config variable, whose default value is 'dallinger'.",
 )
 @click.option(
     "--dns-host",

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -100,9 +100,7 @@ def list__instance_types(ctx, region):
 @click.option("--region", default=None, help="Region name")
 @click.option("--type", default="m5.xlarge", help="Instance type")
 @click.option("--storage", default=32, type=int, help="Storage in GB; default is 32 GB")
-@click.option(
-    "--pem", default="dallinger", help="PEM file name; default is dallinger.pem"
-)
+@click.option("--pem", default=None, help="PEM file name; default is dallinger.pem")
 @click.option(
     "--image_name",
     default="ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-amd64-server-20230516",
@@ -110,7 +108,7 @@ def list__instance_types(ctx, region):
 )
 @click.option(
     "--security_group_name",
-    default="dallinger",
+    default=None,
     help="Security group name; default is dallinger",
 )
 @click.option(
@@ -124,8 +122,13 @@ def ec2__provision(
 ):
     """Provision an EC2 instance for running experiments"""
     config = get_instance_config()
-    pem = config.get("pem", pem)
-    security_group_name = config.get("security_group_name", security_group_name)
+    if not pem:
+        pem = config.get("pem", pem)
+    if not security_group_name:
+        security_group_name = config.get("security_group_name", security_group_name)
+    from .utils import check_valid_subdomain
+
+    check_valid_subdomain("name", dns_host)
 
     provision(
         instance_name=name,

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -84,9 +84,13 @@ def get_instances(region_name=None):
     instances = []
     for reservation in reservations:
         for instance in reservation["Instances"]:
+            try:
+                name = instance["Tags"][0]["Value"]
+            except KeyError:
+                name = "Unnamed"
             instances.append(
                 {
-                    "name": instance["Tags"][0]["Value"],
+                    "name": name,
                     "instance_id": instance["InstanceId"],
                     "instance_type": instance["InstanceType"],
                     "availability_zone": instance["Placement"]["AvailabilityZone"],

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -565,7 +565,7 @@ def prepare_instance(
         instance_id, instance_name, storage_in_gb, ec2
     )
     if callback is not None:
-        callback(host, user, ip_address, executor, dns_host)
+        callback(host, user, ip_address, executor, dns_host, instance_name)
 
     duration = time.time() - start
     print(
@@ -573,7 +573,9 @@ def prepare_instance(
     )
 
 
-def prepare_docker_experiment_setup(host, user, ip_address, executor, dns_host=None):
+def prepare_docker_experiment_setup(
+    host, user, ip_address, executor, dns_host=None, instance_name=None
+):
     from dallinger.config import get_config
 
     config = get_config()
@@ -591,6 +593,8 @@ def prepare_docker_experiment_setup(host, user, ip_address, executor, dns_host=N
 
     dallinger_store_host(dict(host=host, user=user))
     dallinger_store_host(dict(host=dns_host, user=user))
+    if instance_name is not None:
+        dallinger_store_host(dict(host=f"{instance_name}.{dns_host}", user=user))
     print("Host registered in dallinger")
 
 

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -593,8 +593,6 @@ def prepare_docker_experiment_setup(
 
     dallinger_store_host(dict(host=host, user=user))
     dallinger_store_host(dict(host=dns_host, user=user))
-    if instance_name is not None:
-        dallinger_store_host(dict(host=f"{instance_name}.{dns_host}", user=user))
     print("Host registered in dallinger")
 
 
@@ -688,7 +686,7 @@ def stop(region_name, instance_id):
     logger.info(f"Stopping of {instance_id} complete!")
 
 
-def teardown(region_name, instance_id, public_dns_name, dns_host, name=None):
+def teardown(region_name, instance_id, public_dns_name, dns_host):
     logger.info(f"Terminating {instance_id} ({public_dns_name})...")
     get_ec2_client(region_name).terminate_instances(InstanceIds=[instance_id])
     dallinger_remove_host(public_dns_name)
@@ -698,6 +696,4 @@ def teardown(region_name, instance_id, public_dns_name, dns_host, name=None):
         filtered_ids = filter_zone_ids(get_domain(dns_host), route_53)
         remove_dns_records(filtered_ids[0], dns_host, route_53)
         dallinger_remove_host(dns_host)
-        if name is not None:
-            dallinger_remove_host(f"{name}.{dns_host}")
     logger.info(f"Termination of {instance_id} complete!")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -173,7 +173,7 @@ def list_instances(region_name=None, filtered_states=[], pem=None):
     if len(filtered_states) > 0:
         instance_df = instance_df.query("state in @filtered_states")
     if pem is not None:
-        instance_df = instance_df.query("pem == @pem")
+        instance_df = instance_df.query("pem.str.endswith(@pem)")
     print(instance_df.to_markdown())
 
 

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -10,6 +10,7 @@ import boto3
 import click
 import pandas as pd
 import paramiko
+import requests
 from botocore.exceptions import ClientError
 from paramiko.util import deflate_long
 from tqdm import tqdm
@@ -79,7 +80,29 @@ def list_regions():
     print(pd.DataFrame(region_metadata).to_markdown())
 
 
-def get_instances(region_name=None):
+def get_instance_details(instance_types, region_name=None):
+    response = requests.get(
+        "https://ec2.shop",
+        params={
+            "filter": ",".join(instance_types),
+            "region": region_name,
+        },
+        headers={
+            "accept": "json",
+        },
+    )
+    if response.status_code != 200:
+        print(f"Failed to get details for {instance_types} in {region_name}")
+        return None
+
+    price_df = pd.DataFrame(response.json()["Prices"])
+
+    if len(price_df) != len(instance_types):
+        print(f"Failed to get all details for {instance_types} in {region_name}")
+    return price_df
+
+
+def get_instances(region_name):
     reservations = get_ec2_client(region_name).describe_instances()["Reservations"]
     instances = []
     for reservation in reservations:
@@ -93,11 +116,13 @@ def get_instances(region_name=None):
                     "name": name,
                     "instance_id": instance["InstanceId"],
                     "instance_type": instance["InstanceType"],
-                    "availability_zone": instance["Placement"]["AvailabilityZone"],
+                    "region": region_name,
                     "state": instance["State"]["Name"],
                     "public_dns_name": instance["PublicDnsName"],
                     # 'public_ip_address': instance['PublicIpAddress'],
                     "pem": instance["KeyName"],
+                    # Duration since instance was started
+                    "uptime": time.time() - instance["LaunchTime"].timestamp(),
                 }
             )
 
@@ -116,6 +141,27 @@ def get_all_instances(region_name=None):
         instance_df = pd.concat(instance_dfs)
     else:
         instance_df = get_instances(region_name)
+    if len(instance_df) == 0:
+        return instance_df
+    with yaspin(text="Getting instance details..."):
+        instance_details = instance_df.groupby(["instance_type", "region"]).apply(
+            lambda x: get_instance_details(
+                x["instance_type"].unique(), x["region"].unique()
+            )
+        )
+        instance_details = instance_details.reset_index()
+        instance_details = instance_details[
+            ["instance_type", "region", "Memory", "VCPUS", "Cost"]
+        ]
+    instance_df = instance_df.merge(
+        instance_details, on=["instance_type", "region"], how="left"
+    )
+    instance_df["Cost"] = instance_df["Cost"] * instance_df["uptime"] / (60**2)
+    instance_df.sort_values("Cost", inplace=True)
+    instance_df["Cost"] = instance_df["Cost"].apply(lambda x: f"${int(x)}")
+    instance_df["uptime"] = instance_df["uptime"].apply(
+        lambda x: str(int(x / 60**2)) + "h"
+    )
     return instance_df
 
 

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -684,7 +684,7 @@ def stop(region_name, instance_id):
     logger.info(f"Stopping of {instance_id} complete!")
 
 
-def teardown(region_name, instance_id, public_dns_name, dns_host):
+def teardown(region_name, instance_id, public_dns_name, dns_host, name=None):
     logger.info(f"Terminating {instance_id} ({public_dns_name})...")
     get_ec2_client(region_name).terminate_instances(InstanceIds=[instance_id])
     dallinger_remove_host(public_dns_name)
@@ -694,4 +694,6 @@ def teardown(region_name, instance_id, public_dns_name, dns_host):
         filtered_ids = filter_zone_ids(get_domain(dns_host), route_53)
         remove_dns_records(filtered_ids[0], dns_host, route_53)
         dallinger_remove_host(dns_host)
+        if name is not None:
+            dallinger_remove_host(f"{name}.{dns_host}")
     logger.info(f"Termination of {instance_id} complete!")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -4,6 +4,7 @@ import os.path
 import struct
 import subprocess
 import time
+from datetime import datetime
 from typing import Callable
 
 import boto3
@@ -111,6 +112,9 @@ def get_instances(region_name):
                 name = instance["Tags"][0]["Value"]
             except KeyError:
                 name = "Unnamed"
+            instance_time_zone = instance["LaunchTime"].tzinfo
+            now_in_instance_time_zone = datetime.now(instance_time_zone)
+
             instances.append(
                 {
                     "name": name,
@@ -122,7 +126,9 @@ def get_instances(region_name):
                     # 'public_ip_address': instance['PublicIpAddress'],
                     "pem": instance["KeyName"],
                     # Duration since instance was started
-                    "uptime": time.time() - instance["LaunchTime"].timestamp(),
+                    "uptime": (
+                        now_in_instance_time_zone - instance["LaunchTime"]
+                    ).seconds,
                 }
             )
 

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -282,6 +282,14 @@ def verify_no_conflicts(verbose=True):
     return True
 
 
+def check_valid_subdomain(param_name, param_value):
+    """Check if the subdomain is valid."""
+    if not bool(re.match(r"^[a-z0-9-]+$", param_value)):
+        raise click.BadParameter(
+            f"The --{param_name} parameter contains invalid characters. The only characters allowed are: a-z, 0-9, and '-'."
+        )
+
+
 def verify_id(ctx, param, app):
     """Verify the experiment id."""
     if app is None:
@@ -291,10 +299,7 @@ def verify_id(ctx, param, app):
             "The --app parameter requires the full "
             "UUID beginning with {}-...".format(app[5:23])
         )
-    elif not bool(re.match(r"^[a-z0-9-]+$", app)):
-        raise click.BadParameter(
-            "The --app parameter contains invalid characters. The only characters allowed are: a-z, 0-9, and '-'."
-        )
+    check_valid_subdomain("app", app)
     return app
 
 

--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -284,7 +284,7 @@ def verify_no_conflicts(verbose=True):
 
 def check_valid_subdomain(param_name, param_value):
     """Check if the subdomain is valid."""
-    if not bool(re.match(r"^[a-z0-9-]+$", param_value)):
+    if not re.match(r"^[a-z0-9-]+$", param_value):
         raise click.BadParameter(
             f"The --{param_name} parameter contains invalid characters. The only characters allowed are: a-z, 0-9, and '-'."
         )


### PR DESCRIPTION
Includes following fixes:

- Check the instance name complies with same naming conventions as for the app name (underscores lead to errors)
- Allow to override `pem` and `security_group_name` (previously the passed parameters are always overridden by the .dallingerconfig)
- ~~Provide the instance name for adding (during provisioning) and removing (during teardown) the server name. E.g. if you do run this `dallinger ec2 provision --name abc --region eu-west-3 --dns-host xyz.my-experiments.com` you want to add the server `abc.xyz.my-experiments.com` and not just `xyz.my-experiments.com`, since your apps will be deployed to: `my_app.abc.xyz.my-experiments.com`~~ This was actually a mistake in my head, so nvm
- Fix a bug in fetching instance name if it's missing
- Bug fix for pem file stored as absolute path in config
- Add instance details like uptime, total cost, VCPU and memory