### PR TITLE
Release 11.0.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 10.4.0a1
+current_version = 11.0.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,48 @@
 # Change Log
 
+## [v11.0.0](https://github.com/dallinger/dallinger/tree/v11.0.0 (2025-01-XX)
+
+#### Breaking changes
+- Renamed config variable `activate_recruiter_on_start` to `open_recruitment` and allow it to be set to `True` also by using a `--open-recruitment` flag
+
+#### Added
+- Added new config variables `prolific_workspace` and `prolific_project` to support declaration of Prolific workspaces and project names (the workspace must already exist and a new project in that workspace will be created if it doesn't exist already)
+- Added the `dallinger docker-ssh sandbox` command
+- Added `validate_config` methods to recruiters
+- Added `local_only` to `exclusion_policy` used when assembling the deployment directory. Users can then use this directory called `local_only` to store misc files that they don't want deployed to the web server.
+
+#### Fixed
+- Keep Dallinger database in sync with Prolific via combination of regular polling + experiment-requested syncs by adding new `scheduled_job` '`async_recruiter_status_check`'
+- Fixed a regex error in `HerokuApp.db_uri` for Heroku deployments
+- EC2 provisioning:
+  - Check the instance name complies with same naming conventions as for the app name (underscores lead to errors)
+  - Allow to override `PEM` file and `security_group_name` (previously the passed parameters were always overridden by .dallingerconfig)
+  - Fix a bug in fetching instance name if it's missing
+  - Bugfix for `PEM` file stored as absolute path in config
+  - Add instance details like uptime, total cost, VCPU, and memory
+  - Add `restart: unless-stopped` to docker-compose.yml to automatically restart the server
+  - Update an instance's DNS entry to use the new IP address when an EC2 instance is stopped and later restarted
+
+### Changed
+- Scrub `client_ip_address` data from participant anonymous data export
+- Improved handling of exporting data when no AWS credentials are registered by not raising an `S3BucketUnavailable` error
+- Throw an error when deploying to MTurk and `open_recruitment` is not set to `True`, either by setting `open_recruitment` in the config or by using the `--open-recruitment` command flag
+
+### Refactorings
+- `dallinger docker-ssh deploy/sandbox` commands introducing a `_deploy_in_mode` function
+- `dallinger docker deploy/sandbox` commands
+- `dallinger deploy/sandbox` commands
+- `run_pre_launch_checks` method in `dallinger.command_line.utils`
+
+#### Updated
+- Updated `rq` to version `>= 2` by refactoring and thereby getting rid of deprecation warnings
+- Updated dependencies; pin `sphinxcontrib-spelling < 8.0.1`
+
+## [v10.3.3](https://github.com/dallinger/dallinger/tree/v10.3.3) (2024-12-07)
+
+#### Fixed
+- Fixed tagging latest Docker image also as `latest`.
+
 ## [v10.3.0](https://github.com/dallinger/dallinger/tree/v10.3.0) (2024-11-04)
 
 #### Fixed

--- a/constraints.txt
+++ b/constraints.txt
@@ -10,7 +10,7 @@ alabaster==0.7.16
     # via
     #   dallinger
     #   sphinx
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   httpx
     #   jupyter-server
@@ -46,9 +46,9 @@ bleach==6.2.0
     # via nbconvert
 blinker==1.9.0
     # via flask
-boto3==1.35.87
+boto3==1.35.94
     # via dallinger
-botocore==1.35.87
+botocore==1.35.94
     # via
     #   boto3
     #   s3transfer
@@ -77,7 +77,7 @@ cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
@@ -92,7 +92,7 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.6.9
+coverage==7.6.10
     # via
     #   coverage-pth
     #   dallinger
@@ -123,7 +123,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.1.0
     # via stack-data
-faker==33.1.0
+faker==33.3.0
     # via dallinger
 fastjsonschema==2.21.1
     # via nbformat
@@ -173,7 +173,7 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-identify==2.6.3
+identify==2.6.5
     # via pre-commit
 idna==3.10
     # via
@@ -304,7 +304,7 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.0.2
+mistune==3.1.0
     # via nbconvert
 mypy-extensions==1.0.0
     # via black
@@ -312,7 +312,7 @@ myst-parser==3.0.1
     # via dallinger
 nbclient==0.10.2
     # via nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   jupyter
     #   jupyter-server
@@ -420,7 +420,7 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pyflakes==3.2.0
     # via flake8
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   ipython
     #   jupyter-console
@@ -576,7 +576,7 @@ terminado==0.18.1
 timeago==1.0.16
     # via dallinger
 tinycss2==1.4.0
-    # via nbconvert
+    # via bleach
 tokenize-rt==6.1.0
     # via black
 tornado==6.4.2
@@ -607,7 +607,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-trio==0.27.0
+trio==0.28.0
     # via
     #   selenium
     #   trio-websocket
@@ -643,7 +643,7 @@ urllib3==1.26.20
     #   selenium
 user-agents==2.2.0
     # via dallinger
-virtualenv==20.28.0
+virtualenv==20.28.1
     # via
     #   pre-commit
     #   tox

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "10.4.0a1"
+__version__ = "11.0.0"

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,11 +50,11 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -62,11 +62,11 @@ click==8.1.7
     #   nltk
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -76,11 +76,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -108,7 +108,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -145,11 +145,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -184,7 +184,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +206,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -227,11 +227,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -250,11 +250,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,15 +262,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -282,11 +278,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -327,7 +321,7 @@ timeago==1.0.16
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tqdm==4.66.6
+tqdm==4.67.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   nltk
@@ -336,7 +330,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -355,11 +349,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -379,12 +377,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -405,7 +403,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -413,4 +411,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  d39b0f1bdc6cb1547770afc5c290bb0b
+# Hash of requirements.txt file: d39b0f1bdc6cb1547770afc5c290bb0b

--- a/demos/dlgr/demos/chatroom_ws/constraints.txt
+++ b/demos/dlgr/demos/chatroom_ws/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,11 +50,11 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -62,11 +62,11 @@ click==8.1.7
     #   nltk
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -76,11 +76,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -108,7 +108,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -145,11 +145,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -184,7 +184,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +206,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -227,11 +227,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -250,11 +250,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,15 +262,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -282,11 +278,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -327,7 +321,7 @@ timeago==1.0.16
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tqdm==4.66.6
+tqdm==4.67.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   nltk
@@ -336,7 +330,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -355,11 +349,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -379,12 +377,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -405,7 +403,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -413,4 +411,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  d39b0f1bdc6cb1547770afc5c290bb0b
+# Hash of requirements.txt file: d39b0f1bdc6cb1547770afc5c290bb0b

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -6,28 +6,28 @@
 #
 # from the root of the dallinger repository
 #
-apscheduler==3.10.4
+apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-asttokens==2.4.1
+asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.2.0
+attrs==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-blinker==1.8.2
+blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.54
+boto3==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.54
+botocore==1.35.94
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.8.30
+certifi==2024.12.14
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -50,22 +50,22 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
-click==8.1.7
+click==8.1.8
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   flask
     #   pip-tools
     #   rq
-cryptography==43.0.3
+cryptography==44.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==10.3.0
+dallinger==11.0.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
@@ -75,11 +75,11 @@ executing==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==30.8.2
+faker==33.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.0.3
+flask==3.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -107,7 +107,7 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.10.3
+gevent==24.11.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -144,11 +144,11 @@ itsdangerous==2.2.0
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-wtf
-jedi==0.19.1
+jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.4
+jinja2==3.1.5
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -179,7 +179,7 @@ outcome==1.3.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-packaging==24.1
+packaging==24.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -201,7 +201,7 @@ prompt-toolkit==3.0.48
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-psutil==6.1.0
+psutil==6.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -222,11 +222,11 @@ pycparser==2.22
     # via
     #   -c ../../../../dev-requirements.txt
     #   cffi
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.2.1
+pyopenssl==24.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -245,11 +245,7 @@ python-dateutil==2.9.0.post0
     #   botocore
     #   faker
     #   heroku3
-pytz==2024.2
-    # via
-    #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-redis==5.2.0
+redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -259,15 +255,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==1.16.2
+rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.3
+s3transfer==0.10.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.26.1
+selenium==4.27.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -275,11 +271,9 @@ simple-websocket==1.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask-sock
-six==1.16.0
+six==1.17.0
     # via
     #   -c ../../../../dev-requirements.txt
-    #   apscheduler
-    #   asttokens
     #   dallinger
     #   python-dateutil
     #   sqlalchemy-postgres-copy
@@ -325,7 +319,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -344,11 +338,15 @@ tzlocal==5.2
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==0.18.0
+ua-parser==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   user-agents
+ua-parser-builtins==0.18.0.post1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   ua-parser
 urllib3==1.26.20
     # via
     #   -c ../../../../dev-requirements.txt
@@ -368,12 +366,12 @@ websocket-client==1.8.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-werkzeug==3.1.1
+werkzeug==3.1.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
     #   flask-login
-wheel==0.44.0
+wheel==0.45.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pip-tools
@@ -394,7 +392,7 @@ zope-event==5.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
-zope-interface==7.1.1
+zope-interface==7.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   gevent
@@ -402,4 +400,4 @@ zope-interface==7.1.1
 # The following packages are considered to be unsafe in a requirements file:
 # pip
 # setuptools
-# generate from file with hash  0cab82a0f71a21f46d5e1123cd7483ee
+# Hash of requirements.txt file: 0cab82a0f71a21f46d5e1123cd7483ee

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==10.4.0a1
+Dallinger==11.0.0

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="10.4.0a1",
+    version="11.0.0",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -10,7 +10,7 @@ alabaster==0.7.16
     # via
     #   dallinger
     #   sphinx
-anyio==4.7.0
+anyio==4.8.0
     # via
     #   httpx
     #   jupyter-server
@@ -46,9 +46,9 @@ bleach==6.2.0
     # via nbconvert
 blinker==1.9.0
     # via flask
-boto3==1.35.87
+boto3==1.35.94
     # via dallinger
-botocore==1.35.87
+botocore==1.35.94
     # via
     #   boto3
     #   s3transfer
@@ -77,7 +77,7 @@ cfgv==3.4.0
     # via pre-commit
 chardet==5.2.0
     # via tox
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
@@ -92,7 +92,7 @@ comm==0.2.2
     # via
     #   ipykernel
     #   ipywidgets
-coverage==7.6.9
+coverage==7.6.10
     # via
     #   coverage-pth
     #   dallinger
@@ -123,7 +123,7 @@ et-xmlfile==2.0.0
     # via openpyxl
 executing==2.1.0
     # via stack-data
-faker==33.1.0
+faker==33.3.0
     # via dallinger
 fastjsonschema==2.21.1
     # via nbformat
@@ -173,7 +173,7 @@ httpcore==1.0.7
     # via httpx
 httpx==0.28.1
     # via jupyterlab
-identify==2.6.3
+identify==2.6.5
     # via pre-commit
 idna==3.10
     # via
@@ -304,7 +304,7 @@ mdit-py-plugins==0.4.2
     # via myst-parser
 mdurl==0.1.2
     # via markdown-it-py
-mistune==3.0.2
+mistune==3.1.0
     # via nbconvert
 mypy-extensions==1.0.0
     # via black
@@ -312,7 +312,7 @@ myst-parser==3.0.1
     # via dallinger
 nbclient==0.10.2
     # via nbconvert
-nbconvert==7.16.4
+nbconvert==7.16.5
     # via
     #   jupyter
     #   jupyter-server
@@ -420,7 +420,7 @@ pyenchant==3.2.2
     # via sphinxcontrib-spelling
 pyflakes==3.2.0
     # via flake8
-pygments==2.18.0
+pygments==2.19.1
     # via
     #   ipython
     #   jupyter-console
@@ -576,7 +576,7 @@ terminado==0.18.1
 timeago==1.0.16
     # via dallinger
 tinycss2==1.4.0
-    # via nbconvert
+    # via bleach
 tokenize-rt==6.1.0
     # via black
 tornado==6.4.2
@@ -607,7 +607,7 @@ traitlets==5.14.3
     #   nbclient
     #   nbconvert
     #   nbformat
-trio==0.27.0
+trio==0.28.0
     # via
     #   selenium
     #   trio-websocket
@@ -643,7 +643,7 @@ urllib3==1.26.20
     #   selenium
 user-agents==2.2.0
     # via dallinger
-virtualenv==20.28.0
+virtualenv==20.28.1
     # via
     #   pre-commit
     #   tox

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "10.4.0a1"
+version = "11.0.0"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,9 +16,9 @@ attrs==24.3.0
     #   trio
 blinker==1.9.0
     # via flask
-boto3==1.35.87
+boto3==1.35.94
     # via dallinger
-botocore==1.35.87
+botocore==1.35.94
     # via
     #   boto3
     #   s3transfer
@@ -34,7 +34,7 @@ certifi==2024.12.14
     #   selenium
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 click==8.1.8
     # via
@@ -48,7 +48,7 @@ decorator==5.1.1
     # via ipython
 executing==2.1.0
     # via stack-data
-faker==33.1.0
+faker==33.3.0
     # via dallinger
 flask==3.1.0
     # via
@@ -139,7 +139,7 @@ pure-eval==0.2.3
     # via stack-data
 pycparser==2.22
     # via cffi
-pygments==2.18.0
+pygments==2.19.1
     # via ipython
 pyopenssl==24.3.0
     # via dallinger
@@ -199,7 +199,7 @@ traitlets==5.14.3
     # via
     #   ipython
     #   matplotlib-inline
-trio==0.27.0
+trio==0.28.0
     # via
     #   selenium
     #   trio-websocket


### PR DESCRIPTION
# CHANGELOG

#### Breaking changes
- Renamed config variable `activate_recruiter_on_start` to `open_recruitment` and allow it to be set to `True` also by using a `--open-recruitment` flag

#### Added
- Added new config variables `prolific_workspace` and `prolific_project` to support declaration of Prolific workspaces and project names (the workspace must already exist and a new project in that workspace will be created if it doesn't exist already)
- Added the `dallinger docker-ssh sandbox` command
- Added `validate_config` methods to recruiters
- Added `local_only` to `exclusion_policy` used when assembling the deployment directory. Users can then use this directory called `local_only` to store misc files that they don't want deployed to the web server.

#### Fixed
- Keep Dallinger database in sync with Prolific via combination of regular polling + experiment-requested syncs by adding new `scheduled_job` '`async_recruiter_status_check`'
- Fixed a regex error in `HerokuApp.db_uri` for Heroku deployments
- EC2 provisioning:
  - Check the instance name complies with same naming conventions as for the app name (underscores lead to errors)
  - Allow to override `PEM` file and `security_group_name` (previously the passed parameters were always overridden by .dallingerconfig)
  - Fix a bug in fetching instance name if it's missing
  - Bugfix for `PEM` file stored as absolute path in config
  - Add instance details like uptime, total cost, VCPU, and memory
  - Add `restart: unless-stopped` to docker-compose.yml to automatically restart the server
  - Update an instance's DNS entry to use the new IP address when an EC2 instance is stopped and later restarted

### Changed
- Scrub `client_ip_address` data from participant anonymous data export
- Improved handling of exporting data when no AWS credentials are registered by not raising an `S3BucketUnavailable` error
- Throw an error when deploying to MTurk and `open_recruitment` is not set to `True`, either by setting `open_recruitment` in the config or by using the `--open-recruitment` command flag

### Refactorings
- `dallinger docker-ssh deploy/sandbox` commands introducing a `_deploy_in_mode` function
- `dallinger docker deploy/sandbox` commands
- `dallinger deploy/sandbox` commands
- `run_pre_launch_checks` method in `dallinger.command_line.utils`