### PR TITLE
Recover missing Prolific study IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.
+- Fixed Prolific bonus payment and status verification when the current study ID
+  is missing by recovering it from submission or participant records when
+  possible.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.
-- Fixed Prolific bonus payment and status verification when the current study ID
-  is missing by recovering it from submission or participant records when
-  possible.
+- Fixed Prolific bonus payment, status reporting, and status verification when
+  the current study ID is missing by recovering it from submission or
+  participant records when possible.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -833,12 +833,78 @@ class ProlificRecruiter(Recruiter):
         """Reward the Prolific worker for a specified assignment with a bonus."""
         try:
             return self.prolificservice.pay_session_bonus(
-                study_id=self.current_study_id,
+                study_id=self.prolific_study_id_for_bonus(participant),
                 worker_id=participant.worker_id,
                 amount=amount,
             )
         except ProlificServiceException as ex:
             handle_recruitment_error(ex)
+
+    def prolific_study_id_for_bonus(self, participant: Participant) -> str:
+        study_id = self.current_study_id
+        if study_id:
+            return study_id
+
+        submission = self.prolificservice.get_participant_submission(
+            participant.assignment_id
+        )
+        study_id = self._prolific_study_id_from_submission_or_participant(
+            submission, participant
+        )
+        if study_id:
+            logger.warning(
+                "Recovered missing Prolific study ID %s from submission %s.",
+                study_id,
+                participant.assignment_id,
+            )
+            self._record_current_study_id(study_id)
+            return study_id
+
+        raise ProlificServiceException(
+            "Cannot pay Prolific bonus because no current study ID is recorded "
+            f"and submission {participant.assignment_id} did not include a study ID."
+        )
+
+    @staticmethod
+    def _prolific_study_id_from_submission_or_participant(
+        submission, participant: Participant
+    ) -> Optional[str]:
+        return (
+            submission.get("hit_id")
+            or submission.get("study_id")
+            or submission.get("study")
+            or participant.hit_id
+        )
+
+    def prolific_study_id_for_status_verification(
+        self, participants: list[Participant]
+    ) -> Optional[str]:
+        study_id = self.current_study_id
+        if study_id:
+            return study_id
+
+        study_ids = {
+            participant.hit_id
+            for participant in participants
+            if getattr(participant, "hit_id", None)
+        }
+        if len(study_ids) == 1:
+            study_id = next(iter(study_ids))
+            logger.warning(
+                "Recovered missing Prolific study ID %s from participant records.",
+                study_id,
+            )
+            self._record_current_study_id(study_id)
+            return study_id
+
+        if len(study_ids) > 1:
+            logger.warning(
+                "Cannot recover missing Prolific study ID from participant records "
+                "because multiple study IDs were found: %s.",
+                sorted(study_ids),
+            )
+
+        return None
 
     def on_task_completion(self):
         """We cannot perform post-submission actions (approval, bonus payment)
@@ -896,10 +962,15 @@ class ProlificRecruiter(Recruiter):
         discrepancies found, correct the local status by enqueuing an
         asynchronous worker event.
         """
+        study_id = self.prolific_study_id_for_status_verification(participants)
+        if not study_id:
+            logger.info(
+                "Skipping Prolific status verification because no current study ID is recorded."
+            )
+            return
+
         q = get_queue()
-        assignments_by_id = self.prolificservice.get_assignments_for_study(
-            self.current_study_id
-        )
+        assignments_by_id = self.prolificservice.get_assignments_for_study(study_id)
 
         for participant in participants:
             latest_data = assignments_by_id.get(participant.assignment_id)

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -532,7 +532,7 @@ class ProlificRecruiter(Recruiter):
         return pay_per_submission / (median_session_duration / 60)
 
     def get_status(self) -> ProlificRecruitmentStatus:
-        study_id = self.current_study_id
+        study_id = self._prolific_study_id_for_status_report()
         if not study_id:
             logger.info(
                 "Skipping Prolific status check because no current study ID is recorded."
@@ -876,7 +876,18 @@ class ProlificRecruiter(Recruiter):
             or participant.hit_id
         )
 
+    def _prolific_study_id_for_status_report(self) -> Optional[str]:
+        participants = (
+            session.query(Participant).filter_by(recruiter_id=self.nickname).all()
+        )
+        return self._prolific_study_id_from_participants(participants)
+
     def prolific_study_id_for_status_verification(
+        self, participants: list[Participant]
+    ) -> Optional[str]:
+        return self._prolific_study_id_from_participants(participants)
+
+    def _prolific_study_id_from_participants(
         self, participants: list[Participant]
     ) -> Optional[str]:
         study_id = self.current_study_id

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -551,6 +551,58 @@ class TestProlificRecruiter:
         assert status.study_cost == 0
         assert status.participant_status_counts == {}
 
+    def test_verify_status_without_current_study_does_not_call_prolific(
+        self, a, recruiter
+    ):
+        participant = a.participant(assignment_id="some assignment")
+        participant.hit_id = None
+
+        recruiter.verify_status_of([participant])
+
+        recruiter.prolificservice.get_assignments_for_study.assert_not_called()
+
+    def test_verify_status_recovers_missing_current_study_from_participants(
+        self, a, recruiter, queue
+    ):
+        participant = a.participant(
+            assignment_id="aaa111",
+            hit_id="study-from-participant",
+            recruiter_id="prolific",
+        )
+        recruiter.prolificservice.get_assignments_for_study.return_value = {
+            participant.assignment_id: {
+                "participant_id": participant.assignment_id,
+                "hit_id": participant.hit_id,
+                "worker_id": "some-prolific-worker-id",
+                "started_at": "2021-05-20T11:23:00.457Z",
+                "status": "RETURNED",
+            },
+        }
+
+        recruiter.verify_status_of([participant])
+
+        recruiter.prolificservice.get_assignments_for_study.assert_called_once_with(
+            "study-from-participant"
+        )
+        queue.enqueue.assert_called_once_with(
+            mock.ANY, "AssignmentReturned", participant.assignment_id, participant.id
+        )
+        assert recruiter.current_study_id == "study-from-participant"
+
+    def test_verify_status_does_not_recover_ambiguous_current_study(
+        self, a, recruiter, queue
+    ):
+        participants = [
+            a.participant(assignment_id="aaa111", hit_id="study-1"),
+            a.participant(assignment_id="bbb222", hit_id="study-2"),
+        ]
+
+        recruiter.verify_status_of(participants)
+
+        recruiter.prolificservice.get_assignments_for_study.assert_not_called()
+        queue.enqueue.assert_not_called()
+        assert recruiter.current_study_id is None
+
     def test_normalize_entry_information_standardizes_participant_data(self, recruiter):
         prolific_format = {
             "STUDY_ID": "some study ID",
@@ -583,6 +635,7 @@ class TestProlificRecruiter:
 
     def test_reward_bonus_passes_only_whats_needed(self, a, recruiter):
         participant = a.participant(assignment_id="some assignement")
+        recruiter._record_current_study_id("test_study_id")
         recruiter.reward_bonus(
             participant=participant,
             amount=2.99,
@@ -590,10 +643,75 @@ class TestProlificRecruiter:
         )
 
         recruiter.prolificservice.pay_session_bonus.assert_called_once_with(
-            study_id=recruiter.current_study_id,
+            study_id="test_study_id",
             worker_id=participant.worker_id,
             amount=2.99,
         )
+
+    def test_reward_bonus_recovers_missing_study_id_from_submission(self, a, recruiter):
+        participant = a.participant(assignment_id="some assignment")
+        recruiter.prolificservice.get_participant_submission.return_value = {
+            "hit_id": "study-from-submission"
+        }
+
+        recruiter.reward_bonus(
+            participant=participant,
+            amount=2.99,
+            reason="well done!",
+        )
+
+        recruiter.prolificservice.get_participant_submission.assert_called_once_with(
+            participant.assignment_id
+        )
+        recruiter.prolificservice.pay_session_bonus.assert_called_once_with(
+            study_id="study-from-submission",
+            worker_id=participant.worker_id,
+            amount=2.99,
+        )
+        assert recruiter.current_study_id == "study-from-submission"
+
+    def test_reward_bonus_recovers_missing_study_id_from_participant(
+        self, a, recruiter
+    ):
+        participant = a.participant(
+            assignment_id="some assignment", hit_id="study-from-participant"
+        )
+        recruiter.prolificservice.get_participant_submission.return_value = {
+            "status": "RETURNED"
+        }
+
+        recruiter.reward_bonus(
+            participant=participant,
+            amount=2.99,
+            reason="well done!",
+        )
+
+        recruiter.prolificservice.pay_session_bonus.assert_called_once_with(
+            study_id="study-from-participant",
+            worker_id=participant.worker_id,
+            amount=2.99,
+        )
+        assert recruiter.current_study_id == "study-from-participant"
+
+    def test_reward_bonus_logs_exception_when_study_id_cannot_be_resolved(
+        self, a, recruiter
+    ):
+        participant = mock.Mock(
+            assignment_id="some assignment", worker_id="some worker", hit_id=None
+        )
+        recruiter.prolificservice.get_participant_submission.return_value = {
+            "status": "RETURNED"
+        }
+
+        with mock.patch("dallinger.recruiters.logger") as mock_logger:
+            recruiter.reward_bonus(
+                participant=participant,
+                amount=2.99,
+                reason="well done!",
+            )
+
+        recruiter.prolificservice.pay_session_bonus.assert_not_called()
+        mock_logger.exception.assert_called_once()
 
     def test_reward_bonus_logs_exception(self, a, recruiter):
         from dallinger.prolific import ProlificServiceException
@@ -753,6 +871,7 @@ class TestProlificRecruiter:
     def test_verify_status_triggers_corrections(self, a, recruiter, queue):
         p1 = a.participant(assignment_id="aaa111", recruiter_id="prolific")
         p2 = a.participant(assignment_id="bbb222", recruiter_id="prolific")
+        recruiter._record_current_study_id("some-study-id")
 
         # Set up mock response from Prolific regarding these participants:
         recruiter.prolificservice.get_assignments_for_study.return_value = {
@@ -786,6 +905,7 @@ class TestProlificRecruiter:
     ):
         p1 = a.participant(assignment_id="aaa111", recruiter_id="prolific")
         p2 = a.participant(assignment_id="bbb222", recruiter_id="prolific")
+        recruiter._record_current_study_id("some-study-id")
 
         # Set up mock response from Prolific where only the first participant is included:
         recruiter.prolificservice.get_assignments_for_study.return_value = {

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -551,6 +551,62 @@ class TestProlificRecruiter:
         assert status.study_cost == 0
         assert status.participant_status_counts == {}
 
+    def test_get_status_recovers_missing_current_study_from_participants(
+        self, a, recruiter
+    ):
+        participant = a.participant(
+            assignment_id="aaa111",
+            hit_id="study-from-participant",
+            recruiter_id="prolific",
+        )
+        recruiter.prolificservice.get_submissions.return_value = [
+            {
+                "participant_id": participant.assignment_id,
+                "hit_id": participant.hit_id,
+                "worker_id": "some-prolific-worker-id",
+                "started_at": "2021-05-20T11:23:00.457Z",
+                "status": "RETURNED",
+            },
+        ]
+        recruiter.prolificservice.get_study.return_value = {
+            "id": participant.hit_id,
+            "status": "ACTIVE",
+            "internal_name": "test-experiment",
+        }
+        recruiter.prolificservice.get_total_cost.return_value = 1234
+
+        status = recruiter.get_status()
+
+        recruiter.prolificservice.get_submissions.assert_called_once_with(
+            "study-from-participant"
+        )
+        recruiter.prolificservice.get_study.assert_called_once_with(
+            "study-from-participant"
+        )
+        recruiter.prolificservice.get_total_cost.assert_called_once_with(
+            "study-from-participant"
+        )
+        assert recruiter.current_study_id == "study-from-participant"
+        assert status.study_id == "study-from-participant"
+        assert status.study_status == "ACTIVE"
+        assert status.study_cost == 12.34
+        assert status.participant_status_counts == {"RETURNED": 1}
+
+    def test_get_status_does_not_recover_ambiguous_current_study(self, a, recruiter):
+        a.participant(assignment_id="aaa111", hit_id="study-1", recruiter_id="prolific")
+        a.participant(assignment_id="bbb222", hit_id="study-2", recruiter_id="prolific")
+
+        status = recruiter.get_status()
+
+        recruiter.prolificservice.get_submissions.assert_not_called()
+        recruiter.prolificservice.get_study.assert_not_called()
+        recruiter.prolificservice.get_total_cost.assert_not_called()
+        assert recruiter.current_study_id is None
+        assert status.study_id == ""
+        assert status.study_status == ""
+        assert status.study_cost == 0
+        assert status.participant_status_counts == {}
+
     def test_verify_status_without_current_study_does_not_call_prolific(
         self, a, recruiter
     ):

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -426,7 +426,7 @@ def prolificservice(prolific_config, fake_parsed_prolific_study):
     return service
 
 
-@pytest.mark.usefixtures("prolific_config")
+@pytest.mark.usefixtures("prolific_config", "db_session")
 class TestProlificRecruiter:
     @pytest.fixture
     def recruiter(


### PR DESCRIPTION
## Summary
- Fixes Prolific bonus, status-report, and status-verification flows when Dallinger cannot read the current Prolific study ID from its cached lookup.
- Original error: partial bonus payment could reach Prolific with `study_id: null`, status reporting could skip Prolific data because no current study ID was recorded, and status verification could be skipped for the same reason.
- Recovers the study ID from Prolific submission data or participant records when unambiguous, records it for future checks, and avoids API calls when recovery is impossible or ambiguous.

## Why the cached study ID can be unavailable
- Dallinger records the Prolific study ID in `ProlificRecruiter.current_study_id` after `open_recruitment()` creates the Prolific study. That value is a Redis-backed cache entry, not the authoritative record of the Prolific study.
- The cache key is derived from both the recruiter class and Dallinger `config["id"]` (`RedisStore:<RecruiterClassName>:<config id>`). If `config["id"]` changes across setup, deploy, update, debug, or reload flows while participant records persist, Redis may still contain the old entry but Dallinger will look under a new key and `current_study_id` will appear missing.
- Participants can also exist without this cache entry ever being written. Participant admission happens through Prolific URL parameters: Prolific sends `STUDY_ID`, and Dallinger stores it durably as `participant.hit_id`. Creating or loading a participant does not call `_record_current_study_id()`, so manual Prolific studies, restored data, failed/partial launches, or other non-standard entry paths can leave participants with valid study IDs while the cache is empty.
- Recovery is intentionally conservative. If there are no Prolific participants yet, if participants have missing `hit_id`s, or if participant records point to multiple Prolific studies, Dallinger cannot infer one authoritative current study ID and should avoid scoped Prolific API calls instead of guessing.
- Before this fix, bonus payment used `self.current_study_id` directly, so a missing cached lookup could pass `study_id=None` down to the Prolific bonus API. Status reporting and verification also depended on the cached study ID before asking Prolific for submissions, study details, costs, or assignments, so a cache miss prevented Dallinger from reporting or correcting participant statuses.
- The fix treats the cached study ID as recoverable operational state: for bonuses, it resolves the study ID from the Prolific submission or the participant record; for status reporting and verification, it recovers from participant `hit_id` values when all relevant participants point to the same study. Once recovered, it records the ID back into the cache for future calls.

## Test plan
- `python -m pytest -p no:psynet tests/test_recruiters.py::TestProlificRecruiter::test_get_status_without_current_study_does_not_call_prolific tests/test_recruiters.py::TestProlificRecruiter::test_get_status_recovers_missing_current_study_from_participants tests/test_recruiters.py::TestProlificRecruiter::test_get_status_does_not_recover_ambiguous_current_study tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_without_current_study_does_not_call_prolific tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_recovers_missing_current_study_from_participants tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_does_not_recover_ambiguous_current_study tests/test_recruiters.py::TestProlificRecruiter::test_reward_bonus_passes_only_whats_needed tests/test_recruiters.py::TestProlificRecruiter::test_reward_bonus_recovers_missing_study_id_from_submission tests/test_recruiters.py::TestProlificRecruiter::test_reward_bonus_recovers_missing_study_id_from_participant tests/test_recruiters.py::TestProlificRecruiter::test_reward_bonus_logs_exception_when_study_id_cannot_be_resolved tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_triggers_corrections`
- `python -m py_compile dallinger/recruiters.py tests/test_recruiters.py`
- Commit hook: `ruff check` and `ruff format` passed.
- The focused pytest command could not be run locally in this checkout because the active Python environment does not have `pytest` installed.

Made with [Cursor](https://cursor.com)