### PR TITLE
Ensure Git repository exists when listing files

### DIFF
--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -243,6 +243,30 @@ class GitClient(object):
         result = {item for item in raw.split("\0") if item}
         return result
 
+    @property
+    def client_available(self):
+        """Check if the git client is available on the system.
+
+        :returns: True if git is installed and accessible, False otherwise.
+        """
+        try:
+            check_output(["git", "--version"], stderr=subprocess.STDOUT)
+            return True
+        except Exception:
+            return False
+
+    @property
+    def repository_available(self):
+        """Check if there is a git repository available in the current directory.
+
+        :returns: True if the repository can be accessed, False otherwise.
+        """
+        try:
+            check_output(["git", "rev-parse", "--git-dir"], stderr=subprocess.STDOUT)
+            return True
+        except Exception:
+            return False
+
     def _run(self, cmd):
         self._log(cmd)
         try:

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -281,9 +281,8 @@ class GitClient(object):
             msg = msg.encode(self.encoding)
         self.out.write(msg)
 
-    @classmethod
     @contextmanager
-    def with_temporary_repository(cls, config=None):
+    def with_temporary_repository(self, config=None):
         """Create a temporary git repository in the current directory and clean it up when done.
 
         :param config: Git configuration to apply to the repository
@@ -292,12 +291,11 @@ class GitClient(object):
         :type yields: GitClient
         :raises: GitError if a repository already exists
         """
-        git = cls()
         if os.path.isdir(".git"):
             raise GitError("A git repository already exists in this directory")
-        git.init(config=config)
+        self.init(config=config)
         try:
-            yield git
+            yield self
         finally:
             shutil.rmtree(".git")
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -293,7 +293,7 @@ class GitClient(object):
         :raises: GitError if a repository already exists
         """
         git = cls()
-        if git.repository_available:
+        if os.path.isdir(".git"):
             raise GitError("A git repository already exists in this directory")
         git.init(config=config)
         try:

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -14,6 +14,7 @@ import sys
 import tempfile
 import warnings
 import webbrowser
+from contextlib import contextmanager
 from datetime import datetime
 from hashlib import md5
 from importlib.metadata import files as files_metadata
@@ -279,6 +280,26 @@ class GitClient(object):
         if self.encoding:
             msg = msg.encode(self.encoding)
         self.out.write(msg)
+
+    @classmethod
+    @contextmanager
+    def with_temporary_repository(cls, config=None):
+        """Create a temporary git repository in the current directory and clean it up when done.
+
+        :param config: Git configuration to apply to the repository
+        :type config: dict, optional
+        :yields: A GitClient instance with an initialized repository
+        :type yields: GitClient
+        :raises: GitError if a repository already exists
+        """
+        git = cls()
+        if git.repository_available:
+            raise GitError("A git repository already exists in this directory")
+        git.init(config=config)
+        try:
+            yield git
+        finally:
+            shutil.rmtree(".git")
 
 
 class ParticipationTime(object):

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -287,7 +287,7 @@ class GitClient(object):
         self.out.write(msg)
 
     @contextmanager
-    def with_temporary_repository(self, config=None):
+    def temporary_repository(self, config=None):
         """Create a temporary git repository in the current directory and clean it up when done.
 
         :param config: Git configuration to apply to the repository
@@ -938,7 +938,7 @@ class ExperimentFileSource(FileSource):
         if self.git.repository_available:
             git_files = self.git.files()
         else:
-            with self.git.with_temporary_repository():
+            with self.git.temporary_repository():
                 git_files = self.git.files()
 
         git_files = {os.path.join(self.root, normalize("NFC", f)) for f in git_files}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -226,10 +226,10 @@ class TestGitClient(object):
             ["git", "clone", "https://some-fake-repo", tempdir], mock.ANY
         )
 
-    def test_with_temporary_repository(self):
+    def test_with_temporary_repository(self, git):
         config = {"user.name": "Test User", "user.email": "test@example.com"}
 
-        with GitClient.with_temporary_repository(config) as git:
+        with git.with_temporary_repository(config) as git:
             assert git.repository_available
 
             with open("test.txt", "w", encoding="utf-8") as f:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -243,10 +243,10 @@ class TestGitClient(object):
             ["git", "clone", "https://some-fake-repo", tempdir], mock.ANY
         )
 
-    def test_with_temporary_repository(self, git):
+    def test_temporary_repository(self, git):
         config = {"user.name": "Test User", "user.email": "test@example.com"}
 
-        with git.with_temporary_repository(config) as git:
+        with git.temporary_repository(config) as git:
             assert git.repository_available
 
             with open("test.txt", "w", encoding="utf-8") as f:
@@ -259,7 +259,7 @@ class TestGitClient(object):
 
         assert not os.path.exists(git_dir)
 
-    def test_with_temporary_repository_raises_if_repo_exists(self, git):
+    def test_temporary_repository_raises_if_repo_exists(self, git):
         config = {"user.name": "Test User", "user.email": "test@example.com"}
 
         # Create a repository first
@@ -267,7 +267,7 @@ class TestGitClient(object):
 
         # Try to create another repository in the same directory
         with pytest.raises(GitError) as exc_info:
-            with GitClient.with_temporary_repository(config) as git:
+            with GitClient.temporary_repository(config) as git:
                 pass
 
         assert "already exists" in str(exc_info.value)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -202,15 +202,15 @@ class TestGitClient(object):
         with open("subdir/test3.txt", "w", encoding="utf-8") as f:
             f.write("test3")
 
-        # Without ensure_repo_exists, should raise GitError
+        # Should raise GitError when no repository exists
         with pytest.raises(GitError) as exc_info:
             git.files()
         assert "No Git repository found" in str(exc_info.value)
 
-        # With ensure_repo_exists=True, should create temp repo and return all files
-        files = git.files(ensure_repo_exists=True)
+        # After creating a repository, should return all files
+        git.init()
+        files = git.files()
         assert files == {"test1.txt", "test2.txt", "subdir/test3.txt"}
-        assert not os.path.exists(".git")  # Temp repo should be cleaned up
 
     def test_git_availability(self, git):
         assert git.client_available

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -195,6 +195,15 @@ class TestGitClient(object):
     def test_files_on_non_git_repo(self, git):
         assert git.files() == set()
 
+    def test_git_availability(self, git):
+        assert git.client_available
+        assert not git.repository_available
+
+        config = {"user.name": "Test User", "user.email": "test@example.com"}
+        git.init(config=config)
+
+        assert git.repository_available
+
     def test_includes_details_in_exceptions(self, git):
         with pytest.raises(Exception) as ex_info:
             git.push("foo", "bar")


### PR DESCRIPTION
Fixed a bug where `ExperimentFileSource.map_locations_to` was ignoring `.gitignore` when no Git repository was available.