### PR TITLE
Allow customization of maximum experiment size in MB via EXP_MAX_SIZE_MB environment variable

### DIFF
--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -97,7 +97,7 @@ def verify_package(verbose=True):
     return ok
 
 
-def verify_directory(verbose=True, max_size_mb=50):
+def verify_directory(verbose=True):
     """Ensure that the current directory looks like a Dallinger experiment, and
     does not appear to have unintended contents that will be copied on
     deployment.
@@ -114,22 +114,27 @@ def verify_directory(verbose=True, max_size_mb=50):
             log("✗ {} is MISSING".format(f), chevrons=False, verbose=verbose)
             ok = False
 
+    # Get experiment max size in MB from environment variable, default to 50MB
+    exp_max_size_mb = int(os.environ.get("EXP_MAX_SIZE_MB", "50"))
+
     # Check size
-    max_size = max_size_mb * mb_to_bytes
+    max_size = exp_max_size_mb * mb_to_bytes
     file_source = ExperimentFileSource(os.getcwd())
     size = file_source.size
     size_in_mb = round(size / mb_to_bytes)
     if size <= max_size:
         log(
-            "✓ Size OK at {}MB (max is {}MB)".format(size_in_mb, max_size_mb),
+            "✓ Size OK at {}MB (max is {}MB)".format(size_in_mb, exp_max_size_mb),
             chevrons=False,
             verbose=verbose,
         )
     else:
         log(
-            "✗ {}MB is TOO BIG (greater than {}MB)\n\tIncluded files:\n\t{}".format(
-                size_in_mb, max_size_mb, "\n\t".join(file_source.files)
-            ),
+            (
+                "✗ {}MB is TOO BIG (greater than {}MB). "
+                "You can override this limit by setting the EXP_MAX_SIZE_MB environment variable.\n"
+                "\tIncluded files:\n\t{}"
+            ).format(size_in_mb, exp_max_size_mb, "\n\t".join(file_source.files)),
             chevrons=False,
             verbose=verbose,
         )

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -93,16 +93,18 @@ class TestVerify:
             "dallinger.command_line.utils.ExperimentFileSource.size",
             new_callable=mock.PropertyMock,
         ) as size:
-            size.return_value = 6000000  # 6 MB, so over the limit
-            assert v_directory(max_size_mb=5) is False
+            size.return_value = 60000000  # 60 MB, so over the limit
+            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "50"}):
+                assert v_directory() is False
 
     def test_under_limit_returns_true(self, v_directory):
         with mock.patch(
             "dallinger.command_line.utils.ExperimentFileSource.size",
             new_callable=mock.PropertyMock,
         ) as size:
-            size.return_value = 4000000  # 4 MB, so under the limit
-            assert v_directory(max_size_mb=5) is True
+            size.return_value = 40000000  # 40 MB, so under the limit
+            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "50"}):
+                assert v_directory() is True
 
 
 @pytest.mark.slow


### PR DESCRIPTION
#### Added
- Allow customization of  maximum experiment size in MB via `EXP_MAX_SIZE_MB` environment variable

