### PR TITLE
Remove dependency on setuptools.dist.strtobool

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,3 +19,10 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+Portions of this project are derived from code in the setuptools project, which is licensed under the MIT License:
+
+    https://github.com/pypa/setuptools
+
+The following function is based on code from setuptools/distutils:
+    - dallinger/config.py: strtobool

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -24,7 +24,7 @@ def is_valid_json(value):
     json.loads(value)
 
 
-def strtobool(val):
+def strtobool(val: str) -> int:
     """Convert a string representation of truth to true (1) or false (0).
 
     True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
@@ -44,10 +44,9 @@ def strtobool(val):
     val = val.lower()
     if val in ("y", "yes", "t", "true", "on", "1"):
         return 1
-    elif val in ("n", "no", "f", "false", "off", "0"):
+    if val in ("n", "no", "f", "false", "off", "0"):
         return 0
-    else:
-        raise ValueError("invalid truth value {!r}".format(val))
+    raise ValueError(f"invalid truth value {val!r}")
 
 
 default_keys = (

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -10,7 +10,6 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import six
-from setuptools.dist import strtobool
 from six.moves import configparser
 
 logger = logging.getLogger(__name__)
@@ -23,6 +22,32 @@ SENSITIVE_KEY_NAMES = ("access_id", "access_key", "password", "secret", "token")
 
 def is_valid_json(value):
     json.loads(value)
+
+
+def strtobool(val):
+    """Convert a string representation of truth to true (1) or false (0).
+
+    True values are 'y', 'yes', 't', 'true', 'on', and '1'; false values
+    are 'n', 'no', 'f', 'false', 'off', and '0'.  Raises ValueError if
+    'val' is anything else.
+
+    Notes
+    -----
+    This implementation is derived from the `strtobool` function in setuptools,
+    which itself is based on the original in Python's distutils.
+
+    Source: https://github.com/pypa/setuptools/blob/main/setuptools/dist.py
+
+    Copyright (c) 2016-2024 Python Packaging Authority (PyPA)
+    Licensed under the MIT License.
+    """
+    val = val.lower()
+    if val in ("y", "yes", "t", "true", "on", "1"):
+        return 1
+    elif val in ("n", "no", "f", "false", "off", "0"):
+        return 0
+    else:
+        raise ValueError("invalid truth value {!r}".format(val))
 
 
 default_keys = (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -8,6 +8,7 @@ from unittest import mock
 import pytest
 
 from dallinger import config, utils
+from dallinger.config import strtobool
 from dallinger.utils import check_experiment_dependencies
 
 
@@ -373,3 +374,30 @@ def test_check_experiment_dependencies_unsuccessful():
             str(e.value)
             == "Please install the 'NOTINSTALLED' package to run this experiment."
         )
+
+
+def test_strtobool_true_values():
+    """Test that all true values return 1."""
+    true_values = ["y", "yes", "t", "true", "on", "1"]
+    for val in true_values:
+        assert strtobool(val) == 1
+        # Test case insensitivity
+        assert strtobool(val.upper()) == 1
+
+
+def test_strtobool_false_values():
+    """Test that all false values return 0."""
+    false_values = ["n", "no", "f", "false", "off", "0"]
+    for val in false_values:
+        assert strtobool(val) == 0
+        # Test case insensitivity
+        assert strtobool(val.upper()) == 0
+
+
+def test_strtobool_invalid_values():
+    """Test that invalid values raise ValueError."""
+    invalid_values = ["maybe", "sometimes", "2", "", " "]
+    for val in invalid_values:
+        with pytest.raises(ValueError) as excinfo:
+            strtobool(val)
+        assert "invalid truth value" in str(excinfo.value)


### PR DESCRIPTION
This PR removes the dependency on `setuptools.dist.strtobool`, which was causing a deprecation warning.