### PR TITLE
Fetch all paginated Prolific submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   body so they return JSON error messages instead of only a generic HTML 500
   response.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
+- Fixed Prolific submissions lookups so status checks retrieve all paginated
+  submissions instead of only the first page.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Updated

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -153,7 +153,7 @@ class ProlificService:
 
         return get_amount(rewards) + get_amount(bonuses)
 
-    def get_submissions(self, study_id: str) -> dict:
+    def get_submissions(self, study_id: str) -> List[dict]:
         """
         Fetch /submissions endpoint for a given study_id and return the result
 
@@ -176,10 +176,26 @@ class ProlificService:
                 "Cannot fetch Prolific submissions without a study_id."
             )
 
-        query_params = {"study": study_id}
-        return self._req(method="GET", endpoint="/submissions/", params=query_params)[
-            "results"
-        ]
+        page_size = 100
+        page = 1
+        submissions = []
+
+        while True:
+            query_params = {
+                "study": study_id,
+                "ordering": "started_at",
+                "page": page,
+                "page_size": page_size,
+            }
+            results = self._req(
+                method="GET", endpoint="/submissions/", params=query_params
+            )["results"]
+            submissions.extend(results)
+
+            if len(results) < page_size:
+                return submissions
+
+            page += 1
 
     def get_studies(self, states: List[str] = None) -> List[dict]:
         if not states:

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -511,14 +511,20 @@ def test_get_submissions_requires_study_id(subject):
     subject._req.assert_not_called()
 
 
-def test_get_submissions_returns_all_pages(subject):
-    first_page = [{"id": f"submission-{i}"} for i in range(100)]
-    second_page = [{"id": "submission-100"}]
-    subject._req = mock.MagicMock(
-        side_effect=[{"results": first_page}, {"results": second_page}]
-    )
+@pytest.mark.parametrize("page_lengths", ([100, 1], [100, 0], [100, 100, 50]))
+def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
+    pages = []
+    next_id = 0
+    for length in page_lengths:
+        pages.append(
+            [{"id": f"submission-{i}"} for i in range(next_id, next_id + length)]
+        )
+        next_id += length
+    subject._req = mock.MagicMock(side_effect=[{"results": page} for page in pages])
 
-    assert subject.get_submissions("study_123") == first_page + second_page
+    assert subject.get_submissions("study_123") == [
+        item for page in pages for item in page
+    ]
     assert subject._req.call_args_list == [
         mock.call(
             method="GET",
@@ -526,48 +532,11 @@ def test_get_submissions_returns_all_pages(subject):
             params={
                 "study": "study_123",
                 "ordering": "started_at",
-                "page": 1,
+                "page": page,
                 "page_size": 100,
             },
-        ),
-        mock.call(
-            method="GET",
-            endpoint="/submissions/",
-            params={
-                "study": "study_123",
-                "ordering": "started_at",
-                "page": 2,
-                "page_size": 100,
-            },
-        ),
-    ]
-
-
-def test_get_submissions_checks_next_page_after_full_page(subject):
-    first_page = [{"id": f"submission-{i}"} for i in range(100)]
-    subject._req = mock.MagicMock(
-        side_effect=[{"results": first_page}, {"results": []}]
-    )
-
-    assert subject.get_submissions("study_123") == first_page
-    assert subject._req.call_count == 2
-
-
-def test_get_submissions_returns_more_than_two_pages(subject):
-    pages = [
-        [{"id": f"submission-{i}"} for i in range(100)],
-        [{"id": f"submission-{i}"} for i in range(100, 200)],
-        [{"id": f"submission-{i}"} for i in range(200, 250)],
-    ]
-    subject._req = mock.MagicMock(side_effect=[{"results": page} for page in pages])
-
-    assert subject.get_submissions("study_123") == [
-        item for page in pages for item in page
-    ]
-    assert [call.kwargs["params"]["page"] for call in subject._req.call_args_list] == [
-        1,
-        2,
-        3,
+        )
+        for page in range(1, len(page_lengths) + 1)
     ]
 
 

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -511,6 +511,66 @@ def test_get_submissions_requires_study_id(subject):
     subject._req.assert_not_called()
 
 
+def test_get_submissions_returns_all_pages(subject):
+    first_page = [{"id": f"submission-{i}"} for i in range(100)]
+    second_page = [{"id": "submission-100"}]
+    subject._req = mock.MagicMock(
+        side_effect=[{"results": first_page}, {"results": second_page}]
+    )
+
+    assert subject.get_submissions("study_123") == first_page + second_page
+    assert subject._req.call_args_list == [
+        mock.call(
+            method="GET",
+            endpoint="/submissions/",
+            params={
+                "study": "study_123",
+                "ordering": "started_at",
+                "page": 1,
+                "page_size": 100,
+            },
+        ),
+        mock.call(
+            method="GET",
+            endpoint="/submissions/",
+            params={
+                "study": "study_123",
+                "ordering": "started_at",
+                "page": 2,
+                "page_size": 100,
+            },
+        ),
+    ]
+
+
+def test_get_submissions_checks_next_page_after_full_page(subject):
+    first_page = [{"id": f"submission-{i}"} for i in range(100)]
+    subject._req = mock.MagicMock(
+        side_effect=[{"results": first_page}, {"results": []}]
+    )
+
+    assert subject.get_submissions("study_123") == first_page
+    assert subject._req.call_count == 2
+
+
+def test_get_submissions_returns_more_than_two_pages(subject):
+    pages = [
+        [{"id": f"submission-{i}"} for i in range(100)],
+        [{"id": f"submission-{i}"} for i in range(100, 200)],
+        [{"id": f"submission-{i}"} for i in range(200, 250)],
+    ]
+    subject._req = mock.MagicMock(side_effect=[{"results": page} for page in pages])
+
+    assert subject.get_submissions("study_123") == [
+        item for page in pages for item in page
+    ]
+    assert [call.kwargs["params"]["page"] for call in subject._req.call_args_list] == [
+        1,
+        2,
+        3,
+    ]
+
+
 class TestDevProlificServiceScreenOut:
     @pytest.fixture
     def participants(self, a):


### PR DESCRIPTION
## Summary
- Fetch Prolific submissions with explicit `page_size`, `page`, and stable `started_at` ordering.
- Continue paging until the final partial page so status checks include participants beyond Prolific's default first 20 submissions.
- Add regression coverage for two-page, exact-full-page, and 250-submission pagination cases.

## Original error
In a Prolific test deployment with 21 local participants, Dallinger repeatedly logged that it could not find assignment `6a31970283454367318db26f` for participant `21` in Prolific, leaving that failed-prescreening participant stuck locally in `status=working`. The assignment ID was real: it came from Prolific's `SESSION_ID` when the participant entered the app.

The root cause was that Dallinger called `GET /submissions/?study=<study_id>` without pagination parameters. Prolific's default response contains only the first 20 submissions. A direct API check against the live study confirmed the default request returned `20` of `21` submissions and omitted participant `21`'s assignment, while an explicit paginated/large-page request returned all `21` and included it.

## Test plan
- `python -m pytest tests/test_prolific.py -k get_submissions`
- Verified against the live Prolific study that the default request returned 20 of 21 submissions and omitted the affected participant, while paginated/large-page requests included it.

Made with [Cursor](https://cursor.com)