### PR TITLE
Fix regression in insert_tab_after_route (see #7500)

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -152,7 +152,13 @@ class DashboardTabs(object):
         :raises ValueError: When ``before_route`` is not found in registered tabs
 
         """
-        before_check = frozenset((before_route, "dashboard." + before_route))
+        before_check = frozenset(
+            (
+                before_route,
+                "dashboard." + before_route,
+                "dashboard.dashboard_" + before_route,
+            )
+        )
         for i, cur_tab in enumerate(self.tabs):
             if cur_tab.route_name in before_check:
                 position = i

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -186,7 +186,13 @@ class DashboardTabs(object):
         :raises ValueError: When ``after_route`` is not found in registered tabs
 
         """
-        after_check = frozenset((after_route, "dashboard." + after_route))
+        after_check = frozenset(
+            (
+                after_route,
+                "dashboard." + after_route,
+                "dashboard.dashboard_" + after_route,
+            )
+        )
         for i, cur_tab in enumerate(self.tabs):
             if cur_tab.route_name in after_check:
                 position = i + 1


### PR DESCRIPTION
#7500 introduced a regression in `insert_tab_after_route`, such that `@dashboard_tab(after_route=...)` started failing. This PR fixes that.