### PR TITLE
Bump version on master branch post-release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 12.2.0
+current_version = 12.3.0a1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [v12.2.0](https://github.com/dallinger/dallinger/tree/v12.2.0) (2026-04-20)
 
 ### Migration Notes

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "12.2.0"
+__version__ = "12.3.0a1"

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==12.2.0
+Dallinger==12.3.0a1

--- a/demos/setup.py
+++ b/demos/setup.py
@@ -10,7 +10,7 @@ if sys.argv[-1] == "publish":
 
 setup_args = dict(
     name="dlgr.demos",
-    version="12.2.0",
+    version="12.3.0a1",
     description="Demonstration experiments for Dallinger",
     url="http://github.com/Dallinger/Dallinger",
     maintainer="Jordan Suchow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "12.2.0"
+version = "12.3.0a1"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
Post-release version bump after merging v12.2.0.

- Bumps version from `12.2.0` → `12.3.0a1` across `.bumpversion.cfg`, `pyproject.toml`, `dallinger/version.py`, `demos/setup.py`, and `demos/requirements.txt`.
- Restores the `## [Unreleased]` heading at the top of `CHANGELOG.md`.

Per [docs/source/contributing_to_dallinger.rst](https://github.com/Dallinger/Dallinger/blob/master/docs/source/contributing_to_dallinger.rst), this should be merged as soon as possible, before any new feature branches land.

Made with [Cursor](https://cursor.com)