### PR TITLE
Persist Prolific study IDs in recruiter state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.
+- Fixed Prolific study ID consistency across web, worker, and clock processes
+  by sharing dashboard-compatible durable recruiter state and stable
+  deployment-keyed lookup.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -225,6 +225,7 @@ def deploy_image(image_name, mode, config_options):
     heroku_conn = Heroku3Client(session=requests.session())
     print(f"Creating Heroku app in {mode} mode")
     app_name = "dlgr-" + dallinger_uid.split("-")[0]
+    config_dict["DALLINGER_DEPLOYMENT_ID"] = app_name
     app = heroku_conn.create_app(stack_id_or_name="container", name=app_name)
     app_hostname = app.domains()[0].hostname
     config_dict["HOST"] = app_hostname

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -896,6 +896,7 @@ It currently resolves to {ipaddr_experiment}."""
             "mode": mode,
             "CREATOR": f"{USER}@{HOSTNAME}",
             "DALLINGER_UID": experiment_uuid,
+            "DALLINGER_DEPLOYMENT_ID": experiment_id,
             "ADMIN_USER": "admin",
             "docker_image_name": image_name,
         }

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -1061,10 +1061,19 @@ def parse_searchpanes_filters(args) -> dict[str, list[str]]:
     return filters
 
 
+def database_view_label(table, polymorphic_identity):
+    from dallinger.db import get_mapped_class, get_polymorphic_mapping
+
+    if polymorphic_identity is not None:
+        cls = get_polymorphic_mapping(table)[polymorphic_identity]
+    else:
+        cls = get_mapped_class(table)
+    return cls.__name__
+
+
 @dashboard.route("/database", methods=["GET", "POST"])
 @login_required
 def dashboard_database():
-    from dallinger.db import get_mapped_class, get_polymorphic_mapping
     from dallinger.experiment_server.experiment_server import Experiment
 
     exp = Experiment()
@@ -1079,12 +1088,7 @@ def dashboard_database():
     if table is None and polymorphic_identity is None:
         table = "participant"
 
-    if polymorphic_identity is not None:
-        cls = get_polymorphic_mapping(table)[polymorphic_identity]
-        label = cls.__name__
-    else:
-        label = get_mapped_class(table).__name__
-
+    label = database_view_label(table, polymorphic_identity)
     title = "Database View: {}".format(label)
 
     # Initial page render (columns only, no rows as they will be fetched from the client)

--- a/dallinger/experiment_server/dashboard.py
+++ b/dallinger/experiment_server/dashboard.py
@@ -1064,7 +1064,7 @@ def parse_searchpanes_filters(args) -> dict[str, list[str]]:
 @dashboard.route("/database", methods=["GET", "POST"])
 @login_required
 def dashboard_database():
-    from dallinger.db import get_polymorphic_mapping
+    from dallinger.db import get_mapped_class, get_polymorphic_mapping
     from dallinger.experiment_server.experiment_server import Experiment
 
     exp = Experiment()
@@ -1083,7 +1083,7 @@ def dashboard_database():
         cls = get_polymorphic_mapping(table)[polymorphic_identity]
         label = cls.__name__
     else:
-        label = table.capitalize()
+        label = get_mapped_class(table).__name__
 
     title = "Database View: {}".format(label)
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -189,6 +189,28 @@ class SharedMixin:
                     obj.fail()
 
 
+class RecruiterState(Base):
+    """Durable recruiter state shared by web, worker, and clock processes."""
+
+    __tablename__ = "recruiter_state"
+
+    id = Column(Integer, primary_key=True, index=True)
+    recruiter_id = Column(String(50), nullable=False, unique=True, index=True)
+    current_study_id = Column(String(100), nullable=True)
+    experiment_id = Column(String(100), nullable=True)
+    deployment_id = Column(String(100), nullable=True)
+
+    def __json__(self):
+        """Return a JSON representation for dashboard database views."""
+        return {
+            "id": self.id,
+            "recruiter_id": self.recruiter_id,
+            "current_study_id": self.current_study_id,
+            "experiment_id": self.experiment_id,
+            "deployment_id": self.deployment_id,
+        }
+
+
 class Participant(Base, SharedMixin):
     """An ex silico participant."""
 

--- a/dallinger/models.py
+++ b/dallinger/models.py
@@ -190,7 +190,7 @@ class SharedMixin:
 
 
 class RecruiterState(Base):
-    """Durable recruiter state shared by web, worker, and clock processes."""
+    """Durable recruiter state; Prolific currently uses ``current_study_id``."""
 
     __tablename__ = "recruiter_state"
 

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -966,15 +966,8 @@ class ProlificRecruiter(Recruiter):
             self.store.set(key, study_id)
 
     def _current_study_id_from_db(self):
-        if not self._recruiter_state_table_exists():
-            return None
-
         try:
-            state = (
-                session.query(RecruiterState)
-                .filter_by(recruiter_id=self.nickname)
-                .one_or_none()
-            )
+            state = self._get_recruiter_state()
         except SQLAlchemyError:
             session.rollback()
             logger.warning(
@@ -991,18 +984,10 @@ class ProlificRecruiter(Recruiter):
         return state.current_study_id
 
     def _record_current_study_id_in_db(self, study_id):
-        if not self._recruiter_state_table_exists():
-            return
-
         try:
-            state = (
-                session.query(RecruiterState)
-                .filter_by(recruiter_id=self.nickname)
-                .one_or_none()
-            )
+            state = self._get_recruiter_state(create=True)
             if state is None:
-                state = RecruiterState(recruiter_id=self.nickname)
-                session.add(state)
+                return
             state.current_study_id = study_id
             state.experiment_id = self.config.get("id")
             state.deployment_id = self.deployment_storage_id
@@ -1014,6 +999,20 @@ class ProlificRecruiter(Recruiter):
                 self.nickname,
                 exc_info=True,
             )
+
+    def _get_recruiter_state(self, create=False):
+        if not self._recruiter_state_table_exists():
+            return None
+
+        state = (
+            session.query(RecruiterState)
+            .filter_by(recruiter_id=self.nickname)
+            .one_or_none()
+        )
+        if state is None and create:
+            state = RecruiterState(recruiter_id=self.nickname)
+            session.add(state)
+        return state
 
     def _recruiter_state_table_exists(self):
         try:

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -1006,6 +1006,7 @@ class ProlificRecruiter(Recruiter):
             state.current_study_id = study_id
             state.experiment_id = self.config.get("id")
             state.deployment_id = self.deployment_storage_id
+            session.commit()
         except SQLAlchemyError:
             session.rollback()
             logger.warning(

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -14,7 +14,8 @@ from typing import Optional
 
 import flask
 import requests
-from sqlalchemy import func
+from sqlalchemy import func, inspect
+from sqlalchemy.exc import SQLAlchemyError
 
 from dallinger.command_line.utils import Output, render_rich_table
 from dallinger.config import get_config
@@ -22,7 +23,7 @@ from dallinger.db import get_queue, redis_conn, scoped_session_decorator, sessio
 from dallinger.experiment_server.utils import crossdomain, success_response
 from dallinger.experiment_server.worker_events import worker_function
 from dallinger.heroku import tools as heroku_tools
-from dallinger.models import Participant, Recruitment
+from dallinger.models import Participant, RecruiterState, Recruitment
 from dallinger.mturk import (
     DuplicateQualificationNameError,
     MTurkQualificationRequirements,
@@ -884,7 +885,16 @@ class ProlificRecruiter(Recruiter):
         """Return the ID of the Study associated with the active experiment ID
         if any such Study exists.
         """
-        return self.store.get(self.study_id_storage_key)
+        for key in self.study_id_storage_keys:
+            study_id = self.store.get(key)
+            if study_id:
+                self._cache_current_study_id(study_id)
+                return study_id
+
+        study_id = self._current_study_id_from_db()
+        if study_id:
+            self._cache_current_study_id(study_id)
+        return study_id
 
     @property
     def is_in_progress(self) -> bool:
@@ -931,8 +941,108 @@ class ProlificRecruiter(Recruiter):
         experiment_id = self.config.get("id")
         return "{}:{}".format(self.__class__.__name__, experiment_id)
 
+    @property
+    def study_id_storage_keys(self):
+        """Return Redis keys that may hold the current Prolific study ID."""
+        keys = []
+        deployment_id = self.deployment_storage_id
+        if deployment_id:
+            keys.append(f"{self.__class__.__name__}:deployment:{deployment_id}")
+        keys.append(self.study_id_storage_key)
+        return list(dict.fromkeys(keys))
+
+    @property
+    def deployment_storage_id(self):
+        """Return a process-stable deployment ID when one is configured."""
+        return os.getenv("DALLINGER_DEPLOYMENT_ID") or os.getenv("DALLINGER_UID")
+
     def _record_current_study_id(self, study_id):
-        self.store.set(self.study_id_storage_key, study_id)
+        self._cache_current_study_id(study_id)
+        self._record_current_study_id_in_db(study_id)
+
+    def _cache_current_study_id(self, study_id):
+        """Cache the current study ID under all known Redis lookup keys."""
+        for key in self.study_id_storage_keys:
+            self.store.set(key, study_id)
+
+    def _current_study_id_from_db(self):
+        if not self._recruiter_state_table_exists():
+            return None
+
+        try:
+            state = (
+                session.query(RecruiterState)
+                .filter_by(recruiter_id=self.nickname)
+                .one_or_none()
+            )
+        except SQLAlchemyError:
+            session.rollback()
+            logger.warning(
+                "Could not read persisted recruiter state for %s.",
+                self.nickname,
+                exc_info=True,
+            )
+            return None
+
+        if state is None or not state.current_study_id:
+            return None
+
+        self._warn_if_identity_changed(state)
+        return state.current_study_id
+
+    def _record_current_study_id_in_db(self, study_id):
+        if not self._recruiter_state_table_exists():
+            return
+
+        try:
+            state = (
+                session.query(RecruiterState)
+                .filter_by(recruiter_id=self.nickname)
+                .one_or_none()
+            )
+            if state is None:
+                state = RecruiterState(recruiter_id=self.nickname)
+                session.add(state)
+            state.current_study_id = study_id
+            state.experiment_id = self.config.get("id")
+            state.deployment_id = self.deployment_storage_id
+        except SQLAlchemyError:
+            session.rollback()
+            logger.warning(
+                "Could not persist current Prolific study ID for %s.",
+                self.nickname,
+                exc_info=True,
+            )
+
+    def _recruiter_state_table_exists(self):
+        try:
+            return inspect(session.get_bind()).has_table(RecruiterState.__tablename__)
+        except SQLAlchemyError:
+            logger.warning(
+                "Could not check for persisted recruiter state table.",
+                exc_info=True,
+            )
+            return False
+
+    def _warn_if_identity_changed(self, state):
+        current_experiment_id = self.config.get("id")
+        current_deployment_id = self.deployment_storage_id
+        if state.experiment_id and state.experiment_id != current_experiment_id:
+            logger.warning(
+                "Recovered Prolific study ID %s from database state recorded with "
+                "config id %s, but this process is using config id %s.",
+                state.current_study_id,
+                state.experiment_id,
+                current_experiment_id,
+            )
+        if state.deployment_id and state.deployment_id != current_deployment_id:
+            logger.warning(
+                "Recovered Prolific study ID %s from database state recorded with "
+                "deployment id %s, but this process is using deployment id %s.",
+                state.current_study_id,
+                state.deployment_id,
+                current_deployment_id,
+            )
 
     def load_service(self, sandbox):
         return prolific_service_from_config()

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -733,6 +733,19 @@ class TestDashboardDatabase:
         assert resp.status_code == 200
         assert "<h1>Database View: Network</h1>" in resp.data.decode("utf8")
 
+    def test_render_non_polymorphic_table_uses_class_name(
+        self, db_session, webapp_admin
+    ):
+        from dallinger.models import RecruiterState
+
+        db_session.add(RecruiterState(recruiter_id="prolific"))
+        db_session.commit()
+
+        resp = webapp_admin.get("/dashboard/database?table=recruiter_state")
+
+        assert resp.status_code == 200
+        assert "<h1>Database View: RecruiterState</h1>" in resp.data.decode("utf8")
+
     def test_table_columns_and_data_participant(self, a, db_session):
         """Columns now come from table_columns(); data formatting changed."""
         from dallinger.experiment_server.experiment_server import Experiment

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -725,6 +725,13 @@ class TestDashboardDatabase:
     def test_requires_login(self, webapp):
         assert webapp.get("/dashboard/database").status_code == 401
 
+    def test_database_view_label_uses_model_class_names(self):
+        from dallinger.experiment_server.dashboard import database_view_label
+
+        assert database_view_label("network", "network") == "Network"
+        assert database_view_label("participant", None) == "Participant"
+        assert database_view_label("recruiter_state", None) == "RecruiterState"
+
     def test_render(self, active_config, webapp_admin):
         resp = webapp_admin.get(
             "/dashboard/database?table=network&polymorphic_identity=network"
@@ -733,18 +740,41 @@ class TestDashboardDatabase:
         assert resp.status_code == 200
         assert "<h1>Database View: Network</h1>" in resp.data.decode("utf8")
 
-    def test_render_non_polymorphic_table_uses_class_name(
-        self, db_session, webapp_admin
-    ):
+    def test_recruiter_state_database_view(self, db_session, webapp_admin):
+        from dallinger.db import get_all_mapped_classes
+        from dallinger.experiment_server.experiment_server import Experiment
         from dallinger.models import RecruiterState
 
-        db_session.add(RecruiterState(recruiter_id="prolific"))
+        db_session.add(
+            RecruiterState(
+                recruiter_id="prolific",
+                current_study_id="study-from-launch",
+                experiment_id="launch-config-id",
+            )
+        )
         db_session.commit()
 
-        resp = webapp_admin.get("/dashboard/database?table=recruiter_state")
+        assert get_all_mapped_classes()["RecruiterState"] == {
+            "cls": RecruiterState,
+            "table": "recruiter_state",
+            "polymorphic_identity": None,
+        }
 
+        resp = webapp_admin.get("/dashboard/database?table=recruiter_state")
         assert resp.status_code == 200
         assert "<h1>Database View: RecruiterState</h1>" in resp.data.decode("utf8")
+
+        exp = Experiment(db_session)
+        assert exp.table_columns(table="recruiter_state") == [
+            {"name": "id", "data": "id"},
+            {"name": "recruiter_id", "data": "recruiter_id"},
+            {"name": "current_study_id", "data": "current_study_id"},
+            {"name": "experiment_id", "data": "experiment_id"},
+        ]
+        table_data = exp.table_data(start=0, length=10, table="recruiter_state")
+        assert table_data["total_count"] == 1
+        assert table_data["data"][0]["recruiter_id"] == "prolific"
+        assert table_data["data"][0]["current_study_id"] == "study-from-launch"
 
     def test_table_columns_and_data_participant(self, a, db_session):
         """Columns now come from table_columns(); data formatting changed."""

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -546,7 +546,6 @@ class TestProlificRecruiter:
     def test_current_study_id_recovers_from_database_when_config_id_changes(
         self, recruiter, active_config, db_session
     ):
-        from dallinger.db import get_all_mapped_classes
         from dallinger.models import RecruiterState
 
         active_config.extend({"id": "launch-config-id"})
@@ -556,23 +555,7 @@ class TestProlificRecruiter:
         state = db_session.query(RecruiterState).one()
         assert state.id is not None
         assert state.recruiter_id == "prolific"
-        assert get_all_mapped_classes()["RecruiterState"] == {
-            "cls": RecruiterState,
-            "table": "recruiter_state",
-            "polymorphic_identity": None,
-        }
-        assert Experiment().table_columns(table="recruiter_state") == [
-            {"name": "id", "data": "id"},
-            {"name": "recruiter_id", "data": "recruiter_id"},
-            {"name": "current_study_id", "data": "current_study_id"},
-            {"name": "experiment_id", "data": "experiment_id"},
-        ]
-        table_data = Experiment().table_data(
-            start=0, length=10, table="recruiter_state"
-        )
-        assert table_data["total_count"] == 1
-        assert table_data["data"][0]["recruiter_id"] == "prolific"
-        assert table_data["data"][0]["current_study_id"] == "study-from-launch"
+        assert state.current_study_id == "study-from-launch"
 
         active_config.extend({"id": "worker-config-id"})
         recruiter.store.clear()

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -445,7 +445,9 @@ class TestProlificRecruiter:
             "dallinger.recruiters", os=mock.DEFAULT, get_base_url=mock.DEFAULT
         ) as mocks:
             mocks["get_base_url"].return_value = "http://fake-domain"
-            mocks["os"].getenv.return_value = "fake-host-domain"
+            mocks["os"].getenv.side_effect = lambda key, default=None: (
+                "fake-host-domain" if key == "HOST" else default
+            )
             r = ProlificRecruiter(store=hit_id_store)
             r.notifies_admin = notifies_admin
             r.mailer = mailer
@@ -539,6 +541,60 @@ class TestProlificRecruiter:
             recruiter.open_recruitment(n=1)
 
         assert ex_info.match("Can't run a Prolific Study from localhost")
+
+    def test_current_study_id_recovers_from_database_when_config_id_changes(
+        self, recruiter, active_config, db_session
+    ):
+        from dallinger.db import get_all_mapped_classes
+        from dallinger.models import RecruiterState
+
+        active_config.extend({"id": "launch-config-id"})
+        recruiter._record_current_study_id("study-from-launch")
+        db_session.flush()
+
+        state = db_session.query(RecruiterState).one()
+        assert state.id is not None
+        assert state.recruiter_id == "prolific"
+        assert get_all_mapped_classes()["RecruiterState"] == {
+            "cls": RecruiterState,
+            "table": "recruiter_state",
+            "polymorphic_identity": None,
+        }
+        assert Experiment().table_columns(table="recruiter_state") == [
+            {"name": "id", "data": "id"},
+            {"name": "recruiter_id", "data": "recruiter_id"},
+            {"name": "current_study_id", "data": "current_study_id"},
+            {"name": "experiment_id", "data": "experiment_id"},
+        ]
+        table_data = Experiment().table_data(
+            start=0, length=10, table="recruiter_state"
+        )
+        assert table_data["total_count"] == 1
+        assert table_data["data"][0]["recruiter_id"] == "prolific"
+        assert table_data["data"][0]["current_study_id"] == "study-from-launch"
+
+        active_config.extend({"id": "worker-config-id"})
+        recruiter.store.clear()
+
+        assert recruiter.current_study_id == "study-from-launch"
+
+    def test_current_study_id_uses_deployment_storage_key_when_config_id_changes(
+        self, recruiter, active_config
+    ):
+        with mock.patch("dallinger.recruiters.os.getenv") as getenv:
+            getenv.side_effect = lambda key, default=None: (
+                "deployment-1" if key == "DALLINGER_DEPLOYMENT_ID" else default
+            )
+            active_config.extend({"id": "launch-config-id"})
+            recruiter._record_current_study_id("study-from-launch")
+
+            active_config.extend({"id": "worker-config-id"})
+
+            assert recruiter.current_study_id == "study-from-launch"
+            assert (
+                recruiter.store.get("ProlificRecruiter:deployment:deployment-1")
+                == "study-from-launch"
+            )
 
     def test_get_status_without_current_study_does_not_call_prolific(self, recruiter):
         status = recruiter.get_status()

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -427,6 +427,7 @@ def prolificservice(prolific_config, fake_parsed_prolific_study):
 
 
 @pytest.mark.usefixtures("prolific_config")
+@pytest.mark.usefixtures("db_session")
 class TestProlificRecruiter:
     @pytest.fixture
     def recruiter(


### PR DESCRIPTION
## Summary
- Add a generic, dashboard-readable `recruiter_state` table keyed by `recruiter_id`, and use it to persist Prolific's active study ID so web, worker, and clock processes can recover the same study context.
- Cache the Prolific study ID under a deployment-stable Redis key (`DALLINGER_DEPLOYMENT_ID` / `DALLINGER_UID`) in addition to the existing config-ID key.
- Make the new recruiter state table safe to browse in the dashboard, including conventional `id`/JSON serialization and class-name database view titles such as `RecruiterState`.

## Scope across recruiters
Dallinger supports multiple recruiters, including MTurk, Prolific, CLI, bots, and downstream recruiters such as PsyNet's Lucid integrations. The new table is deliberately named `recruiter_state`, not `prolific_recruiter_state`, so it can hold durable state for other recruiters in the future. This PR only writes and reads this state from `ProlificRecruiter`; MTurk, Lucid, and other recruiters are otherwise unchanged.

## Original error
During Prolific test deployments, Dallinger stored the active study ID only in Redis under a key derived from the recruiter class and Dallinger `config["id"]`. If different processes or lifecycle phases used different config IDs, the study ID could still exist in Redis but under a key that the current process no longer checked. Follow-up Prolific operations such as bonus payments, status reporting, and status verification could therefore run without the correct study context or skip unexpectedly.

The fix records the active Prolific study ID as durable recruiter state and also mirrors it under a deployment-stable Redis key. This preserves the fast cache path while giving later web, worker, and clock processes a stable recovery path after config IDs diverge.

## Dashboard fixes
Adding `recruiter_state` exposed dashboard assumptions that database views have a conventional `id` and a JSON representation. This PR makes `RecruiterState` dashboard-compatible and updates database view titles to use mapped model class names for non-polymorphic tables, so the dashboard shows `Database View: RecruiterState` rather than `Recruiter_state`.

## Relationship to #9330
This PR does not fully replace #9330. It prevents the normal future deployment failure mode where `open_recruitment()` records the study ID but later processes look under a different config-specific Redis key. #9330 remains complementary fallback logic for cases where recruiter state is absent or was never written, such as restored data, manual studies, failed or partial launch paths, or participant records that contain a Prolific study ID while recruiter state is missing.

## Test plan
- `CI=true .tox/fast/bin/python -m pytest tests/test_recruiters.py tests/test_dashboard.py::TestDashboardDatabase::test_render_non_polymorphic_table_uses_class_name -q`
- Focused regression before the final commit: `CI=true python -m tox -e fast -- tests/test_recruiters.py`
- Commit hooks: `ruff check` and `ruff format` passed.

Made with [Cursor](https://cursor.com)