### PR TITLE
Implement timeout decorator and apply it to some scheduled tasks

### DIFF
--- a/dallinger/heroku/clock.py
+++ b/dallinger/heroku/clock.py
@@ -10,7 +10,7 @@ import dallinger
 from dallinger import db, recruiters
 from dallinger.experiment import EXPERIMENT_TASK_REGISTRATIONS
 from dallinger.models import Participant
-from dallinger.utils import ParticipationTime
+from dallinger.utils import ParticipationTime, timeout
 
 scheduler = BlockingScheduler()
 
@@ -35,6 +35,7 @@ def run_check(participants, config, reference_time):
 
 
 @scheduler.scheduled_job("interval", minutes=0.5)
+@timeout(seconds=10)
 def check_db_for_missing_notifications():
     """Check the database for missing notifications."""
     config = dallinger.config.get_config()

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -45,6 +45,7 @@ from dallinger.utils import (
     generate_random_id,
     get_base_url,
     get_exp_klass,
+    timeout,
 )
 
 logger = logging.getLogger(__name__)
@@ -98,6 +99,7 @@ CLOSE_RECRUITMENT_LOG_PREFIX = "Close recruitment."
 
 
 @scoped_session_decorator
+@timeout(seconds=60)
 def run_status_check():
     """Update participant status via all active recruiters.
 


### PR DESCRIPTION
Previously, scheduled tasks (e.g. recruiter checks) could run forever if for some reason the internal code got stuck. I have implemented a timeout decorator and applied it to a couple of these tasks so that they will eventually timeout in such situations.