### PR TITLE
Use Docker bitnamilegacy repository for pgbouncer

### DIFF
--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -68,7 +68,7 @@ services:
 
   pgbouncer:
     restart: unless-stopped
-    image: docker.io/bitnami/pgbouncer:1.19.1
+    image: docker.io/bitnamilegacy/pgbouncer:1.24.1
     container_name: {{ experiment_id }}_pgbouncer
     networks:
       dallinger:


### PR DESCRIPTION
#### Fixed
- Use Docker `bitnamilegacy` repository for `pgbouncer` as the bitnami repository was deleted. This is a temporary fix until we move to building our own `pgbouncer` image