### PR TITLE
Document dev environment setup in Sphinx; slim AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,3 +40,66 @@ For the full matrix used in CI, run:
 ```bash
 tox
 ```
+
+## Cursor Cloud specific instructions
+
+### System packages (one-time per VM)
+
+Ubuntu packages needed beyond a stock Python image:
+
+- `python3.12-venv`, `libpq-dev`, `python3-dev`, `build-essential` (editable install / `psycopg2`)
+- `postgresql`, `redis-server` (required for most tests and local experiment runs)
+
+After install, start services before tests or `dallinger develop`:
+
+```bash
+sudo service postgresql start
+sudo service redis-server start
+```
+
+Create the CI-matching database role once (if missing):
+
+```bash
+sudo -u postgres psql -c "CREATE USER dallinger WITH PASSWORD 'dallinger' CREATEDB;"
+sudo -u postgres psql -c "CREATE DATABASE dallinger OWNER dallinger;"
+```
+
+### Environment variables
+
+```bash
+export DATABASE_URL=postgresql://dallinger:dallinger@localhost/dallinger
+export PORT=5000
+```
+
+Demos pin Python in `.python-version` (often 3.13). On 3.12 images, either install that
+version or set `SKIP_PYTHON_VERSION_CHECK=1` when running `dallinger develop` / `verify`.
+
+### Python and Node
+
+- Prefer a repo-local venv: `python3 -m venv .venv` then `source .venv/bin/activate`.
+- Install: `python -m pip install -e ".[dev]"` and `python -m pip install -e demos`.
+- JS: from repo root, `yarn --frozen-lockfile --ignore-engines`, then `npm run test` / `npm run build`.
+
+### Running a demo locally (no Heroku)
+
+From an experiment directory (e.g. `demos/dlgr/demos/bartlett1932`):
+
+```bash
+dallinger develop bootstrap
+dallinger develop debug --port 5000
+```
+
+Recruitment URL (hotair recruiter): `http://127.0.0.1:5000/ad?generate_tokens=true&recruiter=hotair`
+
+`dallinger debug` (classic) needs the Heroku CLI and `heroku local`. Full CI `tox` also
+needs Chromedriver, Heroku CLI, and optional AWS/Prolific tokens; use `tox -e fast` for a
+lighter Python-only pass when those are unavailable.
+
+### Lint and test quick reference
+
+| Check | Command |
+|-------|---------|
+| Lint | `python -m pre_commit run --all-files` |
+| Python tests | `python -m pytest` (Postgres + Redis running, `DATABASE_URL` set) |
+| JS tests | `npm run test` |
+| JS build | `npm run build` |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,7 @@ Install Dallinger with dev dependencies (includes pre-commit, ruff, pytest, tox)
 
 ```bash
 python -m pip install -e ".[dev]"
+python -m pip install -e demos
 ```
 
 If you need additional optional functionality (e.g., `ec2`, `docker`, `jupyter`),
@@ -18,6 +19,10 @@ install those extras as needed:
 ```bash
 python -m pip install -e ".[dev,ec2,docker]"
 ```
+
+System dependencies (PostgreSQL, Redis, Heroku CLI, Chromedriver, Node/Yarn) and
+local experiment workflows are documented in the
+[developer installation guide](https://dallinger.readthedocs.io/en/latest/developing_dallinger_setup_guide.html).
 
 ## Pre-commit
 
@@ -32,6 +37,8 @@ python -m pre_commit run --all-files
 Run tests locally before finalizing a contribution:
 
 ```bash
+export DATABASE_URL=postgresql://dallinger:dallinger@localhost/dallinger
+export PORT=5000
 python -m pytest
 ```
 
@@ -41,89 +48,20 @@ For the full matrix used in CI, run:
 tox
 ```
 
+See [running the tests](https://dallinger.readthedocs.io/en/latest/running_the_tests.html)
+for pytest/tox options, Chromedriver requirements, and integration-test credentials.
+
 ## Cursor Cloud specific instructions
 
-### System packages (one-time per VM)
+Cloud VMs need the same prerequisites as a local Ubuntu dev environment; follow
+the [Ubuntu section of the developer installation guide](https://dallinger.readthedocs.io/en/latest/developing_dallinger_setup_guide.html#ubuntu).
 
-Ubuntu packages needed beyond a stock Python image:
+Cloud-agent notes that are not covered there:
 
-- `python3.12-venv`, `libpq-dev`, `python3-dev`, `build-essential` (editable install / `psycopg2`)
-- `postgresql`, `redis-server` (required for most tests and local experiment runs)
-- **Google Chrome** (preinstalled on many cloud images at `/usr/local/bin/google-chrome`)
-- **Chromedriver** (must match the installed Chrome major version)
-- **Heroku CLI** (for `dallinger debug` / `heroku local`)
-
-Install Chromedriver to match `google-chrome --version` (example for Chrome `148.0.7778.96`):
-
-```bash
-CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+')
-curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/chromedriver.zip
-unzip -qo /tmp/chromedriver.zip -d /tmp
-sudo mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
-sudo chmod +x /usr/local/bin/chromedriver
-chromedriver --version
-```
-
-Install Heroku CLI (same as CI):
-
-```bash
-curl -fsSL https://cli-assets.heroku.com/install.sh | sh
-heroku --version
-```
-
-Quick sanity check for Chromedriver: run a headless Selenium session (requires the editable
-`dallinger` install, which pulls in `selenium`).
-
-After install, start services before tests or `dallinger develop`:
-
-```bash
-sudo service postgresql start
-sudo service redis-server start
-```
-
-Create the CI-matching database role once (if missing):
-
-```bash
-sudo -u postgres psql -c "CREATE USER dallinger WITH PASSWORD 'dallinger' CREATEDB;"
-sudo -u postgres psql -c "CREATE DATABASE dallinger OWNER dallinger;"
-```
-
-### Environment variables
-
-```bash
-export DATABASE_URL=postgresql://dallinger:dallinger@localhost/dallinger
-export PORT=5000
-```
-
-Demos pin Python in `.python-version` (often 3.13). On 3.12 images, either install that
-version or set `SKIP_PYTHON_VERSION_CHECK=1` when running `dallinger develop` / `verify`.
-
-### Python and Node
-
-- Prefer a repo-local venv: `python3 -m venv .venv` then `source .venv/bin/activate`.
-- Install: `python -m pip install -e ".[dev]"` and `python -m pip install -e demos`.
-- JS: from repo root, `yarn --frozen-lockfile --ignore-engines`, then `npm run test` / `npm run build`.
-
-### Running a demo locally (no Heroku)
-
-From an experiment directory (e.g. `demos/dlgr/demos/bartlett1932`):
-
-```bash
-dallinger develop bootstrap
-dallinger develop debug --port 5000
-```
-
-Recruitment URL (hotair recruiter): `http://127.0.0.1:5000/ad?generate_tokens=true&recruiter=hotair`
-
-`dallinger debug` (classic) needs the Heroku CLI and `heroku local`. Full CI `tox` also
-needs Chromedriver, Heroku CLI, and optional AWS/Prolific tokens; use `tox -e fast` for a
-lighter Python-only pass when those are unavailable.
-
-### Lint and test quick reference
-
-| Check | Command |
-|-------|---------|
-| Lint | `python -m pre_commit run --all-files` |
-| Python tests | `python -m pytest` (Postgres + Redis running, `DATABASE_URL` set) |
-| JS tests | `npm run test` |
-| JS build | `npm run build` |
+- Ensure `python3-venv` and `libpq-dev` are installed before the editable install.
+- Start Postgres and Redis before tests or experiment runs:
+  `sudo service postgresql start` and `sudo service redis-server start`.
+- Prefer a repo-local virtualenv: `python3 -m venv .venv` then
+  `source .venv/bin/activate`.
+- The VM **update script** refreshes Python and Yarn dependencies only; it does
+  not start services, run migrations, or execute tests.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,30 @@ Ubuntu packages needed beyond a stock Python image:
 
 - `python3.12-venv`, `libpq-dev`, `python3-dev`, `build-essential` (editable install / `psycopg2`)
 - `postgresql`, `redis-server` (required for most tests and local experiment runs)
+- **Google Chrome** (preinstalled on many cloud images at `/usr/local/bin/google-chrome`)
+- **Chromedriver** (must match the installed Chrome major version)
+- **Heroku CLI** (for `dallinger debug` / `heroku local`)
+
+Install Chromedriver to match `google-chrome --version` (example for Chrome `148.0.7778.96`):
+
+```bash
+CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+')
+curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/chromedriver.zip
+unzip -qo /tmp/chromedriver.zip -d /tmp
+sudo mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
+sudo chmod +x /usr/local/bin/chromedriver
+chromedriver --version
+```
+
+Install Heroku CLI (same as CI):
+
+```bash
+curl -fsSL https://cli-assets.heroku.com/install.sh | sh
+heroku --version
+```
+
+Quick sanity check for Chromedriver: run a headless Selenium session (requires the editable
+`dallinger` install, which pulls in `selenium`).
 
 After install, start services before tests or `dallinger develop`:
 

--- a/docs/source/demoing_dallinger.rst
+++ b/docs/source/demoing_dallinger.rst
@@ -10,6 +10,11 @@ To test out Dallinger, we'll run a demo experiment in "debug" mode.
 
 .. note::
 
+    If you do not have the Heroku CLI installed, you can use ``dallinger develop``
+    instead of ``dallinger debug``. See :doc:`developing_dallinger_setup_guide`.
+
+.. note::
+
     Running the demo in "sandbox" mode as opposed to "debug" mode will require a Heroku account.
     More information for :doc:`running in "sandbox" mode <demos_on_heroku>`.
 

--- a/docs/source/developing_dallinger_setup_guide.rst
+++ b/docs/source/developing_dallinger_setup_guide.rst
@@ -776,3 +776,80 @@ installation command:
 
 Next, you'll need :doc:`access keys for AWS, Heroku,
 etc. <aws_etc_keys>`.
+
+
+Chromedriver
+------------
+
+The full test suite and browser-based :doc:`bots <running_bots>` require
+`Chromedriver <https://developer.chrome.com/docs/chromedriver>`__ installed and
+on your ``PATH``. The driver version must match your installed Google Chrome
+(or Chromium) build.
+
+Check your Chrome version, then download the matching driver from the
+`Chrome for Testing <https://googlechromelabs.github.io/chrome-for-testing/>`__
+availability dashboard. On Linux, a typical install looks like:
+
+::
+
+    CHROME_VERSION=$(google-chrome --version | grep -oP '\d+\.\d+\.\d+\.\d+')
+    curl -fsSL "https://storage.googleapis.com/chrome-for-testing-public/${CHROME_VERSION}/linux64/chromedriver-linux64.zip" -o /tmp/chromedriver.zip
+    unzip -qo /tmp/chromedriver.zip -d /tmp
+    sudo mv /tmp/chromedriver-linux64/chromedriver /usr/local/bin/chromedriver
+    sudo chmod +x /usr/local/bin/chromedriver
+    chromedriver --version
+
+On macOS, install Chrome if needed, then download the ``mac-x64`` or
+``mac-arm64`` Chromedriver archive for the same version and place the
+``chromedriver`` binary on your ``PATH``.
+
+Verify the setup with a headless browser session (``selenium`` is installed
+with Dallinger):
+
+::
+
+    python -c "from selenium import webdriver; from selenium.webdriver.chrome.options import Options; from selenium.webdriver.chrome.service import Service; o=Options(); o.add_argument('--headless=new'); d=webdriver.Chrome(service=Service(), options=o); d.get('https://example.com'); print(d.title); d.quit()"
+
+
+Running experiments without ``heroku local``
+--------------------------------------------
+
+``dallinger develop`` provides an alternative to ``dallinger debug`` that does
+not require ``heroku local``. It still needs
+PostgreSQL and Redis running locally.
+
+From an experiment directory (for example, a demo under ``demos/dlgr/demos/``):
+
+::
+
+    dallinger develop bootstrap
+    dallinger develop debug --port 5000
+
+The recruitment URL for the built-in "hotair" recruiter is:
+
+::
+
+    http://127.0.0.1:5000/ad?generate_tokens=true&recruiter=hotair
+
+Some demos pin a Python version in ``.python-version``. If your environment
+uses a different version, either install the pinned release or set
+``SKIP_PYTHON_VERSION_CHECK=1`` when running ``dallinger verify`` or
+``dallinger develop``.
+
+See also :doc:`demoing_dallinger` for the classic ``dallinger debug`` workflow,
+which uses the Heroku CLI.
+
+
+Contributor install shortcut
+----------------------------
+
+Repository contributors (including automated agents) often install everything
+needed for linting and testing in one step from the repository root:
+
+::
+
+    python -m pip install -e ".[dev]"
+    python -m pip install -e demos
+
+This editable install includes ``pre-commit``, ``ruff``, ``pytest``, and ``tox``.
+See :doc:`running_the_tests` for how to run checks locally.

--- a/docs/source/running_the_tests.rst
+++ b/docs/source/running_the_tests.rst
@@ -10,6 +10,29 @@ Current build status: |status|
 .. |status| image:: https://github.com/dallinger/Dallinger/actions/workflows/deploy.yml/badge.svg
    :target: https://github.com/Dallinger/Dallinger/actions?query=workflow%3Arelease
 
+Prerequisites
+-------------
+
+Most Python tests expect **PostgreSQL** and **Redis** to be running locally.
+See the :doc:`developer installation guide <developing_dallinger_setup_guide>`
+for setup instructions.
+
+Set environment variables to match CI before running ``pytest`` or ``tox``:
+
+::
+
+    export DATABASE_URL=postgresql://dallinger:dallinger@localhost/dallinger
+    export PORT=5000
+
+The full ``tox`` suite (``tox`` or ``tox -e tests``) also requires
+**Chromedriver** (version-matched to Chrome) and the **Heroku CLI** for tests
+that launch ``dallinger debug``. Browser-based bot tests need Chromedriver as
+well. For a lighter pass without those dependencies, use ``tox -e fast`` or
+plain ``pytest`` (which still needs PostgreSQL and Redis).
+
+Optional credentials (AWS, Prolific, MTurk worker ID) are required only for
+specific integration tests; see below.
+
 The tests include:
 
 * Making sure that a source distribution of the Python package can be created.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Centralizes contributor and cloud-agent setup guidance in the Sphinx docs instead of duplicating it in `AGENTS.md`.

**`developing_dallinger_setup_guide.rst`**
- Chromedriver install (Chrome for Testing)
- `dallinger develop` workflow (Heroku-free local runs)
- Contributor install shortcut (`pip install -e ".[dev]"`)

**`running_the_tests.rst`**
- Prerequisites: Postgres, Redis, `DATABASE_URL`/`PORT`, Chromedriver/Heroku for full tox

**`demoing_dallinger.rst`**
- Cross-link to `dallinger develop` when Heroku CLI is unavailable

**`AGENTS.md`**
- Keeps agent workflow (install, pre-commit, pytest/tox)
- Links to Sphinx for system deps and test options
- Cursor Cloud section reduced to VM-specific notes only (venv, service startup, update-script scope)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-58dff8ad-28ec-4c24-aa25-119550d6ff3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-58dff8ad-28ec-4c24-aa25-119550d6ff3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

