### PR TITLE
Throw a better error message if the /launch POST fails early

### DIFF
--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -122,7 +122,7 @@ def handle_launch_data(
     if launch_request is not None:
         launch_request.raise_for_status()
 
-    raise RuntimeError("Launch failed")
+    raise requests.exceptions.ConnectionError
 
 
 def deploy_sandbox_shared_setup(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -796,7 +796,10 @@ class Testhandle_launch_data(object):
         )
 
         log.reset_mock()
-        handler("https://nonexistent.example.com/", log, attempts=1)
+        try:
+            handler("https://nonexistent.example.com/", log, attempts=1)
+        except requests.exceptions.ConnectionError:
+            pass
         assert (
             "Error accessing https://nonexistent.example.com/"
             in log.call_args_list[0][0][0]


### PR DESCRIPTION
This PR fixes this kind of launch error message:

```
❯❯ Launching the experiment...

❯❯ Error accessing http://localhost:5000/launch:
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

❯❯ Experiment launch failed, check server logs for details.

❯❯ Completed debugging of experiment with id ae93a5e0-5b69-6e79-081b-114890b23ce9

❯❯ Cleaning up local Heroku process...

❯❯ Local Heroku process terminated.
Traceback (most recent call last):
  File "/Users/peter/Dallinger/.venv/bin/dallinger", line 8, in <module>
    sys.exit(dallinger())
             ^^^^^^^^^^^
  File "/Users/peter/Dallinger/.venv/lib/python3.12/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/.venv/lib/python3.12/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/.venv/lib/python3.12/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/.venv/lib/python3.12/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/.venv/lib/python3.12/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/dallinger/command_line/utils.py", line 73, in wrapper
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/Users/peter/Dallinger/dallinger/command_line/__init__.py", line 221, in debug
    debugger.run()
  File "/Users/peter/Dallinger/dallinger/deployment.py", line 344, in run
    self.execute(wrapper)
  File "/Users/peter/Dallinger/dallinger/deployment.py", line 410, in execute
    if result["status"] == "success":
       ~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

and instead displays just this:

```
❯❯ Server is running on http://localhost:5000. Press Ctrl+C to exit.

❯❯ Launching the experiment...

❯❯ Error accessing http://localhost:5000/launch:
('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))

❯❯ Experiment launch failed after multiple attempts.
11:38:11 AM web.1   |  [2025-07-11 11:38:11 +0100] [29067] [DEBUG] POST /launch

❯❯ Completed debugging of experiment with id 75eb5e0b-c0fd-6188-8c23-0a653ed9dd1b

❯❯ Cleaning up local Heroku process...

❯❯ Local Heroku process terminated.
```