### PR TITLE
Draft: Fix bug where open_recruitment was always defaulting to True

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -252,6 +252,10 @@ def _deploy_in_mode(mode, verbose, open_recruitment=None, app=None, archive=None
     config.load()
     config.extend({"mode": mode, "logfile": "-"})
 
+    if open_recruitment is not None:
+        assert isinstance(open_recruitment, bool)
+        config.extend({"open_recruitment": open_recruitment})
+
     run_pre_launch_checks(**locals())
 
     prelaunch = []

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -26,7 +26,7 @@ lock_table_when_creating_participant = True
 docker_worker_cpu_shares = 1024
 
 [Recruiter]
-open_recruitment = True
+open_recruitment = False
 auto_recruit = False
 assign_qualifications = False
 us_only = False


### PR DESCRIPTION
Fixed a bug where open_recruitment was always defaulting to True.

Problem that still needs fixing: now `open_recruitment` defaults to False which seems like a reasonable default for Prolific  but tests now fail because `dallinger docker debug` is no longer automatically opening recruitment (which in this case means printing "Initial recruitment list") to the console. Similarly, I suppose that `HotAirRecruiter` will by default not print any participant recruitment links.

Given all this, do we really think it's a good idea that we introduced this breaking change where we make `open_recruitment` default to `False`?

Maybe the cleaner solution is to make `open_recruitment` default to `True`, thereby preserving the previous behaviour of MTurk and HotAirRecruiter but introduce a check with Prolific where we strongly discourage people from deploying with `open_recruitment=True`.

Or we make `open_recruitment` default to `None` and then if it is `None` then it follows the default behaviour for the recruiter, i.e. opening recruitment automatically for MTurk and HotAir but not opening for Prolific.