### PR TITLE
Prefix all dashboard panels with `dashboard_` but remove this prefix in the endpoint

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -225,7 +225,6 @@ dashboard_tabs = DashboardTabs(
         DashboardTab("Monitoring", "dashboard.dashboard_monitoring"),
         DashboardTab("Lifecycle", "dashboard.dashboard_lifecycle"),
         DashboardTab("Database", "dashboard.dashboard_database", database_children),
-        DashboardTab("Logger", "dashboard.dashboard_logger"),
         DashboardTab("Development", "dashboard.dashboard_develop"),
     ]
 )

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -872,6 +872,9 @@ def dashboard_tab(title, **kwargs):
     }
 
     def route_name_from_func_name(func_name: str) -> str:
-        return func_name.replace("dashboard_", "")
+        key = "dashboard_"
+        if func_name.startswith(key):
+            return func_name[len(key) :]
+        return func_name
 
     return deferred_route_decorator(route, registered_routes, route_name_from_func_name)

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -208,7 +208,7 @@ def database_children():
     for cls_name, cls_info in mapped_classes:
         yield DashboardTab(
             cls_name,
-            "dashboard.database",
+            "dashboard.dashboard_database",
             None,
             {
                 "table": cls_info["table"],
@@ -219,13 +219,14 @@ def database_children():
 
 dashboard_tabs = DashboardTabs(
     [
-        DashboardTab("Config", "dashboard.index"),
-        DashboardTab("Heroku", "dashboard.heroku"),
-        DashboardTab("MTurk", "dashboard.mturk"),
-        DashboardTab("Monitoring", "dashboard.monitoring"),
-        DashboardTab("Lifecycle", "dashboard.lifecycle"),
-        DashboardTab("Database", "dashboard.database", database_children),
-        DashboardTab("Development", "dashboard.develop"),
+        DashboardTab("Config", "dashboard.dashboard_index"),
+        DashboardTab("Heroku", "dashboard.dashboard_heroku"),
+        DashboardTab("MTurk", "dashboard.dashboard_mturk"),
+        DashboardTab("Monitoring", "dashboard.dashboard_monitoring"),
+        DashboardTab("Lifecycle", "dashboard.dashboard_lifecycle"),
+        DashboardTab("Database", "dashboard.dashboard_database", database_children),
+        DashboardTab("Logger", "dashboard.dashboard_logger"),
+        DashboardTab("Development", "dashboard.dashboard_develop"),
     ]
 )
 
@@ -296,7 +297,9 @@ def is_safe_url(url):
 def login():
     next_url = request.form.get("next", request.args.get("next"))
     next_url = (
-        next_url if next_url and is_safe_url(next_url) else url_for("dashboard.index")
+        next_url
+        if next_url and is_safe_url(next_url)
+        else url_for("dashboard.dashboard_index")
     )
     if current_user.is_authenticated:
         return redirect(next_url)
@@ -320,13 +323,13 @@ def login():
 @dashboard.route("/logout")
 def logout():
     logout_user()
-    return redirect(url_for("dashboard.index"))
+    return redirect(url_for("dashboard.dashboard_index"))
 
 
 @dashboard.route("/")
 @dashboard.route("/index")
 @login_required
-def index():
+def dashboard_index():
     """Displays active experiment configuation"""
     config = get_config()
     config.load()
@@ -343,7 +346,7 @@ def index():
 
 @dashboard.route("/heroku")
 @login_required
-def heroku():
+def dashboard_heroku():
     """Assemble links from Heroku add-on info, stored in config, plus some
     standard dashboard links.
     """
@@ -541,7 +544,7 @@ def mturk_data_source(config):
 
 @dashboard.route("/mturk")
 @login_required
-def mturk():
+def dashboard_mturk():
     config = get_config()
     try:
         data_source = mturk_data_source(config)
@@ -581,7 +584,7 @@ def auto_recruit(bool_val):
 
 @dashboard.route("/monitoring")
 @login_required
-def monitoring():
+def dashboard_monitoring():
     from sqlalchemy import distinct, func
 
     from dallinger.experiment_server.experiment_server import Experiment, session
@@ -630,7 +633,7 @@ def init_db():
 
 @dashboard.route("/lifecycle")
 @login_required
-def lifecycle():
+def dashboard_lifecycle():
     config = get_config()
 
     try:
@@ -723,7 +726,7 @@ def prep_datatables_options(table_data):
 
 @dashboard.route("/database")
 @login_required
-def database():
+def dashboard_database():
     from dallinger.db import get_polymorphic_mapping
     from dallinger.experiment_server.experiment_server import Experiment, session
 
@@ -795,7 +798,7 @@ def database():
 
 @dashboard.route("/develop", methods=["GET", "POST"])
 @login_required
-def develop():
+def dashboard_develop():
     """Dashboard for working with ``dallinger develop`` Flask server."""
     return render_template(
         "dashboard_develop.html",
@@ -869,4 +872,7 @@ def dashboard_tab(title, **kwargs):
         "tab": full_tab,
     }
 
-    return deferred_route_decorator(route, registered_routes)
+    def route_name_from_func_name(func_name: str) -> str:
+        return func_name.replace("dashboard_", "")
+
+    return deferred_route_decorator(route, registered_routes, route_name_from_func_name)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -214,7 +214,7 @@ def index():
     html = (
         "<html><head></head><body><h1>Dallinger Experiment in progress</h1>"
         "<p><a href={}>Dashboard</a></p></body></html>".format(
-            url_for("dashboard.index")
+            url_for("dashboard.dashboard_index")
         )
     )
 

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -153,10 +153,11 @@ if exp_klass is not None:  # pragma: no cover
         if route_func is not None:
             # All dashboard routes require login
             route_func = login_required(route_func)
-            route_name = route["func_name"]
+            route_name = route["name"]
+            endpoint = route["func_name"]
             dashboard.dashboard.add_url_rule(
                 "/" + route_name,
-                endpoint=route_name,
+                endpoint=endpoint,
                 view_func=route_func,
                 **dict(route["kwargs"]),
             )
@@ -166,18 +167,16 @@ if exp_klass is not None:  # pragma: no cover
                 tabs.insert_tab_before_route(full_tab, route["before_route"])
             elif route.get("before_route"):
                 tabs.insert_before_route(
-                    route["title"], route_name, route["before_route"]
+                    route["title"], endpoint, route["before_route"]
                 )
             elif route.get("after_route") and full_tab:
                 tabs.insert_tab_after_route(full_tab, route["after_route"])
             elif route.get("after_route"):
-                tabs.insert_after_route(
-                    route["title"], route_name, route["after_route"]
-                )
+                tabs.insert_after_route(route["title"], endpoint, route["after_route"])
             elif full_tab:
                 tabs.insert(full_tab)
             else:
-                tabs.insert(route["title"], route_name)
+                tabs.insert(route["title"], endpoint)
 
     # This hides dashboard tabs from view, but doesn't prevent the routes from
     # being registered

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -923,13 +923,20 @@ def build_and_place(source: str, destination: str) -> str:
     return package_path.name
 
 
-def deferred_route_decorator(route, registered_routes):
+def route_name_from_func_name(func_name: str) -> str:
+    return func_name
+
+
+def deferred_route_decorator(
+    route, registered_routes, rename_route_name=route_name_from_func_name
+):
     def new_func(func):
         # Check `__func__` in case we have a classmethod or staticmethod
         base_func = getattr(func, "__func__", func)
-        name = getattr(base_func, "__name__", None)
-        if name is not None:
-            route["func_name"] = name
+        func_name = getattr(base_func, "__name__", None)
+        if func_name is not None:
+            route["func_name"] = func_name
+            route["name"] = rename_route_name(func_name)
             if route not in registered_routes:
                 registered_routes.append(route)
         return func

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -24,81 +24,92 @@ class TestDashboardTabs(object):
     def dashboard_tabs(self):
         from dallinger.experiment_server.dashboard import DashboardTabs
 
-        return DashboardTabs([DashboardTab("Home", "dashboard.index")])
+        return DashboardTabs([DashboardTab("Home", "dashboard.dashboard_index")])
 
     def test_dashboard_iter(self):
         from dallinger.experiment_server.dashboard import DashboardTabs
 
         dashboard_tabs = DashboardTabs(
-            [DashboardTab("Home", "index"), DashboardTab("Second", "dashboard.second")]
+            [
+                DashboardTab("Home", "dashboard.dashboard_index"),
+                DashboardTab("Second", "dashboard.dashboard_second"),
+            ]
         )
         tab_list = list(dashboard_tabs)
         assert len(tab_list) == 2
         assert tab_list[0].title == "Home"
-        assert tab_list[0].route_name == "dashboard.index"
+        assert tab_list[0].route_name == "dashboard.dashboard_index"
         assert tab_list[1].title == "Second"
-        assert tab_list[1].route_name == "dashboard.second"
+        assert tab_list[1].route_name == "dashboard.dashboard_second"
 
     def test_dashboard_insert(self, dashboard_tabs):
-        dashboard_tabs.insert("Next", "next")
+        dashboard_tabs.insert("Next", "dashboard.dashboard_next")
         assert list(dashboard_tabs) == [
-            DashboardTab("Home", "dashboard.index"),
-            DashboardTab("Next", "dashboard.next"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
+            DashboardTab("Next", "dashboard.dashboard_next"),
         ]
 
-        dashboard_tabs.insert("Previous", "dashboard.previous", 1)
+        dashboard_tabs.insert("Previous", "dashboard.dashboard_previous", 1)
         assert list(dashboard_tabs) == [
-            DashboardTab("Home", "dashboard.index"),
-            DashboardTab("Previous", "dashboard.previous"),
-            DashboardTab("Next", "dashboard.next"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
+            DashboardTab("Previous", "dashboard.dashboard_previous"),
+            DashboardTab("Next", "dashboard.dashboard_next"),
         ]
 
     def test_dashboard_insert_before(self, dashboard_tabs):
-        dashboard_tabs.insert_before_route("First", "first", "index")
+        dashboard_tabs.insert_before_route(
+            "First", "dashboard.dashboard_first", "dashboard.dashboard_index"
+        )
         assert list(dashboard_tabs) == [
-            DashboardTab("First", "dashboard.first"),
-            DashboardTab("Home", "dashboard.index"),
+            DashboardTab("First", "dashboard.dashboard_first"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
         ]
 
         dashboard_tabs.insert_before_route(
-            "Second", "dashboard.second", "dashboard.index"
+            "Second", "dashboard.dashboard_second", "dashboard.dashboard_index"
         )
         assert list(dashboard_tabs) == [
-            DashboardTab("First", "dashboard.first"),
-            DashboardTab("Second", "dashboard.second"),
-            DashboardTab("Home", "dashboard.index"),
+            DashboardTab("First", "dashboard.dashboard_first"),
+            DashboardTab("Second", "dashboard.dashboard_second"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
         ]
 
     def test_dashboard_insert_after(self, dashboard_tabs):
-        dashboard_tabs.insert_after_route("Last", "last", "index")
+        dashboard_tabs.insert_after_route(
+            "Last", "dashboard.dashboard_last", "dashboard.dashboard_index"
+        )
         assert list(dashboard_tabs) == [
-            DashboardTab("Home", "dashboard.index"),
-            DashboardTab("Last", "dashboard.last"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
+            DashboardTab("Last", "dashboard.dashboard_last"),
         ]
 
         dashboard_tabs.insert_after_route(
-            "Second", "dashboard.second", "dashboard.index"
+            "Second", "dashboard.dashboard_second", "dashboard.dashboard_index"
         )
         assert list(dashboard_tabs) == [
-            DashboardTab("Home", "dashboard.index"),
-            DashboardTab("Second", "dashboard.second"),
-            DashboardTab("Last", "dashboard.last"),
+            DashboardTab("Home", "dashboard.dashboard_index"),
+            DashboardTab("Second", "dashboard.dashboard_second"),
+            DashboardTab("Last", "dashboard.dashboard_last"),
         ]
 
     def test_dashboard_remove(self, dashboard_tabs):
-        dashboard_tabs.insert("Last", "last")
+        dashboard_tabs.insert("Last", "dashboard.dashboard_last")
         assert len(list(dashboard_tabs)) == 2
 
-        dashboard_tabs.remove("last")
-        assert list(dashboard_tabs) == [DashboardTab("Home", "dashboard.index")]
+        dashboard_tabs.remove("dashboard.dashboard_last")
+        assert list(dashboard_tabs) == [
+            DashboardTab("Home", "dashboard.dashboard_index")
+        ]
 
-        dashboard_tabs.insert("Last", "last")
+        dashboard_tabs.insert("Last", "dashboard.dashboard_last")
         assert len(list(dashboard_tabs)) == 2
 
-        dashboard_tabs.remove("dashboard.last")
-        assert list(dashboard_tabs) == [DashboardTab("Home", "dashboard.index")]
+        dashboard_tabs.remove("dashboard.dashboard_last")
+        assert list(dashboard_tabs) == [
+            DashboardTab("Home", "dashboard.dashboard_index")
+        ]
 
-        dashboard_tabs.remove("index")
+        dashboard_tabs.remove("dashboard.dashboard_index")
         assert len(list(dashboard_tabs)) == 0
 
     def test_deferred_tab_decorator(self, cleared_tab_routes):
@@ -124,6 +135,7 @@ class TestDashboardTabs(object):
             "tab": None,
             "kwargs": (("methods", ["POST", "GET"]),),
             "func_name": "fake_route",
+            "name": "fake_route",
         }
 
 

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -409,6 +409,7 @@ class TestTaskRegistration(object):
         assert len(tasks_with_cleanup) == 1
         assert tasks_with_cleanup[0] == {
             "func_name": "fake_task",
+            "name": "fake_task",
             "trigger": "interval",
             "kwargs": (("minutes", 15),),
         }
@@ -441,4 +442,5 @@ class TestRouteRegistration(object):
             "rule": "/route",
             "kwargs": (("methods", ["POST", "GET"]),),
             "func_name": "fake_route",
+            "name": "fake_route",
         }

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -409,7 +409,6 @@ class TestTaskRegistration(object):
         assert len(tasks_with_cleanup) == 1
         assert tasks_with_cleanup[0] == {
             "func_name": "fake_task",
-            "name": "fake_task",
             "trigger": "interval",
             "kwargs": (("minutes", 15),),
         }
@@ -442,5 +441,4 @@ class TestRouteRegistration(object):
             "rule": "/route",
             "kwargs": (("methods", ["POST", "GET"]),),
             "func_name": "fake_route",
-            "name": "fake_route",
         }


### PR DESCRIPTION
## Problem description
There's an inconsistency in how dashboard tabs are converted to endpoints. Endpoints are created via `/dashboard/<func_name>`. The issue is that in some cases the `<func_name>` is already used in another way, so `dashboard_<func_name>` is used. However, this leads to ugly URLs and it's cumbersome when some dashboard functions follow the convention and others don't.

## Solution
To improve this, I provide a prefix (`dashboard_`) for all dashboard tab functions, e.g. `dashboard_develop()` instead of `develop()`, but remove this prefix in the URL if it exists.

## How Has This Been Tested?
- Locally and CI
