### PR TITLE
Three additions: gunicorn experiment hooks, customisable recruiter error handling, `DevRecruiter` class

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -412,7 +412,15 @@ class Experiment(object):
 
     @classmethod
     def handle_recruitment_error(cls, error, **kwargs):
-        pass
+        """Handle errors that occur during recruitment.
+
+        This method provides a default implementation that logs the error.
+        Subclasses can override this method to implement custom error handling.
+
+        :param error: The exception or error object that occurred.
+        :type error: Exception
+        :param kwargs: Additional context or metadata about the error.
+        """
 
     def receive_message(
         self, message, channel_name=None, participant=None, node=None, receive_time=None

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -410,6 +410,10 @@ class Experiment(object):
             queue_name="high",
         )
 
+    @classmethod
+    def handle_recruitment_error(cls, error, **kwargs):
+        pass
+
     def receive_message(
         self, message, channel_name=None, participant=None, node=None, receive_time=None
     ):

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -202,6 +202,22 @@ class Experiment(object):
     def after_request(request, response):
         return response
 
+    @staticmethod
+    def gunicorn_when_ready(server):
+        pass
+
+    @staticmethod
+    def gunicorn_on_exit(server):
+        pass
+
+    @staticmethod
+    def gunicorn_worker_exit(server, worker):
+        pass
+
+    @staticmethod
+    def gunicorn_post_worker_init(worker):
+        pass
+
     @classmethod
     def get_status(cls):
         """

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -421,6 +421,7 @@ class Experiment(object):
         :type error: Exception
         :param kwargs: Additional context or metadata about the error.
         """
+        logger.exception(str(error))
 
     def receive_message(
         self, message, channel_name=None, participant=None, node=None, receive_time=None

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -16,9 +16,42 @@ logger = logging.getLogger(__name__)
 WORKER_CLASS = "gevent"
 
 
+def get_exp_klass():
+    from dallinger import experiment
+
+    try:
+        return experiment.load()
+    except ImportError:
+        return None  # pragma: no cover
+
+
+def experiment_hook(func_name, *args, **kwargs):
+    exp_klass = get_exp_klass()
+    if exp_klass is not None:
+        return getattr(exp_klass, func_name)(*args, **kwargs)
+    return None
+
+
 def when_ready(arbiter):
     # Signal to parent process that server has started
     logger.warning("Ready.")
+    return experiment_hook("gunicorn_when_ready", arbiter)
+
+
+def on_exit(server):
+    return experiment_hook("gunicorn_on_exit", server)
+
+
+def worker_exit(server, worker):
+    return experiment_hook("gunicorn_worker_exit", server, worker)
+
+
+def worker_abort(worker):
+    return experiment_hook("gunicorn_worker_abort", worker)
+
+
+def post_worker_init(worker):
+    return experiment_hook("gunicorn_post_worker_init", worker)
 
 
 class StandaloneServer(Application):
@@ -85,6 +118,10 @@ class StandaloneServer(Application):
             "proc_name": "dallinger_experiment_server",
             "limit_request_line": "0",
             "when_ready": when_ready,
+            "on_exit": on_exit,
+            "worker_exit": worker_exit,
+            "worker_abort": worker_abort,
+            "post_worker_init": post_worker_init,
         }
 
 

--- a/dallinger/experiment_server/gunicorn.py
+++ b/dallinger/experiment_server/gunicorn.py
@@ -46,10 +46,6 @@ def worker_exit(server, worker):
     return experiment_hook("gunicorn_worker_exit", server, worker)
 
 
-def worker_abort(worker):
-    return experiment_hook("gunicorn_worker_abort", worker)
-
-
 def post_worker_init(worker):
     return experiment_hook("gunicorn_post_worker_init", worker)
 
@@ -120,7 +116,6 @@ class StandaloneServer(Application):
             "when_ready": when_ready,
             "on_exit": on_exit,
             "worker_exit": worker_exit,
-            "worker_abort": worker_abort,
             "post_worker_init": post_worker_init,
         }
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -43,6 +43,20 @@ from dallinger.utils import ParticipationTime, generate_random_id, get_base_url
 
 logger = logging.getLogger(__name__)
 
+# By default, Dallinger logs recruitment errors, but does not raise them. Here, we override the logger.exception method
+# to assign a custom error handler (Experiment.handle_error)
+logger._exception = logger.exception
+
+
+def handle_recruitment_error(ex):
+    logger._exception(str(ex))
+    from dallinger.experiment_server.experiment_server import Experiment, session
+
+    exp = Experiment(session)
+    exp.handle_recruitment_error(ex)
+
+
+logger.exception = handle_recruitment_error
 
 # These are constants because other components may listen for these
 # messages in logs:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -45,7 +45,6 @@ logger = logging.getLogger(__name__)
 
 
 def handle_recruitment_error(ex):
-    logger.exception(str(ex))
     from dallinger.experiment_server.experiment_server import Experiment, session
 
     exp = Experiment(session)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -866,7 +866,13 @@ class ProlificRecruiter(Recruiter):
         self.prolificservice.validate_workspace(workspace)
 
 
-class DevProlificRecruiter(ProlificRecruiter):
+class DevRecruiter(Recruiter):
+    """
+    A dev recruiter class for detecting dev recruiters
+    """
+
+
+class DevProlificRecruiter(DevRecruiter, ProlificRecruiter):
     """A debug recruiter for [Prolific](https://app.prolific.com/)"""
 
     nickname = "devprolific"


### PR DESCRIPTION
# Added
- Experiment hooks for server setup and termination, as well as worker termination and startup
- Experiment hook for recruiter error by overriding `logger.exception` in `recruiters.py`
- A `DevRecruiter` class for easy distinguishing from `MockRecruiter` or a regular `Recruiter`

# Experiment hooks for gunicorn server hooks

## Motivation and Context

Sometimes it is good to be notified when gunicorn workers are killed or when they restart or if the whole process is killed.
While you can catch graceful terminations like `SIGINT` (`Ctrl+C`) or `SIGTERM` (`kill`) with `atexit`, you cannot catch forced termination (`SIGKILL`, `Ctrl+K` or `kill -9 <pid>`). Forced termination are especially important, because they can originate from memory leaks. However, `gunicorn` also provides hooks for forceful termination


## How Has This Been Tested?
- Locally (`psynet debug local --verbose`)
- Local docker
- Remote docker (`psynet deploy ssh`) in multiple deployments on Prolific

# Experiment hook for recruiter error

## Motivation and Context
Currently, Dallinger silently suppresses recruitment errors, e.g. when a submission cannot be approved or a bonus not paid. Here, we override `logger.exception` in `recruiters.py` which is called when a failure occurs in the recruiter and next to logging, we call `Experiment`

## How Has This Been Tested?
- Not yet, but the risk is low

# `DevRecruiter` class

## Motivation and Context
Dallinger currently has three kinds of recruiters, normal recruiters which really recruit, mock recruiters which assign an experiment to an existing study (for testing) and dev recruiters which mock API calls (for testing). However, there is currently no way to distinguish between mock and dev recruiters, which is implemented here.

## How Has This Been Tested?
- Local Prolific dev recruiters
