### PR TITLE
Fix error while failing entities from the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 
 ### Fixed
 
+- Fixed manual entity failure by switching to client-side formatting of data tables
 - Fixed frontend npm audit vulnerabilities by updating transitive JavaScript dependencies in `yarn.lock`, including patched versions of `immutable`, `minimatch`, `ajv`, and related build tooling packages.
 - Fixed clock process startup after Redis restarts by waiting for Redis to finish loading before scheduled tasks begin.
 - Fixed `get_page_from_directory` route returning 500 errors with full tracebacks for missing templates (e.g. from vulnerability scanners). Now returns 404, matching the existing `get_page` behavior.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -1618,7 +1618,7 @@ class Experiment:
         # Page
         items = q.offset(start).limit(length).all()
 
-        # Rows (strings escaped; non-strings pretty-printed inside <code>)
+        # Rows (raw JSON-native values; presentation handled client-side)
         rows, all_keys = [], set()
         for obj in items:
             data = obj.__json__() or {}
@@ -1630,11 +1630,13 @@ class Experiment:
                 if value is None:
                     coerced[key] = None
                 elif isinstance(value, (str, bytes)):
-                    coerced[key] = escape(value)
+                    if isinstance(value, bytes):
+                        coerced[key] = value.decode("utf-8", errors="replace")
+                    else:
+                        coerced[key] = value
                 else:
-                    coerced[key] = (
-                        f"<code>{escape(json.dumps(value, default=date_handler))}</code>"
-                    )
+                    # Ensure the value can be JSON-encoded for the dashboard API.
+                    coerced[key] = json.loads(json.dumps(value, default=date_handler))
             rows.append(coerced)
             all_keys.update(coerced.keys())
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -19,7 +19,6 @@ from typing import Any, List, Optional, Union
 
 import requests
 from flask import Blueprint, url_for
-from markupsafe import escape
 from sqlalchemy import String, Table, and_, asc, cast, create_engine, desc, func, or_
 from sqlalchemy.orm import scoped_session, sessionmaker, undefer
 from sqlalchemy.orm.attributes import InstrumentedAttribute

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -205,6 +205,37 @@
       // Filtering on boolean fields using the search panes requires
       // their values to be converted to strings
       updateBooleanProperties(globals.datatablesOptions.data);
+
+      // Render raw JSON safely for display, without changing the underlying data model.
+      globals.datatablesOptions.columnDefs = (globals.datatablesOptions.columnDefs || []).concat([{
+        targets: '_all',
+        render: function (data, type, row, meta) {
+          if (data === null || data === undefined) {
+            return type === 'display' ? '' : data;
+          }
+
+          const isDisplayLike = (type === 'display' || type === 'filter');
+          const asText = (value) => $.fn.dataTable.render.text().display(String(value));
+          const asCode = (value) => '<code>' + asText(value) + '</code>';
+          const isObject = (typeof data === 'object');
+
+          if (isObject) {
+            const jsonText = JSON.stringify(data);
+            return isDisplayLike ? asCode(jsonText) : jsonText;
+          }
+
+          if (isDisplayLike && (typeof data === 'number' || typeof data === 'boolean')) {
+            return asCode(data);
+          }
+
+          if (isDisplayLike) {
+            return asText(data);
+          }
+
+          return data;
+        }
+      }]);
+
       $('#database-table').DataTable(globals.datatablesOptions);
     });
   </script>

--- a/dallinger/frontend/templates/dashboard_database.html
+++ b/dallinger/frontend/templates/dashboard_database.html
@@ -193,19 +193,6 @@
         }
       };
 
-      function updateBooleanProperties(data) {
-        data.forEach(function(item) {
-          for (let property in item) {
-            if (typeof item[property] === 'boolean') {
-              item[property] = String(item[property]);
-            }
-          }
-        });
-      }
-      // Filtering on boolean fields using the search panes requires
-      // their values to be converted to strings
-      updateBooleanProperties(globals.datatablesOptions.data);
-
       // Render raw JSON safely for display, without changing the underlying data model.
       globals.datatablesOptions.columnDefs = (globals.datatablesOptions.columnDefs || []).concat([{
         targets: '_all',

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -735,8 +735,6 @@ class TestDashboardDatabase:
 
     def test_table_columns_and_data_participant(self, a, db_session):
         """Columns now come from table_columns(); data formatting changed."""
-        from markupsafe import escape
-
         from dallinger.experiment_server.experiment_server import Experiment
 
         exp = Experiment(db_session)
@@ -756,14 +754,12 @@ class TestDashboardDatabase:
         assert isinstance(page["data"], list) and page["data"]
 
         row = page["data"][0]
-        # id and type will be strings or <code>…</code> depending on __json__()
-        # but worker_id is explicitly injected and should be plain (escaped) string
-        assert row["worker_id"] == escape(p.worker_id)
+        # worker_id is explicitly injected and should be a plain string
+        assert row["worker_id"] == p.worker_id
 
-        # Dict fields like details are rendered as <code>JSON</code>
+        # Dict fields like details are returned as raw objects (rendered client-side)
         if "details" in row:
-            assert row["details"].startswith("<code>")
-            assert row["details"].endswith("</code>")
+            assert isinstance(row["details"], dict)
 
     def test_table_data_search_and_order(self, a, db_session):
         """Global search and ordering by a column should work."""
@@ -794,7 +790,7 @@ class TestDashboardDatabase:
             order_dir="desc",
         )
         ids = [d["id"] for d in page_all["data"]]
-        assert ids == ["<code>2</code>", "<code>1</code>"]
+        assert ids == [2, 1]
 
     def test_prep_datatables_options(self):
         """Ensure server-side flags and column normalization are applied."""


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Return raw JSON from the server and apply <code>…</code> formatting client-side during DataTables rendering (without modifying the underlying row data used by actions).

## Motivation and Context

dallinger==12.1.2 did not allow to fail entities from the dashboard because of the following error:

```
File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 1536, in __call__
    return self.wsgi_app(environ, start_response)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 1514, in wsgi_app
    response = self.handle_exception(e)
               ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/flask_login/utils.py", line 290, in decorated_view
    return current_app.ensure_sync(func)(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/dallinger/experiment_server/dashboard.py", line 1261, in database_action
    result = route_func(data)
             ^^^^^^^^^^^^^^^^
  File "/opt/anaconda3/envs/psynet/lib/python3.11/site-packages/dallinger/experiment.py", line 1889, in dashboard_fail
    obj = db.session.query(model).get(int(obj_id))
                                      ^^^^^^^^^^^^
ValueError: invalid literal for int() with base 10: '<code>113</code>'
```

## How Has This Been Tested?

Manually tested locally.