### PR TITLE
Standardize pull request review docs

### DIFF
--- a/.cursor/commands/branch-review.md
+++ b/.cursor/commands/branch-review.md
@@ -1,0 +1,5 @@
+# Branch Review
+
+Use the shared project skill at `.cursor/skills/branch-review/SKILL.md` to review the current branch against `master`.
+
+Apply that skill's workflow and report format in full.

--- a/.cursor/skills/branch-review/SKILL.md
+++ b/.cursor/skills/branch-review/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: branch-review
+description: Review branch changes against `master` using a diff-to-master workflow that emphasizes correctness, regressions, API breaks, side effects, and missing tests. Use when the user asks to review a branch against `master`, compare branch changes, perform pre-merge code review, or review a pull request.
+---
+
+# Branch Review
+
+Use this skill when reviewing a feature branch against `master`.
+
+## Prerequisites
+
+1. Verify you are not already on `master`:
+   - `git rev-parse --abbrev-ref HEAD`
+   - If the result is `master`, ask the user which branch to review.
+2. Refresh the base branch:
+   - `git fetch origin master`
+
+## 1) Scope the change
+
+The review scope is the committed branch diff in `origin/master...HEAD`.
+Do not treat uncommitted local changes as part of the branch review.
+
+- `git rev-parse --abbrev-ref HEAD` - confirm you are on the feature branch, not `master`
+- `git diff --name-status origin/master...HEAD`
+- `git diff --stat origin/master...HEAD`
+- `git status --short` - if non-empty, note that uncommitted work exists locally and was not included in the review
+
+## 2) Inspect code diffs deeply
+
+Review behavior-changing files first, especially core code and tests.
+
+Check for:
+
+- correctness bugs
+- regressions
+- breaking API behavior
+- hidden side effects such as I/O, DB, network, or CLI changes
+
+## 3) Validate test coverage
+
+Behavior changes should typically be covered by tests, including:
+
+- positive paths
+- error paths
+- edge cases
+
+Look for missing tests around:
+
+- mixed or invalid types
+- empty or `None` values
+- filename or path normalization
+- platform-specific behavior
+
+Avoid bloated tests, though: unless the area is particularly high risk,
+recommend avoiding tests that are overly complex or long compared to the original code.
+
+## 4) Refactoring opportunities
+
+Flag:
+
+- repetitive code
+- mixed concerns in the same function or module
+- unclear naming or missing docstrings
+- dead code
+- compatibility shims that may no longer be needed
+
+## 5) Verification
+
+- Run focused tests for changed areas when practical.
+- If tests cannot run, say why and state the residual risk.
+
+## 6) Report format
+
+Present findings first, ordered by severity.
+
+Use this structure:
+
+1. Findings
+2. Missing tests
+3. Refactoring opportunities
+4. Residual risks / assumptions
+
+Keep summaries brief and make the primary feedback actionable.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,31 @@
-<!--- Provide a general summary of your changes in the Title above -->
+# Pull request
 
-## Description
-<!--- Describe your changes in detail -->
+<!-- Provide a concise summary of your changes in the title above. -->
 
-## Motivation and Context
-<!--- Why is this change required? What problem does it solve? -->
-<!--- If it fixes an open issue, please link to the issue here. -->
+## Motivation
 
-## How Has This Been Tested?
-<!--- Please describe in detail how you tested your changes. -->
-<!--- Include details of your testing environment, and the tests you ran to -->
-<!--- see how your change affects other areas of the code, etc. -->
+<!-- Why is this change needed? Link the issue, failing CI job, discussion, or other source when available, and summarize the key evidence. -->
 
-## Screenshots (if appropriate):
+## Summary of changes
+
+<!-- What changed? Mention the main files, APIs, data model changes, architectural implications, and notable implementation choices. -->
+
+## Behavior changes
+
+<!-- What Dallinger users, experiment authors, or deployment operators may notice. Include new functionality, bug fixes, compatibility implications, changed defaults, migration steps, or say there are no outward-facing behavior changes. -->
+
+## Testing
+
+<!-- List checks run and outcomes. Include command names, manual/demo testing, CI results, and tests intentionally not run with the reason. -->
+
+## Changelog
+
+<!-- Confirm CHANGELOG.md has an unreleased entry for this pull request, or explain why no changelog entry is needed. -->
+
+## Automatic code review
+
+<!-- State whether automatic code review has been run, including the command or workflow used. If not run, explain whether it was declined or has not yet been run. -->
+
+## Screenshots
+
+<!-- Include screenshots for UI changes, if appropriate. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,6 @@
-# Pull request
-
-<!-- Provide a concise summary of your changes in the title above. -->
-
 ## Motivation
 
-<!-- Why is this change needed? Link the issue, failing CI job, discussion, or other source when available, and summarize the key evidence. -->
+<!-- Why is this change needed? Reconstruct this from the initial prompt and investigation. Link the issue, failing CI job, discussion, or other source when available, and summarize the key evidence. -->
 
 ## Summary of changes
 
@@ -16,7 +12,7 @@
 
 ## Testing
 
-<!-- List checks run and outcomes. Include command names, manual/demo testing, CI results, and tests intentionally not run with the reason. -->
+<!-- List checks run and outcomes. Include command names, manual/demo testing, CI results, evidence that the change works, and tests intentionally not run with the reason. -->
 
 ## Changelog
 
@@ -24,7 +20,7 @@
 
 ## Automatic code review
 
-<!-- State whether automatic code review has been run, including the command or workflow used. If not run, explain whether it was declined or has not yet been run. -->
+<!-- State whether automatic code review has been run, including whether it used the repo-local `/branch-review` command or another review workflow. If not run, explain whether it was declined or has not yet been prompted. -->
 
 ## Screenshots
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,49 +48,8 @@ record that explicitly in the pull request description.
 
 ## Pull request descriptions
 
-Use the following standardized format for pull request descriptions:
-
-```markdown
-## Motivation
-
-Why this change is needed. Reconstruct this from the initial user prompt and
-any investigation performed during the agent conversation. Link to the original
-issue, failing CI job, pull request discussion, or other source when available,
-and summarize the key evidence, such as the relevant error message.
-
-## Summary of changes
-
-What changed in the code. Mention the main files, APIs, data model changes,
-architectural implications, and any notable implementation choices.
-
-## Behavior changes
-
-What Dallinger users, experiment authors, or deployment operators may notice.
-Describe new functionality, bug fixes, compatibility implications, changed
-defaults, migration steps, or state that there are no outward-facing behavior
-changes.
-
-## Testing
-
-List the checks that were run and their outcomes. Include command names,
-relevant demo/manual testing, CI results, and any tests that were intentionally
-not run with the reason.
-
-## Changelog
-
-State whether `CHANGELOG.md` has been updated for the pull request and, if not,
-why no changelog entry is needed.
-
-## Automatic code review
-
-State whether an automatic code review has been run on the pull request,
-including the command or workflow used. If it has not been run, explain whether
-the user declined it or has not yet been prompted.
-```
-
-Keep the description concise, but include enough context for a reviewer to
-understand the original motivation, the implemented approach, the user-facing
-impact, the changelog status, and the evidence that the change works.
+Use `.github/PULL_REQUEST_TEMPLATE.md` for the required pull request description
+format.
 
 ## Tests
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,64 @@ unreleased section of `CHANGELOG.md`. Do not create separate changelog fragment
 files for Dallinger. Keep the changelog entry and the pull request description
 up to date as the PR evolves.
 
+## Automatic code review
+
+Before finalizing a Dallinger pull request, prompt the user to run an automatic
+code review. Suggest the repo-local Cursor command `/branch-review`, which
+invokes the `branch-review` skill at `.cursor/skills/branch-review/SKILL.md`.
+This specific command name avoids ambiguity with generic Cursor-provided review
+commands.
+
+If the user runs an automatic review, address any actionable findings before
+finalizing the pull request. If the user declines or the review is not run,
+record that explicitly in the pull request description.
+
+## Pull request descriptions
+
+Use the following standardized format for pull request descriptions:
+
+```markdown
+## Motivation
+
+Why this change is needed. Reconstruct this from the initial user prompt and
+any investigation performed during the agent conversation. Link to the original
+issue, failing CI job, pull request discussion, or other source when available,
+and summarize the key evidence, such as the relevant error message.
+
+## Summary of changes
+
+What changed in the code. Mention the main files, APIs, data model changes,
+architectural implications, and any notable implementation choices.
+
+## Behavior changes
+
+What Dallinger users, experiment authors, or deployment operators may notice.
+Describe new functionality, bug fixes, compatibility implications, changed
+defaults, migration steps, or state that there are no outward-facing behavior
+changes.
+
+## Testing
+
+List the checks that were run and their outcomes. Include command names,
+relevant demo/manual testing, CI results, and any tests that were intentionally
+not run with the reason.
+
+## Changelog
+
+State whether `CHANGELOG.md` has been updated for the pull request and, if not,
+why no changelog entry is needed.
+
+## Automatic code review
+
+State whether an automatic code review has been run on the pull request,
+including the command or workflow used. If it has not been run, explain whether
+the user declined it or has not yet been prompted.
+```
+
+Keep the description concise, but include enough context for a reviewer to
+understand the original motivation, the implemented approach, the user-facing
+impact, the changelog status, and the evidence that the change works.
+
 ## Tests
 
 Run tests locally before finalizing a contribution:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the Dallinger pull request template, branch review command, and agent instructions to use a standardized pull request description and review workflow.
+
 ### Fixed
 
 - Fixed Docker SSH deployments so app containers use an app-scoped Redis
@@ -20,6 +24,7 @@
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Removed
+
 - Removed nanasess/setup-chromedriver action to instead use the GitHub-hosted runner's preinstalled Chrome and ChromeDriver versions.
 
 ### Updated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Fixed
 
+- Fixed Docker SSH deployments so app containers use an app-scoped Redis
+  hostname and private app network, preventing concurrent deployments from
+  resolving another app's Redis service.
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
   body so they return JSON error messages instead of only a generic HTML 500
   response.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Updated the Dallinger pull request template, branch review command, and agent instructions to use a standardized pull request description and review workflow.
+
 ### Fixed
 
 - Fixed `dallinger debug` launch failures that happen before the `/launch` route
@@ -17,6 +21,7 @@
 - Fixed GitHub Dependabot npm security alerts by bumping transitive JavaScript dependencies in `yarn.lock`: `follow-redirects` 1.15.9 → 1.16.0, `lodash` 4.17.23 → 4.18.1, and `picomatch` 2.3.1 → 2.3.2 / 4.0.3 → 4.0.4.
 
 ### Removed
+
 - Removed nanasess/setup-chromedriver action to instead use the GitHub-hosted runner's preinstalled Chrome and ChromeDriver versions.
 
 ### Updated

--- a/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
+++ b/dallinger/docker/ssh_templates/docker-compose-experiment.yml.j2
@@ -10,7 +10,9 @@ services:
         interval: 2s
         timeout: 1s
     networks:
-      - dallinger
+      app:
+        aliases:
+          - {{ experiment_id }}_redis
 
   web:
     restart: unless-stopped
@@ -23,7 +25,7 @@ services:
       pgbouncer:
         condition: service_started
     environment: &commonenv
-      REDIS_URL: redis://redis:6379
+      REDIS_URL: redis://{{ experiment_id }}_redis:6379
       DATABASE_URL: postgresql://{{ experiment_id }}:{{ postgresql_password }}@{{ experiment_id }}_pgbouncer/{{ experiment_id }}
       HOME: /tmp
       HOST: 0.0.0.0
@@ -32,6 +34,7 @@ services:
       {{ key }}: {{ value | string() | tojson }}
     {%- endfor %}
     networks:
+      app:
       dallinger:
         aliases:
           - {{ experiment_id }}_web
@@ -56,7 +59,7 @@ services:
     environment:
       <<: *commonenv
     networks:
-      - dallinger
+      - app
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
     {%- if docker_volumes | length > 0 %}
@@ -71,6 +74,9 @@ services:
     image: docker.io/bitnamilegacy/pgbouncer:1.24.1
     container_name: {{ experiment_id }}_pgbouncer
     networks:
+      app:
+        aliases:
+          - {{ experiment_id }}_pgbouncer
       dallinger:
     environment:
       - POSTGRESQL_HOST=postgresql
@@ -97,9 +103,7 @@ services:
       <<: *commonenv
       PORT: 5000
     networks:
-      dallinger:
-        aliases:
-          - {{ experiment_id }}_clock
+      - app
     volumes:
       - ${HOME}/dallinger-data/{{ experiment_id }}:/var/lib/dallinger
 {%- endif %}
@@ -108,5 +112,7 @@ volumes:
   redis_data:
 
 networks:
+  app:
+    name: {{ experiment_id }}_app
   dallinger:
     name: dallinger

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -19,6 +19,26 @@ def test_get_docker_compose_yml_core_config():
     assert "HOME" in result["services"]["worker_1"]["environment"]
 
 
+def test_get_docker_compose_yml_uses_app_scoped_redis():
+    """Experiment containers should not resolve Redis through a shared alias."""
+    result = get_yaml({})
+    services = result["services"]
+
+    assert (
+        services["worker_1"]["environment"]["REDIS_URL"]
+        == "redis://dlgr-8c43a887_redis:6379"
+    )
+    assert services["redis"]["networks"] == {
+        "app": {"aliases": ["dlgr-8c43a887_redis"]}
+    }
+    assert services["web"]["networks"]["app"] is None
+    assert services["worker_1"]["networks"] == ["app"]
+    assert services["pgbouncer"]["networks"]["app"]["aliases"] == [
+        "dlgr-8c43a887_pgbouncer"
+    ]
+    assert result["networks"]["app"]["name"] == "dlgr-8c43a887_app"
+
+
 def test_get_docker_compose_yml_env_vars_always_strings():
     """The docker-compose.yml file we generate should always have strings as
     values in the `environment` section of each service.


### PR DESCRIPTION
## Motivation

PsyNet has standardized agent guidance for merge request descriptions and a repo-local `/branch-review` workflow. Dallinger had an older GitHub pull request template and agent notes, but no corresponding repo-local branch review command, so contributors and agents lacked the same structured review workflow.

## Summary of changes

- Updated `.github/PULL_REQUEST_TEMPLATE.md` to use standardized sections for motivation, change summary, behavior changes, testing, changelog status, and automatic code review.
- Added `.cursor/commands/branch-review.md` and `.cursor/skills/branch-review/SKILL.md`, adapted from PsyNet with Dallinger/GitHub pull request wording.
- Updated `AGENTS.md` to tell agents to use the repo-local `/branch-review` command and document the expected pull request description format.
- Added an unreleased `CHANGELOG.md` entry.

## Behavior changes

No runtime package behavior changes. Contributors and agents will see a more structured pull request template and can run Dallinger's repo-local `/branch-review` command before merge.

## Testing

- `ReadLints` on the touched Markdown files: no diagnostics.
- `uvx pre-commit run --all-files`: passed (`ruff check`, `ruff format`).

## Changelog

`CHANGELOG.md` has been updated with an unreleased entry for this contributor workflow change.

## Automatic code review

The repo-local `/branch-review` command was run against `origin/master...HEAD`. It found no correctness or regression issues, no missing tests, and no refactoring opportunities; the only noted residual risk was unrelated local untracked `RELEASING.md`, which is not included in this pull request.

## Screenshots

Not applicable.