### PR TITLE
Better error message on broken symlink

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -806,6 +806,12 @@ class FileSource(object):
             ensure_directory(target_folder)
             if os.path.exists(to_path):
                 continue
+            if is_broken_symlink(from_path):
+                raise OSError(
+                    f"Cannot copy broken symlink: {from_path}. "
+                    "If this file comes from a virtual environment directory (e.g. .venv), we recommend adding that "
+                    "virtual environment directory to your .gitignore file."
+                )
             copy_func(from_path, to_path)
 
     def map_locations_to(self, destination):
@@ -814,6 +820,14 @@ class FileSource(object):
         target location under @dst.
         """
         raise NotImplementedError()
+
+
+def is_broken_symlink(path):
+    """Check if the given path is a broken symlink.
+    Relies on the documented behavior of ``os.path.exists``:
+    "Return True if path refers to an existing path. Returns False for broken symbolic links".
+    """
+    return os.path.islink(path) and not os.path.exists(path)
 
 
 class DallingerFileSource(FileSource):

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -822,7 +822,7 @@ class FileSource(object):
         raise NotImplementedError()
 
 
-def is_broken_symlink(path):
+def is_broken_symlink(path: str) -> bool:
     """Check if the given path is a broken symlink.
     Relies on the documented behavior of ``os.path.exists``:
     "Return True if path refers to an existing path. Returns False for broken symbolic links".

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 import io
 import locale
+import os
+import tempfile
 from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
 from unittest import mock
@@ -337,6 +339,41 @@ class TestIsolatedWebbrowser(object):
             patches["sys"].platform = 'anything but "darwin"'
             isolated = utils._new_webbrowser_profile()
         assert isolated == webbrowser
+
+
+class TestIsBrokenSymlink(object):
+    @pytest.fixture
+    def temp_dir(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            yield tmpdir
+
+    def test_regular_file_is_not_broken_symlink(self, temp_dir):
+        """Test that a regular file is not considered a broken symlink."""
+        file_path = os.path.join(temp_dir, "test.txt")
+        with open(file_path, "w") as f:
+            f.write("test")
+        assert not utils.is_broken_symlink(file_path)
+
+    def test_working_symlink_is_not_broken(self, temp_dir):
+        """Test that a working symlink is not considered broken."""
+        target_path = os.path.join(temp_dir, "target.txt")
+        with open(target_path, "w") as f:
+            f.write("test")
+        symlink_path = os.path.join(temp_dir, "symlink.txt")
+        os.symlink(target_path, symlink_path)
+        assert not utils.is_broken_symlink(symlink_path)
+
+    def test_broken_symlink_is_detected(self, temp_dir):
+        """Test that a broken symlink is correctly detected."""
+        target_path = os.path.join(temp_dir, "nonexistent.txt")
+        symlink_path = os.path.join(temp_dir, "broken_symlink.txt")
+        os.symlink(target_path, symlink_path)
+        assert utils.is_broken_symlink(symlink_path)
+
+    def test_nonexistent_path_is_not_broken_symlink(self, temp_dir):
+        """Test that a nonexistent path is not considered a broken symlink."""
+        path = os.path.join(temp_dir, "nonexistent.txt")
+        assert not utils.is_broken_symlink(path)
 
 
 def test_check_experiment_dependencies_successful():


### PR DESCRIPTION
This PR gives a more informative error message when `FileSource` tries to copy a broken symlink.