### PR TITLE
Release 11.2.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.2.0a1
+current_version = 11.2.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [v11.2.0](https://github.com/dallinger/dallinger/tree/v11.2.0) (2025-04-04)
+
+#### Added
+- Ported `classproperty` decorator from PsyNet to Dallinger
+- Added a hook for overriding hidden dashboard tabs and a hook for sorting the dashboard tabs
+- Added option to disable strict config variable loading, which is useful for cross-compatibility with PsyNet
+- Added new dashboard tab 'Logger' by dumping logs in `jsonl` format and streaming them to the frontend, incl. search functionality and added new dependencies ansi2html, beautifulsoup4, pygtail, and python-json-logger
+- Added standardized status reporting across recruiters:
+  - Introduced new class `RecruitmentStatus` which reports standardized status across recruiters. The class contains the following entries:
+    - `participant_status`: this is a histogram in dictionary format where the keys are the statuses of submissions (e.g. "APPROVED" or "REJECTED") and the values are the respective counts
+    - `study_id`: the ID used on the recruiting platform
+    - `study_status`: status of the recruitment, e.g. "ACTIVE" or "AWAITING REVIEW" are valid study statuses on Prolific
+    - `study_cost`: total cost for a recruitment this includes both base payments (rewards on Prolific) and bonuses as well as service fees and taxes if returned by the API
+    - `meta_information`: dictionary of any information specific to the recruiter, e.g. for Prolific the median duration of approved participants and the `wage_per_hour` computed by the platform
+    - Additional changes:
+      - Make `reward` a property of the Prolific recruiter
+      - Always emit the recruiter name (nickname) in `get_status`
+- Added support for Heroku regions via new config variable `heroku_region`
+
+#### Changed
+- Renamed all functions used for rendering dashboard tabs to use the prefix `dashboard_` and removed this prefix in the final route used in Flask (i.e. instead of `/dashboard/dashboard_func` →  `/dashboard/func`)
+
+#### Updated
+- Updated dependencies; updated black, flake8
+
 ## [v11.1.1](https://github.com/dallinger/dallinger/tree/v11.1.1) (2025-02-26)
 
 #### Changed

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "11.2.0a1"
+__version__ = "11.2.0"

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -62,11 +70,11 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -76,7 +84,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -149,7 +157,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -232,6 +240,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -250,6 +262,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -262,15 +278,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -292,6 +308,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -339,16 +359,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/chatroom_ws/constraints.txt
+++ b/demos/dlgr/demos/chatroom_ws/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -62,11 +70,11 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -76,7 +84,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -149,7 +157,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -232,6 +240,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -250,6 +262,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -262,15 +278,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -292,6 +308,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -339,16 +359,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -6,6 +6,10 @@
 #
 # from the root of the dallinger repository
 #
+ansi2html==1.9.2
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 apscheduler==3.11.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -14,20 +18,24 @@ asttokens==3.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
+beautifulsoup4==4.13.3
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.1
+boto3==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.1
+botocore==1.37.23
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -61,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.1
+cryptography==44.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.1.1
+dallinger==11.2.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -75,7 +83,7 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==36.1.1
+faker==37.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -148,7 +156,7 @@ jedi==0.19.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
-jinja2==3.1.5
+jinja2==3.1.6
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
@@ -227,6 +235,10 @@ pygments==2.19.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
+pygtail==0.14.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 pyopenssl==25.0.0
     # via
     #   -c ../../../../dev-requirements.txt
@@ -245,6 +257,10 @@ python-dateutil==2.9.0.post0
     #   -c ../../../../dev-requirements.txt
     #   botocore
     #   heroku3
+python-json-logger==3.3.0
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   dallinger
 redis==5.2.1
     # via
     #   -c ../../../../dev-requirements.txt
@@ -255,15 +271,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.1.0
+rq==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.2
+s3transfer==0.11.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.29.0
+selenium==4.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -285,6 +301,10 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
+soupsieve==2.6
+    # via
+    #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
 sqlalchemy==1.4.54
     # via
     #   -c ../../../../dev-requirements.txt
@@ -328,16 +348,17 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   -c ../../../../dev-requirements.txt
+    #   beautifulsoup4
     #   pyopenssl
     #   selenium
-tzdata==2025.1
+tzdata==2025.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   faker
-tzlocal==5.3
+tzlocal==5.3.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   apscheduler

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==11.2.0a1
+Dallinger==11.2.0

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="11.2.0a1",
+    version="11.2.0",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "11.2.0a1"
+version = "11.2.0"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
#### Added
- Ported `classproperty` decorator from PsyNet to Dallinger
- Added a hook for overriding hidden dashboard tabs and a hook for sorting the dashboard tabs
- Added option to disable strict config variable loading, which is useful for cross-compatibility with PsyNet
- Added new dashboard tab 'Logger' by dumping logs in `jsonl` format and streaming them to the frontend, incl. search functionality and added new dependencies ansi2html, beautifulsoup4, pygtail, and python-json-logger
- Added standardized status reporting across recruiters:
  - Introduced new class `RecruitmentStatus` which reports standardized status across recruiters. The class contains the following entries:
    - `participant_status`: this is a histogram in dictionary format where the keys are the statuses of submissions (e.g. "APPROVED" or "REJECTED") and the values are the respective counts
    - `study_id`: the ID used on the recruiting platform
    - `study_status`: status of the recruitment, e.g. "ACTIVE" or "AWAITING REVIEW" are valid study statuses on Prolific
    - `study_cost`: total cost for a recruitment this includes both base payments (rewards on Prolific) and bonuses as well as service fees and taxes if returned by the API
    - `meta_information`: dictionary of any information specific to the recruiter, e.g. for Prolific the median duration of approved participants and the `wage_per_hour` computed by the platform
    - Additional changes:
      - Make `reward` a property of the Prolific recruiter
      - Always emit the recruiter name (nickname) in `get_status`
- Added support for Heroku regions via new config variable `heroku_region`

#### Changed
- Renamed all functions used for rendering dashboard tabs to use the prefix `dashboard_` and removed this prefix in the final route used in Flask (i.e. instead of `/dashboard/dashboard_func` →  `/dashboard/func`)

#### Updated
- Updated dependencies; updated black, flake8