### PR TITLE
Guard Prolific submissions by study

### DIFF
--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -171,6 +171,11 @@ class ProlificService:
             }
         ]
         """
+        if not study_id:
+            raise ProlificServiceException(
+                "Cannot fetch Prolific submissions without a study ID."
+            )
+
         query_params = {"study": study_id}
         return self._req(method="GET", endpoint="/submissions/", params=query_params)[
             "results"

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -445,6 +445,30 @@ def test_translate_draft_study(
     assert subject.draft_study(**study_request) == expected_project_id
 
 
+def test_get_submissions_filters_by_study(subject):
+    """get_submissions fetches submissions for the supplied study only."""
+    study_id = "study_123"
+    expected_results = [{"id": "submission_456"}]
+    subject._req = mock.MagicMock(return_value={"results": expected_results})
+
+    assert subject.get_submissions(study_id) == expected_results
+
+    subject._req.assert_called_once_with(
+        method="GET", endpoint="/submissions/", params={"study": study_id}
+    )
+
+
+@pytest.mark.parametrize("study_id", [None, ""])
+def test_get_submissions_requires_study_id(subject, study_id):
+    """get_submissions does not allow unfiltered Prolific submission requests."""
+    subject._req = mock.MagicMock()
+
+    with pytest.raises(ProlificServiceException, match="without a study ID"):
+        subject.get_submissions(study_id)
+
+    subject._req.assert_not_called()
+
+
 def test_screen_out_multiple_ids(subject):
     """Test that screen_out sends the correct payload to Prolific's API when given multiple submission IDs."""
     study_id = "study_123"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Adds a guard to `ProlificService.get_submissions()` so Dallinger refuses to call Prolific's list submissions endpoint without a study ID. Adds regression coverage confirming valid calls include `params={"study": study_id}` and missing study IDs never call the API.

## Motivation and Context
Prolific warned that unfiltered `GET /submissions/` calls can pull submissions across all studies and strain their systems. Normal Dallinger code paths pass a study ID, but `requests` omits query parameters whose value is `None`, so a missing `current_study_id` could produce the exact unfiltered request.

## How Has This Been Tested?
- `python3 -m pytest tests/test_prolific.py -k 'get_submissions'`
- `python3 -m pytest tests/test_prolific.py`
- `export PATH="$HOME/.local/bin:$PATH"; python3 -m pytest tests/test_recruiters.py::TestProlificRecruiter`
- `python3 -m pre_commit run --all-files`
- `export PATH="$HOME/.local/bin:$PATH"; python3 -m pytest`

## Screenshots (if appropriate):
N/A
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc32277e-3160-406e-8741-f0d85a7850c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc32277e-3160-406e-8741-f0d85a7850c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

