### PR TITLE
Fix pre-commit CI Node warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,4 +240,7 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.13"
-      - uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit
+        run: |
+          python -m pip install -c constraints.txt pre-commit
+          pre-commit run --show-diff-on-failure --color=always --all-files

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,16 @@
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.
+- Fixed the GitHub Actions `pre-commit` job to avoid the deprecated Node.js 20
+  runtime by replacing `pre-commit/action` with explicit pre-commit installation
+  and execution.
 - Fixed Prolific status polling so it does not make unscoped submissions API requests when no current study ID is recorded.
 - Fixed Prolific submissions lookups so status checks retrieve all paginated
   submissions instead of only the first page.
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Removed
+
 - Removed nanasess/setup-chromedriver action to instead use the GitHub-hosted runner's preinstalled Chrome and ChromeDriver versions.
 
 ### Updated


### PR DESCRIPTION
## Summary
- Replace the maintenance-only `pre-commit/action@v3.0.1` wrapper in CI with an explicit `pre-commit` install and run step.
- Keep the job on GitHub Actions while avoiding the wrapper's internal `actions/cache@v4` dependency, which targets the deprecated Node.js 20 runtime.
- Add an unreleased changelog entry for the CI fix.

## Motivation
GitHub is phasing out Node.js 20 support for GitHub Actions runners and now warns when actions still target Node 20. Dallinger's `pre-commit` job used `pre-commit/action@v3.0.1`; that action is in maintenance mode and its current implementation still pulls in `actions/cache@v4`, which triggers the Node 20 warning.

We considered `j178/prek-action@v2` (https://github.com/j178/prek#who-is-using-prek) as a shorter Node 24-compatible alternative. It is promising and used by projects such as Home Assistant, but it runs `prek` rather than the canonical `pre-commit` CLI. This PR keeps Dallinger on canonical `pre-commit` behavior with only a small explicit shell step.

## Testing
- `git diff --check -- .github/workflows/ci.yml CHANGELOG.md`
- Commit-time pre-commit hook invocation ran and skipped because the changed files are not Python files.

Full Dallinger tests were not run because this is limited to GitHub Actions workflow/changelog metadata.

Made with [Cursor](https://cursor.com)