### PR TITLE
Server-side pagination in dashboard database tab

### DIFF
--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -973,7 +973,19 @@ TABLE_DEFAULTS = {
     "select": True,
     "paging": True,
     "lengthChange": True,
-    "searchPanes": {"threshold": 1.00},
+    "serverSide": True,
+    "processing": True,
+    "deferRender": True,
+    "columnDefs": [],
+    "order": [],
+    "data": [],
+    "searchPanes": {
+        "serverSide": True,
+        "viewCount": True,
+        "viewTotal": True,
+        "cascadePanes": True,
+        "threshold": 1.00,
+    },
     "buttons": [
         {
             "extend": "collection",
@@ -988,7 +1000,6 @@ def prep_datatables_options(table_data):
     """Attempts to generate a reasonable a DataTables config"""
     datatables_options = deepcopy(TABLE_DEFAULTS)
     datatables_options.update(deepcopy(table_data))
-
     columns = datatables_options.get("columns", [])
     for column in columns:
         d = column.get("data")
@@ -999,17 +1010,6 @@ def prep_datatables_options(table_data):
         column.pop("searchPanes", None)
         column.setdefault("defaultContent", "")
     datatables_options["columns"] = columns
-
-    datatables_options["serverSide"] = True
-    datatables_options["processing"] = True
-    datatables_options["deferRender"] = True
-    datatables_options["searchPanes"]["serverSide"] = True
-
-    datatables_options.setdefault("buttons", [])
-    datatables_options.setdefault("columnDefs", [])
-    datatables_options.setdefault("order", [])
-    datatables_options.setdefault("data", [])
-
     return datatables_options
 
 
@@ -1078,7 +1078,8 @@ def dashboard_database():
         col_keys = []
         col_filters = parse_searchpanes_filters(request.args)
 
-        # iterate over contiguous columns until none is found
+        # DataTables sends contiguous indices so we stop at the first
+        # missing index
         i = 0
         while (
             request.args.get(f"columns[{i}][data]") is not None


### PR DESCRIPTION
Related to issue #7969 

## Description
This PR refactors the database dashboard to use **server-side pagination** with DataTables. This implied also implementing **server-side SearchPanes support** to not break existing functionality.  

### Key changes
- Switched from client-side pagination and filtering to fully server-side processing
- Updated `table_data()` to handle paging, searching, ordering, and JSON serialization of rows
- Added `table_search_panes()` to compute SearchPanes options server-side with configurable thresholds and max distinct value limits
- Implements `table_columns()` to include only columns with actual data (checked via fast SQL `EXISTS` queries)
- Updated tests to test for server side options, data, search and filtering

## Motivation and Context
Client-side pagination and filtering caused **performance issues** with larger datasets, since all rows had to be loaded into the browser.  

This refactor solves the performance problem by delegating pagination, search, and filtering to the database while keeping DataTables UI functionality intact.  

Additionally, SearchPanes now works with server-side data:
- Panes are only shown when distinct values are below a configurable threshold
- Counts and totals are computed efficiently with SQL aggregates
- Panels now match the behavior of the original client-side implementation but scale properly with large datasets

## How Has This Been Tested?
Manual testing with `dallinger debug` and `dallinger develop debug` in the `bartlett1932` experiment demo