### PR TITLE
Release 11.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.1.0a1
+current_version = 11.1.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Change Log
 
+## [v11.1.0](https://github.com/dallinger/dallinger/tree/v11.1.0) (2025-02-11)
+
+#### Fixed
+- Fixed a bug in `DevProlificService` when debugging locally with `recruiter = prolific`. Previously, an exception was raised erroneously saying that no corresponding Prolific workspace was found
+
+#### Added
+- Added `disable_browser_autotranslate` config variable to prevent automatic translation when using the Google translator built into Chrome. `Default is False`
+- Added `publish_experiment` config variable to indicate if the experiment should be published when deploying. Currently only used in Prolific recruitment; if `False` a draft study will be created which later can be published via the Prolific web UI. Default is `True`
+- Added `Recruiter.supports_delayed_publishing` attribute
+
+#### Removed
+- Removed `--open-recruitment` config variable; removed `--open-recruitment` flag from `deploy` and `sandbox` commands
+
+#### Changed
+- Use `tenacity` for better logging in `wait_for_instance`
+
+#### Updated
+- Updated dependencies; update black, isort; minor reformatting
+
 ## [v11.0.1](https://github.com/dallinger/dallinger/tree/v11.0.1) (2025-01-16)
 
 #### Fixed

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "11.1.0a1"
+__version__ = "11.1.0"

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -62,21 +62,21 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -202,7 +202,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -231,7 +231,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -248,7 +248,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -266,11 +265,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -342,14 +341,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/chatroom_ws/constraints.txt
+++ b/demos/dlgr/demos/chatroom_ws/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -62,21 +62,21 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -202,7 +202,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -231,7 +231,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -248,7 +248,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -266,11 +265,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -342,14 +341,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -14,7 +14,7 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==24.3.0
+attrs==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
@@ -23,11 +23,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.35.94
+boto3==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.35.94
+botocore==1.36.18
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -41,7 +41,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2024.12.14
+certifi==2025.1.31
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -61,21 +61,21 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.0
+cryptography==44.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.0.1
+dallinger==11.1.0
     # via -r requirements.txt
 decorator==5.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-executing==2.1.0
+executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==33.3.0
+faker==36.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -197,7 +197,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -226,7 +226,7 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-pyopenssl==24.3.0
+pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -243,7 +243,6 @@ python-dateutil==2.9.0.post0
     # via
     #   -c ../../../../dev-requirements.txt
     #   botocore
-    #   faker
     #   heroku3
 redis==5.2.1
     # via
@@ -259,11 +258,11 @@ rq==2.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.10.4
+s3transfer==0.11.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.27.1
+selenium==4.28.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -331,14 +330,18 @@ trio-websocket==0.11.1
 typing-extensions==4.12.2
     # via
     #   -c ../../../../dev-requirements.txt
-    #   faker
+    #   pyopenssl
     #   selenium
+tzdata==2025.1
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   faker
 tzlocal==5.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler
     #   dallinger
-ua-parser==1.0.0
+ua-parser==1.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==11.1.0a1
+Dallinger==11.1.0

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="11.1.0a1",
+    version="11.1.0",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "11.1.0a1"
+version = "11.1.0"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
#### Fixed
- Fixed a bug in `DevProlificService` when debugging locally with `recruiter = prolific`. Previously, an exception was raised erroneously saying that no corresponding Prolific workspace was found

#### Added
- Added `disable_browser_autotranslate` config variable to prevent automatic translation when using the Google translator built into Chrome. `Default is False`
- Added `publish_experiment` config variable to indicate if the experiment should be published when deploying. Currently only used in Prolific recruitment; if `False` a draft study will be created which later can be published via the Prolific web UI. Default is `True`
- Added `Recruiter.supports_delayed_publishing` attribute

#### Removed
- Removed `--open-recruitment` config variable; removed `--open-recruitment` flag from `deploy` and `sandbox` commands

#### Changed
- Use `tenacity` for better logging in `wait_for_instance`

#### Updated
- Updated dependencies; update black, isort; minor reformatting