### PR TITLE
Fix `dallinger debug` to work when `loglevel` > 0

### DIFF
--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -424,7 +424,6 @@ class HerokuLocalWrapper(object):
     """
 
     shell_command = "heroku"
-    success_regex = r"^.*? \d+ workers$"
     # On Windows, use 'CTRL_C_EVENT', otherwise SIGINT
     int_signal = getattr(signal, "CTRL_C_EVENT", signal.SIGINT)
     MONITOR_STOP = object()
@@ -453,10 +452,9 @@ class HerokuLocalWrapper(object):
 
     def start(self, timeout_secs=60):
         """Start the heroku local subprocess group and verify that
-        it has started successfully.
+        it has started successfully by polling the relevant port.
 
-        The subprocess output is checked for a line matching 'success_regex'
-        to indicate success. If no match is seen after 'timeout_secs',
+        If the port is not available after 'timeout_secs',
         a HerokuTimeoutError is raised.
         """
 

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -8,6 +8,7 @@ import os
 import random
 import re
 import shutil
+import socket
 import string
 import subprocess
 import sys
@@ -1094,3 +1095,23 @@ BOLD = "\033[1m"
 def print_bold(message):
     """Print with bold formatting."""
     print(f"{BOLD}{message}{END}")
+
+
+def port_is_open(port, host="127.0.0.1"):
+    """
+    Check if a TCP port is open on a given host.
+
+    Args:
+        port (int): The port number to check.
+        host (str, optional): The host to check (default is '127.0.0.1').
+
+    Returns:
+        bool: True if the port is open, False otherwise.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(1)
+        try:
+            s.connect((host, port))
+            return True
+        except (ConnectionRefusedError, OSError):
+            return False

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -587,15 +587,15 @@ class TestHerokuLocalWrapper(object):
         with pytest.raises(HerokuStartupError):
             heroku.start()
 
-    def test_start_fails_if_stream_ends_without_matching_success_regex(self, heroku):
+    def test_start_fails_if_port_never_opens(self, heroku):
         from dallinger.heroku.tools import HerokuStartupError
 
         heroku._stream = mock.Mock(
             return_value=["apple", "orange", heroku.STREAM_SENTINEL]
         )
-        heroku.success_regex = "not going to match anything"
-        with pytest.raises(HerokuStartupError):
-            heroku.start()
+        with mock.patch("dallinger.utils.port_is_open", return_value=False):
+            with pytest.raises(HerokuStartupError):
+                heroku.start()
         assert not heroku.is_running
 
     def test_error_flushes_logs(self, heroku):
@@ -604,10 +604,10 @@ class TestHerokuLocalWrapper(object):
         heroku._stream = mock.Mock(
             return_value=["apple", "orange", heroku.STREAM_SENTINEL]
         )
-        heroku.success_regex = "not going to match anything"
         heroku._log_failure = mock.Mock()
-        with pytest.raises(HerokuStartupError):
-            heroku.start()
+        with mock.patch("dallinger.utils.port_is_open", return_value=False):
+            with pytest.raises(HerokuStartupError):
+                heroku.start()
         heroku._log_failure.assert_called_once()
 
     def test_failure_logs_until_process_end(self, heroku):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,6 +2,7 @@
 import io
 import locale
 import os
+import socket
 import tempfile
 from datetime import datetime, timedelta
 from tempfile import NamedTemporaryFile
@@ -11,7 +12,7 @@ import pytest
 
 from dallinger import config, utils
 from dallinger.config import strtobool
-from dallinger.utils import check_experiment_dependencies
+from dallinger.utils import check_experiment_dependencies, port_is_open
 
 
 class TestSubprocessWrapper(object):
@@ -438,3 +439,19 @@ def test_strtobool_invalid_values():
         with pytest.raises(ValueError) as excinfo:
             strtobool(val)
         assert "invalid truth value" in str(excinfo.value)
+
+
+def test_port_is_open(tmp_path):
+    """
+    Test the port_is_open utility function.
+
+    Checks that it returns True for an open port and False for a closed port.
+    """
+    # Find a free port and start a temporary server
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        addr, port = s.getsockname()
+        s.listen(1)
+        assert port_is_open(port, host="127.0.0.1") is True
+    # After closing, the port should not be open
+    assert port_is_open(port, host="127.0.0.1") is False


### PR DESCRIPTION
`dallinger debug` previously waited for a particular log line to be printed to know that the server had started successfully. This log line is not printed when `loglevel` > 1, however. I have therefore changed this logic to instead check whether the server is available by listening to the appropriate port.