### PR TITLE
 Removed tqdm from the ec2optional dependency set and migrated to Rich

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Improved `dallinger docker-ssh` server selection UX: when multiple servers are configured and `--server` is omitted (and for `servers remove` when `--host` is omitted), users now choose from a numbered list; explicit host/server options and single-server behavior remain unchanged.
 - Migrated CLI table rendering from `tabulate` to Rich tables for consistent formatting and non-interactive output behavior.
 - Improved EC2/provisioning CLI output: replaced noisy error messages and bare data dumps with clearer progress indicators (spinners/checkmarks plus list progress where appropriate), clarified `--dns` vs `--dns-host` option help text, and added friendly validation/errors for EC2 instance lookup and selector usage (`--name`/`--dns`).
+- Replaced `tqdm` progress display in EC2 CLI paths with `rich.progress` for consistent spinner/bar output and simplified dependency surface.
+- Adjusted EC2 all-regions listing log level from WARNING to INFO to avoid signaling normal behavior as an issue.
 
 #### Added
 - Added `allow_repeat_worker_ids` config option to allow recruiters to accept multiple submissions from the same worker ID.
@@ -29,6 +31,7 @@
 - Removed unused `pyopenssl` dependency.
 - Removed redundant `paramiko` from `docker` and `ec2` optional dependencies (already in core dependencies).
 - Removed redundant `yaspin` from `ec2` optional dependencies (already in core dependencies).
+- Removed `tqdm` from the `ec2` optional dependency set and generated dev requirements after migrating EC2 progress rendering to Rich.
 - Removed redundant `alabaster` from dev dependencies (transitive dependency of `sphinx`).
 - Removed redundant `pycodestyle` from dev dependencies (transitive dependency of `flake8`).
 - Removed redundant `black` from dev dependencies (already included via `black[jupyter]`).

--- a/dallinger/command_line/lib/ec2.py
+++ b/dallinger/command_line/lib/ec2.py
@@ -15,6 +15,7 @@ import paramiko
 import requests
 from botocore.exceptions import ClientError
 from paramiko import ssh_exception as pse
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 from tenacity import (
     before_sleep_log,
     retry,
@@ -22,7 +23,6 @@ from tenacity import (
     stop_after_attempt,
     wait_fixed,
 )
-from tqdm import tqdm
 from yaspin import yaspin
 
 from ..config import remove_host as dallinger_remove_host
@@ -222,13 +222,28 @@ def get_instances(region_name, show_spinner=True):
 
 def get_all_instances(region_name=None):
     if region_name is None:
-        logger.warning("Listing instances in all regions...")
+        logger.info("Listing instances in all regions...")
         instance_dfs = []
         all_regions = get_ec2_client().describe_regions()["Regions"]
-        pb = tqdm(all_regions, total=len(all_regions))
-        for region in pb:
-            pb.set_description("Retrieving instances in " + region["RegionName"])
-            instance_dfs.append(get_instances(region["RegionName"], show_spinner=False))
+        with Progress(
+            SpinnerColumn(style="green"),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TextColumn("{task.completed}/{task.total}"),
+            transient=True,
+        ) as progress:
+            task = progress.add_task(
+                "Retrieving instances in all regions...", total=len(all_regions)
+            )
+            for region in all_regions:
+                progress.update(
+                    task,
+                    description=f"Retrieving instances in {region['RegionName']}...",
+                )
+                instance_dfs.append(
+                    get_instances(region["RegionName"], show_spinner=False)
+                )
+                progress.advance(task)
         click.echo(
             click.style("✔ Finished retrieving instances in all regions.", fg="green")
         )
@@ -291,14 +306,24 @@ def list_instances(region_name=None, filtered_states=[], pem=None):
 
 def get_instance_types(region_name=None):
     ec2 = get_ec2_client(region_name)
-    pb = tqdm()
-    response = ec2.describe_instance_types()
-    instance_types = response["InstanceTypes"]
-    pb.update(len(instance_types))
-    while "NextToken" in response:
-        response = ec2.describe_instance_types(NextToken=response["NextToken"])
-        instance_types += response["InstanceTypes"]
-        pb.update(len(instance_types))
+    with Progress(
+        SpinnerColumn(style="green"),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        task = progress.add_task("Retrieving instance types...", total=None)
+        response = ec2.describe_instance_types()
+        instance_types = response["InstanceTypes"]
+        progress.update(
+            task, description=f"Retrieving instance types... ({len(instance_types)})"
+        )
+        while "NextToken" in response:
+            response = ec2.describe_instance_types(NextToken=response["NextToken"])
+            instance_types += response["InstanceTypes"]
+            progress.update(
+                task,
+                description=f"Retrieving instance types... ({len(instance_types)})",
+            )
 
     instance_type_metadata = []
     for instance_type in instance_types:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,6 @@ docker = [
 ec2 = [
     "numpy<2.3",
     "pandas<3",
-    "tqdm",
 ]
 jupyter = [
     "ipython<9",


### PR DESCRIPTION
#### Changed
- Replaced `tqdm` progress display in EC2 CLI paths with `rich.progress` for consistent spinner/bar output and simplified dependency surface.
- Adjusted EC2 all-regions listing log level from WARNING to INFO to avoid signaling normal behavior as an issue.

#### Removed
- Removed `tqdm` from the `ec2` optional dependency set and generated dev requirements after migrating EC2 progress rendering to Rich.