### PR TITLE
Add restart: unless-stopped to all services

### DIFF
--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -1,5 +1,6 @@
 services:
   redis_{{ experiment_id }}:
+    restart: unless-stopped
     image: redis
     command: redis-server --appendonly yes
     volumes:
@@ -12,6 +13,7 @@ services:
       - dallinger
 
   web:
+    restart: unless-stopped
     image: {{ experiment_image }}
     user: "${UID}:${GID}"
     command: dallinger_heroku_web
@@ -44,6 +46,7 @@ services:
   {% set num_dynos = config["num_dynos_worker"] | default('1') | int %}
   {%- for number in range(num_dynos) %}
   worker_{{ number + 1 }}:
+    restart: unless-stopped
     image: {{ experiment_image }}
     command: dallinger_heroku_worker
     cpu_shares: {{ config["docker_worker_cpu_shares"] }}
@@ -64,6 +67,7 @@ services:
   {%- endfor %}
 
   pgbouncer:
+    restart: unless-stopped
     image: docker.io/bitnami/pgbouncer:1.19.1
     container_name: {{ experiment_id }}_pgbouncer
     networks:
@@ -83,6 +87,7 @@ services:
 
 {%- if config["clock_on"] %}
   clock:
+    restart: unless-stopped
     image: {{ experiment_image }}
     user: "${UID}:${GID}"
     command: dallinger_heroku_clock

--- a/dallinger/docker/ssh_templates/docker-compose-server.yml
+++ b/dallinger/docker/ssh_templates/docker-compose-server.yml
@@ -29,6 +29,7 @@ services:
       - dallinger
   dozzle:
     container_name: dozzle
+    restart: unless-stopped
     image: amir20/dozzle:latest
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock


### PR DESCRIPTION
Automatically restart docker image after restarting the server

## Description
Add `restart: unless-stopped` to `docker-compose.yml` to automatically restart the server

## How Has This Been Tested?
- Provision a server using EC2
- ssh into it use `docker ps` to check the running containers
- Restart the server using `dallinger ec2 restart`
- ssh into the instance it verify using `docker ps` the same containers are running

## Further testing needed
Deploy an experiment to the server, restart and make sure the experiment stays reachable
@fmhoeger, can you support me here?
