### PR TITLE
More extensive WebSocket documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,7 +11,6 @@ build:
 python:
   install:
     - requirements: dev-requirements.txt
-    - requirements: requirements-readthedocs.txt
     - method: pip
       path: .
       extra_requirements:

--- a/constraints.txt
+++ b/constraints.txt
@@ -548,9 +548,12 @@ sphinx==8.1.3
     # via
     #   dallinger
     #   myst-parser
+    #   sphinx-js
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-spelling
+sphinx-js==4.0.0
+    # via dallinger
 sphinx-rtd-theme==3.0.2
     # via dallinger
 sphinxcontrib-applehelp==2.0.0

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -389,7 +389,9 @@ class Experiment(object):
             if message.get("immediate"):
                 with db.sessions_scope():
                     self.receive_message(
-                        message_string, channel_name=channel_name, receive_time=receive_time
+                        message_string,
+                        channel_name=channel_name,
+                        receive_time=receive_time,
                     )
                     return
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -273,8 +273,8 @@ class Experiment(object):
 
     @property
     def background_tasks(self):
-        """An experiment may define functions or methods to be started as
-        background tasks upon experiment launch.
+        """Optional list of functions that will be run at launch time in
+        separate threads.
         """
         return []
 

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -129,7 +129,7 @@ def worker_function(
                 key,
             )
             return
-    elif not participant and not node:
+    elif not participant and not node and event_type != "WebSocketMessage":
         raise ValueError(
             "Error: worker_function needs either an assignment_id or a "
             "participant_id, they cannot both be None"

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,6 +16,8 @@ anyio==4.10.0
     # via
     #   httpx
     #   jupyter-server
+appnope==0.1.4
+    # via ipykernel
 apscheduler==3.11.0
     # via dallinger
 argon2-cffi==25.1.0
@@ -164,7 +166,6 @@ greenlet==3.2.4
     # via
     #   dallinger
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via dallinger
 h11==0.16.0
@@ -227,6 +228,7 @@ jinja2==3.1.6
     #   myst-parser
     #   nbconvert
     #   sphinx
+    #   sphinx-js
 jmespath==1.0.1
     # via
     #   boto3
@@ -301,6 +303,7 @@ markupsafe==3.0.2
     #   flask
     #   jinja2
     #   nbconvert
+    #   sphinx-js
     #   werkzeug
     #   wtforms
 matplotlib-inline==0.1.7
@@ -380,6 +383,8 @@ paramiko==4.0.0
     # via
     #   dallinger
     #   sshtunnel
+parsimonious==0.10.0
+    # via sphinx-js
 parso==0.8.4
     # via jedi
 pathspec==0.12.1
@@ -548,9 +553,12 @@ sphinx==8.1.3
     # via
     #   dallinger
     #   myst-parser
+    #   sphinx-js
     #   sphinx-rtd-theme
     #   sphinxcontrib-jquery
     #   sphinxcontrib-spelling
+sphinx-js==4.0.0
+    # via dallinger
 sphinx-rtd-theme==3.0.2
     # via dallinger
 sphinxcontrib-applehelp==2.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -168,7 +168,6 @@ html_theme_options = {
     #    'logo_name': True,
     "canonical_url": "",
     "analytics_id": "",
-    "display_version": True,
     "prev_next_buttons_location": "bottom",
     "style_external_links": True,
     # Toc options

--- a/docs/source/the_experiment_class.rst
+++ b/docs/source/the_experiment_class.rst
@@ -45,6 +45,9 @@ what to do with the database when the server receives requests from outside.
   .. autoattribute:: hidden_dashboards
     :annotation:
 
+  .. autoattribute:: background_tasks
+    :annotation:
+
   .. autoattribute:: channel
     :annotation:
 

--- a/docs/source/using_websockets.rst
+++ b/docs/source/using_websockets.rst
@@ -4,30 +4,186 @@ Using WebSockets in Dallinger Experiments
 Dallinger provides some helpers to facilitate realtime communication between
 participants and the experiment using the WebSocket protocol.
 
-The integration consists of a web API route `GET /chat?channel=<channel>` (see
-:doc:`The Web API <web_api>`) to open a WebSocket connection with a
-"subscription" to messages on a specific "channel".
+The experiment server runs a WebSocket service located at the route `/chat` that
+implements a Publish-Subscribe pattern. Connecting to that service with a
+`channel` argument in the url will subscribe a client to all messages sent to
+the named channel. If the named "channel" doesn't already exist it will be
+created on the server. Both clients (participants) and the experiment instance
+can subscribe and create channels.
 
-Additionally, Experiment classes can implement a
-:attr:`~dallinger.experiment.Experiment.channel` attribute which will subscribe
-the experiment class to a the named channel. Such experiments should implement a
-:func:`~dallinger.experiment.Experiment.receive_message` method to receive and
-process any messages on the specified channel as well as the control channel
-named `"dallinger_control"`. This function will be called asynchronously by a
-worker when the message contains JSON data that includes a ``sender`` or
-``participant_id`` property containing the sender's Participant id or a
-``node_id`` containing a Node id.
+The channel backend publishes all incoming messages to a redis queue. It also looks for
+new messages on the queue for and relays channel specific messages to all
+channel subscribers (generally either participants or the experiment itself).
 
-Experiments may also send messages to clients subscribed to a channel using the
+When a client makes a WebSocket connection to the `/chat?channel=<channel>`
+route (see :doc:`The Web API <web_api>`) it opens a persistent connection to the
+experiment over which it can send messages (to any channel) and will receive all
+messages published to the `channel` named in the initial request.
+
+Additionally, Experiment classes can provide a
+:attr:`~dallinger.experiment.Experiment.channel` attribute which will
+automatically subscribe the experiment class to the named channel. Experiments
+that specify a channel will also be subscribed to a control channel named
+`"dallinger_control"` to which client connection, disconnection, subscribe, and
+unsubscribe messages are automatically sent. Such experiments should implement a
+custom :func:`~dallinger.experiment.Experiment.receive_message` method to
+receive and process incoming WebSocket messages.
+
+Experiments may also send messages to all channel subscribers using the
 :func:`~dallinger.experiment.Experiment.publish_to_subscribers` method.
 
-If you would like your experiment class to receive messages published on
-additional WebSocket channels, you will need to subscribe to them in your
-Experiment class's :func:`~dallinger.experiment.Experiment.on_launch` method.
-For example
+It's possible for an experiment class to subscribe to messages on
+additional WebSocket channels. To avoid duplicate subscriptions it's generally
+best to create such subscriptions in your Experiment class's
+:func:`~dallinger.experiment.Experiment.on_launch` method which is only run at
+experiment launch time, or using the experiment's
+:func:`~dallinger.experiment.Experiment.background_tasks`. For example
 
 ::
 
     def on_launch(self):
         from dallinger.experiment_server.sockets import chat_backend
         chat_backend.subscribe(self, 'my_secondary_channel')
+
+An experiment can create and subscribe to channels after launch, but would need
+to be careful to ensure each channel is only ever subscribed once per experiment
+run. This is likely to be difficult because the experiment potentially has many
+instances running concurrently across multiple processes and servers.
+
+Websocket messages are strings consisting of a channel name followed by a `:`
+and then a message payload. The message payload is usually a string representing
+a JSON object. When an experiment receives a message where the payload is a JSON
+object containing either a `node_id` property or a `participant_id` value (the
+properties `participant_id`, `sender`, and `client.participant_id` are treated
+as equivalent), then the experiment will queue such messages to be processed
+asynchronously. Otherwise, the messages will be processed synchronously by an
+experiment instance. In either case, the
+:func:`~dallinger.experiment.Experiment.receive_message` method will handle the
+message.
+
+Client Implementation
+---------------------
+
+The default experiment layout includes a `basic websocket communication library
+<https://www.npmjs.com/package/reconnecting-websocket>`_ which implements a
+`ReconnectingWebSocket` object that can be used to establish channel
+subscriptions, send messages to various channels, and receive messages on
+subscribed channels.
+
+Typically experiments set up a WebSocket connection after completing the initial
+call to `createAgent` using code similar to this
+
+::
+    var broadcast_socket;
+
+    var open_socket = function (channel_id) {
+        var ws_scheme = (window.location.protocol === "https:") ? 'wss://' : 'ws://';
+        // Setup a websocket connection to the channel, passing our worker_id and participant_id
+        socket = new ReconnectingWebSocket(
+            ws_scheme + location.host + "/chat?channel=" + channel_id +"&worker_id=" + dallinger.identity.workerId + '&participant_id=' + dallinger.identity.participantId
+        );
+        // Once the connection is established, send an initial message to the channel
+        socket.onopen(function () {
+            socket.send(channel_id + ':{"message": "Hello world!"}');
+        });
+        // Handle any incoming messages
+        socket.onmessage = function (msg) {
+            // Ignore messages not from the channel subscribed channel
+            if (msg.data.indexOf(channel_id + ':') !== 0) { return; }
+            // Parse the payload
+            var data = JSON.parse(msg.data.substring(channel_id.length + 1));
+            // Example message data
+            var type = data.type;
+            // Take different actions based on message type
+            switch(type) {
+               ...
+            }
+        };
+        return socket;
+    };
+
+    // Create the agent.
+    var create_agent = function() {
+        dallinger.createAgent()
+            .done(function (resp) {
+                ...
+                broadcast_socket = open_socket("broadcast_channel");
+            })
+            .fail(function (rejection) {
+                ...
+            });
+    };
+
+
+When establishing a channel subscription using the `/chat` route, the client can
+include `worker_id` and `participant_id` values which will be included in the
+`"dallinger_control"` channel messages alerting the experiment to WebSocket
+connection, disconnection, subscription, and un-subscription events.
+
+Messages sent over the socket connection can be prefixed with any channel name,
+not just the channel to which the connection is subscribed. Additional
+subscriptions can be established by opening new websocket connections to
+the `/chat` route with different `channel` values.
+
+
+Experiment Channel Setup
+------------------------
+
+Many experiment use cases will only need a "broadcast channel" to which all
+clients subscribe. That subscription can be established when the experiment
+starts (i.e. when `createAgent` returns). This "broadcast channel" would be
+separate from the one set in the `Experiment.channel` attribute, which we will
+call the "experiment control channel".
+
+Clients will receive all messages sent to the "broadcast channel" by either the
+experiment or other clients. The messages will generally contain JSON payloads
+that indicate the messages' purpose. For example, messages may have a `type`
+property to differentiate e.g. "state" messages sent by the experiment server
+from "chat" messages sent by other clients. Additionally, such "chat" messages
+might have `room` or `recipient` properties to allow clients to filter
+out messages not intended for them.
+
+Generally, clients will send messages about their actions to the "experiment
+control channel". Those messages will be processed by the experiment and will
+not be relayed to other clients, because clients are not generally
+subscribed to the "experiment control channel".
+
+The experiment sends messages to all clients over the "broadcast channel", but
+generally does not subscribe to the "broadcast channel". If an experiment needs
+to handle messages sent by clients over the "broadcast channel", then it's
+generally simplest for clients to send such messages both to the "broadcast
+channel" and to the "experiment control channel" (perhaps with an additional
+`broadcast` flag). It is possible to subscribe the experiment to the "broadcast
+channel", but that would also require the experiment to handle/ignore the
+messages that the experiment itself sends over that channel.
+
+
+Multiple Client Channels
+------------------------
+
+If it's important for an experiment to have participant and/or group specific
+channels, e.g. to ensure messages are only ever seen by their targets, or to
+reduce the total number of messages sent to or processed by clients, then
+clients can subscribe to multiple channels.
+
+For example, after launch an experiment could broadcast a `create_chatroom` type
+message with a `chatroom` property set to "room_name" and an array of
+`partcicpant_ids`. Clients could then subscribe to the "room_name" channel using
+the `/chat` route only if their `participant_id` matches one of the values in
+`participant_ids`. That way only only the clients with the matching
+`participant_ids` would receive messages for "room_name".
+
+If these chat room messages need to be handled by the experiment code, then the
+clients could also send these messages to the "experiment control channel", with
+an additional `chatroom` property to specify the channel. Alternatively, if the
+names of all chatrooms could be determined at experiment launch time, then
+duplicate messages can be avoided by having the experiment subscribe to all
+chatrooms in :func:`~dallinger.experiment.Experiment.on_launch` or using
+:func:`~dallinger.experiment.Experiment.background_tasks`.
+
+Similarly, if the experiment needs to send messages privately to specific
+participants, then every client could use the `/chat` route to subscribe to a
+unique channel like `participant_${participant_id}_channel`, to which the
+experiment instance could send private messages using
+`self.publish_to_subscribers(payload, channel_name=channel)` or
+`redis_conn.publish(f"participant_${participant_id}_channel", payload)`.

--- a/docs/source/using_websockets.rst
+++ b/docs/source/using_websockets.rst
@@ -53,16 +53,12 @@ Websocket messages are strings consisting of a channel name followed by a `:`
 and then a message payload. The message payload is usually a string representing
 a JSON object.
 
-Messages are handled by the
+Messages are handled asynchronously by the
 :func:`~dallinger.experiment.Experiment.receive_message` method of the
-experiment class. Messages that include a `node_id` or `participant_id`/`sender`
-in their JSON payload are handled asynchronously, all other messages will be
-processed synchronously because the asynchronous worker requires node or
-participant information.
-
-Experiments that wish to override the default asynchronous handling of WebSocket
-messages may override the :func:`~dallinger.experiment.Experiment.send` method
-of the experiment class.
+experiment class. Experiments which wish to override the default asynchronous
+handling of WebSocket messages (e.g. because they retain non-persisted state in
+the experiment instance that is needed to process the message) may override the
+:func:`~dallinger.experiment.Experiment.send` method of the experiment class.
 
 Client Implementation
 ---------------------

--- a/docs/source/using_websockets.rst
+++ b/docs/source/using_websockets.rst
@@ -60,6 +60,14 @@ handling of WebSocket messages (e.g. because they retain non-persisted state in
 the experiment instance that is needed to process the message) may override the
 :func:`~dallinger.experiment.Experiment.send` method of the experiment class.
 
+If your experiment implements synchronous handling of messages either using a
+custom :func:`~dallinger.experiment.Experiment.send` or by sending the
+`immediate` flag in your message payload, it will need to ensure that it takes
+care to manage any database sessions. The
+`dallinger.db.scoped_session_decorator` can be used to wrap functions and the
+`dallinger.db.sessions_scope` contextmanager can provide more granular/repeated
+session management.
+
 Client Implementation
 ---------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ dev = [
     "sphinx < 8.2",
     "sphinx_rtd_theme",
     "sphinxcontrib-spelling",
-    "sphinx_js",
+    "sphinx-js",
     "tox",
 ]
 docker = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ dev = [
     "sphinx < 8.2",
     "sphinx_rtd_theme",
     "sphinxcontrib-spelling",
+    "sphinx_js",
     "tox",
 ]
 docker = [

--- a/requirements-readthedocs.txt
+++ b/requirements-readthedocs.txt
@@ -1,1 +1,0 @@
-sphinx-js@https://github.com/Dallinger/sphinx-js/archive/refs/tags/3.2.2-markupsafe-fix.zip

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,6 @@ greenlet==3.2.4
     # via
     #   dallinger
     #   gevent
-    #   sqlalchemy
 gunicorn==23.0.0
     # via dallinger
 h11==0.16.0

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
-compat=""
-if [ "$OSTYPE" = "darwin"* ]; then
-    compat=" "
-fi
 
 dir=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 cd $dir/..
@@ -13,7 +9,7 @@ pip-compile --rebuild --strip-extras --upgrade dev-requirements.in
 pip-compile --rebuild --strip-extras --upgrade
 
 # Remove the line specifying dallinger as editable dependency
-sed -e "s/^-e.*//" -i$compat'' *.txt
+sed -e "s/^-e.*//" -i.bak *.txt
 
 # Post-process the constraints.txt and dev-requirements.txt files to replace "via file://..."
 # with "via constraints.in" and " via dev-requirements.in", respectively.

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -112,7 +112,11 @@ class TestVerify(object):
 class TestCommandLine(object):
     def test_dallinger_no_args(self):
         result = subprocess.run(["dallinger"], capture_output=True, text=True)
-        assert "Usage: dallinger [OPTIONS] COMMAND [ARGS]" in result.stderr
+        # Output may go different places depending on context
+        # (OS version, Github Actions, etc), so merge them for
+        # better predictability
+        output = result.stdout + result.stderr
+        assert "Usage: dallinger [OPTIONS] COMMAND [ARGS]" in output
 
     def test_log_empty(self):
         id = "dlgr-3b9c2aeb"

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -371,26 +371,18 @@ class TestExperimentBaseClass(object):
                 queue_name="high",
             )
 
-    def test_send_non_json_calls_synchronously(self, exp):
-        with mock.patch(
-            "dallinger.experiment.Experiment.receive_message"
-        ) as mock_receive:
-            exp.channel = "exp_default"
-            exp.send("exp_default:value!")
-            mock_receive.assert_called_once_with(
-                "value!", channel_name="exp_default", receive_time=mock.ANY
-            )
-
-    def test_send_no_participant_calls_synchronously(self, exp):
+    def test_send_immediate_calls_synchronously(self, exp):
         # In order to make an async call we need to be able to get a
         # participant_id or a node_id from the message
         with mock.patch(
             "dallinger.experiment.Experiment.receive_message"
         ) as mock_receive:
             exp.channel = "exp_default"
-            exp.send('exp_default:{"key":"value"}')
+            exp.send('exp_default:{"key":"value","immediate":true}')
             mock_receive.assert_called_once_with(
-                '{"key":"value"}', channel_name="exp_default", receive_time=mock.ANY
+                '{"key":"value","immediate":true}',
+                channel_name="exp_default",
+                receive_time=mock.ANY,
             )
 
 


### PR DESCRIPTION
## Description
This PR implements more complete documentation for the Dallinger WebSocket implementation.

## Motivation and Context
See #5388. This documentation provides additional information about what WebSocket features Dallinger provides and how to use them. This PR also relates to #7788 and may be influenced by the eventual implementation of that ticket. Specifically, the updated documentation provides some suggestions for how chat functionality might be implemented by an experiment.
