### PR TITLE
Update to rq v2

### DIFF
--- a/constraints.txt
+++ b/constraints.txt
@@ -498,7 +498,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-rq==1.16.2
+rq==2.0.0
     # via dallinger
 s3transfer==0.10.4
     # via boto3

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,11 +10,11 @@ alabaster==0.7.16
     # via
     #   dallinger
     #   sphinx
-anyio==4.6.2.post1
+anyio==4.7.0
     # via
     #   httpx
     #   jupyter-server
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via dallinger
 argon2-cffi==23.1.0
     # via jupyter-server
@@ -22,7 +22,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
@@ -36,7 +36,7 @@ babel==2.16.0
     # via
     #   jupyterlab-server
     #   sphinx
-bcrypt==4.2.0
+bcrypt==4.2.1
     # via paramiko
 beautifulsoup4==4.12.3
     # via nbconvert
@@ -44,11 +44,11 @@ black==24.10.0
     # via dallinger
 bleach==6.2.0
     # via nbconvert
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.35.54
+boto3==1.35.77
     # via dallinger
-botocore==1.35.54
+botocore==1.35.77
     # via
     #   boto3
     #   s3transfer
@@ -92,17 +92,17 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.6.4
+coverage==7.6.9
     # via
     #   coverage-pth
     #   dallinger
 coverage-pth==0.0.2
     # via dallinger
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   paramiko
     #   pyopenssl
-debugpy==1.8.7
+debugpy==1.8.9
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -123,9 +123,9 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.1.0
     # via stack-data
-faker==30.8.2
+faker==33.1.0
     # via dallinger
-fastjsonschema==2.20.0
+fastjsonschema==2.21.1
     # via nbformat
 filelock==3.16.1
     # via
@@ -133,7 +133,7 @@ filelock==3.16.1
     #   virtualenv
 flake8==7.1.1
     # via dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   dallinger
     #   flask-crossdomain
@@ -152,7 +152,7 @@ fqdn==1.5.1
     # via jsonschema
 future==1.0.0
     # via dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   dallinger
     #   gunicorn
@@ -169,11 +169,11 @@ h11==0.14.0
     #   wsproto
 heroku3==5.2.1
     # via dallinger
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via jupyterlab
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 idna==3.10
     # via
@@ -210,7 +210,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -225,7 +225,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.25
+json5==0.10.0
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -270,7 +270,7 @@ jupyter-server==2.14.2
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.2.5
+jupyterlab==4.3.2
     # via
     #   jupyter
     #   notebook
@@ -310,7 +310,7 @@ mypy-extensions==1.0.0
     # via black
 myst-parser==3.0.1
     # via dallinger
-nbclient==0.10.0
+nbclient==0.10.1
     # via nbconvert
 nbconvert==7.16.4
     # via
@@ -325,7 +325,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.9.1
     # via pre-commit
-notebook==7.2.2
+notebook==7.3.1
     # via jupyter
 notebook-shim==0.2.4
     # via
@@ -343,7 +343,7 @@ outcome==1.3.0.post0
     # via trio
 overrides==7.7.0
     # via jupyter-server
-packaging==24.1
+packaging==24.2
     # via
     #   black
     #   build
@@ -390,7 +390,7 @@ pluggy==1.5.0
     #   tox
 pre-commit==4.0.1
     # via dallinger
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via jupyter-server
 prompt-toolkit==3.0.48
     # via
@@ -428,7 +428,7 @@ pygments==2.18.0
     #   sphinx
 pynacl==1.5.0
     # via paramiko
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via dallinger
 pypandoc==1.14
     # via dallinger
@@ -440,11 +440,11 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pysocks==1.7.1
     # via urllib3
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   dallinger
     #   pytest-rerunfailures
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via dallinger
 python-dateutil==2.9.0.post0
     # via
@@ -457,9 +457,7 @@ python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
     # via jupyter-events
 pytz==2024.2
-    # via
-    #   apscheduler
-    #   pandas
+    # via pandas
 pyyaml==6.0.2
     # via
     #   jupyter-events
@@ -472,7 +470,7 @@ pyzmq==26.2.0
     #   jupyter-client
     #   jupyter-console
     #   jupyter-server
-redis==5.2.0
+redis==5.2.1
     # via
     #   dallinger
     #   rq
@@ -496,24 +494,22 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.20.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
 rq==1.16.2
     # via dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
-selenium==4.26.1
+selenium==4.27.1
     # via dallinger
 send2trash==1.8.3
     # via jupyter-server
 simple-websocket==1.1.0
     # via flask-sock
-six==1.16.0
+six==1.17.0
     # via
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   rfc3339-validator
@@ -521,7 +517,6 @@ six==1.16.0
 sniffio==1.3.1
     # via
     #   anyio
-    #   httpx
     #   trio
 snowballstemmer==2.2.0
     # via sphinx
@@ -536,7 +531,7 @@ sphinx==7.4.7
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-spelling
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via dallinger
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -584,7 +579,7 @@ tinycss2==1.4.0
     # via nbconvert
 tokenize-rt==6.1.0
     # via black
-tornado==6.4.1
+tornado==6.4.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -594,7 +589,7 @@ tornado==6.4.1
     #   terminado
 tox==4.23.2
     # via dallinger
-tqdm==4.66.6
+tqdm==4.67.1
     # via dallinger
 traitlets==5.14.3
     # via
@@ -618,10 +613,11 @@ trio==0.27.0
     #   trio-websocket
 trio-websocket==0.11.1
     # via selenium
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   faker
     #   selenium
 tzdata==2024.2
@@ -630,10 +626,12 @@ tzlocal==5.2
     # via
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via ua-parser
 uri-template==1.3.0
     # via jsonschema
 urllib3==1.26.20
@@ -645,13 +643,13 @@ urllib3==1.26.20
     #   selenium
 user-agents==2.2.0
     # via dallinger
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via
     #   pre-commit
     #   tox
 wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==24.8.0
+webcolors==24.11.1
     # via jsonschema
 webencodings==0.5.1
     # via
@@ -661,11 +659,11 @@ websocket-client==1.8.0
     # via
     #   jupyter-server
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
 widgetsnbextension==4.0.13
     # via ipywidgets
@@ -683,7 +681,7 @@ yaspin==3.1.0
     # via dallinger
 zope-event==5.0
     # via gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -21,7 +21,7 @@ from pathlib import Path
 import click
 import requests
 import tabulate
-from rq import Connection, Worker
+from rq import Worker
 from sqlalchemy import exc as sa_exc
 
 from dallinger import data, db
@@ -884,10 +884,9 @@ def verify():
 def rq_worker():
     """Start an rq worker in the context of dallinger."""
     setup_experiment(log)
-    with Connection(db.redis_conn):
-        # right now we care about low queue for bots
-        worker = Worker("low")
-        worker.work()
+    # right now we care about low queue for bots
+    worker = Worker("low", connection=db.redis_conn)
+    worker.work()
 
 
 @dallinger.command()

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -498,7 +498,7 @@ rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
-rq==1.16.2
+rq==2.0.0
     # via dallinger
 s3transfer==0.10.4
     # via boto3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,11 +10,11 @@ alabaster==0.7.16
     # via
     #   dallinger
     #   sphinx
-anyio==4.6.2.post1
+anyio==4.7.0
     # via
     #   httpx
     #   jupyter-server
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via dallinger
 argon2-cffi==23.1.0
     # via jupyter-server
@@ -22,7 +22,7 @@ argon2-cffi-bindings==21.2.0
     # via argon2-cffi
 arrow==1.3.0
     # via isoduration
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
 async-lru==2.0.4
     # via jupyterlab
@@ -36,7 +36,7 @@ babel==2.16.0
     # via
     #   jupyterlab-server
     #   sphinx
-bcrypt==4.2.0
+bcrypt==4.2.1
     # via paramiko
 beautifulsoup4==4.12.3
     # via nbconvert
@@ -44,11 +44,11 @@ black==24.10.0
     # via dallinger
 bleach==6.2.0
     # via nbconvert
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.35.54
+boto3==1.35.77
     # via dallinger
-botocore==1.35.54
+botocore==1.35.77
     # via
     #   boto3
     #   s3transfer
@@ -92,17 +92,17 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.6.4
+coverage==7.6.9
     # via
     #   coverage-pth
     #   dallinger
 coverage-pth==0.0.2
     # via dallinger
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   paramiko
     #   pyopenssl
-debugpy==1.8.7
+debugpy==1.8.9
     # via ipykernel
 decorator==5.1.1
     # via ipython
@@ -123,9 +123,9 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.1.0
     # via stack-data
-faker==30.8.2
+faker==33.1.0
     # via dallinger
-fastjsonschema==2.20.0
+fastjsonschema==2.21.1
     # via nbformat
 filelock==3.16.1
     # via
@@ -133,7 +133,7 @@ filelock==3.16.1
     #   virtualenv
 flake8==7.1.1
     # via dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   dallinger
     #   flask-crossdomain
@@ -152,7 +152,7 @@ fqdn==1.5.1
     # via jsonschema
 future==1.0.0
     # via dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   dallinger
     #   gunicorn
@@ -169,11 +169,11 @@ h11==0.14.0
     #   wsproto
 heroku3==5.2.1
     # via dallinger
-httpcore==1.0.6
+httpcore==1.0.7
     # via httpx
-httpx==0.27.2
+httpx==0.28.1
     # via jupyterlab
-identify==2.6.1
+identify==2.6.3
     # via pre-commit
 idna==3.10
     # via
@@ -210,7 +210,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via
@@ -225,7 +225,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-json5==0.9.25
+json5==0.10.0
     # via jupyterlab-server
 jsonpointer==3.0.0
     # via jsonschema
@@ -270,7 +270,7 @@ jupyter-server==2.14.2
     #   notebook-shim
 jupyter-server-terminals==0.5.3
     # via jupyter-server
-jupyterlab==4.2.5
+jupyterlab==4.3.2
     # via
     #   jupyter
     #   notebook
@@ -310,7 +310,7 @@ mypy-extensions==1.0.0
     # via black
 myst-parser==3.0.1
     # via dallinger
-nbclient==0.10.0
+nbclient==0.10.1
     # via nbconvert
 nbconvert==7.16.4
     # via
@@ -325,7 +325,7 @@ nest-asyncio==1.6.0
     # via ipykernel
 nodeenv==1.9.1
     # via pre-commit
-notebook==7.2.2
+notebook==7.3.1
     # via jupyter
 notebook-shim==0.2.4
     # via
@@ -343,7 +343,7 @@ outcome==1.3.0.post0
     # via trio
 overrides==7.7.0
     # via jupyter-server
-packaging==24.1
+packaging==24.2
     # via
     #   black
     #   build
@@ -390,7 +390,7 @@ pluggy==1.5.0
     #   tox
 pre-commit==4.0.1
     # via dallinger
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via jupyter-server
 prompt-toolkit==3.0.48
     # via
@@ -428,7 +428,7 @@ pygments==2.18.0
     #   sphinx
 pynacl==1.5.0
     # via paramiko
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via dallinger
 pypandoc==1.14
     # via dallinger
@@ -440,11 +440,11 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pysocks==1.7.1
     # via urllib3
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   dallinger
     #   pytest-rerunfailures
-pytest-rerunfailures==14.0
+pytest-rerunfailures==15.0
     # via dallinger
 python-dateutil==2.9.0.post0
     # via
@@ -457,9 +457,7 @@ python-dateutil==2.9.0.post0
 python-json-logger==2.0.7
     # via jupyter-events
 pytz==2024.2
-    # via
-    #   apscheduler
-    #   pandas
+    # via pandas
 pyyaml==6.0.2
     # via
     #   jupyter-events
@@ -472,7 +470,7 @@ pyzmq==26.2.0
     #   jupyter-client
     #   jupyter-console
     #   jupyter-server
-redis==5.2.0
+redis==5.2.1
     # via
     #   dallinger
     #   rq
@@ -496,24 +494,22 @@ rfc3986-validator==0.1.1
     # via
     #   jsonschema
     #   jupyter-events
-rpds-py==0.20.1
+rpds-py==0.22.3
     # via
     #   jsonschema
     #   referencing
 rq==1.16.2
     # via dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
-selenium==4.26.1
+selenium==4.27.1
     # via dallinger
 send2trash==1.8.3
     # via jupyter-server
 simple-websocket==1.1.0
     # via flask-sock
-six==1.16.0
+six==1.17.0
     # via
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   rfc3339-validator
@@ -521,7 +517,6 @@ six==1.16.0
 sniffio==1.3.1
     # via
     #   anyio
-    #   httpx
     #   trio
 snowballstemmer==2.2.0
     # via sphinx
@@ -536,7 +531,7 @@ sphinx==7.4.7
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-spelling
-sphinx-rtd-theme==3.0.1
+sphinx-rtd-theme==3.0.2
     # via dallinger
 sphinxcontrib-applehelp==2.0.0
     # via sphinx
@@ -584,7 +579,7 @@ tinycss2==1.4.0
     # via nbconvert
 tokenize-rt==6.1.0
     # via black
-tornado==6.4.1
+tornado==6.4.2
     # via
     #   ipykernel
     #   jupyter-client
@@ -594,7 +589,7 @@ tornado==6.4.1
     #   terminado
 tox==4.23.2
     # via dallinger
-tqdm==4.66.6
+tqdm==4.67.1
     # via dallinger
 traitlets==5.14.3
     # via
@@ -618,10 +613,11 @@ trio==0.27.0
     #   trio-websocket
 trio-websocket==0.11.1
     # via selenium
-types-python-dateutil==2.9.0.20241003
+types-python-dateutil==2.9.0.20241206
     # via arrow
 typing-extensions==4.12.2
     # via
+    #   anyio
     #   faker
     #   selenium
 tzdata==2024.2
@@ -630,10 +626,12 @@ tzlocal==5.2
     # via
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via ua-parser
 uri-template==1.3.0
     # via jsonschema
 urllib3==1.26.20
@@ -645,13 +643,13 @@ urllib3==1.26.20
     #   selenium
 user-agents==2.2.0
     # via dallinger
-virtualenv==20.27.1
+virtualenv==20.28.0
     # via
     #   pre-commit
     #   tox
 wcwidth==0.2.13
     # via prompt-toolkit
-webcolors==24.8.0
+webcolors==24.11.1
     # via jsonschema
 webencodings==0.5.1
     # via
@@ -661,11 +659,11 @@ websocket-client==1.8.0
     # via
     #   jupyter-server
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
 widgetsnbextension==4.0.13
     # via ipywidgets
@@ -683,7 +681,7 @@ yaspin==3.1.0
     # via dallinger
 zope-event==5.0
     # via gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "pyopenssl",
     "redis",
     "requests",
-    "rq < 2",
+    "rq",
     "selenium",
     "six",
     "sqlalchemy < 2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,19 +6,19 @@
 #
 
     # via -r requirements.in
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via stack-data
 attrs==24.2.0
     # via
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via flask
-boto3==1.35.54
+boto3==1.35.77
     # via dallinger
-botocore==1.35.54
+botocore==1.35.77
     # via
     #   boto3
     #   s3transfer
@@ -42,15 +42,15 @@ click==8.1.7
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via pyopenssl
 decorator==5.1.1
     # via ipython
 executing==2.1.0
     # via stack-data
-faker==30.8.2
+faker==33.1.0
     # via dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   dallinger
     #   flask-crossdomain
@@ -67,7 +67,7 @@ flask-wtf==1.2.2
     # via dallinger
 future==1.0.0
     # via dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   dallinger
     #   gunicorn
@@ -92,7 +92,7 @@ itsdangerous==2.2.0
     # via
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via ipython
 jinja2==3.1.4
     # via flask
@@ -113,7 +113,7 @@ numpy==2.0.2
     # via dallinger
 outcome==1.3.0.post0
     # via trio
-packaging==24.1
+packaging==24.2
     # via
     #   build
     #   gunicorn
@@ -141,7 +141,7 @@ pycparser==2.22
     # via cffi
 pygments==2.18.0
     # via ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via dallinger
 pyproject-hooks==1.2.0
     # via
@@ -154,9 +154,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   dallinger
     #   rq
@@ -166,16 +164,14 @@ requests==2.32.3
     #   heroku3
 rq==1.16.2
     # via dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via boto3
-selenium==4.26.1
+selenium==4.27.1
     # via dallinger
 simple-websocket==1.1.0
     # via flask-sock
-six==1.16.0
+six==1.17.0
     # via
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -217,10 +213,12 @@ tzlocal==5.2
     # via
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via ua-parser
 urllib3==1.26.20
     # via
     #   botocore
@@ -233,11 +231,11 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.8.0
     # via selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via pip-tools
 wsproto==1.2.0
     # via
@@ -249,7 +247,7 @@ yaspin==3.1.0
     # via dallinger
 zope-event==5.0
     # via gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via gevent
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -162,7 +162,7 @@ requests==2.32.3
     # via
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.0.0
     # via dallinger
 s3transfer==0.10.4
     # via boto3


### PR DESCRIPTION
Refactor to make Dallinger compatible with `rq >= 2` . We thereby get rid of the many deprecation warnings like
```
/home/frank/.virtualenvs/psynet-3.12/lib/python3.12/site-packages/rq/utils.py:227: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  return calendar.timegm(datetime.datetime.utcnow().utctimetuple())
```