### PR TITLE
Add support for customizing the index page via the Experiment class

### DIFF
--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -21,7 +21,7 @@ from typing import List, Optional, Union
 
 import requests
 from cached_property import cached_property
-from flask import Blueprint
+from flask import Blueprint, url_for
 from sqlalchemy import Table, and_, create_engine, func
 from sqlalchemy.orm import scoped_session, sessionmaker, undefer
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
@@ -109,6 +109,15 @@ class Experiment(object):
         template_folder="templates",
         static_folder="static",
     )
+
+    @classproperty
+    def index_html(cls):
+        return (
+            "<html><head></head><body><h1>Dallinger Experiment in progress</h1>"
+            "<p><a href={}>Dashboard</a></p></body></html>".format(
+                url_for("dashboard.dashboard_index")
+            )
+        )
 
     #: Sequence of dashboard route/function names that should be excluded from
     #: rendering as tabs in the dashboard view.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -110,8 +110,8 @@ class Experiment(object):
         static_folder="static",
     )
 
-    @classproperty
-    def index_html(cls):
+    @classmethod
+    def get_index_html(cls):
         return (
             "<html><head></head><body><h1>Dallinger Experiment in progress</h1>"
             "<p><a href={}>Dashboard</a></p></body></html>".format(

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -227,14 +227,10 @@ app.jinja_env.globals.update(get_from_config=get_from_config)
 @app.route("/")
 def index():
     """Index route"""
-    html = (
-        "<html><head></head><body><h1>Dallinger Experiment in progress</h1>"
-        "<p><a href={}>Dashboard</a></p></body></html>".format(
-            url_for("dashboard.dashboard_index")
-        )
-    )
+    from dallinger import experiment as dallinger_experiment
 
-    return html
+    experiment_class = dallinger_experiment.load()
+    return experiment_class.index_html
 
 
 @app.route("/robots.txt")

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -230,7 +230,7 @@ def index():
     from dallinger import experiment as dallinger_experiment
 
     experiment_class = dallinger_experiment.load()
-    return experiment_class.index_html
+    return experiment_class.get_index_html()
 
 
 @app.route("/robots.txt")


### PR DESCRIPTION
It is now possible to display custom HTML content on the deployed experiment's index page by customising the `Experiment.index_html` property.

The PR is covered by existing tests.