### PR TITLE
Fix Prolific study deletion endpoint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,13 @@ Run the full pre-commit suite before submitting changes:
 python -m pre_commit run --all-files
 ```
 
+## Changelog
+
+When preparing a Dallinger pull request, add a changelog entry for the PR in the
+unreleased section of `CHANGELOG.md`. Do not create separate changelog fragment
+files for Dallinger. Keep the changelog entry and the pull request description
+up to date as the PR evolves.
+
 ## Tests
 
 Run tests locally before finalizing a contribution:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
   submissions instead of only the first page.
 - Fixed deprecated `Experiment.session` warnings in dashboard table queries while
   preserving injected-session compatibility.
+- Fixed Prolific draft study deletion to use the documented study endpoint and
+  accept documented successful delete responses.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Removed

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -505,8 +505,8 @@ class ProlificService:
 
     def delete_study(self, study_id: str) -> bool:
         """Delete a Study entirely. This is only possible on UNPUBLISHED studies."""
-        response = self._req(method="DELETE", endpoint=f"/studies/{study_id}")
-        return response == {"status_code": 204}
+        response = self._req(method="DELETE", endpoint=f"/studies/{study_id}/")
+        return response.get("status_code") in {200, 204}
 
     def pay_session_bonus(self, study_id: str, worker_id: str, amount: float) -> bool:
         """Pay a worker a bonus.
@@ -812,7 +812,7 @@ class DevProlificService(ProlificService):
                 }
 
             elif method == "DELETE":
-                # method="DELETE", endpoint=f"/studies/{study_id}"
+                # method="DELETE", endpoint=f"/studies/{study_id}/"
                 response = {"status_code": 204}
 
         # Submissions

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -260,6 +260,29 @@ def test_can_create_a_draft_study_and_delete_it(subject):
     assert subject.delete_study(study_id=result["id"])
 
 
+@pytest.mark.parametrize("status_code", [200, 204])
+def test_delete_study_uses_canonical_endpoint(subject, status_code):
+    subject._req = mock.MagicMock(return_value={"status_code": status_code})
+
+    assert subject.delete_study(study_id="study_123")
+    subject._req.assert_called_once_with(
+        method="DELETE", endpoint="/studies/study_123/"
+    )
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"status_code": 404},
+        {"error": "Not found"},
+    ],
+)
+def test_delete_study_returns_false_for_unsuccessful_responses(subject, response):
+    subject._req = mock.MagicMock(return_value=response)
+
+    assert not subject.delete_study(study_id="study_123")
+
+
 @pytest.mark.usefixtures("check_prolific_writes")
 @pytest.mark.slow
 def test_can_add_to_available_place_count(subject):


### PR DESCRIPTION
## Summary
- Use Prolific's canonical trailing-slash study detail URL for draft study DELETE requests.
- Treat both documented successful Prolific delete responses, HTTP 200 and 204, as success.
- Add focused tests for the Prolific delete endpoint and accepted status codes, plus an unreleased changelog entry.
- Document in `AGENTS.md` that Dallinger PRs should update the unreleased `CHANGELOG.md` section.

## Prolific API confirmation
Prolific's current delete-study documentation specifies `DELETE https://api.prolific.com/api/v1/studies/{id}/` and documents a successful `200` response with an empty object body (`{}`). Reference: https://docs.prolific.com/api-reference/studies/delete-study

Dallinger previously sent the non-trailing-slash URL and only treated `204` as success. This PR updates the endpoint and accepts both `200` and `204`: `200` matches the current Prolific docs, while `204` preserves compatibility with the previously supported successful no-content DELETE response.

## Test plan
- Passed: commit hook `ruff check`.
- Passed: commit hook `ruff format`.
- Verified: Prolific's current delete-study API docs document the trailing-slash endpoint and a successful `200`/`{}` response.
- Not run: `python -m pytest tests/test_prolific.py::test_delete_study_uses_canonical_endpoint -q` because the default Python environment lacks pytest (`/usr/bin/python: No module named pytest`).
- Not run: live `--prolific_writes` tests, because they create/delete real Prolific studies.