### PR TITLE
Isolate Redis for Docker SSH deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Fixed Docker SSH deployments so app containers use an app-scoped Redis
+  hostname and private app network, preventing concurrent deployments from
+  resolving another app's Redis service.
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -10,7 +10,9 @@ services:
         interval: 2s
         timeout: 1s
     networks:
-      - dallinger
+      app:
+        aliases:
+          - {{ experiment_id }}_redis
 
   web:
     restart: unless-stopped
@@ -23,7 +25,7 @@ services:
       pgbouncer:
         condition: service_started
     environment: &commonenv
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://{{ experiment_id }}_redis:6379
       DATABASE_URL: postgresql://{{ experiment_id }}:{{ postgresql_password }}@{{ experiment_id }}_pgbouncer/{{ experiment_id }}
       HOME: /tmp
       HOST: 0.0.0.0
@@ -32,6 +34,7 @@ services:
       {{ key }}: {{ value | string() | tojson }}
     {%- endfor %}
     networks:
+      app:
       dallinger:
         aliases:
           - {{ experiment_id }}_web
@@ -56,7 +59,7 @@ services:
     environment:
       <<: *commonenv
     networks:
-      - dallinger
+      - app
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if docker_volumes | length > 0 %}
@@ -71,6 +74,9 @@ services:
     image: docker.io/bitnamilegacy/pgbouncer:1.24.1
     container_name: {{ experiment_id }}_pgbouncer
     networks:
+      app:
+        aliases:
+          - {{ experiment_id }}_pgbouncer
       dallinger:
     environment:
       - POSTGRESQL_HOST=postgresql
@@ -97,9 +103,7 @@ services:
       <<: *commonenv
       PORT: 5000
     networks:
-      dallinger:
-        aliases:
-          - {{ experiment_id }}_clock
+      - app
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
@@ -108,5 +112,7 @@ volumes:
   redis_data:
 
 networks:
+  app:
+    name: {{ experiment_id }}_app
   dallinger:
     name: dallinger

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -19,6 +19,26 @@ def test_get_docker_compose_yml_core_config():
     assert "HOME" in result["services"]["worker_1"]["environment"]
 
 
+def test_get_docker_compose_yml_uses_app_scoped_redis():
+    """Experiment containers should not resolve Redis through a shared alias."""
+    result = get_yaml({})
+    services = result["services"]
+
+    assert (
+        services["worker_1"]["environment"]["REDIS_URL"]
+        == "redis://dlgr-8c43a887_redis:6379"
+    )
+    assert services["redis"]["networks"] == {
+        "app": {"aliases": ["dlgr-8c43a887_redis"]}
+    }
+    assert services["web"]["networks"]["app"] is None
+    assert services["worker_1"]["networks"] == ["app"]
+    assert services["pgbouncer"]["networks"]["app"]["aliases"] == [
+        "dlgr-8c43a887_pgbouncer"
+    ]
+    assert result["networks"]["app"]["name"] == "dlgr-8c43a887_app"
+
+
 def test_get_docker_compose_yml_env_vars_always_strings():
     """The docker-compose.yml file we generate should always have strings as
     values in the `environment` section of each service.


### PR DESCRIPTION
## Motivation

This fixes a Docker SSH deployment bug found while investigating missing Prolific study IDs in a PsyNet deployment. The web process recorded the Prolific `current_study_id`, but worker/status-check code could not see it because it was resolving Redis to a different deployment's Redis instance.

The behavior traces back to [`a297f367162a0885aabb1bdd94391d3773630864`](https://github.com/Dallinger/Dallinger/commit/a297f367162a0885aabb1bdd94391d3773630864) (`Fix Redis container name`). That commit changed the SSH compose template from an experiment-specific Redis service name, `redis_{{ experiment_id }}`, to the Compose-local service name `redis`, and similarly simplified the Redis volume name.

That name fix is worth keeping: service and volume names inside a Compose file should be local Compose resources, and Docker Compose already scopes the actual created containers and volumes by project/deployment. Keeping the service named `redis` makes `depends_on`, health checks, and volume naming simpler and avoids reintroducing the container-name problem that commit fixed.

The regression was not the local Compose service name itself. The regression was that Redis also remained attached to the shared `dallinger` Docker network, so the generic hostname `redis` became visible across concurrent deployments. With multiple apps on that shared network, app containers resolving `redis` could reach another deployment's Redis instance.

## Summary of changes

- Add a private app network to generated Docker SSH experiment compose files.
- Give each app's Redis service an app-scoped network alias, `{{ experiment_id }}_redis`, and set `REDIS_URL` to use it.
- Keep Redis's Compose-local service and volume names from the earlier container-name fix.
- Keep `web` and `pgbouncer` on the shared `dallinger` network where they need Caddy/PostgreSQL connectivity, while moving worker and clock containers onto the private app network only.
- Add regression coverage in `tests/test_docker.py` for the generated Redis URL and network topology.

## Behavior changes

Docker SSH deployments now isolate app-internal Redis DNS resolution per deployment. Concurrent apps on the same server should no longer be able to resolve another app's Redis service through the shared `redis` hostname.

Deployment operators should not need migration steps. Existing generated Compose projects will use the new network layout after redeployment with this Dallinger version.

## Testing

- Passed: `python -m pytest tests/test_docker.py` (`7 passed`).
- Passed: live PsyNet SSH deployment verification showed web and worker processes resolving and using the same app-scoped Redis instance.
- Reviewed rendered compose output with `clock_on=True` and `num_dynos_worker=3`; Redis, workers, and clock were on the private app network, while web and pgbouncer retained expected shared-network access.

## Changelog

`CHANGELOG.md` has been updated under the unreleased `Fixed` section.

## Automatic code review

Automatic branch review was run using the Dallinger branch-review workflow (`/Dallinger/branch-review`, backed by `.cursor/skills/branch-review/SKILL.md`). It found no correctness issues in the committed branch diff. It noted one non-blocking possible test expansion: explicitly covering `clock_on=True` and the shared-network attachments for `web`/`pgbouncer`.