### PR TITLE
Heroku_region support

### DIFF
--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -899,8 +899,7 @@ def apps():
     if not config.ready:
         config.load()
     team = config.get("heroku_team", None)
-    region = config.get("heroku_region", None)
-    command_runner = HerokuInfo(team=team, region=region)
+    command_runner = HerokuInfo(team=team)
     my_apps = command_runner.my_apps()
     my_user = command_runner.login_name()
     listing = []

--- a/dallinger/command_line/__init__.py
+++ b/dallinger/command_line/__init__.py
@@ -899,7 +899,8 @@ def apps():
     if not config.ready:
         config.load()
     team = config.get("heroku_team", None)
-    command_runner = HerokuInfo(team=team)
+    region = config.get("heroku_region", None)
+    command_runner = HerokuInfo(team=team, region=region)
     my_apps = command_runner.my_apps()
     my_user = command_runner.login_name()
     listing = []

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -356,7 +356,7 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
 
     out = None if verbose else open(os.devnull, "w")
     team = config.get("heroku_team", None)
-    team = config.get("heroku_region", None)
+    region = config.get("heroku_region", None)
     heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team, region=region)
     heroku_app.bootstrap(buildpack=None)
 

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -356,7 +356,8 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
 
     out = None if verbose else open(os.devnull, "w")
     team = config.get("heroku_team", None)
-    heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team)
+    team = config.get("heroku_region", None)
+    heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team, region=region)
     heroku_app.bootstrap(buildpack=None)
 
     # Set up add-ons and AWS environment variables.

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -67,6 +67,7 @@ default_keys = (
     ("heroku_auth_token", six.text_type, [], True),
     ("heroku_python_version", six.text_type, []),
     ("heroku_team", six.text_type, ["team"]),
+    ("heroku_region", six.text_type, ["region"]),
     ("host", six.text_type, []),
     ("id", six.text_type, []),
     ("infrastructure_debug_details", six.text_type, [], False),

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -67,7 +67,7 @@ default_keys = (
     ("heroku_auth_token", six.text_type, [], True),
     ("heroku_python_version", six.text_type, []),
     ("heroku_team", six.text_type, ["team"]),
-    ("heroku_region", six.text_type, ["region"]),
+    ("heroku_region", six.text_type, []),
     ("host", six.text_type, []),
     ("id", six.text_type, []),
     ("infrastructure_debug_details", six.text_type, [], False),

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -135,7 +135,8 @@ def deploy_sandbox_shared_setup(
     # Initialize the app on Heroku.
     log("Initializing app on Heroku...")
     team = config.get("heroku_team", None)
-    heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team)
+    region = config.get("heroku_region", None)
+    heroku_app = HerokuApp(dallinger_uid=heroku_app_id, output=out, team=team, region=region)
     heroku_app.bootstrap()
     heroku_app.buildpack("https://github.com/stomita/heroku-buildpack-phantomjs")
 

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -103,7 +103,7 @@ class HerokuInfo(HerokuCommandRunner):
         if self.team:
             cmd.extend(["--team", self.team])
         if self.region:
-            cmd.extend(["--region", self.team])
+            cmd.extend(["--region", self.region])
         return json.loads(self._result(cmd))
 
     def my_apps(self):

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -58,9 +58,10 @@ def request_headers(auth_token):
 class HerokuCommandRunner(object):
     """Heroku command runner base class"""
 
-    def __init__(self, output=None, team=None):
+    def __init__(self, output=None, team=None, region=None):
         self.out = output
         self.team = team
+        self.region = region
         self.out_muted = open(os.devnull, "w")
 
     @property
@@ -101,6 +102,8 @@ class HerokuInfo(HerokuCommandRunner):
         cmd = ["heroku", "apps", "--json"]
         if self.team:
             cmd.extend(["--team", self.team])
+        if self.region:
+            cmd.extend(["--region", self.team])
         return json.loads(self._result(cmd))
 
     def my_apps(self):
@@ -120,9 +123,9 @@ class HerokuInfo(HerokuCommandRunner):
 class HerokuApp(HerokuCommandRunner):
     """Representation of a Heroku app"""
 
-    def __init__(self, dallinger_uid, output=None, team=None):
+    def __init__(self, dallinger_uid, output=None, team=None, region=None):
         self.dallinger_uid = dallinger_uid
-        super(HerokuApp, self).__init__(output, team)
+        super(HerokuApp, self).__init__(output, team, region)
 
     def bootstrap(self, buildpack="heroku/python"):
         """Creates the heroku app and local git remote. Call this once you're
@@ -135,6 +138,10 @@ class HerokuApp(HerokuCommandRunner):
         # If a team is specified, assign the app to the team.
         if self.team:
             cmd.extend(["--team", self.team])
+
+        # If a region is specified, create the app in the specified region
+        if self.region:
+            cmd.extend(["--region", self.region])
 
         self._run(cmd)
         # Set HOST value


### PR DESCRIPTION
Implement support for setting the heroku region in the config

To implement support for setting heroku_region, I added to the existing heroku_teams settings. This appeared to work in testing for bartlett1932:

![Dallinger region](https://github.com/user-attachments/assets/e5b04c36-f826-4a6f-89d4-d0baf2344f19)

However, right before the experiment finishes deploying, there is an error in papertrail. It sounds unrelated, but I'm not sure:

![Error](https://github.com/user-attachments/assets/8e09d3c5-0fa5-46e1-94cf-d0c3302e8e83)

