### PR TITLE
Sanitize new participant URL base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 #### Fixed
 - Fixed `TypeError` in `dallinger constraints generate` when `constraints=None` and `uv pip compile` fails.
 - Fixed flaky MTurk test by including Python version in qualification names to prevent collisions between parallel CI jobs.
+- Fixed new participant link to avoid propagating credentials from the dashboard URL.
 
 #### Updated
 - Updated to PostgreSQL 16

--- a/dallinger/frontend/templates/dashboard_develop.html
+++ b/dallinger/frontend/templates/dashboard_develop.html
@@ -53,7 +53,9 @@
         function handleNewParticipant() {
             let url = "/ad?generate_tokens=true&recruiter={{ recruiter }}&source=dashboard";
             log("Recruiting new participant...");
-            window.open(url, "_blank").focus();
+            // Use origin to avoid propagating any credentials in window.location.href.
+            let participantUrl = new URL(url, window.location.origin);
+            window.open(participantUrl.toString(), "_blank").focus();
         }
 
         function handleInitDB() {


### PR DESCRIPTION
Avoid propagating dashboard credentials into new participant URLs so pages that use fetch (e.g. Unity WebGL) do not hit the browser's rejection of URLs with embedded credentials. CHANGELOG entry added.