### PR TITLE
Unify bot completion with recruiter submission event

### DIFF
--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -30,7 +30,6 @@ LOG_EVENT_TYPES = frozenset(
         "AssignmentReassigned",
         "AssignmentReturned",
         "RecruiterSubmissionComplete",
-        "BotRecruiterSubmissionComplete",
         "BotAssignmentRejected",
         "NotificationMissing",
     )
@@ -266,19 +265,6 @@ class RecruiterSubmissionComplete(WorkerEvent):
         self.experiment.on_recruiter_submission_complete(
             participant=self.participant, event=self.data
         )
-
-
-class BotRecruiterSubmissionComplete(WorkerEvent):
-    def __call__(self):
-        self.log("Received bot submission.")
-        self.update_participant_end_time()
-
-        # No checks for bot submission
-        self.participant.recruiter.approve_hit(self.assignment_id)
-        self.participant.status = "approved"
-        self.experiment.submission_successful(participant=self.participant)
-        self.commit()
-        self.experiment.recruit()
 
 
 class BotAssignmentRejected(WorkerEvent):

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -2201,7 +2201,7 @@ class BotRecruiter(Recruiter):
     def on_task_completion(self):
         return {
             "new_status": "submitted",
-            "action": "BotRecruiterSubmissionComplete",
+            "action": "RecruiterSubmissionComplete",
         }
 
     def verify_status_of(self, participants: list[Participant]):

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -177,6 +177,28 @@ class TestExperimentBaseClass:
 
         assert participant.bonus is None
 
+    def test_on_recruiter_submission_complete__bots_follow_shared_completion_path(
+        self, a, active_config, exp
+    ):
+        participant = a.participant(recruiter_id="bots")
+        participant.status = "submitted"
+        exp.bonus = mock.Mock(return_value=0.01)
+        end_time = datetime(2000, 1, 1)
+
+        exp.on_recruiter_submission_complete(
+            participant=participant,
+            event={
+                "event_type": "RecruiterSubmissionComplete",
+                "participant_id": participant.id,
+                "assignment_id": participant.assignment_id,
+                "timestamp": end_time,
+            },
+        )
+
+        assert participant.base_pay == active_config.get("base_payment")
+        assert participant.status == "approved"
+        assert participant.bonus == 0.01
+
     def test_on_recruiter_submission_complete__sets_end_time_if_not_set(self, a, exp):
         participant = a.participant()
         participant.status = "submitted"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -321,7 +321,7 @@ class TestWorkerComplete:
 
         assert (
             models.Notification.query.one().event_type
-            == "BotRecruiterSubmissionComplete"
+            == "RecruiterSubmissionComplete"
         )
 
     def test_records_notification_for_non_mturk_recruiter(
@@ -1918,38 +1918,21 @@ class TestRecruiterSubmissionComplete:
         runner.experiment.on_recruiter_submission_complete.assert_called_once()
 
 
-class TestBotRecruiterSubmissionComplete:
+class TestBotRecruiterUsesRecruiterSubmissionComplete:
     @pytest.fixture
     def runner(self, standard_args):
         from dallinger.experiment_server.worker_events import (
-            BotRecruiterSubmissionComplete,
+            RecruiterSubmissionComplete,
         )
 
-        return BotRecruiterSubmissionComplete(**standard_args)
+        return RecruiterSubmissionComplete(**standard_args)
 
-    def test_participant_status_set(self, runner):
+    def test_calls_on_recruiter_submission_complete(self, runner):
         runner()
-        assert runner.participant.status == "approved"
-
-    def test_participant_end_time_set(self, runner):
-        runner()
-        assert runner.participant.end_time == end_time
-
-    def test_submission_successful_called_on_experiment(self, runner):
-        runner()
-        runner.experiment.submission_successful.assert_called_once_with(
-            participant=runner.participant
+        runner.experiment.on_recruiter_submission_complete.assert_called_once_with(
+            participant=runner.participant,
+            event=runner.data,
         )
-
-    def test_approve_hit_called_on_recruiter(self, runner):
-        runner()
-        runner.participant.recruiter.approve_hit.assert_called_once_with(
-            "some assignment id"
-        )
-
-    def test_recruit_called_on_experiment(self, runner):
-        runner()
-        runner.experiment.recruit.assert_called_once()
 
 
 class TestBotAssignmentRejected:

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -320,8 +320,7 @@ class TestWorkerComplete:
         )
 
         assert (
-            models.Notification.query.one().event_type
-            == "RecruiterSubmissionComplete"
+            models.Notification.query.one().event_type == "RecruiterSubmissionComplete"
         )
 
     def test_records_notification_for_non_mturk_recruiter(

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -359,7 +359,7 @@ class TestBotRecruiter:
     def test_on_task_completion__returns_event_type_and_new_status(self, recruiter):
         assert recruiter.on_task_completion() == {
             "new_status": "submitted",
-            "action": "BotRecruiterSubmissionComplete",
+            "action": "RecruiterSubmissionComplete",
         }
 
     def test_notify_duration_exceeded_rejects_participants(self, a, recruiter):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Unify bot completion with the same post-submission worker-event path used by human participants by removing the dedicated bot completion event path.

## Motivation and Context
Bots previously emitted `BotRecruiterSubmissionComplete`, which bypassed `Experiment.on_recruiter_submission_complete`. This change routes bot completion through `RecruiterSubmissionComplete` so bots and humans share the same completion callback path.

## How Has This Been Tested?
- `python3 -m pytest tests/test_recruiters.py -k "BotRecruiter or on_task_completion"`
- `python3 -m pytest tests/test_experiment_server.py -k "RecruiterSubmissionComplete or BotRecruiterSubmissionComplete"`
- `python3 -m pytest tests/test_experiment.py -k "on_recruiter_submission_complete"`

Additionally, CI pre-commit formatting failure was reproduced from logs and fixed by applying `ruff format` to `tests/test_experiment_server.py`.

## Screenshots (if appropriate):
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2735bb9f-2d2c-4d12-994b-9215963c3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2735bb9f-2d2c-4d12-994b-9215963c3140"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

