### PR TITLE
Persist returned Prolific assignment corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.
+- Fixed repeated Prolific returned-assignment correction jobs by preserving the
+  returned participant status after experiment return hooks run.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 

--- a/dallinger/experiment_server/worker_events.py
+++ b/dallinger/experiment_server/worker_events.py
@@ -259,6 +259,8 @@ class AssignmentReturned(WorkerEvent):
             self.update_participant_end_time()
             self.participant.status = "returned"
             self.experiment.assignment_returned(participant=self.participant)
+            # The external return event is authoritative even if hooks mutate status.
+            self.participant.status = "returned"
 
 
 class RecruiterSubmissionComplete(WorkerEvent):

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -2061,6 +2061,18 @@ class TestAssignmentReturned:
         runner()
         assert runner.participant.status == "returned"
 
+    def test_returned_status_wins_over_experiment_hook(self, runner):
+        runner.participant.failed = True
+
+        def reset_status(participant):
+            participant.status = "working"
+
+        runner.experiment.assignment_returned.side_effect = reset_status
+
+        runner()
+
+        assert runner.participant.status == "returned"
+
     def test_sets_participant_end_time(self, runner):
         runner()
         assert runner.participant.end_time == end_time

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -781,6 +781,49 @@ class TestProlificRecruiter:
             ]
         )
 
+    def test_returned_assignment_correction_is_not_repeated(self, a, recruiter, queue):
+        from dallinger.experiment_server.worker_events import AssignmentReturned
+
+        p1 = a.participant(assignment_id="aaa111", recruiter_id="prolific")
+        p1.failed = True
+        recruiter._record_current_study_id("some-study-id")
+        recruiter.prolificservice.get_assignments_for_study.return_value = {
+            p1.assignment_id: {
+                "participant_id": p1.assignment_id,
+                "hit_id": "some-study-id",
+                "worker_id": "some-prolific-worker-id-1",
+                "started_at": "2021-05-20T11:23:00.457Z",
+                "status": "RETURNED",
+            },
+        }
+
+        recruiter.verify_status_of([p1])
+
+        queue.enqueue.assert_called_once_with(
+            mock.ANY, "AssignmentReturned", "aaa111", p1.id
+        )
+
+        experiment = mock.Mock()
+        experiment.assignment_returned.side_effect = lambda participant: setattr(
+            participant, "status", "working"
+        )
+        AssignmentReturned(
+            participant=p1,
+            assignment_id=p1.assignment_id,
+            experiment=experiment,
+            session=mock.Mock(),
+            config={},
+            now=datetime.now(),
+            receive_time=datetime.now(),
+        )()
+
+        assert p1.status == "returned"
+
+        queue.reset_mock()
+        recruiter.verify_status_of([p1])
+
+        queue.enqueue.assert_not_called()
+
     def test_verify_status_copes_with_assignments_not_in_prolific(
         self, a, recruiter, queue
     ):


### PR DESCRIPTION
## Summary
- Fixes repeated Prolific `AssignmentReturned` corrective jobs for participants whose Prolific submission is already `RETURNED` while Dallinger still locally records them as `working`.
- Treats a successful `AssignmentReturned` worker event as the authoritative local transition to `participant.status = "returned"`.
- Adds regression coverage for both the worker event final state and the recruiter status-check loop.

## Original error
In Prolific return-for-bonus test deployments, Dallinger's periodic recruiter status check could repeatedly enqueue the same `AssignmentReturned` correction for a participant whose Prolific submission was already returned.

No custom experiment hook is needed to create the initial mismatch. In the PsyNet return-for-bonus path, the return/payment flow and Dallinger's canonical participant status are updated through separate paths:

1. A participant exits early through the failed/return-for-bonus path.
2. PsyNet marks the participant as failed and routes them through the return-for-bonus UI, but Dallinger's `Participant.status` can still be `working`.
3. The participant returns the submission in Prolific.
4. PsyNet checks Prolific directly from the return-for-bonus page, sees `RETURNED`, records the page-level return flag, and pays the partial bonus.
5. That page-level flow does not itself set Dallinger's `Participant.status` to `returned`.
6. The next periodic Dallinger recruiter status check still sees the participant as locally `working`, asks Prolific for the assignment status, and sees remote `RETURNED`.
7. Dallinger detects the mismatch (`working` locally, `RETURNED` remotely) and enqueues an `AssignmentReturned` worker event.
8. If another status check sees the same local `working` state before the local correction has been durably represented as `returned`, it can enqueue the same correction again.

This was noisy and could keep re-running return handling even though the authoritative external state had already been observed.

## Solution
`AssignmentReturned` is the Dallinger worker event that bridges Prolific's external `RETURNED` status into Dallinger's local participant status. This PR makes that final state explicit: after the worker event's return handling runs, the participant is left as `participant.status = "returned"`.

The post-hook assignment is a defensive final-state invariant. It does not assume that the observed deployment had custom experiment code; it ensures that any successful `AssignmentReturned` correction ends with the local status matching the authoritative Prolific return state. After that, later recruiter status checks no longer see `working` locally against `RETURNED` remotely, so they do not enqueue another correction.

## Test plan
- `python -m pytest -p no:psynet tests/test_recruiters.py::TestProlificRecruiter::test_returned_assignment_correction_is_not_repeated tests/test_experiment_server.py::TestAssignmentReturned::test_returned_status_wins_over_experiment_hook`

Made with [Cursor](https://cursor.com)