### PR TITLE
Update paramiko to 4; add support for Ed25519, and ECDSA keys; remove support for DSS/DSA SSH keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Fail CI if there is no CHANGELOG entry in a pull request (except 'pyup-update' branches which are excluded)
 - Allow root domain deploments (such has my-domain.com) as well as multi subdomain deployments (such as subdom-2.subdom-1.my-domain.com).
 - Added support for custom Prolific completion codes and actions.
-- Added tests for EC2 `get_all_instances`, `get_instance_details`, and `get_pem_path`
+- Added tests for EC2 `get_all_instances`, `get_instance_details`, `get_pem_path`, and `register_key_pair` (RSA, Ed25519, ECDSA key types)
 
 #### Fixed
 - Disabled Prolific's custom screening in the test suite by changing the default for `is_custom_screening` to `False`     
@@ -27,14 +27,18 @@
 - Renamed label used in pyup Pull Requests from 'enhancement' to 'dependencies'
 - **The `server_pem` configuration is now required** for SSH-based deployments (docker-ssh and EC2). PEM file paths are now validated upfront with clear error messages if missing or invalid. This ensures SSH authentication is properly configured before attempting deployments.
 - **PEM files are now searched in `~/.ssh/` directory first** (recommended best practice), with fallback to `~/` for backwards compatibility. A warning is logged when PEM files are found in the legacy `~/` location with migration instructions. All documentation and examples have been updated to promote `~/.ssh/` as the standard location for SSH key files.
+- EC2 key pair registration now supports RSA, Ed25519, and ECDSA key types (previously only RSA was supported)
 
 #### Removed
 - Removed Danger and its dependencies
 - Removed automatic ssh-agent key management; SSH keys are now used directly via key files
+- Removed support for DSS/DSA SSH keys due to paramiko 4.0.0 upgrade and industry-wide deprecation for security reasons
 
 #### Updated
 - Updated dependencies
 - Enhanced documentation for `server_pem` and `ec2_default_pem` configuration variables, including SSH setup instructions, security group ingress rules, and AWS documentation links for key pair creation and SSH connections
+- Upgraded paramiko to 4.0.0, which removes support for DSS/DSA SSH keys. Users must migrate to RSA (2048+ bit), Ed25519, or ECDSA keys. See documentation migration instructions.
+
 
 ## [v11.5.5](https://github.com/dallinger/dallinger/tree/v11.5.5) (2025-10-23)
 

--- a/docs/source/docker_support.rst
+++ b/docs/source/docker_support.rst
@@ -235,6 +235,20 @@ Given an IP address or a DNS name of the server and a username, add the host to 
 
 The ``server_pem`` configuration will be used automatically for SSH authentication when connecting to the server.
 
+**Supported SSH Key Types:**
+
+Dallinger supports the following SSH key types (DSS/DSA keys are NOT supported):
+
+* **Ed25519** (recommended) - Modern, fast, and secure. Generate with: ``ssh-keygen -t ed25519 -f ~/.ssh/my-key.pem``
+* **RSA** (2048-bit or higher) - Most compatible. Generate with: ``ssh-keygen -t rsa -b 4096 -f ~/.ssh/my-key.pem``
+* **ECDSA** (256-bit or higher) - Modern and secure. Generate with: ``ssh-keygen -t ecdsa -b 521 -f ~/.ssh/my-key.pem``
+
+Both PEM and OpenSSH private key formats are supported.
+
+.. note::
+
+    DSS/DSA keys are no longer supported as they have been deprecated industry-wide since 2015 due to security weaknesses (limited to 1024-bit key length).
+
 Dallinger verifies that ``docker`` and ``docker compose`` are installed, and installs them if they are not.
 The installation should take a couple of minutes.
 

--- a/docs/source/ec2_deployment.rst
+++ b/docs/source/ec2_deployment.rst
@@ -87,6 +87,21 @@ or if the PEM file doesn't exist at the specified path, the deployment will fail
 For more information, see the `AWS EC2 documentation on creating key pairs 
 <https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/create-key-pairs.html>`__.
 
+**Supported SSH Key Types:**
+
+AWS EC2 and Dallinger support the following key types:
+
+* **RSA** (2048-bit or higher) - Most common and compatible. Generate with: ``ssh-keygen -t rsa -b 4096 -f ~/.ssh/my-key.pem``
+* **Ed25519** - Modern and secure (recommended). Generate with: ``ssh-keygen -t ed25519 -f ~/.ssh/my-key.pem``
+* **ECDSA** (256-bit or higher) - Modern and secure. Generate with: ``ssh-keygen -t ecdsa -b 521 -f ~/.ssh/my-key.pem``
+
+Both PEM and OpenSSH private key formats are supported.
+
+.. note::
+
+    DSS/DSA keys are NOT supported. They have been deprecated industry-wide since 2015
+    due to security weaknesses (limited to 1024-bit). AWS EC2 does not generate DSS keys.
+
 AWS Region
 ----------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
     "heroku3",
     "ipython < 9",
     "numpy < 2.3",
-    "paramiko < 4",
+    "paramiko",
     "pexpect",
     "pip<25.3", # to address temporary incompatibility between pip and pip-compile versions, see https://stackoverflow.com/questions/79802659/trying-to-solve-a-pip-compile-stack-trace-error. We should be able to remove this if we finalize the move to uv.
     "pip-tools",  # TODO: consider removing at some point if we are happy with uv?


### PR DESCRIPTION
## Added
- Added multi-key type support to EC2 `register_key_pair()`
  - Support RSA, Ed25519, and ECDSA keys (was RSA-only)
  - Add comprehensive tests for all key types
  - Simplify code using paramiko's built-in methods
## Updated
- Updated paramiko to 4.0.0, which removes support for DSS/DSA SSH keys. Users must migrate to RSA (2048+ bit), Ed25519, or ECDSA keys. DSS keys have been deprecated since OpenSSH 7.0 (2015) due to security weaknesses (limited to 1024-bit). Modern infrastructure (AWS EC2, etc.) does not generate DSS keys.
