### PR TITLE
Add `local_only` to `exclusion_policy`

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -890,6 +890,7 @@ def exclusion_policy():
             "config.txt",
             "*.db",
             "*.dmg",
+            "local_only",
             "node_modules",
             "snapshots",
             "data",


### PR DESCRIPTION
Added `local_only` to `exclusion_policy` used when assembling the deployment directory. Users can then use this directory called `local_only` to store misc files that they don't want deployed to the web server.