### PR TITLE
Disable automatic translation in the browser

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -52,6 +52,7 @@ default_keys = (
     ("database_url", six.text_type, [], True),
     ("debug_recruiter", six.text_type, []),
     ("description", six.text_type, []),
+    ("disable_browser_autotranslate", bool, []),
     ("disable_when_duration_exceeded", bool, []),
     ("duration", float, []),
     ("dyno_type", six.text_type, []),

--- a/dallinger/default_configs/global_config_defaults.txt
+++ b/dallinger/default_configs/global_config_defaults.txt
@@ -50,3 +50,6 @@ prolific_api_version = v1
 prolific_estimated_completion_minutes = 0
 prolific_is_custom_screening = False
 prolific_recruitment_config = {}
+
+[Internationalization]
+disable_browser_autotranslate = False

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -28,7 +28,7 @@ from dallinger import db, experiment, models, recruiters
 from dallinger.config import get_config
 from dallinger.notifications import MessengerError, admin_notifier
 from dallinger.recruiters import ProlificRecruiter
-from dallinger.utils import disable_browser_autotranslate, generate_random_id
+from dallinger.utils import generate_random_id, get_from_config
 
 from . import dashboard
 from .replay import ReplayBackend
@@ -201,9 +201,7 @@ login.user_loader(dashboard.load_user)
 login.unauthorized_handler(dashboard.unauthorized)
 app.config["dashboard_tabs"] = dashboard.dashboard_tabs
 
-app.jinja_env.globals.update(
-    disable_browser_autotranslate=disable_browser_autotranslate
-)
+app.jinja_env.globals.update(get_from_config=get_from_config)
 
 """Basic routes."""
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -28,7 +28,7 @@ from dallinger import db, experiment, models, recruiters
 from dallinger.config import get_config
 from dallinger.notifications import MessengerError, admin_notifier
 from dallinger.recruiters import ProlificRecruiter
-from dallinger.utils import generate_random_id
+from dallinger.utils import disable_browser_autotranslate, generate_random_id
 
 from . import dashboard
 from .replay import ReplayBackend
@@ -200,6 +200,10 @@ login.request_loader(dashboard.load_user_from_request)
 login.user_loader(dashboard.load_user)
 login.unauthorized_handler(dashboard.unauthorized)
 app.config["dashboard_tabs"] = dashboard.dashboard_tabs
+
+app.jinja_env.globals.update(
+    disable_browser_autotranslate=disable_browser_autotranslate
+)
 
 """Basic routes."""
 

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-{% if disable_browser_autotranslate() %}
+{% if get_from_config("disable_browser_autotranslate") %}
     <html translate="no">
 {% else %}
     <html>

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html translate="no">
     <head>
         <title>{% block title %}Experiment{% endblock %}</title>
         {% block head %}

--- a/dallinger/frontend/templates/base/layout.html
+++ b/dallinger/frontend/templates/base/layout.html
@@ -1,5 +1,9 @@
 <!doctype html>
-<html translate="no">
+{% if disable_browser_autotranslate() %}
+    <html translate="no">
+{% else %}
+    <html>
+{% endif %}
     <head>
         <title>{% block title %}Experiment{% endblock %}</title>
         {% block head %}

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -143,6 +143,7 @@ def stub_config():
         "contact_email_on_error": "error_contact@test.com",
         "dallinger_email_address": "test@example.com",
         "database_size": "standard-0",
+        "disable_browser_autotranslate": True,
         "disable_when_duration_exceeded": True,
         "enable_global_experiment_registry": False,
         "redis_size": "premium-0",

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -935,3 +935,10 @@ def deferred_route_decorator(route, registered_routes):
         return func
 
     return new_func
+
+
+def disable_browser_autotranslate():
+    config = get_config()
+    if not config.ready:
+        config.load()
+    return config.get("disable_browser_autotranslate")

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -937,8 +937,8 @@ def deferred_route_decorator(route, registered_routes):
     return new_func
 
 
-def disable_browser_autotranslate():
+def get_from_config(key):
     config = get_config()
     if not config.ready:
         config.load()
-    return config.get("disable_browser_autotranslate")
+    return config.get(key)


### PR DESCRIPTION

## Description
Automatic translation using Google translator built in to Chrome can lead to unexpected errors.

## How Has This Been Tested?
- Run a Korean local psynet experiment on `master` and auto translate translates the whole page to English
- Run a Korean local psynet experiment on `disable-browser-autotranslate` and auto translate DOES NOT translate to English
