### PR TITLE
Release 11.3.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 11.3.0a1
+current_version = 11.3.0
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Change Log
 
+## [v11.3.0](https://github.com/dallinger/dallinger/tree/v11.3.0) (2025-05-22)
+
+#### Added
+- Added support for screen-out-submissions in ProlificRecruiter
+- Added experiment hooks for server setup and termination, as well as worker termination and startup
+- Added experiment hook for recruiter error by overriding `logger.exception` in `recruiters.py`
+- Added `DevRecruiter` class for easily distinguishing between `MockRecruiter` or a regular `Recruiter`
+- Prolific command line improvements:
+  - Added `dallinger prolific list studies ` to list all studies associated with an account (across workspaces and projects)
+  - Added `dallinger prolific delete-drafts` delete all unpublished draft surveys in the account
+
+## Changed
+- Only show deprecation warnings once
+- When loading the defaults, load `.dallingerconfig` last
+- Give a more informative error message when `FileSource` tries to copy a broken symlink
+- Make `scripts/update_dependencies.sh` POSIX compliant
+
+#### Updated
+- Update AMI image for EC2 provisioning to use Ubuntu 24.04
+- Updated dependencies; pin click < 8.2
+
+#### Removed
+- Removed dependency on `setuptools.dist.strtobool`, which was causing a deprecation warning
+- Removed unnecessary 'Initializing recruiter' messages
+
 ## [v11.2.0](https://github.com/dallinger/dallinger/tree/v11.2.0) (2025-04-04)
 
 #### Added

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "11.3.0a1"
+__version__ = "11.3.0"

--- a/demos/dlgr/demos/bartlett1932/constraints.txt
+++ b/demos/dlgr/demos/bartlett1932/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/chatroom/constraints.txt
+++ b/demos/dlgr/demos/chatroom/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -70,11 +70,11 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -84,11 +84,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -116,12 +116,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -131,7 +131,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -175,6 +175,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -193,7 +194,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -211,7 +212,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -244,7 +245,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,7 +267,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -278,15 +279,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -308,7 +309,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -329,7 +330,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -350,7 +351,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -359,7 +360,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/chatroom_ws/constraints.txt
+++ b/demos/dlgr/demos/chatroom_ws/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -70,11 +70,11 @@ click==8.1.8
     #   nltk
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -84,11 +84,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -116,12 +116,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -131,7 +131,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -175,6 +175,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -193,7 +194,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -211,7 +212,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -244,7 +245,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -266,7 +267,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -278,15 +279,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -308,7 +309,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -329,7 +330,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -350,7 +351,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -359,7 +360,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/concentration/constraints.txt
+++ b/demos/dlgr/demos/concentration/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/function_learning/constraints.txt
+++ b/demos/dlgr/demos/function_learning/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/iterated_drawing/constraints.txt
+++ b/demos/dlgr/demos/iterated_drawing/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/mcmcp/constraints.txt
+++ b/demos/dlgr/demos/mcmcp/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/rogers/constraints.txt
+++ b/demos/dlgr/demos/rogers/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/sheep_market/constraints.txt
+++ b/demos/dlgr/demos/sheep_market/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/snake/constraints.txt
+++ b/demos/dlgr/demos/snake/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/twentyfortyeight/constraints.txt
+++ b/demos/dlgr/demos/twentyfortyeight/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/dlgr/demos/vox_populi/constraints.txt
+++ b/demos/dlgr/demos/vox_populi/constraints.txt
@@ -23,7 +23,7 @@ attrs==25.3.0
     #   -c ../../../../dev-requirements.txt
     #   outcome
     #   trio
-beautifulsoup4==4.13.3
+beautifulsoup4==4.13.4
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -31,11 +31,11 @@ blinker==1.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   flask
-boto3==1.37.23
+boto3==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-botocore==1.37.23
+botocore==1.38.20
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
@@ -49,7 +49,7 @@ cached-property==2.0.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-certifi==2025.1.31
+certifi==2025.4.26
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -58,7 +58,7 @@ cffi==1.17.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   cryptography
-charset-normalizer==3.4.1
+charset-normalizer==3.4.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   requests
@@ -69,11 +69,11 @@ click==8.1.8
     #   flask
     #   pip-tools
     #   rq
-cryptography==44.0.2
+cryptography==45.0.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   pyopenssl
-dallinger==11.2.0
+dallinger==11.3.0
     # via -r requirements.txt
 decorator==5.2.1
     # via
@@ -83,11 +83,11 @@ executing==2.2.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   stack-data
-faker==37.1.0
+faker==37.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-flask==3.1.0
+flask==3.1.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -115,12 +115,12 @@ future==1.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-gevent==24.11.1
+gevent==25.5.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   gunicorn
-greenlet==3.1.1
+greenlet==3.2.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -130,7 +130,7 @@ gunicorn==23.0.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-h11==0.14.0
+h11==0.16.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   wsproto
@@ -172,6 +172,7 @@ localconfig==1.1.4
 markupsafe==3.0.2
     # via
     #   -c ../../../../dev-requirements.txt
+    #   flask
     #   jinja2
     #   werkzeug
     #   wtforms
@@ -188,7 +189,7 @@ outcome==1.3.0.post0
     #   -c ../../../../dev-requirements.txt
     #   trio
     #   trio-websocket
-packaging==24.2
+packaging==25.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   build
@@ -206,7 +207,7 @@ pip-tools==7.4.1
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-prompt-toolkit==3.0.50
+prompt-toolkit==3.0.51
     # via
     #   -c ../../../../dev-requirements.txt
     #   ipython
@@ -239,7 +240,7 @@ pygtail==0.14.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-pyopenssl==25.0.0
+pyopenssl==25.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -261,7 +262,7 @@ python-json-logger==3.3.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-redis==5.2.1
+redis==6.1.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -271,15 +272,15 @@ requests==2.32.3
     #   -c ../../../../dev-requirements.txt
     #   dallinger
     #   heroku3
-rq==2.2.0
+rq==2.3.3
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-s3transfer==0.11.4
+s3transfer==0.12.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   boto3
-selenium==4.30.0
+selenium==4.32.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -301,7 +302,7 @@ sortedcontainers==2.4.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   trio
-soupsieve==2.6
+soupsieve==2.7
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4
@@ -322,7 +323,7 @@ tabulate==0.9.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
-tenacity==9.0.0
+tenacity==9.1.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   dallinger
@@ -339,7 +340,7 @@ traitlets==5.14.3
     #   -c ../../../../dev-requirements.txt
     #   ipython
     #   matplotlib-inline
-trio==0.29.0
+trio==0.30.0
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
@@ -348,7 +349,7 @@ trio-websocket==0.12.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   selenium
-typing-extensions==4.13.0
+typing-extensions==4.13.2
     # via
     #   -c ../../../../dev-requirements.txt
     #   beautifulsoup4

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==11.3.0a1
+Dallinger==11.3.0

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="11.3.0a1",
+    version="11.3.0",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "11.3.0a1"
+version = "11.3.0"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
#### Added
- Added support for screen-out-submissions in ProlificRecruiter
- Added experiment hooks for server setup and termination, as well as worker termination and startup
- Added experiment hook for recruiter error by overriding `logger.exception` in `recruiters.py`
- Added `DevRecruiter` class for easily distinguishing between `MockRecruiter` or a regular `Recruiter`
- Prolific command line improvements:
  - Added `dallinger prolific list studies ` to list all studies associated with an account (across workspaces and projects)
  - Added `dallinger prolific delete-drafts` delete all unpublished draft surveys in the account

## Changed
- Only show deprecation warnings once
- When loading the defaults, load `.dallingerconfig` last
- Give a more informative error message when `FileSource` tries to copy a broken symlink
- Make `scripts/update_dependencies.sh` POSIX compliant

#### Updated
- Update AMI image for EC2 provisioning to use Ubuntu 24.04
- Updated dependencies; pin click < 8.2

#### Removed
- Removed dependency on `setuptools.dist.strtobool`, which was causing a deprecation warning
- Removed unnecessary 'Initializing recruiter' messages