### PR TITLE
Fix CI ChromeDriver setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,10 +87,10 @@ jobs:
         uses: actions/checkout@v5
       - name: Install Ubuntu packages
         run: sudo apt-get --yes install pandoc enchant-2 curl
-      - name: Chromedriver setup
-        uses: browser-actions/setup-chrome@v2
-        with:
-          install-chromedriver: true
+      - name: Check Chrome/ChromeDriver versions
+        run: |
+          google-chrome --version
+          chromedriver --version
       - name: Install snap packages
         run: curl https://cli-assets.heroku.com/install.sh | sh
       - name: Set up Node.js
@@ -211,10 +211,10 @@ jobs:
         run: sudo apt-get --yes install enchant-2 curl
       - name: Install and upgrade wheel, pip and tox
         run: pip install --upgrade pip wheel tox build
-      - name: Chromedriver setup
-        uses: browser-actions/setup-chrome@v2
-        with:
-          install-chromedriver: true
+      - name: Check Chrome/ChromeDriver versions
+        run: |
+          google-chrome --version
+          chromedriver --version
       - name: Change dallinger version required by bartlett1932 to match current version
         run: |
           VERSION=$(grep __version__ dallinger/version.py |sed -e 's/__version__ = "//;s/"//')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,9 @@ jobs:
       - name: Install Ubuntu packages
         run: sudo apt-get --yes install pandoc enchant-2 curl
       - name: Chromedriver setup
-        uses: nanasess/setup-chromedriver@v2.4.0
+        uses: browser-actions/setup-chrome@v2
+        with:
+          install-chromedriver: true
       - name: Install snap packages
         run: curl https://cli-assets.heroku.com/install.sh | sh
       - name: Set up Node.js
@@ -210,7 +212,9 @@ jobs:
       - name: Install and upgrade wheel, pip and tox
         run: pip install --upgrade pip wheel tox build
       - name: Chromedriver setup
-        uses: nanasess/setup-chromedriver@v2.4.0
+        uses: browser-actions/setup-chrome@v2
+        with:
+          install-chromedriver: true
       - name: Change dallinger version required by bartlett1932 to match current version
         run: |
           VERSION=$(grep __version__ dallinger/version.py |sed -e 's/__version__ = "//;s/"//')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   response.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
-- Fixed CI ChromeDriver setup failures by installing Chrome and its matching driver with `browser-actions/setup-chrome`.
+
+### Removed
+- Removed nanasess/setup-chromedriver action to instead use the GitHub-hosted runner's preinstalled Chrome and ChromeDriver versions.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
   response.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
+- Fixed CI ChromeDriver setup failures by installing Chrome and its matching driver with `browser-actions/setup-chrome`.
 
 ### Updated
 


### PR DESCRIPTION
## Summary
- Remove the `nanasess/setup-chromedriver@v2.4.0` setup action from the CI workflows.
- Use the GitHub runner's available Chrome and ChromeDriver instead, and print both versions in the affected jobs for visibility.
- Add an unreleased changelog entry for the CI ChromeDriver setup failure.

## Motivation
The standalone ChromeDriver setup path was failing in CI while trying to resolve/download Chrome for Testing assets. The final workflow no longer performs a separate ChromeDriver setup step; it relies on the runner-provided browser/driver pair and logs their versions so future failures include the exact browser environment.

## Test plan
- Passed: GitHub Actions `pre-commit`.
- Passed: GitHub Actions `check_changelog`.
- Passed: GitHub Actions `build` for Python 3.10, 3.11, 3.12, and 3.13.
- Passed: GitHub Actions `docker`.
- Passed: GitHub Actions `check_mturk_changes`.
- Not run locally: full Dallinger test suite.