### PR TITLE
Change DNS entry on restart

### DIFF
--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -118,7 +118,7 @@ def list__instance_types(ctx, region):
 )
 @click.option(
     "--dns-host",
-    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as SSH host",
     default=None,
 )
 @click.pass_context
@@ -164,7 +164,7 @@ def ec2__increase_storage(ctx, dns, name, region, storage):
 @click.option("--region", default=None, help="Region name")
 @click.option(
     "--dns-host",
-    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as SSH host",
     default=None,
 )
 @click.pass_context
@@ -184,7 +184,7 @@ def ec2__stop(ctx, dns, name, region, dns_host):
 @click.option("--region", default=None, help="Region name")
 @click.option(
     "--dns-host",
-    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as SSH host",
     default=None,
 )
 @click.pass_context
@@ -202,7 +202,7 @@ def ec2__start(ctx, dns, name, region, dns_host):
     instance_row = wait_for_instance_state_change(region, name, "stopped")
     assert (
         instance_row["state"] == "stopped"
-    ), f"Instance {name} is not stopped, but in state {instance_row['state']}"
+    ), f"Instance {name} is not stopped, but in state '{instance_row['state']}'"
     dns, instance_id, name = (
         instance_row["public_dns_name"],
         instance_row["instance_id"],
@@ -237,7 +237,7 @@ def ec2__restart(ctx, dns, name, region):
 @click.option("--region", default=None, help="Region name")
 @click.option(
     "--dns-host",
-    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as SSH host",
     default=None,
 )
 @click.pass_context

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -202,7 +202,7 @@ def ec2__start(ctx, dns, name, region, dns_host):
     instance_row = wait_for_instance_state_change(region, name, "stopped")
     assert (
         instance_row["state"] == "stopped"
-    ), f"Instance {name} is not stopped, but in state '{instance_row['state']}'"
+    ), f"Instance '{name}' is not stopped, but in state '{instance_row['state']}'"
     dns, instance_id, name = (
         instance_row["public_dns_name"],
         instance_row["instance_id"],

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -191,6 +191,7 @@ def ec2__stop(ctx, dns, name, region, dns_host):
 def ec2__start(ctx, dns, name, region, dns_host):
     """Start a stopped EC2 instance"""
     from dallinger.command_line.config import get_configured_hosts
+
     CONFIGURED_HOSTS = get_configured_hosts()
     instance_row = _get_instance_row_from(
         region_name=region,
@@ -199,8 +200,14 @@ def ec2__start(ctx, dns, name, region, dns_host):
         filter_by=None,
     )
     instance_row = wait_for_instance_state_change(region, name, "stopped")
-    assert instance_row['state'] == 'stopped', f"Instance {name} is not stopped, but in state {instance_row['state']}"
-    dns, instance_id, name = instance_row["public_dns_name"], instance_row["instance_id"], instance_row["name"]
+    assert (
+        instance_row["state"] == "stopped"
+    ), f"Instance {name} is not stopped, but in state {instance_row['state']}"
+    dns, instance_id, name = (
+        instance_row["public_dns_name"],
+        instance_row["instance_id"],
+        instance_row["name"],
+    )
     start(region, instance_id)
 
     old_dns_host = CONFIGURED_HOSTS.get(dns, {})

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -5,16 +5,19 @@ import click
 from .lib.ec2 import (
     _get_instance_id_from,
     _get_instance_row_from,
+    create_dns_records,
     get_instances,
     increase_storage,
     list_instance_types,
     list_instances,
     list_regions,
     provision,
+    remove_dns_record,
     restart,
     start,
     stop,
     teardown,
+    wait_for_instance_state_change,
 )
 
 
@@ -159,12 +162,19 @@ def ec2__increase_storage(ctx, dns, name, region, storage):
 @click.option("--dns", default=None, help="Public DNS name")
 @click.option("--name", default=None, help="Instance ID")
 @click.option("--region", default=None, help="Region name")
+@click.option(
+    "--dns-host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    default=None,
+)
 @click.pass_context
-def ec2__stop(ctx, dns, name, region):
+def ec2__stop(ctx, dns, name, region, dns_host):
     """Stop (pause) an existing EC2 instance"""
     instance_id = _get_instance_id_from(
         region_name=region, instance_name=name, public_dns_name=dns
     )
+    # Remove old DNS records, but keep the dallinger host
+    remove_dns_record(dns_host, remove_dallinger_host=False)
     stop(region, instance_id)
 
 
@@ -172,16 +182,33 @@ def ec2__stop(ctx, dns, name, region):
 @click.option("--dns", default=None, help="Public DNS name")
 @click.option("--name", default=None, help="Instance ID")
 @click.option("--region", default=None, help="Region name")
+@click.option(
+    "--dns-host",
+    help="DNS name to use. Must resolve all its subdomains to the IP address specified as ssh host",
+    default=None,
+)
 @click.pass_context
-def ec2__start(ctx, dns, name, region):
+def ec2__start(ctx, dns, name, region, dns_host):
     """Start a stopped EC2 instance"""
-    instance_id = _get_instance_id_from(
+    from dallinger.command_line.config import get_configured_hosts
+    CONFIGURED_HOSTS = get_configured_hosts()
+    instance_row = _get_instance_row_from(
         region_name=region,
         instance_name=name,
         public_dns_name=dns,
-        filter_by="state == 'stopped'",
+        filter_by=None,
     )
+    instance_row = wait_for_instance_state_change(region, name, "stopped")
+    assert instance_row['state'] == 'stopped', f"Instance {name} is not stopped, but in state {instance_row['state']}"
+    dns, instance_id, name = instance_row["public_dns_name"], instance_row["instance_id"], instance_row["name"]
     start(region, instance_id)
+
+    old_dns_host = CONFIGURED_HOSTS.get(dns, {})
+    user = old_dns_host.get("user", "ubuntu")
+
+    instance_row = wait_for_instance_state_change(region, name, "running")
+
+    create_dns_records(dns_host, user, instance_row["public_dns_name"])
 
 
 @ec2.command("restart")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -631,10 +631,10 @@ def provision(
 
 
 def _get_instance_row_from(
-        region_name,
-        instance_name=None,
-        public_dns_name=None,
-        filter_by="state == 'running'",
+    region_name,
+    instance_name=None,
+    public_dns_name=None,
+    filter_by="state == 'running'",
 ):
     instances_df = get_instances(region_name)
     if filter_by is not None:
@@ -669,19 +669,23 @@ def _get_instance_id_from(
 
 
 def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
-    with yaspin(text=f"Waiting for the instance to change to {state}: ", color="yellow") as sp:
+    with yaspin(
+        text=f"Waiting for the instance to change to {state}: ", color="yellow"
+    ) as sp:
         for _ in range(n_tries):
             instance_row = _get_instance_row_from(
                 region_name=region,
                 instance_name=name,
                 filter_by=None,
             )
-            if instance_row['state'] == state:
+            if instance_row["state"] == state:
                 break
             time.sleep(wait)
-        if instance_row['state'] != state:
+        if instance_row["state"] != state:
             sp.fail("❌")
-            raise Exception(f"Instance did not change to state '{name}' after {n_tries * wait} seconds")
+            raise Exception(
+                f"Instance did not change to state '{name}' after {n_tries * wait} seconds"
+            )
         else:
             sp.text = f"Instance {name} changed to state {state}"
             sp.ok("✅")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -684,7 +684,7 @@ def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
         if instance_row["state"] != state:
             sp.fail("❌")
             raise Exception(
-                f"Instance did not change to state '{name}' after {n_tries * wait} seconds"
+                f"Instance '{name}' did not change to state '{state}' after {n_tries * wait} seconds"
             )
         else:
             sp.text = f"Instance '{name}' changed to state '{state}'"

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -687,7 +687,7 @@ def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
                 f"Instance did not change to state '{name}' after {n_tries * wait} seconds"
             )
         else:
-            sp.text = f"Instance '{name}' changed to state {state}"
+            sp.text = f"Instance '{name}' changed to state '{state}'"
             sp.ok("✅")
         return instance_row
 

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -670,7 +670,7 @@ def _get_instance_id_from(
 
 def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
     with yaspin(
-        text=f"Waiting for the instance to change to {state}: ", color="yellow"
+        text=f"Waiting for the instance to change to state '{state}': ", color="yellow"
     ) as sp:
         for _ in range(n_tries):
             instance_row = _get_instance_row_from(
@@ -687,7 +687,7 @@ def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
                 f"Instance did not change to state '{name}' after {n_tries * wait} seconds"
             )
         else:
-            sp.text = f"Instance {name} changed to state {state}"
+            sp.text = f"Instance '{name}' changed to state {state}"
             sp.ok("✅")
         return instance_row
 

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -573,6 +573,21 @@ def prepare_instance(
     )
 
 
+def create_dns_records(dns_host, user, host):
+    if dns_host is not None:
+        create_dns_record(dns_host, user, host)
+        create_dns_record("*." + dns_host, user, host)
+
+
+def remove_dns_record(dns_host, remove_dallinger_host=True):
+    if dns_host is not None:
+        route_53 = get_53_client()
+        filtered_ids = filter_zone_ids(get_domain(dns_host), route_53)
+        remove_dns_records(filtered_ids[0], dns_host, route_53)
+        if remove_dallinger_host:
+            dallinger_remove_host(dns_host)
+
+
 def prepare_docker_experiment_setup(host, user, ip_address, executor, dns_host=None):
     from dallinger.config import get_config
 
@@ -585,9 +600,7 @@ def prepare_docker_experiment_setup(host, user, ip_address, executor, dns_host=N
 
     dallinger_prepare_server(host, user)
 
-    if dns_host is not None:
-        create_dns_record(dns_host, user, host)
-        create_dns_record("*." + dns_host, user, host)
+    create_dns_records(dns_host, user, host)
 
     dallinger_store_host(dict(host=host, user=user))
     dallinger_store_host(dict(host=dns_host, user=user))
@@ -618,10 +631,10 @@ def provision(
 
 
 def _get_instance_row_from(
-    region_name,
-    instance_name=None,
-    public_dns_name=None,
-    filter_by="state == 'running'",
+        region_name,
+        instance_name=None,
+        public_dns_name=None,
+        filter_by="state == 'running'",
 ):
     instances_df = get_instances(region_name)
     if filter_by is not None:
@@ -653,6 +666,26 @@ def _get_instance_id_from(
     return _get_instance_row_from(
         region_name, instance_name, public_dns_name, filter_by
     )["instance_id"]
+
+
+def wait_for_instance_state_change(region, name, state, n_tries=12, wait=10):
+    with yaspin(text=f"Waiting for the instance to change to {state}: ", color="yellow") as sp:
+        for _ in range(n_tries):
+            instance_row = _get_instance_row_from(
+                region_name=region,
+                instance_name=name,
+                filter_by=None,
+            )
+            if instance_row['state'] == state:
+                break
+            time.sleep(wait)
+        if instance_row['state'] != state:
+            sp.fail("❌")
+            raise Exception(f"Instance did not change to state '{name}' after {n_tries * wait} seconds")
+        else:
+            sp.text = f"Instance {name} changed to state {state}"
+            sp.ok("✅")
+        return instance_row
 
 
 def get_instance_id_from_url(region_name, public_dns_name):
@@ -688,10 +721,5 @@ def teardown(region_name, instance_id, public_dns_name, dns_host):
     logger.info(f"Terminating {instance_id} ({public_dns_name})...")
     get_ec2_client(region_name).terminate_instances(InstanceIds=[instance_id])
     dallinger_remove_host(public_dns_name)
-
-    if dns_host is not None:
-        route_53 = get_53_client()
-        filtered_ids = filter_zone_ids(get_domain(dns_host), route_53)
-        remove_dns_records(filtered_ids[0], dns_host, route_53)
-        dallinger_remove_host(dns_host)
+    remove_dns_record(dns_host, remove_dallinger_host=True)
     logger.info(f"Termination of {instance_id} complete!")


### PR DESCRIPTION
Implements https://github.com/Dallinger/Dallinger/issues/7099

## How Has This Been Tested?
- I stopped an existing server using `--dns-host` which removed the DNS entry
- I started the server again using `--dns-host` which added the DNS entry for the newly given public dns
- All docker containers with `restart: always` started as expected and the app was available under the requested dns
