### PR TITLE
Fix Prolific status checks without study IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Updated

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -171,6 +171,11 @@ class ProlificService:
             }
         ]
         """
+        if not study_id:
+            raise ProlificServiceException(
+                "Cannot fetch Prolific submissions without a study_id."
+            )
+
         query_params = {"study": study_id}
         return self._req(method="GET", endpoint="/submissions/", params=query_params)[
             "results"

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -532,10 +532,28 @@ class ProlificRecruiter(Recruiter):
         return pay_per_submission / (median_session_duration / 60)
 
     def get_status(self) -> ProlificRecruitmentStatus:
-        submissions = self.prolificservice.get_submissions(self.current_study_id)
+        study_id = self.current_study_id
+        if not study_id:
+            logger.info(
+                "Skipping Prolific status check because no current study ID is recorded."
+            )
+            return ProlificRecruitmentStatus(
+                recruiter_name=self.nickname,
+                participant_status_counts={},
+                study_id="",
+                study_status="",
+                study_cost=0,
+                currency="£",
+                internal_name=self.config.get("id"),
+                base_payment_cents=self.base_payment_cents,
+                median_session_duration_minutes=None,
+                real_wage_per_hour_excluding_bonuses=None,
+            )
+
+        submissions = self.prolificservice.get_submissions(study_id)
         submission_status_counts = dict(Counter([s["status"] for s in submissions]))
-        study = self.prolificservice.get_study(self.current_study_id)
-        total_cost = self.prolificservice.get_total_cost(self.current_study_id) / 100
+        study = self.prolificservice.get_study(study_id)
+        total_cost = self.prolificservice.get_total_cost(study_id) / 100
 
         durations_minutes, total_reward = self.get_durations_and_total_reward(
             submissions

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -499,6 +499,18 @@ def test_screen_out_single_id(subject):
     )
 
 
+def test_get_submissions_requires_study_id(subject):
+    subject._req = mock.MagicMock()
+
+    with pytest.raises(ProlificServiceException) as exc_info:
+        subject.get_submissions(None)
+
+    assert (
+        str(exc_info.value) == "Cannot fetch Prolific submissions without a study_id."
+    )
+    subject._req.assert_not_called()
+
+
 class TestDevProlificServiceScreenOut:
     @pytest.fixture
     def participants(self, a):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -540,6 +540,17 @@ class TestProlificRecruiter:
 
         assert ex_info.match("Can't run a Prolific Study from localhost")
 
+    def test_get_status_without_current_study_does_not_call_prolific(self, recruiter):
+        status = recruiter.get_status()
+
+        recruiter.prolificservice.get_submissions.assert_not_called()
+        recruiter.prolificservice.get_study.assert_not_called()
+        recruiter.prolificservice.get_total_cost.assert_not_called()
+        assert status.study_id == ""
+        assert status.study_status == ""
+        assert status.study_cost == 0
+        assert status.participant_status_counts == {}
+
     def test_normalize_entry_information_standardizes_participant_data(self, recruiter):
         prolific_format = {
             "STUDY_ID": "some study ID",


### PR DESCRIPTION
## Summary
- Fixes #9283.
- Avoids Prolific submissions, study, and cost API calls during status polling when no current study ID is recorded.
- Adds a service-level guard so direct `get_submissions()` calls cannot produce unscoped `GET /submissions/` requests.

## Test plan
- `python -m pytest tests/test_recruiters.py::TestProlificRecruiter::test_get_status_without_current_study_does_not_call_prolific tests/test_prolific.py::test_get_submissions_requires_study_id`
- `python -m pre_commit run --all-files`

Made with [Cursor](https://cursor.com)