### PR TITLE
Generate constraints

### DIFF
--- a/dallinger/generate_constraints.py
+++ b/dallinger/generate_constraints.py
@@ -1,0 +1,267 @@
+import contextlib
+import functools
+import io
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from hashlib import md5
+from os import PathLike
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+import requests
+
+from dallinger.utils import abspath_from_egg
+
+logger = logging.getLogger(__name__)
+
+
+def generate_constraints(input_path: PathLike, constraints_path: PathLike):
+    dallinger_version = _get_dallinger_version(input_path)
+    dallinger_dev_requirements_path = _get_dallinger_dev_requirements_path(
+        dallinger_version
+    )
+
+    print(
+        f"Compiling constraints.txt file from {input_path} and {dallinger_dev_requirements_path}"
+    )
+    compile_info = f"dallinger generate-constraints\n#\n# Compiled from a {Path(input_path).name} file with md5sum: {_hash_input_file(input_path)}"
+
+    with TemporaryDirectory() as tmpdirname:
+        tmpfile = Path(tmpdirname) / "requirements.txt"
+        tmpfile.write_text(
+            Path("requirements.txt").read_text()
+            + "\n-c "
+            + dallinger_dev_requirements_path
+        )
+        _check_output(
+            [
+                "pip-compile",
+                "-v",
+                str(tmpfile),
+                "-o",
+                str(constraints_path),
+            ],
+            env=dict(
+                os.environ,
+                CUSTOM_COMPILE_COMMAND=compile_info,
+            ),
+        )
+
+    _make_paths_relative(constraints_path)
+
+
+def ensure_constraints_file_presence(directory: str):
+    """Looks into the path represented by the string `directory`.
+    Does nothing if a `constraints.txt` file exists there and contains
+    the same md5sum as the `requirements.txt` file.
+    If it exists but is not up to date a ValueError exception is raised.
+    Otherwise it creates the constraints.txt file based on the
+    contents of the `requirements.txt` file.
+
+    If the `requirements.txt` does not exist one is created with
+    `dallinger` as its only dependency.
+
+    If the environment variable SKIP_DEPENDENCY_CHECK is set, no action
+    will be performed.
+    """
+    if os.environ.get("SKIP_DEPENDENCY_CHECK"):
+        return
+
+    input_path = _find_input_path(directory)
+    constraints_path = Path(directory) / "constraints.txt"
+
+    if constraints_path.exists():
+        _assert_constraints_up_to_date(constraints_path, input_path)
+        return
+
+    generate_constraints(input_path, constraints_path)
+
+
+def _find_input_path(directory: str) -> Path:
+    requirements_path = Path(directory) / "requirements.txt"
+    pyproject_path = Path(directory) / "pyproject.toml"
+
+    if requirements_path.exists():
+        input_path = requirements_path
+    elif pyproject_path.exists():
+        input_path = pyproject_path
+    else:
+        logger.warning(
+            "No requirements.txt or pyproject.toml file found, will autogenerate a requirements.txt"
+        )
+        requirements_path.write_text("dallinger\n")
+        input_path = requirements_path
+
+    return input_path
+
+
+def _hash_input_file(input_path: PathLike) -> str:
+    with open(input_path, "rb") as f:
+        return md5(f.read()).hexdigest()
+
+
+def _constraints_up_to_date(constraints_path: Path, input_path: Path) -> bool:
+    return _hash_input_file(input_path) in constraints_path.read_text()
+
+
+def _assert_constraints_up_to_date(constraints_path: Path, input_path: Path):
+    if not _constraints_up_to_date(constraints_path, input_path):
+        raise ValueError(
+            "\nChanges detected to requirements.txt: run the command\n    dallinger generate-constraints\nand retry"
+        )
+
+
+def _get_dallinger_version(input_path: PathLike) -> str:
+    explicit_version = _get_explicit_dallinger_version(input_path)
+    if explicit_version:
+        return explicit_version
+    else:
+        return _get_implied_dallinger_version(input_path)
+
+
+def _get_explicit_dallinger_version(input_path: PathLike) -> str | None:
+    """Extract the Dallinger version string from a file.
+
+    Parameters
+    ----------
+    input_path : Path
+        Path to the file to search.
+
+    Returns
+    -------
+    str
+        The extracted version string (e.g., '10.2.1'), or None if not found.
+    """
+    version = _get_explicit_dallinger_release_version(input_path)
+    if version:
+        return version
+    else:
+        return _get_explicit_dallinger_github_requirement(input_path)
+
+
+def _get_explicit_dallinger_release_version(input_path: PathLike) -> str | None:
+    pattern = re.compile(r"dallinger==([0-9]+\.[0-9]+\.[0-9]+)")
+    with open(input_path, "r") as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _get_explicit_dallinger_github_requirement(input_path: PathLike) -> str | None:
+    # dallinger@git+https://github.com/Dallinger/Dallinger.git@my-branch#egg=dallinger
+    pattern = re.compile(
+        r"dallinger@git\+https:\/\/github\.com\/Dallinger\/Dallinger(?:\.git)?@([^\s#]+)(?:#.*)?"
+    )
+    with open(input_path, "r") as f:
+        for line in f:
+            match = pattern.search(line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def _get_implied_dallinger_version(input_path: PathLike) -> str:
+    with tempfile.NamedTemporaryFile(suffix=".txt") as tmpfile:
+        _check_output(
+            [
+                "pip-compile",
+                "-v",
+                str(input_path),
+                "-o",
+                str(tmpfile),
+            ],
+        )
+        retrieved = _get_explicit_dallinger_version(tmpfile.name)
+    if retrieved is None:
+        raise ValueError(
+            f"Failed to retrieve an implied Dallinger version from {input_path}. "
+            "Consider specifying Dallinger explicitly ."
+        )
+    return retrieved
+
+
+def _get_dallinger_dev_requirements_path(dallinger_version: str) -> str:
+    url = f"https://raw.githubusercontent.com/Dallinger/Dallinger/v{dallinger_version}/dev-requirements.txt"
+    try:
+        response = requests.get(url, timeout=10)
+    except requests.exceptions.ConnectionError as e:
+        raise RuntimeError(
+            """It looks like you're offline. Dallinger can't generate constraints
+To get a valid constraints.txt file you can copy the requirements.txt file:
+cp requirements.txt constraints.txt"""
+        ) from e
+    if response.status_code != 200:
+        print(f"{url} not found. Using local dev-requirements.txt")
+        url_path = abspath_from_egg("dallinger", "dev-requirements.txt")
+        if not url_path.exists():
+            print(
+                f"{url_path} is not a valid file. Either use a released dallinger version for this experiment or install dallinger in editable mode"
+            )
+            raise ValueError(
+                f"Can't find constraints for dallinger version {dallinger_version}"
+            )
+        url = str(url_path)
+    return url
+
+
+def _make_paths_relative(constraints_path: Path):
+    constraints_contents = constraints_path.read_text()
+    constraints_contents_amended = re.sub(
+        "via -r .*requirements.txt", "via -r requirements.txt", constraints_contents
+    )
+    constraints_path.write_text(constraints_contents_amended)
+
+
+@contextlib.contextmanager
+def working_directory(path):
+    start_dir = os.getcwd()
+    try:
+        os.chdir(path)
+        yield
+    finally:
+        os.chdir(start_dir)
+
+
+def _wrap_subprocess_call(func, wrap_stdout=True):
+    @functools.wraps(func)
+    def wrapper(*popenargs, **kwargs):
+        out = kwargs.get("stdout", None)
+        err = kwargs.get("stderr", None)
+        replay_out = False
+        replay_err = False
+        if out is None and wrap_stdout:
+            try:
+                sys.stdout.fileno()
+            except io.UnsupportedOperation:
+                kwargs["stdout"] = tempfile.NamedTemporaryFile()
+                replay_out = True
+        if err is None:
+            try:
+                sys.stderr.fileno()
+            except io.UnsupportedOperation:
+                kwargs["stderr"] = tempfile.NamedTemporaryFile()
+                replay_err = True
+        try:
+            return func(*popenargs, **kwargs)
+        finally:
+            if replay_out:
+                kwargs["stdout"].seek(0)
+                sys.stdout.write(kwargs["stdout"].read())
+            if replay_err:
+                kwargs["stderr"].seek(0)
+                sys.stderr.write(kwargs["stderr"].read())
+
+    return wrapper
+
+
+_check_call = _wrap_subprocess_call(subprocess.check_call)  # noqa
+_call = _wrap_subprocess_call(subprocess.call)  # noqa
+_check_output = _wrap_subprocess_call(
+    subprocess.check_output, wrap_stdout=False
+)  # noqa

--- a/dallinger/generate_constraints.py
+++ b/dallinger/generate_constraints.py
@@ -8,58 +8,43 @@ import subprocess
 import sys
 import tempfile
 from hashlib import md5
-from os import PathLike
+from importlib.metadata import files as files_metadata
 from pathlib import Path
-from tempfile import TemporaryDirectory
+from typing import Optional
 
 import requests
-
-from dallinger.utils import abspath_from_egg
 
 logger = logging.getLogger(__name__)
 
 
-def generate_constraints(input_path: PathLike, constraints_path: PathLike):
-    dallinger_version = _get_dallinger_version(input_path)
+def generate_constraints(input_path, output_path):
+    dallinger_reference = _get_dallinger_reference(input_path)
     dallinger_dev_requirements_path = _get_dallinger_dev_requirements_path(
-        dallinger_version
+        dallinger_reference
     )
+    _test_dallinger_dev_requirements_path(dallinger_dev_requirements_path)
 
     print(
         f"Compiling constraints.txt file from {input_path} and {dallinger_dev_requirements_path}"
     )
     compile_info = f"dallinger generate-constraints\n#\n# Compiled from a {Path(input_path).name} file with md5sum: {_hash_input_file(input_path)}"
 
-    with TemporaryDirectory() as tmpdirname:
-        tmpfile = Path(tmpdirname) / "requirements.txt"
-        tmpfile.write_text(
-            Path("requirements.txt").read_text()
-            + "\n-c "
-            + dallinger_dev_requirements_path
-        )
-        _check_output(
-            [
-                "pip-compile",
-                "-v",
-                str(tmpfile),
-                "-o",
-                str(constraints_path),
-            ],
-            env=dict(
-                os.environ,
-                CUSTOM_COMPILE_COMMAND=compile_info,
-            ),
-        )
+    _pip_compile(
+        input_path,
+        output_path,
+        constraints=[dallinger_dev_requirements_path],
+        compile_info=compile_info,
+    )
 
-    _make_paths_relative(constraints_path)
+    _make_paths_relative(output_path)
 
 
 def ensure_constraints_file_presence(directory: str):
     """Looks into the path represented by the string `directory`.
     Does nothing if a `constraints.txt` file exists there and contains
     the same md5sum as the `requirements.txt` file.
-    If it exists but is not up to date a ValueError exception is raised.
-    Otherwise it creates the constraints.txt file based on the
+    If it exists but is not up-to-date a ValueError exception is raised.
+    Otherwise, it creates the constraints.txt file based on the
     contents of the `requirements.txt` file.
 
     If the `requirements.txt` does not exist one is created with
@@ -72,13 +57,13 @@ def ensure_constraints_file_presence(directory: str):
         return
 
     input_path = _find_input_path(directory)
-    constraints_path = Path(directory) / "constraints.txt"
+    output_path = Path(directory) / "constraints.txt"
 
-    if constraints_path.exists():
-        _assert_constraints_up_to_date(constraints_path, input_path)
+    if output_path.exists():
+        _assert_constraints_up_to_date(output_path, input_path)
         return
 
-    generate_constraints(input_path, constraints_path)
+    generate_constraints(input_path, output_path)
 
 
 def _find_input_path(directory: str) -> Path:
@@ -99,7 +84,7 @@ def _find_input_path(directory: str) -> Path:
     return input_path
 
 
-def _hash_input_file(input_path: PathLike) -> str:
+def _hash_input_file(input_path: Path) -> str:
     with open(input_path, "rb") as f:
         return md5(f.read()).hexdigest()
 
@@ -115,36 +100,25 @@ def _assert_constraints_up_to_date(constraints_path: Path, input_path: Path):
         )
 
 
-def _get_dallinger_version(input_path: PathLike) -> str:
-    explicit_version = _get_explicit_dallinger_version(input_path)
-    if explicit_version:
-        return explicit_version
+def _get_dallinger_reference(input_path: Path) -> str:
+    explicit_reference = _get_explicit_dallinger_reference(input_path)
+    if explicit_reference:
+        return explicit_reference
     else:
-        return _get_implied_dallinger_version(input_path)
+        return _get_implied_dallinger_reference(input_path)
 
 
-def _get_explicit_dallinger_version(input_path: PathLike) -> str | None:
-    """Extract the Dallinger version string from a file.
-
-    Parameters
-    ----------
-    input_path : Path
-        Path to the file to search.
-
-    Returns
-    -------
-    str
-        The extracted version string (e.g., '10.2.1'), or None if not found.
-    """
-    version = _get_explicit_dallinger_release_version(input_path)
-    if version:
-        return version
+def _get_explicit_dallinger_reference(input_path: Path) -> str | None:
+    release = _get_explicit_dallinger_numbered_release(input_path)
+    if release:
+        return f"v{release}"
     else:
         return _get_explicit_dallinger_github_requirement(input_path)
 
 
-def _get_explicit_dallinger_release_version(input_path: PathLike) -> str | None:
-    pattern = re.compile(r"dallinger==([0-9]+\.[0-9]+\.[0-9]+)")
+def _get_explicit_dallinger_numbered_release(input_path: Path) -> str | None:
+    # Should catch patterns like dallinger[docker,test]==11.5.0
+    pattern = re.compile(r"dallinger(?:\[[^\]]+\])?==([0-9]+\.[0-9]+\.[0-9]+)")
     with open(input_path, "r") as f:
         for line in f:
             match = pattern.search(line)
@@ -153,10 +127,10 @@ def _get_explicit_dallinger_release_version(input_path: PathLike) -> str | None:
     return None
 
 
-def _get_explicit_dallinger_github_requirement(input_path: PathLike) -> str | None:
+def _get_explicit_dallinger_github_requirement(input_path: Path) -> str | None:
     # dallinger@git+https://github.com/Dallinger/Dallinger.git@my-branch#egg=dallinger
     pattern = re.compile(
-        r"dallinger@git\+https:\/\/github\.com\/Dallinger\/Dallinger(?:\.git)?@([^\s#]+)(?:#.*)?"
+        r"dallinger@git\+https://github\.com/Dallinger/Dallinger(?:\.git)?@([^\s#]+)(?:#.*)?"
     )
     with open(input_path, "r") as f:
         for line in f:
@@ -166,28 +140,23 @@ def _get_explicit_dallinger_github_requirement(input_path: PathLike) -> str | No
     return None
 
 
-def _get_implied_dallinger_version(input_path: PathLike) -> str:
+def _get_implied_dallinger_reference(input_path: Path) -> str:
     with tempfile.NamedTemporaryFile(suffix=".txt") as tmpfile:
-        _check_output(
-            [
-                "pip-compile",
-                "-v",
-                str(input_path),
-                "-o",
-                str(tmpfile),
-            ],
-        )
-        retrieved = _get_explicit_dallinger_version(tmpfile.name)
-    if retrieved is None:
-        raise ValueError(
-            f"Failed to retrieve an implied Dallinger version from {input_path}. "
-            "Consider specifying Dallinger explicitly ."
-        )
+        _pip_compile(input_path, tmpfile.name, constraints=None)
+        retrieved = _get_explicit_dallinger_reference(Path(tmpfile.name))
+        if retrieved is None:
+            raise ValueError(
+                f"Failed to retrieve an implied Dallinger reference from {input_path}. "
+                "Consider specifying Dallinger explicitly in the requirements.txt file."
+            )
     return retrieved
 
 
-def _get_dallinger_dev_requirements_path(dallinger_version: str) -> str:
-    url = f"https://raw.githubusercontent.com/Dallinger/Dallinger/v{dallinger_version}/dev-requirements.txt"
+def _get_dallinger_dev_requirements_path(dallinger_reference: str) -> str:
+    return f"https://raw.githubusercontent.com/Dallinger/Dallinger/{dallinger_reference}/dev-requirements.txt"
+
+
+def _test_dallinger_dev_requirements_path(url: str):
     try:
         response = requests.get(url, timeout=10)
     except requests.exceptions.ConnectionError as e:
@@ -197,17 +166,56 @@ To get a valid constraints.txt file you can copy the requirements.txt file:
 cp requirements.txt constraints.txt"""
         ) from e
     if response.status_code != 200:
-        print(f"{url} not found. Using local dev-requirements.txt")
-        url_path = abspath_from_egg("dallinger", "dev-requirements.txt")
-        if not url_path.exists():
-            print(
-                f"{url_path} is not a valid file. Either use a released dallinger version for this experiment or install dallinger in editable mode"
-            )
-            raise ValueError(
-                f"Can't find constraints for dallinger version {dallinger_version}"
-            )
-        url = str(url_path)
-    return url
+        raise ValueError(
+            f"{url} not found. Please make sure your specified Dallinger "
+            "version exists in the Dallinger repository. "
+        )
+
+
+def _pip_compile(
+    in_file, out_file, constraints: Optional[list] = None, compile_info=None
+):
+    use_uv = uv_available()
+    if use_uv:
+        logger.info("Calling `uv pip-compile`...")
+        cmd = ["uv", "pip", "compile"]
+    else:
+        logger.info(
+            "Calling `pip-compile` (consider installing uv for faster compilation)..."
+        )
+        cmd = ["pip-compile"]
+    cmd += [
+        # "--verbose",
+        str(in_file),
+        "--output-file",
+        str(out_file),
+    ]
+    if constraints:
+        for constraint in constraints:
+            cmd += ["--constraint", constraint]
+
+    env = dict(os.environ)
+    if compile_info:
+        if use_uv:
+            env["UV_CUSTOM_COMPILE_COMMAND"] = compile_info
+        else:
+            env["CUSTOM_COMPILE_COMMAND"] = compile_info
+    _check_output(
+        cmd,
+        env=env,
+    )
+
+
+def uv_available() -> bool:
+    """
+    Check whether uv is available for use.
+    """
+    # return False
+    try:
+        _check_output(["uv", "--version"])
+        return True
+    except subprocess.CalledProcessError:
+        return False
 
 
 def _make_paths_relative(constraints_path: Path):
@@ -265,3 +273,16 @@ _call = _wrap_subprocess_call(subprocess.call)  # noqa
 _check_output = _wrap_subprocess_call(
     subprocess.check_output, wrap_stdout=False
 )  # noqa
+
+
+def abspath_from_egg(egg, path):
+    """Given a path relative to the egg root, find the absolute
+    filesystem path for that resource.
+    For instance this file's absolute path can be found invoking
+    `abspath_from_egg("dallinger", "dallinger/utils.py")`.
+    Returns a `pathlib.Path` object or None if the path was not found.
+    """
+    for file in files_metadata(egg):
+        if str(file) == path:
+            return file.locate()
+    return None

--- a/dallinger/generate_constraints.py
+++ b/dallinger/generate_constraints.py
@@ -18,6 +18,23 @@ logger = logging.getLogger(__name__)
 
 
 def generate_constraints(input_path, output_path):
+    """
+    Generate a constraints.txt file for the current directory.
+
+    The process takes as a starting point the contents of the input_path file,
+    and relates this to the dev-requirements.txt file for the requested Dallinger version.
+    This dev-requirements.txt file is sourced from the Dallinger GitHub repository,
+    paying attention to the precise version of Dallinger that is requested by input_path.
+
+    ``uv pip compile`` is used if uv is available, otherwise ``pip-compile`` is used.
+
+    Parameters
+    ----------
+    input_path : str
+        The path to the input file, typically requirements.txt or pyproject.toml.
+    output_path : str
+        The path to the output file, typically constraints.txt.
+    """
     dallinger_reference = _get_dallinger_reference(input_path)
     dallinger_dev_requirements_path = _get_dallinger_dev_requirements_path(
         dallinger_reference

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -14,7 +14,6 @@ import tempfile
 import warnings
 import webbrowser
 from datetime import datetime
-from importlib.metadata import files as files_metadata
 from importlib.util import find_spec
 from pathlib import Path
 from unicodedata import normalize
@@ -385,17 +384,10 @@ def struct_to_html(data):
     return "<br>".join(parts)
 
 
-def abspath_from_egg(egg, path):
-    """Given a path relative to the egg root, find the absolute
-    filesystem path for that resource.
-    For instance this file's absolute path can be found invoking
-    `abspath_from_egg("dallinger", "dallinger/utils.py")`.
-    Returns a `pathlib.Path` object or None if the path was not found.
-    """
-    for file in files_metadata(egg):
-        if str(file) == path:
-            return file.locate()
-    return None
+# generate_constraints needs to be dependency-free,
+# so we put the definitions of abspath_from_egg there,
+# but still expose it from dallinger.utils as before.
+abspath_from_egg = dallinger.generate_constraints.abspath_from_egg  # noqa
 
 
 def get_editable_dallinger_path():

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1180,36 +1180,3 @@ class TestLoad(object):
                 mock.call("Local Heroku process terminated."),
             ]
         )
-
-
-class TestConstraints(object):
-    @pytest.mark.slow
-    def test_constraints_generation(self):
-        from dallinger.utils import ensure_constraints_file_presence
-
-        tmp_path = tempfile.mkdtemp()
-        # We will be looking for
-        # https://raw.githubusercontent.com/Dallinger/Dallinger/v[__version__]
-        # so use an older version we know will exist, rather than the current
-        # version, which may not be tagged/released yet:
-
-        # Change this to the current version after release
-        extant_github_tag = "b98f719c1ce851353f7cfcc78362cfaace51bb8d"
-        (Path(tmp_path) / "requirements.txt").write_text("black")
-        with mock.patch("dallinger.utils.__version__", extant_github_tag):
-            ensure_constraints_file_presence(tmp_path)
-            constraints_file = Path(tmp_path) / "constraints.txt"
-            # If not present a `constraints.txt` file will be generated
-            assert constraints_file.exists()
-            if sys.version_info >= (3, 11):
-                assert "toml" not in constraints_file.read_text()
-            else:
-                assert "toml" in constraints_file.read_text()
-
-            # An existing file will be left untouched
-            constraints_file.write_text("foobar")
-            with pytest.raises(ValueError):
-                ensure_constraints_file_presence(tmp_path)
-            assert constraints_file.read_text() == "foobar"
-
-        shutil.rmtree(tmp_path)

--- a/tests/test_generate_constraints.py
+++ b/tests/test_generate_constraints.py
@@ -25,63 +25,70 @@ def pyproject_path(tempdir):
     return Path(tempdir) / "pyproject.toml"
 
 
-def test_constraints_dallinger_release(requirements_path, constraints_path):
-    with open(requirements_path, "w") as f:
-        f.write("dallinger==11.4.0")
-    generate_constraints(requirements_path, constraints_path)
-    assert constraints_path.exists()
-
-    # see https://raw.githubusercontent.com/Dallinger/Dallinger/v11.4.0/dev-requirements.txt
-    # # to verify that flask==3.1.1 is indeed the correct version
-    assert "flask==3.1.1" in constraints_path.read_text()
-
-
-def test_constraints_dallinger_commit(requirements_path, constraints_path):
-    with open(requirements_path, "w") as f:
-        f.write(
-            "dallinger@git+https://github.com/Dallinger/Dallinger.git@c9e0ecf554f0d6bd05b745bbf3983afdcaa848f5#egg=dallinger"
+@pytest.mark.parametrize("uv_available_value", [True, False])
+@pytest.mark.slow
+class TestGenerateConstraints:
+    @pytest.fixture(autouse=True)
+    def mock_uv_available(self, monkeypatch, uv_available_value):
+        # We test both uv and pip-compile (the fallback if uv is not available)
+        monkeypatch.setattr(
+            "dallinger.generate_constraints.uv_available", lambda: uv_available_value
         )
-    generate_constraints(requirements_path, constraints_path)
 
-    # see https://raw.githubusercontent.com/Dallinger/Dallinger/c9e0ecf554f0d6bd05b745bbf3983afdcaa848f5/dev-requirements.txt
-    # to verify that 3.1.0 is indeed the correct version
-    assert "flask==3.1.0" in constraints_path.read_text()
+    def test_constraints_dallinger_release(self, requirements_path, constraints_path):
+        with open(requirements_path, "w") as f:
+            f.write("dallinger==11.4.0")
+        generate_constraints(requirements_path, constraints_path)
+        assert constraints_path.exists()
 
+        # see https://raw.githubusercontent.com/Dallinger/Dallinger/v11.4.0/dev-requirements.txt
+        # # to verify that flask==3.1.1 is indeed the correct version
+        assert "flask==3.1.1" in constraints_path.read_text()
 
-def test_constraints_psynet(requirements_path, constraints_path):
-    with open(requirements_path, "w") as f:
-        f.write("psynet==12.0.0")
-    generate_constraints(requirements_path, constraints_path)
-    assert constraints_path.exists()
-    dallinger_version = _get_explicit_dallinger_numbered_release(constraints_path)
-    major, minor, patch = dallinger_version.split(".")
+    def test_constraints_dallinger_commit(self, requirements_path, constraints_path):
+        with open(requirements_path, "w") as f:
+            f.write(
+                "dallinger@git+https://github.com/Dallinger/Dallinger.git@c9e0ecf554f0d6bd05b745bbf3983afdcaa848f5#egg=dallinger"
+            )
+        generate_constraints(requirements_path, constraints_path)
 
-    # To verify the correct version see https://gitlab.com/PsyNetDev/PsyNet/-/blob/v12.0.0/pyproject.toml?ref_type=tags
-    assert major == "11"
-    assert int(minor) >= 1
-    if int(minor) == 1:
-        assert int(patch) >= 1
+        # see https://raw.githubusercontent.com/Dallinger/Dallinger/c9e0ecf554f0d6bd05b745bbf3983afdcaa848f5/dev-requirements.txt
+        # to verify that 3.1.0 is indeed the correct version
+        assert "flask==3.1.0" in constraints_path.read_text()
 
+    def test_constraints_psynet(self, requirements_path, constraints_path):
+        with open(requirements_path, "w") as f:
+            f.write("psynet==12.0.0")
+        generate_constraints(requirements_path, constraints_path)
+        assert constraints_path.exists()
+        dallinger_version = _get_explicit_dallinger_numbered_release(constraints_path)
+        major, minor, patch = dallinger_version.split(".")
 
-def test_caching(tmpdir):
-    requirements_path = Path(tmpdir) / "requirements.txt"
-    requirements_path.write_text("dallinger==11.4.0")
-    constraints_path = Path(tmpdir) / "constraints.txt"
+        # To verify the correct version see https://gitlab.com/PsyNetDev/PsyNet/-/blob/v12.0.0/pyproject.toml?ref_type=tags
+        assert major == "11"
+        assert int(minor) >= 1
+        if int(minor) == 1:
+            assert int(patch) >= 1
 
-    ensure_constraints_file_presence(tmpdir)
+    def test_caching(self, tmpdir):
+        requirements_path = Path(tmpdir) / "requirements.txt"
+        requirements_path.write_text("dallinger==11.4.0")
+        constraints_path = Path(tmpdir) / "constraints.txt"
 
-    assert constraints_path.exists()
-    assert "dallinger==11.4.0" in constraints_path.read_text()
-
-    original_mtime = os.path.getmtime(constraints_path)
-
-    ensure_constraints_file_presence(tmpdir)
-
-    # No change to requirements.txt so no change to constraints.txt
-    assert os.path.getmtime(constraints_path) == original_mtime
-
-    with open(requirements_path, "w+") as f:
-        f.write("scipy")
-
-    with pytest.raises(ValueError, match="Changes detected to requirements"):
         ensure_constraints_file_presence(tmpdir)
+
+        assert constraints_path.exists()
+        assert "dallinger==11.4.0" in constraints_path.read_text()
+
+        original_mtime = os.path.getmtime(constraints_path)
+
+        ensure_constraints_file_presence(tmpdir)
+
+        # No change to requirements.txt so no change to constraints.txt
+        assert os.path.getmtime(constraints_path) == original_mtime
+
+        with open(requirements_path, "w+") as f:
+            f.write("scipy")
+
+        with pytest.raises(ValueError, match="Changes detected to requirements"):
+            ensure_constraints_file_presence(tmpdir)


### PR DESCRIPTION
I have revamped the `generate constraints` functionality in Dallinger.

- Now uses `uv` instead of `pip-tools`, greatly increasing speed (`pip-tools` provides a fallback if `uv` is not installed).
- Constraints are now sourced from the Dallinger version specified in the input file (e.g. requirements.txt), rather than the currently installed version of Dallinger, fixing #8034.
- Now supports `pyproject.toml` as well as `requirements.txt` for input files.
- The `generate constraints` functionality is now contained in a standalone `generate_constraints.py` file with no Dallinger dependencies, meaning that it can be sourced in a clean Python environment and used to generate constraints without an existing Dallinger installation.

Behaviour tests are provided in `test_generate_constraints.py`.