### PR TITLE
Dallinger DNS record upsert

### DIFF
--- a/dallinger/command_line/ec2.py
+++ b/dallinger/command_line/ec2.py
@@ -240,7 +240,7 @@ def ec2__start(ctx, dns, name, region, dns_host):
 
     instance_row = wait_for_instance_state_change(region, name, "running")
 
-    create_dns_records(dns_host, user, instance_row["public_dns_name"])
+    create_dns_records(dns_host, user, instance_row["public_dns_name"], upsert=True)
 
 
 @ec2.command("restart")

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -615,18 +615,19 @@ def remove_dns_records(zone_id, dns_host, route_53=None, confirm=False):
         print(f"Removed DNS record {dns_host}")
 
 
-def create_dns_record(dns_host, user, host, route_53=None):
+def create_dns_record(dns_host, user, host, route_53=None, upsert=False):
     if route_53 is None:
         route_53 = get_53_client()
 
     filtered_hosts = filter_zone_ids(get_domain(dns_host), route_53)
     hosted_zone_id = filtered_hosts[0]
+    action = "UPSERT" if upsert else "CREATE"
     response = route_53.change_resource_record_sets(
         HostedZoneId=hosted_zone_id,
         ChangeBatch={
             "Changes": [
                 {
-                    "Action": "UPSERT",
+                    "Action": action,
                     "ResourceRecordSet": {
                         "Type": "CNAME",
                         "Name": dns_host,
@@ -738,10 +739,10 @@ def prepare_instance(
     )
 
 
-def create_dns_records(dns_host, user, host):
+def create_dns_records(dns_host, user, host, upsert=False):
     if dns_host is not None:
-        create_dns_record(dns_host, user, host)
-        create_dns_record("*." + dns_host, user, host)
+        create_dns_record(dns_host, user, host, upsert=upsert)
+        create_dns_record("*." + dns_host, user, host, upsert=upsert)
 
 
 def remove_dns_record(dns_host, remove_dallinger_host=True):


### PR DESCRIPTION
## Description
Adds an `upsert` flag to the `create_dns_record` function, allowing explicit control over whether a DNS record is created or upserted. This flag is now used when creating DNS records during EC2 instance startup.

## Motivation and Context
Previously, DNS record creation always used an `UPSERT` action. This change introduces an explicit `upsert` flag to control the Route 53 action (`CREATE` or `UPSERT`). By setting `upsert=True` during EC2 start, we ensure that existing DNS records are updated rather than causing an error if they already exist, improving the robustness of the EC2 startup process.

## How Has This Been Tested?
New unit tests were added in `tests/test_ec2.py` to verify:
- `create_dns_record` defaults to `CREATE` when `upsert` is not specified.
- `create_dns_record` uses `UPSERT` when `upsert=True`.
- `create_dns_records` correctly propagates the `upsert` flag to its internal calls.
Tests were run using `python3 -m pytest tests/test_ec2.py -k "dns_record"`.

## Screenshots (if appropriate):
N/A

---
[Slack Thread](https://computationalaudition.slack.com/archives/C05EMHN35MZ/p1765294927861209?thread_ts=1765294927.861209&cid=C05EMHN35MZ)

<p><a href="https://cursor.com/background-agent?bcId=bc-5ae8428e-5258-5f59-a0d0-51963488c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-5ae8428e-5258-5f59-a0d0-51963488c642"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

