### PR TITLE
Issues/7787 quieter debug

### DIFF
--- a/dallinger/data.py
+++ b/dallinger/data.py
@@ -477,7 +477,8 @@ class Table(object):
     """Dallinger data-table object."""
 
     def __init__(self, path):
-        self.tablib_dataset = tablib.Dataset().load(open(path).read(), "csv")
+        with open(path) as f:
+            self.tablib_dataset = tablib.Dataset().load(f.read(), "csv")
 
     @property
     def csv(self):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -272,16 +272,10 @@ class DevelopmentDeployment(object):
 
     def run(self):
         """Bootstrap the environment and reset the database."""
-        self.out.log("Preparing your pristine development environment...")
         experiment_uid, dst = bootstrap_development_session(
             self.exp_config, os.getcwd(), self.out.log
         )
         db.init_db(drop_all=True)
-        self.out.log(
-            f"Files symlinked in {dst}.\n"
-            "Run './run.sh' in that directory to start Flask, "
-            "plus the worker and clock processes."
-        )
 
 
 class HerokuLocalDeployment(object):

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -268,7 +268,7 @@ class DevelopmentDeployment(object):
     def __init__(self, output, exp_config):
         self.out = output
         self.exp_config = exp_config or {}
-        self.exp_config.update({"mode": "debug", "loglevel": 0})
+        self.exp_config.update({"mode": "debug"})
 
     def run(self):
         """Bootstrap the environment and reset the database."""
@@ -289,7 +289,7 @@ class HerokuLocalDeployment(object):
     DO_INIT_DB = True
 
     def configure(self):
-        self.exp_config.update({"mode": "debug", "loglevel": 0})
+        self.exp_config.update({"mode": "debug"})
 
     def setup(self):
         self.exp_id, self.tmp_dir = setup_experiment(

--- a/dallinger/dev_server/run.sh
+++ b/dallinger/dev_server/run.sh
@@ -5,6 +5,5 @@ export FLASK_DEBUG=1
 # --eager-loading is required because we're patching IO with gevent.monkey.patch_all()
 # See somewhat indirect reference:
 # https://github.com/miguelgrinberg/Flask-SocketIO/issues/901
-echo "Starting flask..."
-echo "Remember to terminate this process with <control-c> before running 'dallinger bootstrap' again"
+
 flask run ${FLASK_OPTIONS} "$@"

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -420,14 +420,6 @@ def launch():
             status=500,
             simple=True,
         )
-    try:
-        exp.log("Launching experiment...", "-----")
-    except IOError as ex:
-        return error_response(
-            error_text="IOError writing to experiment log: {}".format(str(ex)),
-            status=500,
-            simple=True,
-        )
 
     try:
         exp.on_launch()

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -432,6 +432,9 @@ def launch():
         )
 
     recruitment_details = None
+    config = _config()
+    loglevel = config.get("loglevel", 0)
+    recruiters.set_log_level(loglevel)
     try:
         recruitment_details = exp.recruiter.open_recruitment(
             n=exp.initial_recruitment_size
@@ -456,7 +459,7 @@ def launch():
                 simple=True,
             )
 
-    if _config().get("replay", False):
+    if config.get("replay", False):
         try:
             task = ReplayBackend(exp)
             gevent.spawn(task)

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -66,8 +66,10 @@ class HerokuCommandRunner(object):
 
     def __del__(self):
         # Make sure we close our filehandle when object deleted
-        if hasattr(self, "out_muted") and self.out_muted and not self.out_muted.closed:
+        try:
             self.out_muted.close()
+        except Exception:
+            pass
 
     @property
     def sys_encoding(self):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -50,6 +50,34 @@ from dallinger.utils import (
 logger = logging.getLogger(__name__)
 
 
+def set_log_level(level):
+    """Set the logging level for this module's logger at runtime.
+
+    Args:
+        level (int): An integer from 0 to 4, corresponding to the desired logging level.
+        This is the scale used by Dallinger's ``loglevel`` config variable.
+
+    Notes:
+        - If an invalid level is provided, the logger will be set to NOTSET,
+          which inherits the parent logger's level.
+        - This only affects logging output from this module, not globally.
+    """
+
+    loglevels = [
+        logging.DEBUG,
+        logging.INFO,
+        logging.WARNING,
+        logging.ERROR,
+        logging.CRITICAL,
+    ]
+    try:
+        new_level = loglevels[level]
+    except IndexError:
+        new_level = logging.NOTSET
+
+    logger.setLevel(new_level)
+
+
 def handle_recruitment_error(ex):
     # Default behavior for backward compatibility
     logger.exception(str(ex))

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -83,7 +83,7 @@ def run_status_check():
     for participant in Participant.query.all():
         participants_by_recruiter_nick[participant.recruiter_id].append(participant)
 
-    logger.info(
+    logger.debug(
         "Checking status of all participants: {}".format(participants_by_recruiter_nick)
     )
 
@@ -538,7 +538,7 @@ class ProlificRecruiter(Recruiter):
     def open_recruitment(self, n: int = 1) -> dict:
         """Create a Study on Prolific."""
 
-        logger.info(f"Opening Prolific recruitment for {n} participants")
+        logger.debug(f"Opening Prolific recruitment for {n} participants")
         if self.is_in_progress:
             raise ProlificRecruiterException(
                 "Tried to open recruitment, but a Prolific Study "
@@ -606,7 +606,7 @@ class ProlificRecruiter(Recruiter):
     def recruit(self, n: int = 1):
         """Recruit `n` new participants to an existing Prolific Study"""
         if not self.config.get("auto_recruit"):
-            logger.info("auto_recruit is False: recruitment suppressed")
+            logger.debug("auto_recruit is False: recruitment suppressed")
             return
 
         return self.prolificservice.add_participants_to_study(
@@ -751,7 +751,7 @@ class ProlificRecruiter(Recruiter):
                     participant.id,
                 )
             else:
-                logger.info(f"Status already in sync for {participant.id}")
+                logger.debug(f"Status already in sync for {participant.id}")
 
     @property
     def study_id_storage_key(self):
@@ -958,7 +958,7 @@ class MockRecruiter(Recruiter):
         """
         Open recruitment for the current experiment.
         """
-        logger.info(f"Mock recruiter {self.nickname} NOT opening any recruitment")
+        logger.debug(f"Mock recruiter {self.nickname} NOT opening any recruitment")
         self.register_study()
         return {"items": [], "message": ""}
 
@@ -1022,7 +1022,7 @@ class CLIRecruiter(Recruiter):
         """Return initial experiment URL list, plus instructions
         for finding subsequent recruitment events in experiment logs.
         """
-        logger.info("Opening CLI recruitment for {} participants".format(n))
+        logger.debug("Opening CLI recruitment for {} participants".format(n))
         recruitments = self.recruit(n)
         message = (
             "\nSingle recruitment link: {}/ad?recruiter={}&generate_tokens=1&mode={}\n\n"
@@ -1040,7 +1040,7 @@ class CLIRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Generate experiment URLs and print them to the console."""
-        logger.info("Recruiting {} CLI participants".format(n))
+        logger.debug("Recruiting {} CLI participants".format(n))
         urls = []
         template = "{}/ad?recruiter={}&assignmentId={}&hitId={}&workerId={}&mode={}"
         for i in range(n):
@@ -1063,12 +1063,12 @@ class CLIRecruiter(Recruiter):
 
     def approve_hit(self, assignment_id):
         """Approve the HIT."""
-        logger.info("Assignment {} has been marked for approval".format(assignment_id))
+        logger.debug("Assignment {} has been marked for approval".format(assignment_id))
         return True
 
     def assign_experiment_qualifications(self, worker_id, qualifications):
         """Assigns recruiter-specific qualifications to a worker."""
-        logger.info(
+        logger.debug(
             "Worker ID {} earned these qualifications: {}".format(
                 worker_id, qualifications
             )
@@ -1076,7 +1076,7 @@ class CLIRecruiter(Recruiter):
 
     def reward_bonus(self, participant, amount, reason):
         """Print out bonus info for the assignment"""
-        logger.info(
+        logger.debug(
             'Award ${} for assignment {}, with reason "{}"'.format(
                 amount, participant.assignment_id, reason
             )
@@ -1085,8 +1085,8 @@ class CLIRecruiter(Recruiter):
     def verify_status_of(self, participants: list[Participant]):
         """We only track participants locally, so we have nothing to do."""
         for p in participants:
-            logger.info("{} -> {}".format(p.id, p.status))
-        logger.info(
+            logger.debug("{} -> {}".format(p.id, p.status))
+        logger.debug(
             f"{self.__class__.__name__} implicitly verifying status "
             "of all its participants. 👍"
         )
@@ -1108,7 +1108,7 @@ class HotAirRecruiter(CLIRecruiter):
         """Return initial experiment URL list, plus instructions
         for finding subsequent recruitment events in experiment logs.
         """
-        logger.info("Opening HotAir recruitment for {} participants".format(n))
+        logger.debug("Opening HotAir recruitment for {} participants".format(n))
         recruitments = self.recruit(n)
         message = (
             "\nSingle recruitment link: {}/ad?recruiter={}&generate_tokens=1&mode={}\n\n"
@@ -1121,7 +1121,7 @@ class HotAirRecruiter(CLIRecruiter):
 
     def reward_bonus(self, participant, amount, reason):
         """Logging-only, Hot Air implementation"""
-        logger.info(
+        logger.debug(
             "Were this a real Recruiter, we'd be awarding ${} for assignment {}, "
             'with reason "{}"'.format(amount, participant.assignment_id, reason)
         )
@@ -1147,12 +1147,12 @@ class SimulatedRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Open recruitment."""
-        logger.info("Opening Sim recruitment for {} participants".format(n))
+        logger.debug("Opening Sim recruitment for {} participants".format(n))
         return {"items": self.recruit(n), "message": "Simulated recruitment only"}
 
     def recruit(self, n=1):
         """Recruit n participants."""
-        logger.info("Recruiting {} Sim participants".format(n))
+        logger.debug("Recruiting {} Sim participants".format(n))
         return []
 
     def close_recruitment(self):
@@ -1444,7 +1444,7 @@ class MTurkRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Open a connection to AWS MTurk and create a HIT."""
-        logger.info("Opening MTurk recruitment for {} participants".format(n))
+        logger.debug("Opening MTurk recruitment for {} participants".format(n))
         if self.is_in_progress:
             raise MTurkRecruiterException(
                 "Tried to open recruitment on already open recruiter."
@@ -1562,14 +1562,14 @@ class MTurkRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n new participants to an existing HIT"""
-        logger.info("Recruiting {} MTurk participants".format(n))
+        logger.debug("Recruiting {} MTurk participants".format(n))
         if not self.config.get("auto_recruit"):
-            logger.info("auto_recruit is False: recruitment suppressed")
+            logger.debug("auto_recruit is False: recruitment suppressed")
             return
 
         hit_id = self.current_hit_id()
         if hit_id is None:
-            logger.info("no HIT in progress: recruitment aborted")
+            logger.debug("no HIT in progress: recruitment aborted")
             return
 
         try:
@@ -1648,7 +1648,7 @@ class MTurkRecruiter(Recruiter):
         because MTurk sends prompt SNS notifications when participants
         submit, return, or abandon HITs.
         """
-        logger.info("MTurkRecruiter assuming all is well with participant status...")
+        logger.debug("MTurkRecruiter assuming all is well with participant status...")
 
     def reward_bonus(self, participant, amount, reason):
         """Reward the Turker for a specified assignment with a bonus."""
@@ -1929,7 +1929,7 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         super(MTurkLargeRecruiter, self).__init__(*args, **kwargs)
 
     def open_recruitment(self, n=1):
-        logger.info("Opening MTurkLarge recruitment for {} participants".format(n))
+        logger.debug("Opening MTurkLarge recruitment for {} participants".format(n))
         if self.is_in_progress:
             raise MTurkRecruiterException(
                 "Tried to open recruitment on already open recruiter."
@@ -1939,9 +1939,9 @@ class MTurkLargeRecruiter(MTurkRecruiter):
         return super(MTurkLargeRecruiter, self).open_recruitment(to_recruit)
 
     def recruit(self, n=1):
-        logger.info("Recruiting {} MTurkLarge participants".format(n))
+        logger.debug("Recruiting {} MTurkLarge participants".format(n))
         if not self.config.get("auto_recruit"):
-            logger.info("auto_recruit is False: recruitment suppressed")
+            logger.debug("auto_recruit is False: recruitment suppressed")
             return
 
         needed = max(0, n - self.remaining_pool)
@@ -1966,7 +1966,7 @@ class BotRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Start recruiting right away."""
-        logger.info("Opening Bot recruitment for {} participants".format(n))
+        logger.debug("Opening Bot recruitment for {} participants".format(n))
         factory = self._get_bot_factory()
         bot_class_name = factory("", "", "").__class__.__name__
         return {
@@ -1976,7 +1976,7 @@ class BotRecruiter(Recruiter):
 
     def recruit(self, n=1):
         """Recruit n new participant bots to the queue"""
-        logger.info("Recruiting {} Bot participants".format(n))
+        logger.debug("Recruiting {} Bot participants".format(n))
         factory = self._get_bot_factory()
         urls = []
         q = get_queue(name="low")
@@ -2017,7 +2017,7 @@ class BotRecruiter(Recruiter):
 
     def reward_bonus(self, participant, amount, reason):
         """Logging only. These are bots."""
-        logger.info("Bots don't get bonuses. Sorry, bots.")
+        logger.debug("Bots don't get bonuses. Sorry, bots.")
 
     def on_task_completion(self):
         return {
@@ -2027,7 +2027,7 @@ class BotRecruiter(Recruiter):
 
     def verify_status_of(self, participants: list[Participant]):
         """All our bots are belong to us, so we don't need to do anything."""
-        logger.info("BotRecruiter assuming all is well with participant status...")
+        logger.debug("BotRecruiter assuming all is well with participant status...")
 
     def _get_bot_factory(self):
         # Must be imported at run-time
@@ -2101,7 +2101,7 @@ class MultiRecruiter(Recruiter):
 
     def open_recruitment(self, n=1):
         """Return initial experiment URL list."""
-        logger.info("Multi recruitment running for {} participants".format(n))
+        logger.debug("Multi recruitment running for {} participants".format(n))
         recruitments = []
         messages = {}
         remaining = n
@@ -2120,7 +2120,7 @@ class MultiRecruiter(Recruiter):
             if remaining <= 0:
                 break
 
-        logger.info(
+        logger.debug(
             (
                 "Multi-recruited {} out of {} participants, " "using {} recruiters."
             ).format(n - remaining, n, len(messages))

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -442,10 +442,9 @@ def get_editable_dallinger_path():
 def check_local_db_connection(log):
     """Verify that the local Postgres server is running."""
     try:
-        log("Checking your local Postgres database connection...")
         db.check_connection()
     except Exception:
-        log("There was a problem connecting!")
+        log("There was a problem connecting to the local Postgres server!")
         raise
 
 
@@ -530,7 +529,6 @@ def bootstrap_development_session(exp_config, experiment_path, log):
     source_path = Path(dallinger_package_path()) / "dev_server"
     destination_path = develop_target_path(config)
 
-    log("Wiping develop directory and re-writing it...")
     ensure_directory(destination_path)
     expunge_directory(destination_path)
     collate_experiment_files(

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -45,8 +45,7 @@ General
 
 ``loglevel`` *unicode*
     A number between 0 and 4 that controls the verbosity of logs, from ``debug``
-    to ``critical``. Note that ``dallinger debug`` ignores this setting and always
-    runs at 0 (``debug``).
+    to ``critical``.
 
 ``loglevel_worker`` *unicode*
     A number between 0 and 4 that controls the verbosity of worker logs, from 0 (debug)

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -207,7 +207,6 @@ class TestDevelopCommand(object):
         result = CliRunner().invoke(develop, ["bootstrap"])
 
         assert result.exit_code == 0
-        assert "Preparing your pristine development environment" in result.output
         assert found_in("app.py", develop_directory)
         assert found_in("run.sh", develop_directory)
         assert found_in("experiment.py", develop_directory)

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1609,24 +1609,6 @@ class TestLaunchRoute(object):
         assert resp.status_code == 200
         mock_exp.recruiter.open_recruitment.assert_called()
 
-    def test_launch_logging_fails(self, webapp):
-        with mock.patch(
-            "dallinger.experiment_server.experiment_server.Experiment"
-        ) as mock_class:
-            bad_log = mock.Mock(side_effect=IOError)
-            mock_exp = mock.Mock(log=bad_log)
-            mock_exp.protected_routes = []
-            mock_exp.channel = None
-            mock_class.return_value = mock_exp
-            resp = webapp.post("/launch", data={})
-
-        assert resp.status_code == 500
-        data = json.loads(resp.get_data())
-        assert data == {
-            "message": "IOError writing to experiment log: ",
-            "status": "error",
-        }
-
     def test_launch_establishes_channel_subscription(self, webapp, active_config):
         with mock.patch(
             "dallinger.experiment_server.experiment_server.Experiment"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -115,7 +115,9 @@ class TestAppConfiguration(object):
     ):
         active_config.set("protected_routes", '["/robots.txt"]')
 
-        assert webapp_admin.get("/robots.txt").status == "200 OK"
+        resp = webapp_admin.get("/robots.txt")
+        assert resp.status == "200 OK"
+        resp.close()
 
 
 @pytest.mark.usefixtures("experiment_dir")
@@ -608,10 +610,12 @@ class TestSimpleGETRoutes(object):
         resp = webapp.get("/favicon.ico")
         assert resp.content_type == "image/x-icon"
         assert resp.content_length > 0
+        resp.close()
 
     def test_robots(self, webapp):
         resp = webapp.get("/robots.txt")
         assert b"User-agent" in resp.data
+        resp.close()
 
     def test_consent(self, webapp):
         resp = webapp.get(

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -660,9 +660,10 @@ class TestHerokuLocalWrapper(object):
         heroku.start()
         heroku._process.terminate()
         heroku.stop()
+        log_calls = [call.args[0] for call in heroku.out.log.mock_calls]
         assert (
-            mock.call("Local Heroku was already terminated.")
-            in heroku.out.log.mock_calls
+            "Local Heroku was already terminated." in log_calls
+            or "Local Heroku process terminated." in log_calls
         )
 
     def test_start_when_shell_command_fails(self, heroku):

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -557,12 +557,7 @@ class TestHerokuLocalWrapper(object):
 
         wrapper = HerokuLocalWrapper(config, output, env=env)
         yield wrapper
-        try:
-            print("Calling stop() on {}".format(wrapper))
-            print(wrapper._record[-1])
-            wrapper.stop(signal.SIGKILL)
-        except (IndexError, TypeError):
-            pass
+        wrapper.stop()
 
     def test_start(self, heroku):
         assert heroku.start()
@@ -619,7 +614,7 @@ class TestHerokuLocalWrapper(object):
         heroku._stream = mock.Mock(
             return_value=["real", "stopped", heroku.STREAM_SENTINEL]
         )
-        heroku._process = mock.Mock()
+        heroku._process = mock.Mock(pid=12345)
         heroku._process.poll = mock.Mock(return_value=1)
         heroku._log_failure()
         heroku._process.poll.assert_called_once()
@@ -635,7 +630,7 @@ class TestHerokuLocalWrapper(object):
                 heroku.STREAM_SENTINEL,
             ]
         )
-        heroku._process = mock.Mock()
+        heroku._process = mock.Mock(pid=12345)
         heroku._process.poll = mock.Mock(return_value=None)
         heroku._log_failure()
         assert heroku._record == ["real", "more"]
@@ -649,7 +644,7 @@ class TestHerokuLocalWrapper(object):
             yield heroku.STREAM_SENTINEL
 
         heroku._stream = mock.Mock(return_value=timeout_stream())
-        heroku._process = mock.Mock()
+        heroku._process = mock.Mock(pid=12345)
         heroku._process.poll = mock.Mock(return_value=None)
         start_time = time.time()
         heroku._log_failure()
@@ -665,7 +660,10 @@ class TestHerokuLocalWrapper(object):
         heroku.start()
         heroku._process.terminate()
         heroku.stop()
-        mock.call("Local Heroku was already terminated.") in heroku.out.log.mock_calls
+        assert (
+            mock.call("Local Heroku was already terminated.")
+            in heroku.out.log.mock_calls
+        )
 
     def test_start_when_shell_command_fails(self, heroku):
         heroku.shell_command = "nonsense"


### PR DESCRIPTION
## Description
Addresses https://github.com/Dallinger/Dallinger/issues/7787

Additionally, improves cleanup of resources (file handles, sub-processes) to quiet warning in test output (and possibly improve production code)

## Motivation and Context
Debug/develop mode is overly verbose, particularly on startup. This PR reduces overall verbosity, and removes the hard-coding of `loglevel=0` when running in debug mode (though it's still the default).

## How Has This Been Tested?
* Automated tests
* `dallinger develop debug` in local Bartlett1932 demo

