### PR TITLE
Fix race condition when launching with multiple web dynos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,8 +80,7 @@
 
 ### Fixed
 
-#### Fixed
-- Fixed race condition in `DebugDeployment` where the `/launch` request could fire before the selected web dyno was accepting connections (when `num_dynos_web > 1`). A TCP readiness check now runs before launching.
+- Fixed race condition in `DebugDeployment` where the `/launch` request could fire before the selected web dyno was accepting connections. `heroku local` now runs with a single web dyno (multiple dynos provide no load distribution locally), and an HTTP readiness check now runs before launching.
 - Improved error message for AWS authentication failures (wrong credentials, expired tokens, clock skew) in EC2 commands: now displays a concise, actionable message instead of a full stack trace.
 
 ## [v12.1.1](https://github.com/dallinger/dallinger/tree/v12.1.1) (2026-02-11) [YANKED]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@
 
 ### Fixed
 
+#### Fixed
+- Fixed race condition in `DebugDeployment` where the `/launch` request could fire before the selected web dyno was accepting connections (when `num_dynos_web > 1`). A TCP readiness check now runs before launching.
 - Improved error message for AWS authentication failures (wrong credentials, expired tokens, clock skew) in EC2 commands: now displays a concise, actionable message instead of a full stack trace.
 
 ## [v12.1.1](https://github.com/dallinger/dallinger/tree/v12.1.1) (2026-02-11) [YANKED]

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -450,15 +450,13 @@ class DebugDeployment(HerokuLocalDeployment):
             self.exp_config["recruiter"] = "bots"
 
     def execute(self, heroku):
-        server_url = get_base_url()
-        wait_for_server(server_url, timeout=60)
-        self.out.log(
-            "Server is running on {}. Press Ctrl+C to exit.".format(server_url)
-        )
+        base_url = get_base_url()
+        wait_for_server(base_url, timeout=60)
+        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
         self.out.log("Launching the experiment...")
         try:
             result = handle_launch_data(
-                "{}/launch".format(server_url), error=self.out.error, attempts=1
+                "{}/launch".format(base_url), error=self.out.error, attempts=1
             )
         except Exception:
             # Show output from server
@@ -467,7 +465,7 @@ class DebugDeployment(HerokuLocalDeployment):
         else:
             if result["status"] == "success":
                 self.out.log(result["recruitment_msg"])
-                dashboard_url = self.with_proxy_port("{}/dashboard/".format(server_url))
+                dashboard_url = self.with_proxy_port("{}/dashboard/".format(base_url))
                 self.display_dashboard_access_details(dashboard_url)
                 if not self.no_browsers:
                     self.async_open_dashboard(dashboard_url)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -380,13 +380,48 @@ class HerokuLocalDeployment:
         raise NotImplementedError()
 
 
+def wait_for_server(server_url, timeout, interval=0.5):
+    """Wait for the server at *server_url* to accept TCP connections."""
+    import socket
+
+    parsed = urlparse(server_url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or 80
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            with socket.create_connection(
+                (host, port), timeout=min(interval, remaining)
+            ):
+                return
+        except OSError:
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(interval, remaining))
+    raise RuntimeError(
+        f"Server at {server_url} did not become ready within {timeout} seconds"
+    )
+
+
 class DebugDeployment(HerokuLocalDeployment):
     dispatch = {
         r"[^\"]{} (.*)$".format(recruiters.NEW_RECRUIT_LOG_PREFIX): "new_recruit",
         r"{}".format(recruiters.CLOSE_RECRUITMENT_LOG_PREFIX): "recruitment_closed",
     }
 
-    def __init__(self, output, verbose, bot, proxy_port, exp_config, no_browsers=False):
+    def __init__(
+        self,
+        output,
+        verbose,
+        bot,
+        proxy_port,
+        exp_config,
+        no_browsers=False,
+        server_readiness_check=wait_for_server,
+    ):
         self.out = output
         self.verbose = verbose
         self.bot = bot
@@ -396,6 +431,7 @@ class DebugDeployment(HerokuLocalDeployment):
         self.complete = False
         self.status_thread = None
         self.no_browsers = no_browsers
+        self.server_readiness_check = server_readiness_check
         self.environ = {
             "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex").decode("ascii"),
         }
@@ -412,12 +448,24 @@ class DebugDeployment(HerokuLocalDeployment):
             self.exp_config["recruiter"] = "bots"
 
     def execute(self, heroku):
-        base_url = get_base_url()
-        self.out.log("Server is running on {}. Press Ctrl+C to exit.".format(base_url))
+        server_url = get_base_url()
+        try:
+            self.server_readiness_check(
+                server_url, timeout=0.001
+            )  # TODO: restore default 30s
+        except RuntimeError:
+            self.out.error(
+                f"Server at {server_url} did not become ready in time. "
+                f"Check that gunicorn is starting correctly."
+            )
+            return
+        self.out.log(
+            "Server is running on {}. Press Ctrl+C to exit.".format(server_url)
+        )
         self.out.log("Launching the experiment...")
         try:
             result = handle_launch_data(
-                "{}/launch".format(base_url), error=self.out.error, attempts=1
+                "{}/launch".format(server_url), error=self.out.error, attempts=1
             )
         except Exception:
             # Show output from server
@@ -426,7 +474,7 @@ class DebugDeployment(HerokuLocalDeployment):
         else:
             if result["status"] == "success":
                 self.out.log(result["recruitment_msg"])
-                dashboard_url = self.with_proxy_port("{}/dashboard/".format(base_url))
+                dashboard_url = self.with_proxy_port("{}/dashboard/".format(server_url))
                 self.display_dashboard_access_details(dashboard_url)
                 if not self.no_browsers:
                     self.async_open_dashboard(dashboard_url)

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -381,25 +381,19 @@ class HerokuLocalDeployment:
 
 
 def wait_for_server(server_url, timeout, interval=0.5):
-    """Wait for the server at *server_url* to accept TCP connections."""
-    import socket
-
-    parsed = urlparse(server_url)
-    host = parsed.hostname or "localhost"
-    port = parsed.port or 80
+    """Wait for the server at *server_url* to respond to HTTP requests."""
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             break
         try:
-            with socket.create_connection(
-                (host, port), timeout=min(interval, remaining)
-            ):
-                return
-        except OSError:
+            requests.get(server_url, timeout=min(interval, remaining))
+            return
+        except (requests.ConnectionError, requests.Timeout):
             remaining = deadline - time.monotonic()
             if remaining > 0:
+                print(f"Waiting for {server_url} ...")
                 time.sleep(min(interval, remaining))
     raise RuntimeError(
         f"Server at {server_url} did not become ready within {timeout} seconds"

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -312,7 +312,17 @@ class HerokuLocalDeployment:
     DO_INIT_DB = True
 
     def configure(self):
-        self.exp_config.update({"mode": "debug"})
+        config = get_config()
+        original = self.exp_config.get("num_dynos_web") or (
+            config.get("num_dynos_web") if config.ready else None
+        )
+        if original is not None and original > 1:
+            self.out.log(
+                f"Overriding num_dynos_web={original} → 1 "
+                "(multiple web dynos provide no load distribution in local mode; "
+                "all traffic hits one dyno regardless)"
+            )
+        self.exp_config.update({"mode": "debug", "num_dynos_web": 1})
 
     def setup(self):
         self.exp_id, self.tmp_dir = setup_experiment(
@@ -414,7 +424,6 @@ class DebugDeployment(HerokuLocalDeployment):
         proxy_port,
         exp_config,
         no_browsers=False,
-        server_readiness_check=wait_for_server,
     ):
         self.out = output
         self.verbose = verbose
@@ -425,7 +434,6 @@ class DebugDeployment(HerokuLocalDeployment):
         self.complete = False
         self.status_thread = None
         self.no_browsers = no_browsers
-        self.server_readiness_check = server_readiness_check
         self.environ = {
             "FLASK_SECRET_KEY": codecs.encode(os.urandom(16), "hex").decode("ascii"),
         }
@@ -443,14 +451,7 @@ class DebugDeployment(HerokuLocalDeployment):
 
     def execute(self, heroku):
         server_url = get_base_url()
-        try:
-            self.server_readiness_check(server_url, timeout=30)
-        except RuntimeError:
-            self.out.error(
-                f"Server at {server_url} did not become ready in time. "
-                f"Check that gunicorn is starting correctly."
-            )
-            return
+        wait_for_server(server_url, timeout=60)
         self.out.log(
             "Server is running on {}. Press Ctrl+C to exit.".format(server_url)
         )
@@ -584,7 +585,8 @@ class LoaderDeployment(HerokuLocalDeployment):
         self.zip_path = None
 
     def configure(self):
-        self.exp_config.update({"mode": "debug", "loglevel": 0})
+        super().configure()
+        self.exp_config.update({"loglevel": 0})
 
         self.zip_path = data.find_experiment_export(self.app_id)
         if self.zip_path is None:

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -450,9 +450,7 @@ class DebugDeployment(HerokuLocalDeployment):
     def execute(self, heroku):
         server_url = get_base_url()
         try:
-            self.server_readiness_check(
-                server_url, timeout=0.001
-            )  # TODO: restore default 30s
+            self.server_readiness_check(server_url, timeout=30)
         except RuntimeError:
             self.out.error(
                 f"Server at {server_url} did not become ready in time. "

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -535,7 +535,7 @@ class HerokuLocalWrapper:
             if self.verbose:
                 self.out.blather(line)
             line = line.strip()
-            if port_is_open(port):
+            if self._up_and_running(port):
                 return True
 
             if self._redis_not_running(line):
@@ -614,6 +614,9 @@ class HerokuLocalWrapper:
                 yield line.decode("utf-8")
             else:
                 yield line
+
+    def _up_and_running(self, port):
+        return port_is_open(port)
 
     def _redis_not_running(self, line):
         if isinstance(line, bytes):

--- a/dallinger/heroku/tools.py
+++ b/dallinger/heroku/tools.py
@@ -535,7 +535,7 @@ class HerokuLocalWrapper:
             if self.verbose:
                 self.out.blather(line)
             line = line.strip()
-            if self._up_and_running(port):
+            if port_is_open(port):
                 return True
 
             if self._redis_not_running(line):
@@ -614,9 +614,6 @@ class HerokuLocalWrapper:
                 yield line.decode("utf-8")
             else:
                 yield line
-
-    def _up_and_running(self, port):
-        return port_is_open(port)
 
     def _redis_not_running(self, line):
         if isinstance(line, bytes):

--- a/dallinger/utils.py
+++ b/dallinger/utils.py
@@ -117,8 +117,9 @@ def get_base_url():
     else:
         # debug mode
         base_port = config.get("base_port")
-        port = random.randrange(base_port, base_port + config.get("num_dynos_web"))
-        base_url = "http://{}:{}".format(host, port)
+        viable_ports = range(base_port, base_port + config.get("num_dynos_web"))
+        port = random.choice(viable_ports)
+        base_url = f"http://{host}:{port}"
 
     return base_url
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -861,10 +861,6 @@ class Testhandle_launch_data:
             mock_print.assert_not_called()
 
 
-def _noop_readiness_check(*args, **kwargs):
-    pass
-
-
 @pytest.mark.usefixtures("bartlett_dir", "clear_workers", "env")
 @pytest.mark.slow
 class TestDebugServer:
@@ -878,7 +874,6 @@ class TestDebugServer:
             bot=False,
             proxy_port=None,
             exp_config={},
-            server_readiness_check=_noop_readiness_check,
         )
         yield debugger
         if debugger.status_thread:
@@ -895,7 +890,6 @@ class TestDebugServer:
             proxy_port=None,
             exp_config={},
             no_browsers=True,
-            server_readiness_check=_noop_readiness_check,
         )
         yield debugger
         if debugger.status_thread:
@@ -998,17 +992,18 @@ class TestDebugServer:
 
     def test_failure(self, debugger):
         with mock.patch("dallinger.deployment.HerokuLocalDeployment.WRAPPER_CLASS"):
-            with mock.patch("dallinger.deployment.requests.post") as mock_post:
-                mock_post.return_value = mock.Mock(
-                    ok=False,
-                    json=mock.Mock(return_value={"message": "msg!"}),
-                    raise_for_status=mock.Mock(
-                        side_effect=requests.exceptions.HTTPError
-                    ),
-                    status_code=500,
-                    text="Failure",
-                )
-                debugger.run()
+            with mock.patch("dallinger.deployment.wait_for_server"):
+                with mock.patch("dallinger.deployment.requests.post") as mock_post:
+                    mock_post.return_value = mock.Mock(
+                        ok=False,
+                        json=mock.Mock(return_value={"message": "msg!"}),
+                        raise_for_status=mock.Mock(
+                            side_effect=requests.exceptions.HTTPError
+                        ),
+                        status_code=500,
+                        text="Failure",
+                    )
+                    debugger.run()
 
         # Only one launch attempt should be made in debug mode
         debugger.out.error.assert_has_calls(
@@ -1076,63 +1071,78 @@ class TestWaitForServer:
             assert elapsed < 0.5
 
 
-class TestDebugServerExecuteWaitsForServer:
+class TestHerokuLocalDeploymentNumDynos:
     @pytest.fixture
     def output(self):
         from dallinger.command_line import Output
 
         return Output(log=mock.Mock(), error=mock.Mock(), blather=mock.Mock())
 
-    @pytest.fixture
-    def subject(self):
+    def test_configure_forces_single_web_dyno(self, output):
         from dallinger.deployment import DebugDeployment
 
-        return DebugDeployment
-
-    def test_execute_returns_early_when_server_unreachable(self, subject, output):
-        debugger = subject(
+        debugger = DebugDeployment(
             output,
-            verbose=True,
+            verbose=False,
             bot=False,
             proxy_port=None,
-            exp_config={},
-            server_readiness_check=mock.Mock(side_effect=RuntimeError("not ready")),
+            exp_config={"num_dynos_web": 4},
         )
-        heroku = mock.Mock()
-        with mock.patch(
-            "dallinger.deployment.get_base_url",
-            return_value="http://127.0.0.1:5000",
-        ):
-            debugger.execute(heroku)
-        debugger.out.error.assert_called_once()
-        assert "did not become ready in time" in debugger.out.error.call_args[0][0]
-        debugger.out.log.assert_not_called()
+        debugger.configure()
+        assert debugger.exp_config["num_dynos_web"] == 1
 
-    def test_execute_proceeds_when_server_reachable(
-        self, subject, output, dashboard_config
-    ):
-        debugger = subject(
+    def test_configure_warns_when_exp_config_has_multiple_web_dynos(self, output):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
             output,
-            verbose=True,
+            verbose=False,
             bot=False,
             proxy_port=None,
-            exp_config={},
-            server_readiness_check=mock.Mock(),
+            exp_config={"num_dynos_web": 3},
         )
-        heroku = mock.Mock()
-        with mock.patch(
-            "dallinger.deployment.get_base_url",
-            return_value="http://127.0.0.1:5000",
-        ):
-            with mock.patch(
-                "dallinger.deployment.handle_launch_data",
-                return_value={"status": "success", "recruitment_msg": "ok"},
-            ):
-                debugger.execute(heroku)
-        debugger.out.log.assert_any_call(
-            "Server is running on http://127.0.0.1:5000. Press Ctrl+C to exit."
+        debugger.configure()
+        logged = " ".join(str(c) for c in output.log.call_args_list)
+        assert "num_dynos_web" in logged
+        assert "3" in logged
+
+    def test_configure_warns_when_global_config_has_multiple_web_dynos(self, output):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
+            output, verbose=False, bot=False, proxy_port=None, exp_config={}
         )
-        debugger.out.log.assert_any_call("Launching the experiment...")
+        mock_config = mock.Mock()
+        mock_config.ready = True
+        mock_config.get.return_value = 4
+        with mock.patch("dallinger.deployment.get_config", return_value=mock_config):
+            debugger.configure()
+        logged = " ".join(str(c) for c in output.log.call_args_list)
+        assert "num_dynos_web" in logged
+        assert "4" in logged
+
+    def test_configure_does_not_warn_when_already_1(self, output):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
+            output,
+            verbose=False,
+            bot=False,
+            proxy_port=None,
+            exp_config={"num_dynos_web": 1},
+        )
+        debugger.configure()
+        assert debugger.exp_config["num_dynos_web"] == 1
+        output.log.assert_not_called()
+
+    def test_configure_forces_single_web_dyno_when_not_set(self, output):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
+            output, verbose=False, bot=False, proxy_port=None, exp_config={}
+        )
+        debugger.configure()
+        assert debugger.exp_config["num_dynos_web"] == 1
 
 
 if os.environ.get("CI"):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2,7 +2,6 @@ import configparser
 import os
 import re
 import shutil
-import socket
 import sys
 import tempfile
 import textwrap
@@ -1030,36 +1029,51 @@ class TestWaitForServer:
 
         return wait_for_server
 
-    def test_returns_when_server_is_listening(self, subject):
-        sock = socket.socket()
-        sock.bind(("127.0.0.1", 0))
-        sock.listen(1)
-        port = sock.getsockname()[1]
-        try:
-            subject(f"http://127.0.0.1:{port}", timeout=2)
-        finally:
-            sock.close()
+    def test_returns_when_server_responds(self, subject):
+        with mock.patch("dallinger.deployment.requests") as mock_requests:
+            mock_requests.ConnectionError = requests.ConnectionError
+            mock_requests.Timeout = requests.Timeout
+            subject("http://127.0.0.1:5000", timeout=2)
+        mock_requests.get.assert_called()
 
-    def test_raises_when_server_not_listening(self, subject):
-        with pytest.raises(RuntimeError, match="did not become ready"):
-            subject("http://127.0.0.1:19999", timeout=0.05, interval=0.01)
+    def test_returns_on_error_status(self, subject):
+        """Any HTTP response (even 500) means the worker is alive."""
+        with mock.patch("dallinger.deployment.requests") as mock_requests:
+            mock_requests.ConnectionError = requests.ConnectionError
+            mock_requests.Timeout = requests.Timeout
+            mock_requests.get.return_value = mock.Mock(status_code=500)
+            subject("http://127.0.0.1:5000", timeout=2)
+
+    def test_raises_when_server_not_responding(self, subject):
+        with mock.patch("dallinger.deployment.requests") as mock_requests:
+            mock_requests.ConnectionError = requests.ConnectionError
+            mock_requests.Timeout = requests.Timeout
+            mock_requests.get.side_effect = requests.ConnectionError()
+            with pytest.raises(RuntimeError, match="did not become ready"):
+                subject("http://127.0.0.1:5000", timeout=0.05, interval=0.01)
+
+    def test_retries_then_succeeds(self, subject):
+        """Retries on ConnectionError, then succeeds."""
+        with mock.patch("dallinger.deployment.requests") as mock_requests:
+            mock_requests.ConnectionError = requests.ConnectionError
+            mock_requests.Timeout = requests.Timeout
+            mock_requests.get.side_effect = [
+                requests.ConnectionError(),
+                mock.Mock(status_code=200),
+            ]
+            subject("http://127.0.0.1:5000", timeout=2, interval=0.01)
+        assert mock_requests.get.call_count == 2
 
     def test_respects_timeout(self, subject):
-        start = time.monotonic()
-        with pytest.raises(RuntimeError):
-            subject("http://127.0.0.1:19999", timeout=0.1, interval=0.02)
-        elapsed = time.monotonic() - start
-        assert elapsed < 0.5
-
-    def test_ignores_path_in_url(self, subject):
-        sock = socket.socket()
-        sock.bind(("127.0.0.1", 0))
-        sock.listen(1)
-        port = sock.getsockname()[1]
-        try:
-            subject(f"http://127.0.0.1:{port}/some/path", timeout=2)
-        finally:
-            sock.close()
+        with mock.patch("dallinger.deployment.requests") as mock_requests:
+            mock_requests.ConnectionError = requests.ConnectionError
+            mock_requests.Timeout = requests.Timeout
+            mock_requests.get.side_effect = requests.ConnectionError()
+            start = time.monotonic()
+            with pytest.raises(RuntimeError):
+                subject("http://127.0.0.1:5000", timeout=0.1, interval=0.02)
+            elapsed = time.monotonic() - start
+            assert elapsed < 0.5
 
 
 class TestDebugServerExecuteWaitsForServer:
@@ -1069,10 +1083,14 @@ class TestDebugServerExecuteWaitsForServer:
 
         return Output(log=mock.Mock(), error=mock.Mock(), blather=mock.Mock())
 
-    def test_execute_returns_early_when_server_unreachable(self, output):
+    @pytest.fixture
+    def subject(self):
         from dallinger.deployment import DebugDeployment
 
-        debugger = DebugDeployment(
+        return DebugDeployment
+
+    def test_execute_returns_early_when_server_unreachable(self, subject, output):
+        debugger = subject(
             output,
             verbose=True,
             bot=False,
@@ -1090,10 +1108,10 @@ class TestDebugServerExecuteWaitsForServer:
         assert "did not become ready in time" in debugger.out.error.call_args[0][0]
         debugger.out.log.assert_not_called()
 
-    def test_execute_proceeds_when_server_reachable(self, output, dashboard_config):
-        from dallinger.deployment import DebugDeployment
-
-        debugger = DebugDeployment(
+    def test_execute_proceeds_when_server_reachable(
+        self, subject, output, dashboard_config
+    ):
+        debugger = subject(
             output,
             verbose=True,
             bot=False,

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -2,9 +2,11 @@ import configparser
 import os
 import re
 import shutil
+import socket
 import sys
 import tempfile
 import textwrap
+import time
 import uuid
 from pathlib import Path
 from unittest import mock
@@ -860,6 +862,10 @@ class Testhandle_launch_data:
             mock_print.assert_not_called()
 
 
+def _noop_readiness_check(*args, **kwargs):
+    pass
+
+
 @pytest.mark.usefixtures("bartlett_dir", "clear_workers", "env")
 @pytest.mark.slow
 class TestDebugServer:
@@ -868,7 +874,12 @@ class TestDebugServer:
         from dallinger.deployment import DebugDeployment
 
         debugger = DebugDeployment(
-            output, verbose=True, bot=False, proxy_port=None, exp_config={}
+            output,
+            verbose=True,
+            bot=False,
+            proxy_port=None,
+            exp_config={},
+            server_readiness_check=_noop_readiness_check,
         )
         yield debugger
         if debugger.status_thread:
@@ -885,6 +896,7 @@ class TestDebugServer:
             proxy_port=None,
             exp_config={},
             no_browsers=True,
+            server_readiness_check=_noop_readiness_check,
         )
         yield debugger
         if debugger.status_thread:
@@ -1009,6 +1021,105 @@ class TestDebugServer:
                 mock.call("msg!"),
             ]
         )
+
+
+class TestWaitForServer:
+    @pytest.fixture
+    def subject(self):
+        from dallinger.deployment import wait_for_server
+
+        return wait_for_server
+
+    def test_returns_when_server_is_listening(self, subject):
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+        try:
+            subject(f"http://127.0.0.1:{port}", timeout=2)
+        finally:
+            sock.close()
+
+    def test_raises_when_server_not_listening(self, subject):
+        with pytest.raises(RuntimeError, match="did not become ready"):
+            subject("http://127.0.0.1:19999", timeout=0.05, interval=0.01)
+
+    def test_respects_timeout(self, subject):
+        start = time.monotonic()
+        with pytest.raises(RuntimeError):
+            subject("http://127.0.0.1:19999", timeout=0.1, interval=0.02)
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.5
+
+    def test_ignores_path_in_url(self, subject):
+        sock = socket.socket()
+        sock.bind(("127.0.0.1", 0))
+        sock.listen(1)
+        port = sock.getsockname()[1]
+        try:
+            subject(f"http://127.0.0.1:{port}/some/path", timeout=2)
+        finally:
+            sock.close()
+
+    def test_defaults_port_80(self, subject):
+        # URL without explicit port should default to 80
+        with pytest.raises(RuntimeError, match="did not become ready"):
+            subject("http://127.0.0.1", timeout=0.05, interval=0.01)
+
+
+class TestDebugServerExecuteWaitsForServer:
+    @pytest.fixture
+    def output(self):
+        from dallinger.command_line import Output
+
+        return Output(log=mock.Mock(), error=mock.Mock(), blather=mock.Mock())
+
+    def test_execute_returns_early_when_server_unreachable(self, output):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
+            output,
+            verbose=True,
+            bot=False,
+            proxy_port=None,
+            exp_config={},
+            server_readiness_check=mock.Mock(side_effect=RuntimeError("not ready")),
+        )
+        heroku = mock.Mock()
+        with mock.patch(
+            "dallinger.deployment.get_base_url",
+            return_value="http://127.0.0.1:5000",
+        ):
+            debugger.execute(heroku)
+        debugger.out.error.assert_called_once()
+        assert "did not become ready in time" in debugger.out.error.call_args[0][0]
+        debugger.out.log.assert_not_called()
+
+    def test_execute_proceeds_when_server_reachable(self, output, dashboard_config):
+        from dallinger.deployment import DebugDeployment
+
+        debugger = DebugDeployment(
+            output,
+            verbose=True,
+            bot=False,
+            proxy_port=None,
+            exp_config={},
+            server_readiness_check=mock.Mock(),
+        )
+        heroku = mock.Mock()
+        with mock.patch(
+            "dallinger.deployment.get_base_url",
+            return_value="http://127.0.0.1:5000",
+        ):
+            with mock.patch(
+                "dallinger.deployment.handle_launch_data",
+                return_value={"status": "success", "recruitment_msg": "ok"},
+            ):
+                debugger.execute(heroku)
+        debugger.out.log.assert_any_call(
+            "Server is running on http://127.0.0.1:5000. Press Ctrl+C to exit."
+        )
+        debugger.out.log.assert_any_call("Launching the experiment...")
 
 
 if os.environ.get("CI"):

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -1061,11 +1061,6 @@ class TestWaitForServer:
         finally:
             sock.close()
 
-    def test_defaults_port_80(self, subject):
-        # URL without explicit port should default to 80
-        with pytest.raises(RuntimeError, match="did not become ready"):
-            subject("http://127.0.0.1", timeout=0.05, interval=0.01)
-
 
 class TestDebugServerExecuteWaitsForServer:
     @pytest.fixture

--- a/tests/test_heroku.py
+++ b/tests/test_heroku.py
@@ -602,7 +602,7 @@ class TestHerokuLocalWrapper:
     def test_gives_up_after_timeout(self, heroku):
         from dallinger.heroku.tools import HerokuTimeoutError
 
-        with mock.patch.object(heroku, "_up_and_running", return_value=False):
+        with mock.patch("dallinger.heroku.tools.port_is_open", return_value=False):
             with pytest.raises(HerokuTimeoutError):
                 heroku.start(timeout_secs=1)
 
@@ -611,7 +611,7 @@ class TestHerokuLocalWrapper:
 
         heroku.verbose = False  # more coverage
         heroku._stream = mock.Mock(return_value=["[DONE] Killing all processes"])
-        with mock.patch.object(heroku, "_up_and_running", return_value=False):
+        with mock.patch("dallinger.heroku.tools.port_is_open", return_value=False):
             with pytest.raises(HerokuStartupError):
                 heroku.start()
 
@@ -621,7 +621,7 @@ class TestHerokuLocalWrapper:
         heroku._stream = mock.Mock(
             return_value=["apple", "orange", heroku.STREAM_SENTINEL]
         )
-        with mock.patch.object(heroku, "_up_and_running", return_value=False):
+        with mock.patch("dallinger.heroku.tools.port_is_open", return_value=False):
             with pytest.raises(HerokuStartupError):
                 heroku.start()
         assert not heroku.is_running
@@ -633,7 +633,7 @@ class TestHerokuLocalWrapper:
             return_value=["apple", "orange", heroku.STREAM_SENTINEL]
         )
         heroku._log_failure = mock.Mock()
-        with mock.patch.object(heroku, "_up_and_running", return_value=False):
+        with mock.patch("dallinger.heroku.tools.port_is_open", return_value=False):
             with pytest.raises(HerokuStartupError):
                 heroku.start()
         heroku._log_failure.assert_called_once()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -300,6 +300,18 @@ class TestBaseURL:
         config.set("num_dynos_web", 1)
         assert subject() == "https://dlgr-bogus.herokuapp.com"
 
+    def test_base_url_picks_from_viable_ports(self, subject, config):
+        config.set("host", "127.0.0.1")
+        config.set("base_port", 5000)
+        config.set("num_dynos_web", 3)
+        with mock.patch("dallinger.utils.random.choice") as mock_choice:
+            mock_choice.return_value = 5002
+            result = subject()
+        mock_choice.assert_called_once()
+        ports = mock_choice.call_args[0][0]
+        assert list(ports) == [5000, 5001, 5002]
+        assert result == "http://127.0.0.1:5002"
+
     @pytest.mark.xfail(
         reason="HOST aliasing removed to fix https://github.com/Dallinger/Dallinger/issues/2130"
     )


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description

- Force `num_dynos_web=1` in `HerokuLocalDeployment.configure()`, with a warning if the user had a higher value set. Multiple web dynos in local mode provide no load distribution (there is no reverse proxy, so all traffic hits one dyno regardless of how many are runni8ng), but did cause non-deterministic port selection in `get_base_url()`.
- `LoaderDeployment.configure()` now calls `super().configure()` to inherit the override
- Restore two-phase startup readiness: `_verify_startup` uses a TCP check (`port_is_open`) to confirm gunicorn bound the port; `execute()` uses `wait_for_server()` for an HTTP-level check before sending `/launch`. With `num_dynos_web=1`, both checks are always against `base_port` — no random port selection.
- Remove `server_readiness_check` injectable from `DebugDeployment` (no longer needed).
- Remove `_up_and_running` method from `HerokuLocalWrapper`; TCP check is inlined directly in `_verify_startup`.

## Motivation and Context

When `num_dynos_web > 1`, `heroku local` assigns sequential ports (5000, 5001, ...) and `get_base_url()` picks one at random. This caused two problems: the `/launch` request could fire before the chosen dyno's gunicorn worker was accepting connections, and `on_launch` would save a non-`base_port` URL to Redis, making the saved `base_url` non-deterministic.

`heroku local` provides no reverse proxy, so extra web dynos start and listen but receive no traffic. Forcing `num_dynos_web=1` eliminates both problems and avoids wasting resources on idle dynos.

  ## How Has This Been Tested?

  - `pytest tests/test_deployment.py::TestHerokuLocalDeploymentNumDynos` — override behavior and warning
  - `pytest tests/test_deployment.py::TestWaitForServer` — existing unit tests for `wait_for_server`
  - `pytest tests/test_deployment.py::TestDebugServer --runslow` — end-to-end debug server tests
  - `pytest tests/test_heroku.py` — startup/error detection with TCP readiness check

