### PR TITLE
Reinstate async_recruiter_status_check

### DIFF
--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -66,12 +66,12 @@ def warn_on_idle_transactions():
             )
 
 
-# @scheduler.scheduled_job("interval", minutes=0.5)
-# def async_recruiter_status_check():
-#     """Ask recruiters to check the status of their participants"""
+@scheduler.scheduled_job("interval", minutes=0.5)
+def async_recruiter_status_check():
+    """Ask recruiters to check the status of their participants"""
 
-#     q = db.get_queue()
-#     q.enqueue(recruiters.run_status_check)
+    q = db.get_queue()
+    q.enqueue(recruiters.run_status_check)
 
 
 def launch():


### PR DESCRIPTION
Now that `scoped_session_decorator` has been applied to `run_status_check`, we think it should be safe to reinstate `async_recruiter_status_check`, which previously was causing some kind of deadlock on long-running experiments.