### PR TITLE
Change default max experiment size to 256 MB

### DIFF
--- a/dallinger/command_line/utils.py
+++ b/dallinger/command_line/utils.py
@@ -114,8 +114,8 @@ def verify_directory(verbose=True):
             log("✗ {} is MISSING".format(f), chevrons=False, verbose=verbose)
             ok = False
 
-    # Get experiment max size in MB from environment variable, default to 50MB
-    exp_max_size_mb = int(os.environ.get("EXP_MAX_SIZE_MB", "50"))
+    # Get experiment max size in MB from environment variable, default to 256MB
+    exp_max_size_mb = int(os.environ.get("EXP_MAX_SIZE_MB", "256"))
 
     # Check size
     max_size = exp_max_size_mb * mb_to_bytes

--- a/tests/test_command_line.py
+++ b/tests/test_command_line.py
@@ -93,8 +93,8 @@ class TestVerify:
             "dallinger.command_line.utils.ExperimentFileSource.size",
             new_callable=mock.PropertyMock,
         ) as size:
-            size.return_value = 60000000  # 60 MB, so over the limit
-            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "50"}):
+            size.return_value = 300000000  # 300 MB, so over the limit
+            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "256"}):
                 assert v_directory() is False
 
     def test_under_limit_returns_true(self, v_directory):
@@ -102,8 +102,8 @@ class TestVerify:
             "dallinger.command_line.utils.ExperimentFileSource.size",
             new_callable=mock.PropertyMock,
         ) as size:
-            size.return_value = 40000000  # 40 MB, so under the limit
-            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "50"}):
+            size.return_value = 200000000  # 200 MB, so under the limit
+            with mock.patch.dict(os.environ, {"EXP_MAX_SIZE_MB": "256"}):
                 assert v_directory() is True
 
 


### PR DESCRIPTION
Increase the default maximum experiment size from 50 to 256MB