### PR TITLE
Get rid of python2 __init__.py creation

### DIFF
--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -417,10 +417,6 @@ def get_config(load=False):
 
 def initialize_experiment_package(path):
     """Make the specified directory importable as the `dallinger_experiment` package."""
-    # Create __init__.py if it doesn't exist (needed for Python 2)
-    init_py = os.path.join(path, "__init__.py")
-    if not os.path.exists(init_py):
-        open(init_py, "a").close()
     # Retain already set experiment module
     if sys.modules.get("dallinger_experiment") is not None:
         return


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
We don't support python2, so we shouldn't be adding `__init__.py` files to working directories when registering experiment package.

## Motivation and Context
Potentially causes problems, and has no benefit.

## How Has This Been Tested?
Automated tests

