### PR TITLE
Improve provisioning output with spinners and checkmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Replaced third-party `cached_property` package with Python's built-in `functools.cached_property` (available since Python 3.8).
 - Moved `ipython` from core dependencies to `jupyter` optional dependency, reducing install size for users who don't need Jupyter features.
 - Moved `numpy` from core dependencies to `data` and `ec2` optional dependencies.
+- Improved provisioning output: replaced noisy error messages and bare data dumps with yaspin spinners and green checkmarks for all long-running steps (Docker check/install, storage resize, DNS record creation, etc.).
 
 #### Added
 - Added `allow_repeat_worker_ids` config option to allow recruiters to accept multiple submissions from the same worker ID.

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -180,19 +180,17 @@ def prepare_server(host, user):
             ) from exc
         raise
 
-    print("Checking docker presence")
-    try:
-        executor.run("docker ps")
-    except ExecuteException:
-        print("Installing docker")
-        executor.check_sudo()
-        executor.run("wget -O - https://get.docker.com | sudo -n bash")
-        executor.run("sudo -n adduser $(id --user --name) docker")
-        print("Docker installed")
-        # Log in again in case we need to be part of the `docker` group
-        executor = Executor(host, user)
-    else:
-        print("Docker daemon already installed")
+    with yaspin(text="Checking for Docker...", color="green") as sp:
+        if executor.run("command -v docker", raise_=False).strip():
+            sp.ok("✔")
+        else:
+            sp.text = "Installing Docker..."
+            executor.check_sudo()
+            executor.run("wget -O - https://get.docker.com | sudo -n bash")
+            executor.run("sudo -n adduser $(id --user --name) docker")
+            sp.ok("✔")
+            # Log in again in case we need to be part of the `docker` group
+            executor = Executor(host, user)
 
 
 def copy_docker_config(host, user):

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -583,10 +583,12 @@ def boot_instance(ec2, image_id, instance_type, key_name, instance_name, region_
     instance = response["Instances"][0]
     instance_id = instance["InstanceId"]
 
-    print(f"Waiting for {instance_name} to be ready...")
-    waiter = get_ec2_client(region_name).get_waiter("instance_running")
-    waiter.wait(InstanceIds=[instance_id])
-    print(f"{instance_name} is ready!")
+    with yaspin(
+        text=f"Waiting for {instance_name} to be ready...", color="green"
+    ) as sp:
+        waiter = get_ec2_client(region_name).get_waiter("instance_running")
+        waiter.wait(InstanceIds=[instance_id])
+        sp.ok("✔")
     return instance_id
 
 
@@ -611,9 +613,6 @@ def increase_storage(
     if ec2 is None:
         assert region_name is not None
         ec2 = get_ec2_client(region_name)
-    # Set sufficient storage
-    print(f"Increasing storage of {instance_name} to {storage_in_gb} GB...")
-
     # get volume id
     response = ec2.describe_instances(InstanceIds=[instance_id])
     instance = response["Reservations"][0]["Instances"][0]
@@ -626,16 +625,19 @@ def increase_storage(
         volume_size < storage_in_gb
     ), f"Volume size {volume_size} GB is already greater than {storage_in_gb} GB"
 
-    # increase volume size
-    ec2.modify_volume(
-        VolumeId=volume_id,
-        Size=storage_in_gb,
-    )
+    with yaspin(
+        text=f"Increasing storage of {instance_name} to {storage_in_gb} GB...",
+        color="green",
+    ) as sp:
+        ec2.modify_volume(
+            VolumeId=volume_id,
+            Size=storage_in_gb,
+        )
 
-    print(f"Waiting for {instance_name} to be ready...")
-    waiter = ec2.get_waiter("volume_in_use")
-    waiter.wait(VolumeIds=[volume_id])
-    print(f"{instance_name} is ready!")
+        sp.text = "Waiting for volume to be ready..."
+        waiter = ec2.get_waiter("volume_in_use")
+        waiter.wait(VolumeIds=[volume_id])
+        sp.ok("✔")
 
     # Extend partition
     host, user, ip_address = (
@@ -668,14 +670,21 @@ def increase_storage(
     selected_volume = selected_volumes[0]
     selected_partition = volume_to_partitions[selected_volume][0]
 
+    print("Disk usage before resize:")
     print(executor.run("df -h"))
-    print(executor.run("lsblk"))
-    time.sleep(20)
-    executor.run(f"sudo growpart /dev/{selected_volume} 1")
 
-    time.sleep(10)
-    executor.run(f"sudo resize2fs /dev/{selected_partition}")
+    with yaspin(
+        text=f"Resizing partition /dev/{selected_volume}...", color="green"
+    ) as sp:
+        time.sleep(20)
+        executor.run(f"sudo growpart /dev/{selected_volume} 1")
 
+        sp.text = f"Resizing filesystem on /dev/{selected_partition}..."
+        time.sleep(10)
+        executor.run(f"sudo resize2fs /dev/{selected_partition}")
+        sp.ok("✔")
+
+    print("Disk usage after resize:")
     print(executor.run("df -h"))
     return host, user, ip_address, executor
 
@@ -756,8 +765,9 @@ def create_dns_record(dns_host, user, host, route_53=None):
     ), "Failed to set up DNS record"
 
     with yaspin(
-        text="Waiting for DNS record to be set up (can take up to two minutes)..."
-    ):
+        text=f"Waiting for DNS record for {dns_host} (can take up to two minutes)...",
+        color="green",
+    ) as sp:
         change_id = response["ChangeInfo"]["Id"]
         n_tries = 24
         wait = 5
@@ -769,13 +779,13 @@ def create_dns_record(dns_host, user, host, route_53=None):
             time.sleep(wait)
         else:
             raise Exception(f"DNS record setup timed out after {timeout} seconds.")
+        sp.ok("✔")
 
     is_wild_card = dns_host.startswith("*.")
     full_domain = dns_host.replace("*.", "")
     test_host = f"test.{full_domain}" if is_wild_card else dns_host
 
     dns_executor = Executor(test_host, user)
-    print("DNS record set up!")
     return dns_executor
 
 
@@ -871,19 +881,22 @@ def prepare_docker_experiment_setup(
 ):
     from dallinger.config import get_config
 
-    config = get_config(load=True)
-    assert config.get("dashboard_user") and config.get(
-        "dashboard_password"
-    ), "dashboard_user and dashboard_password must be set in ~/.dallingerconfig"
+    with yaspin(text="Loading Dallinger configuration...", color="green") as sp:
+        config = get_config(load=True)
+        assert config.get("dashboard_user") and config.get(
+            "dashboard_password"
+        ), "dashboard_user and dashboard_password must be set in ~/.dallingerconfig"
+        sp.ok("✔")
 
     dallinger_prepare_server(host, user)
 
     create_dns_records(dns_host, user, host)
 
-    dallinger_store_host(dict(host=host, user=user))
-    if dns_host:
-        dallinger_store_host(dict(host=dns_host, user=user))
-    print("Host registered in dallinger")
+    with yaspin(text="Registering host in Dallinger...", color="green") as sp:
+        dallinger_store_host(dict(host=host, user=user))
+        if dns_host:
+            dallinger_store_host(dict(host=dns_host, user=user))
+        sp.ok("✔")
 
 
 def provision(


### PR DESCRIPTION
## Summary
- Replace noisy error output during provisioning with yaspin spinners and green checkmarks
- Add labels to raw `df -h` output

## Test plan
- [x] Provision a new EC2 instance and verify clean spinner/checkmark output throughout

Made with [Cursor](https://cursor.com)