### PR TITLE
Option to disable strict config variable loading

### DIFF
--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -7,7 +7,6 @@ from .lib.ec2 import (
     _get_instance_row_from,
     create_dns_records,
     get_instances,
-    get_keys,
     increase_storage,
     list_instance_types,
     list_instances,
@@ -22,12 +21,17 @@ from .lib.ec2 import (
 )
 
 
-def get_instance_config():
+def get_config(strict=True):
     from dallinger.config import get_config
 
     config = get_config()
     if not config.ready:
-        config.load()
+        config.load(strict=strict)
+    return config
+
+
+def get_instance_config():
+    config = get_config(False)
     return {
         "pem": config.get("ec2_default_pem", "dallinger"),
         "security_group_name": config.get("ec2_default_security_group", "dallinger"),
@@ -39,7 +43,9 @@ def get_instance_config():
 @click.pass_context
 def ec2(ctx):
     """Sub-commands for provisioning on AWS EC2"""
-    get_keys()  # Loads the config file with strict=False in case additional keys are present in .dallingerconfig
+    # Load the config with strict=False so that experimenters don't encounter an error
+    # if they are using custom config parameters that are not supported in Dallinger
+    get_config(strict=False)
 
 
 @ec2.group("ssh")

--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -7,6 +7,7 @@ from .lib.ec2 import (
     _get_instance_row_from,
     create_dns_records,
     get_instances,
+    get_keys,
     increase_storage,
     list_instance_types,
     list_instances,
@@ -38,7 +39,7 @@ def get_instance_config():
 @click.pass_context
 def ec2(ctx):
     """Sub-commands for provisioning on AWS EC2"""
-    pass
+    get_keys()  # Loads the config file with strict=False in case additional keys are present in .dallingerconfig
 
 
 @ec2.group("ssh")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -32,7 +32,7 @@ def get_keys(region_name=None):
 
     config = get_config()
     if not config.ready:
-        config.load()
+        config.load(strict=False)
     keys = {}
     # If keys are not set let boto get them from ~/.aws/config or other standard places
     if config.get("aws_access_key_id"):

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -315,7 +315,7 @@ class Configuration(object):
 
         localConfig = os.path.join(os.getcwd(), LOCAL_CONFIG)
         if os.path.exists(localConfig):
-            self.load_from_file(localConfig)
+            self.load_from_file(localConfig, strict)
 
         self.load_from_environment()
         self.ready = True

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -263,13 +263,13 @@ class Configuration(object):
         if sensitive:
             self.sensitive.add(key)
 
-    def load_from_file(self, filename):
+    def load_from_file(self, filename, strict=True):
         parser = configparser.ConfigParser()
         parser.read(filename)
         data = {}
         for section in parser.sections():
             data.update(dict(parser.items(section)))
-        self.extend(data, cast_types=True, strict=True)
+        self.extend(data, cast_types=True, strict=strict)
 
     def write(self, filter_sensitive=False, directory=None):
         parser = configparser.ConfigParser()
@@ -288,7 +288,7 @@ class Configuration(object):
     def load_from_environment(self):
         self.extend(os.environ, cast_types=True)
 
-    def load_defaults(self):
+    def load_defaults(self, strict=True):
         """Load default configuration values"""
         # Apply extra parameters before loading the configs
         if experiment_available():
@@ -305,13 +305,13 @@ class Configuration(object):
 
         # Load the configuration, with local parameters overriding global ones.
         for config_file in [global_defaults_file, local_defaults_file, global_config]:
-            self.load_from_file(config_file)
+            self.load_from_file(config_file, strict)
 
         if experiment_available():
             self.load_experiment_config_defaults()
 
-    def load(self):
-        self.load_defaults()
+    def load(self, strict=True):
+        self.load_defaults(strict)
 
         localConfig = os.path.join(os.getcwd(), LOCAL_CONFIG)
         if os.path.exists(localConfig):


### PR DESCRIPTION
Option to disable strict config variable loading.
Useful for EC2 deployment in psynet, as psynet has custom config variables.
In the past they had to all be commented out.

## Description
Default parameter `strict=True` (how it was before), but can be overridden when needed.

## How Has This Been Tested?
- Running EC2 command line tools with `dallinger ec2 …` with custom config variables in `.dallingerconfig`
