### PR TITLE
Surface early launch errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Fixed `dallinger debug` launch failures that happen before the `/launch` route
+  body so they return JSON error messages instead of only a generic HTML 500
+  response.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Updated

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -77,9 +77,7 @@ def launch_error_guard(error_prefix):
                 return func(*args, **kwargs)
             except Exception as ex:
                 if request.path == "/launch":
-                    return launch_error_response(
-                        "{}: {}".format(error_prefix, str(ex))
-                    )
+                    return launch_error_response("{}: {}".format(error_prefix, str(ex)))
                 raise
 
         return wrapper

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -61,9 +61,21 @@ WAITING_ROOM_CHANNEL = "quorum"
 app = Flask("Experiment_Server")
 
 
+def launch_error_response(error_text):
+    """Return a JSON error for failures that happen before `/launch` runs."""
+    return error_response(error_text=error_text, status=500, simple=True)
+
+
 @app.before_request
 def _load_config():
-    _config()
+    try:
+        _config()
+    except Exception as ex:
+        if request.path == "/launch":
+            return launch_error_response(
+                "Failed to load configuration before /launch: {}".format(str(ex))
+            )
+        raise
 
 
 @app.before_request
@@ -76,7 +88,15 @@ def check_for_protected_routes():
     except AttributeError:
         return
 
-    protected = Experiment(no_configure=True).protected_routes
+    try:
+        protected = Experiment(no_configure=True).protected_routes
+    except Exception as ex:
+        if request.path == "/launch":
+            return launch_error_response(
+                "Failed to load experiment before /launch while checking protected "
+                "routes: {}".format(str(ex))
+            )
+        raise
     if active_rule in protected:
         raise PermissionError(
             f'Unauthorized call to protected route "{active_rule}": {request}'
@@ -138,7 +158,16 @@ except ImportError:
 @app.before_request
 def before_request():
     if exp_klass is not None:
-        return exp_klass.before_request()
+        try:
+            return exp_klass.before_request()
+        except Exception as ex:
+            if request.path == "/launch":
+                return launch_error_response(
+                    "Experiment before_request failed before /launch: {}".format(
+                        str(ex)
+                    )
+                )
+            raise
 
 
 @app.after_request

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 from datetime import datetime
+from functools import wraps
 from json import dumps, loads
 
 import gevent
@@ -66,19 +67,36 @@ def launch_error_response(error_text):
     return error_response(error_text=error_text, status=500, simple=True)
 
 
+def launch_error_guard(error_prefix):
+    """Return simple JSON for exceptions raised while preparing `/launch`."""
+
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as ex:
+                if request.path == "/launch":
+                    return launch_error_response(
+                        "{}: {}".format(error_prefix, str(ex))
+                    )
+                raise
+
+        return wrapper
+
+    return decorator
+
+
 @app.before_request
+@launch_error_guard("Failed to load configuration before /launch")
 def _load_config():
-    try:
-        _config()
-    except Exception as ex:
-        if request.path == "/launch":
-            return launch_error_response(
-                "Failed to load configuration before /launch: {}".format(str(ex))
-            )
-        raise
+    _config()
 
 
 @app.before_request
+@launch_error_guard(
+    "Failed to load experiment before /launch while checking protected routes"
+)
 def check_for_protected_routes():
     if current_user.is_authenticated:
         return
@@ -88,15 +106,7 @@ def check_for_protected_routes():
     except AttributeError:
         return
 
-    try:
-        protected = Experiment(no_configure=True).protected_routes
-    except Exception as ex:
-        if request.path == "/launch":
-            return launch_error_response(
-                "Failed to load experiment before /launch while checking protected "
-                "routes: {}".format(str(ex))
-            )
-        raise
+    protected = Experiment(no_configure=True).protected_routes
     if active_rule in protected:
         raise PermissionError(
             f'Unauthorized call to protected route "{active_rule}": {request}'
@@ -156,18 +166,10 @@ except ImportError:
 
 
 @app.before_request
+@launch_error_guard("Experiment before_request failed before /launch")
 def before_request():
     if exp_klass is not None:
-        try:
-            return exp_klass.before_request()
-        except Exception as ex:
-            if request.path == "/launch":
-                return launch_error_response(
-                    "Experiment before_request failed before /launch: {}".format(
-                        str(ex)
-                    )
-                )
-            raise
+        return exp_klass.before_request()
 
 
 @app.after_request

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
+import requests
 
 from dallinger import db, models
 
@@ -1656,6 +1657,18 @@ class TestTransformationPost:
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestLaunchRoute:
+    class _RequestsResponse:
+        def __init__(self, flask_response):
+            self.status_code = flask_response.status_code
+            self.text = flask_response.get_data(as_text=True)
+            self.ok = flask_response.status_code < 400
+
+        def json(self):
+            return json.loads(self.text)
+
+        def raise_for_status(self):
+            raise requests.exceptions.HTTPError
+
     def assert_launch_error(self, resp, message):
         assert resp.status_code == 500
         data = json.loads(resp.get_data())
@@ -1695,6 +1708,47 @@ class TestLaunchRoute:
             resp = webapp.post("/launch", data={})
 
         self.assert_launch_error(resp, "hook exploded")
+
+    def test_local_debug_launch_reports_protected_route_load_error(self, webapp):
+        from dallinger.deployment import handle_launch_data
+
+        error = mock.Mock()
+        app_config = webapp.application.config
+        original_testing = app_config["TESTING"]
+        original_propagate_exceptions = app_config.get("PROPAGATE_EXCEPTIONS")
+        app_config.update({"TESTING": False, "PROPAGATE_EXCEPTIONS": False})
+
+        try:
+            with (
+                mock.patch(
+                    "dallinger.experiment_server.experiment_server.Experiment",
+                    side_effect=TypeError(
+                        "unexpected keyword argument 'no_configure'"
+                    ),
+                ),
+                mock.patch(
+                    "dallinger.deployment.requests.post",
+                    side_effect=lambda _: self._RequestsResponse(
+                        webapp.post("/launch", data={})
+                    ),
+                ),
+                pytest.raises(requests.exceptions.HTTPError),
+            ):
+                handle_launch_data(
+                    "http://localhost:5001/launch", error=error, attempts=1
+                )
+        finally:
+            app_config.update(
+                {
+                    "TESTING": original_testing,
+                    "PROPAGATE_EXCEPTIONS": original_propagate_exceptions,
+                }
+            )
+
+        error.assert_any_call(
+            "Failed to load experiment before /launch while checking protected "
+            "routes: unexpected keyword argument 'no_configure'"
+        )
 
     def test_launch_with_recruitment(self, webapp, active_config):
         with mock.patch(

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1722,9 +1722,7 @@ class TestLaunchRoute:
             with (
                 mock.patch(
                     "dallinger.experiment_server.experiment_server.Experiment",
-                    side_effect=TypeError(
-                        "unexpected keyword argument 'no_configure'"
-                    ),
+                    side_effect=TypeError("unexpected keyword argument 'no_configure'"),
                 ),
                 mock.patch(
                     "dallinger.deployment.requests.post",

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1688,11 +1688,10 @@ class TestLaunchRoute:
     def test_launch_reports_before_request_error(self, webapp):
         from dallinger.experiment_server import experiment_server
 
-        with mock.patch.object(
-            experiment_server.exp_klass,
-            "before_request",
-            side_effect=RuntimeError("hook exploded"),
-        ):
+        mock_exp_klass = mock.Mock()
+        mock_exp_klass.before_request.side_effect = RuntimeError("hook exploded")
+        mock_exp_klass.after_request.side_effect = lambda request, response: response
+        with mock.patch.object(experiment_server, "exp_klass", mock_exp_klass):
             resp = webapp.post("/launch", data={})
 
         self.assert_launch_error(resp, "hook exploded")

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -3,7 +3,6 @@ from datetime import datetime
 from unittest import mock
 
 import pytest
-import requests
 
 from dallinger import db, models
 
@@ -1657,18 +1656,6 @@ class TestTransformationPost:
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestLaunchRoute:
-    class _RequestsResponse:
-        def __init__(self, flask_response):
-            self.status_code = flask_response.status_code
-            self.text = flask_response.get_data(as_text=True)
-            self.ok = flask_response.status_code < 400
-
-        def json(self):
-            return json.loads(self.text)
-
-        def raise_for_status(self):
-            raise requests.exceptions.HTTPError
-
     def assert_launch_error(self, resp, message):
         assert resp.status_code == 500
         data = json.loads(resp.get_data())
@@ -1708,45 +1695,6 @@ class TestLaunchRoute:
             resp = webapp.post("/launch", data={})
 
         self.assert_launch_error(resp, "hook exploded")
-
-    def test_local_debug_launch_reports_protected_route_load_error(self, webapp):
-        from dallinger.deployment import handle_launch_data
-
-        error = mock.Mock()
-        app_config = webapp.application.config
-        original_testing = app_config["TESTING"]
-        original_propagate_exceptions = app_config.get("PROPAGATE_EXCEPTIONS")
-        app_config.update({"TESTING": False, "PROPAGATE_EXCEPTIONS": False})
-
-        try:
-            with (
-                mock.patch(
-                    "dallinger.experiment_server.experiment_server.Experiment",
-                    side_effect=TypeError("unexpected keyword argument 'no_configure'"),
-                ),
-                mock.patch(
-                    "dallinger.deployment.requests.post",
-                    side_effect=lambda _: self._RequestsResponse(
-                        webapp.post("/launch", data={})
-                    ),
-                ),
-                pytest.raises(requests.exceptions.HTTPError),
-            ):
-                handle_launch_data(
-                    "http://localhost:5001/launch", error=error, attempts=1
-                )
-        finally:
-            app_config.update(
-                {
-                    "TESTING": original_testing,
-                    "PROPAGATE_EXCEPTIONS": original_propagate_exceptions,
-                }
-            )
-
-        error.assert_any_call(
-            "Failed to load experiment before /launch while checking protected "
-            "routes: unexpected keyword argument 'no_configure'"
-        )
 
     def test_launch_with_recruitment(self, webapp, active_config):
         with mock.patch(

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -1656,10 +1656,46 @@ class TestTransformationPost:
 @pytest.mark.usefixtures("experiment_dir")
 @pytest.mark.slow
 class TestLaunchRoute:
+    def assert_launch_error(self, resp, message):
+        assert resp.status_code == 500
+        data = json.loads(resp.get_data())
+        assert data["status"] == "error"
+        assert message in data["message"]
+
     def test_launch(self, webapp):
         resp = webapp.post("/launch", data={})
         data = json.loads(resp.get_data())
         assert "recruitment_msg" in data
+
+    def test_launch_reports_config_load_error(self, webapp):
+        with mock.patch(
+            "dallinger.experiment_server.experiment_server._config",
+            side_effect=RuntimeError("config exploded"),
+        ):
+            resp = webapp.post("/launch", data={})
+
+        self.assert_launch_error(resp, "config exploded")
+
+    def test_launch_reports_protected_route_load_error(self, webapp):
+        with mock.patch(
+            "dallinger.experiment_server.experiment_server.Experiment",
+            side_effect=TypeError("unexpected keyword argument 'no_configure'"),
+        ):
+            resp = webapp.post("/launch", data={})
+
+        self.assert_launch_error(resp, "unexpected keyword argument 'no_configure'")
+
+    def test_launch_reports_before_request_error(self, webapp):
+        from dallinger.experiment_server import experiment_server
+
+        with mock.patch.object(
+            experiment_server.exp_klass,
+            "before_request",
+            side_effect=RuntimeError("hook exploded"),
+        ):
+            resp = webapp.post("/launch", data={})
+
+        self.assert_launch_error(resp, "hook exploded")
 
     def test_launch_with_recruitment(self, webapp, active_config):
         with mock.patch(


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Return simple JSON error responses for `/launch` failures that occur in pre-request setup, including configuration loading, protected-route experiment loading, and experiment `before_request` hooks. The repeated launch-only exception handling now flows through a small decorator helper.

## Motivation and Context
Previously, exceptions raised before the `/launch` route body could fall through to Flask's generic HTML 500 page. `dallinger debug` then reported only that the HTML response could not be parsed, while the useful exception stayed in server logs.

## How Has This Been Tested?
- Manual red-green local debug run with a temporary broken experiment whose `__init__` omits `no_configure`: old server behavior printed only the generic HTML parse error; fixed server behavior printed the underlying `unexpected keyword argument 'no_configure'` message.
- `PATH="$HOME/.local/bin:$PATH" python3 -m pytest tests/test_experiment_server.py::TestLaunchRoute -q --runslow`
- `python3 -m pytest tests/test_deployment.py::Testhandle_launch_data -q`
- `PATH="$HOME/.local/bin:$PATH" python3 -m pre_commit run --all-files`
- `PATH="$HOME/.local/bin:$PATH" python3 -m pytest`
- CI: `gh pr checks 9260 --watch=false`

## Screenshots (if appropriate):
N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19a2638b-7511-4e92-8774-cad7928498bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19a2638b-7511-4e92-8774-cad7928498bd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

