### PR TITLE
Handle timed-out Prolific approval failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Fixed Prolific timed-out submissions so they are not marked approved locally
+  after Prolific rejects the approval request.
 - Fixed Docker SSH deployments so app containers use an app-scoped Redis
   hostname and private app network, preventing concurrent deployments from
   resolving another app's Redis service.

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -856,15 +856,7 @@ class Experiment:
             participant.end_time = event["timestamp"]
         participant.base_pay = config.get("base_payment")
         approval_result = participant.recruiter.approve_hit(participant.assignment_id)
-        if (
-            isinstance(approval_result, recruiters.RecruiterApprovalResult)
-            and not approval_result.approved
-        ):
-            participant.status = approval_result.participant_status
-            if participant.status == "abandoned":
-                self.assignment_abandoned(participant=participant)
-            elif participant.status == "returned":
-                self.assignment_returned(participant=participant)
+        if self._handle_failed_recruiter_approval(participant, approval_result):
             return
 
         # Data Check
@@ -915,6 +907,23 @@ class Experiment:
             # NB: if MultiRecruiter is in use, this may not be the same recruiter
             # that provided the participant we're replacing:
             self.recruiter.recruit(n=1)
+
+    def _handle_failed_recruiter_approval(self, participant, approval_result):
+        """Apply local status changes reported by a failed recruiter approval."""
+        if not isinstance(approval_result, recruiters.RecruiterApprovalResult):
+            return False
+        if approval_result.approved:
+            return False
+
+        participant.status = approval_result.participant_status
+        status_handlers = {
+            "abandoned": self.assignment_abandoned,
+            "returned": self.assignment_returned,
+        }
+        status_handler = status_handlers.get(participant.status)
+        if status_handler is not None:
+            status_handler(participant=participant)
+        return True
 
     def participant_task_completed(self, participant):
         """Called when an experiment task is first finished, and prior

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -855,7 +855,17 @@ class Experiment:
         if participant.end_time is None:
             participant.end_time = event["timestamp"]
         participant.base_pay = config.get("base_payment")
-        participant.recruiter.approve_hit(participant.assignment_id)
+        approval_result = participant.recruiter.approve_hit(participant.assignment_id)
+        if (
+            isinstance(approval_result, recruiters.RecruiterApprovalResult)
+            and not approval_result.approved
+        ):
+            participant.status = approval_result.participant_status
+            if participant.status == "abandoned":
+                self.assignment_abandoned(participant=participant)
+            elif participant.status == "returned":
+                self.assignment_returned(participant=participant)
+            return
 
         # Data Check
         if not self.data_check(participant=participant):

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -25,6 +25,16 @@ class ProlificServiceException(Exception):
     """Some error from Prolific"""
 
 
+class ProlificSubmissionNotApprovableError(ProlificServiceException):
+    """Raised when a Prolific submission is not in an approvable status."""
+
+    def __init__(self, status: str):
+        self.status = status
+        super().__init__(
+            f"Prolific submission is not approvable (current status is '{status}')."
+        )
+
+
 class ProlificServiceNoSuchProject(Exception):
     """A specified project was not found in any of the user's workspaces."""
 
@@ -39,6 +49,13 @@ class ProlificServiceMultipleWorkspacesException(Exception):
 
 class ProlificScreenOutDenied(Exception):
     """Raised when Prolific denies a screen-out request."""
+
+
+def _should_retry_approval_error(exception):
+    """Return whether an approval error should trigger another retry."""
+    if isinstance(exception, ProlificSubmissionNotApprovableError):
+        return exception.status == "ACTIVE"
+    return True
 
 
 ########
@@ -94,6 +111,7 @@ class ProlificService:
     @tenacity.retry(
         wait=tenacity.wait_exponential(multiplier=1, min=2, max=8),
         stop=tenacity.stop_after_attempt(5),
+        retry=tenacity.retry_if_exception(_should_retry_approval_error),
         reraise=True,
     )
     def approve_participant_submission(self, submission_id: str) -> dict:
@@ -110,10 +128,8 @@ class ProlificService:
                 "Participant submission is already approved, no need to approve again."
             )
         elif status != "AWAITING REVIEW":
-            # This will trigger a retry from the decorator
-            raise ProlificServiceException(
-                f"Prolific session not yet submitted (current status is '{status}')."
-            )
+            # ACTIVE may be transient; terminal statuses should fail immediately.
+            raise ProlificSubmissionNotApprovableError(status)
 
         return self._req(
             method="POST",

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -479,9 +479,24 @@ def prolific_submission_listener():
 # with the right values when they redirect participants to us
 PROLIFIC_AD_QUERYSTRING = "&PROLIFIC_PID={{%PROLIFIC_PID%}}&STUDY_ID={{%STUDY_ID%}}&SESSION_ID={{%SESSION_ID%}}"
 
+
+@dataclass(frozen=True)
+class _ProlificTerminalStatusHandling:
+    """How to reconcile a terminal Prolific status locally."""
+
+    worker_event_name: str
+    participant_status: str
+
+
 PROLIFIC_TERMINAL_STATUS_HANDLING = {
-    "RETURNED": ("AssignmentReturned", "returned"),
-    "TIMED-OUT": ("AssignmentAbandoned", "abandoned"),
+    "RETURNED": _ProlificTerminalStatusHandling(
+        worker_event_name="AssignmentReturned",
+        participant_status="returned",
+    ),
+    "TIMED-OUT": _ProlificTerminalStatusHandling(
+        worker_event_name="AssignmentAbandoned",
+        participant_status="abandoned",
+    ),
 }
 
 
@@ -496,7 +511,7 @@ def check_for_prolific_worker_status_discrepancy(local_status, prolific_status):
         return None
 
     handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(prolific_status)
-    return handling[0] if handling else None
+    return handling.worker_event_name if handling else None
 
 
 class ProlificRecruiter(Recruiter):
@@ -788,7 +803,7 @@ class ProlificRecruiter(Recruiter):
             participant_status = None
             if isinstance(ex, ProlificSubmissionNotApprovableError):
                 handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(ex.status)
-                participant_status = handling[1] if handling else None
+                participant_status = handling.participant_status if handling else None
             next_step = (
                 f"Marking the local participant as '{participant_status}'."
                 if participant_status is not None

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -165,7 +165,12 @@ class ProlificRecruitmentStatus(RecruitmentStatus):
 
 @dataclass
 class RecruiterApprovalResult:
-    """Result of attempting to approve a participant with their recruiter."""
+    """Structured recruiter approval outcome.
+
+    Recruiters may return this when approval does not complete and the
+    experiment should update local participant state instead of continuing
+    through the normal post-submission checks.
+    """
 
     approved: bool
     participant_status: Optional[str] = None
@@ -793,8 +798,14 @@ class ProlificRecruiter(Recruiter):
             study_id=self.current_study_id, number_to_add=n
         )
 
-    def approve_hit(self, assignment_id: str):
-        """Approve a participant's assignment/submission on Prolific"""
+    def approve_hit(self, assignment_id: str) -> dict | RecruiterApprovalResult | None:
+        """Approve a participant's assignment/submission on Prolific.
+
+        Returns Prolific's API response when approval succeeds, a
+        RecruiterApprovalResult when the local participant status should be
+        reconciled with a terminal Prolific status, or None when an approval
+        error has been logged but does not map to a local status update.
+        """
         try:
             return self.prolificservice.approve_participant_submission(
                 submission_id=assignment_id

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -35,6 +35,7 @@ from dallinger.notifications import MessengerError, admin_notifier, get_mailer
 from dallinger.prolific import (
     ProlificScreenOutDenied,
     ProlificServiceException,
+    ProlificSubmissionNotApprovableError,
     dev_prolific_service_from_config,
     prolific_service_from_config,
 )
@@ -160,6 +161,14 @@ class ProlificRecruitmentStatus(RecruitmentStatus):
     base_payment_cents: float
     median_session_duration_minutes: float
     real_wage_per_hour_excluding_bonuses: float
+
+
+@dataclass
+class RecruiterApprovalResult:
+    """Result of attempting to approve a participant with their recruiter."""
+
+    approved: bool
+    participant_status: Optional[str] = None
 
 
 class Recruiter:
@@ -470,6 +479,11 @@ def prolific_submission_listener():
 # with the right values when they redirect participants to us
 PROLIFIC_AD_QUERYSTRING = "&PROLIFIC_PID={{%PROLIFIC_PID%}}&STUDY_ID={{%STUDY_ID%}}&SESSION_ID={{%SESSION_ID%}}"
 
+PROLIFIC_TERMINAL_STATUS_HANDLING = {
+    "RETURNED": ("AssignmentReturned", "returned"),
+    "TIMED-OUT": ("AssignmentAbandoned", "abandoned"),
+}
+
 
 def check_for_prolific_worker_status_discrepancy(local_status, prolific_status):
     """Return an action/command name to correct a local vs. remote status
@@ -478,13 +492,11 @@ def check_for_prolific_worker_status_discrepancy(local_status, prolific_status):
     Currently we only make corrections for assignments we have marked as
     "working" locally.
     """
-    actions = {
-        # (local status, remote Prolific status): action to take
-        ("working", "TIMED-OUT"): "AssignmentAbandoned",
-        ("working", "RETURNED"): "AssignmentReturned",
-    }
+    if local_status != "working":
+        return None
 
-    return actions.get((local_status, prolific_status))
+    handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(prolific_status)
+    return handling[0] if handling else None
 
 
 class ProlificRecruiter(Recruiter):
@@ -773,11 +785,25 @@ class ProlificRecruiter(Recruiter):
                 submission_id=assignment_id
             )
         except ProlificServiceException as ex:
+            participant_status = None
+            if isinstance(ex, ProlificSubmissionNotApprovableError):
+                handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(ex.status)
+                participant_status = handling[1] if handling else None
+            next_step = (
+                f"Marking the local participant as '{participant_status}'."
+                if participant_status is not None
+                else "Will try to proceed anyway."
+            )
             logger.warning(
                 f"approve_participant_submission for assignment_id '{assignment_id}' "
-                f"failed with error '{str(ex)}'. Will try to proceed anyway."
+                f"failed with error '{str(ex)}'. {next_step}"
             )
             handle_recruitment_error(ex)
+            if participant_status is not None:
+                return RecruiterApprovalResult(
+                    approved=False,
+                    participant_status=participant_status,
+                )
 
     def close_recruitment(self):
         """Do nothing.

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -159,6 +159,53 @@ class TestExperimentBaseClass:
         assert participant.status == "approved"
         assert participant.bonus == 0.01
 
+    @pytest.mark.parametrize(
+        "participant_status, hook_name",
+        [
+            ("abandoned", "assignment_abandoned"),
+            ("returned", "assignment_returned"),
+        ],
+    )
+    def test_on_recruiter_submission_complete__does_not_approve_terminal_submission(
+        self, a, active_config, exp, participant_status, hook_name
+    ):
+        from dallinger.recruiters import RecruiterApprovalResult
+
+        participant = a.participant(recruiter_id="prolific")
+        participant.status = "submitted"
+        end_time = datetime(2000, 1, 1)
+        recruiter = mock.Mock()
+        recruiter.approve_hit.return_value = RecruiterApprovalResult(
+            approved=False,
+            participant_status=participant_status,
+        )
+        exp.data_check = mock.Mock(return_value=True)
+        exp.bonus = mock.Mock(return_value=0.01)
+        exp.attention_check = mock.Mock(return_value=True)
+        exp.submission_successful = mock.Mock()
+        exp.assignment_abandoned = mock.Mock()
+        exp.assignment_returned = mock.Mock()
+
+        with mock.patch("dallinger.recruiters.by_name", return_value=recruiter):
+            exp.on_recruiter_submission_complete(
+                participant=participant,
+                event={
+                    "event_type": "RecruiterSubmissionComplete",
+                    "participant_id": participant.id,
+                    "assignment_id": participant.assignment_id,
+                    "timestamp": end_time,
+                },
+            )
+
+        assert participant.base_pay == active_config.get("base_payment")
+        assert participant.status == participant_status
+        assert participant.bonus is None
+        getattr(exp, hook_name).assert_called_once_with(participant=participant)
+        exp.data_check.assert_not_called()
+        exp.bonus.assert_not_called()
+        exp.attention_check.assert_not_called()
+        exp.submission_successful.assert_not_called()
+
     def test_on_recruiter_submission_complete__pays_no_bonus_if_less_than_one_cent(
         self, a, exp
     ):

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -9,10 +9,12 @@ import pytest
 from dallinger.config import get_config
 from dallinger.prolific import (
     DevProlificService,
+    ProlificService,
     ProlificServiceException,
     ProlificServiceMultipleWorkspacesException,
     ProlificServiceNoSuchProject,
     ProlificServiceNoSuchWorkspaceException,
+    ProlificSubmissionNotApprovableError,
 )
 
 study_request = {
@@ -216,6 +218,56 @@ def subject(prolific_creds):
 def test_make_quick_study(subject):
     result = subject.draft_study(**private_study_request)
     assert result["name"] == "Test Private Study for One"
+
+
+def test_approve_participant_submission_fails_immediately_for_timed_out_submission():
+    service = ProlificService(
+        api_token="fake-token",
+        api_version="v1",
+        referer_header="fake-referer",
+    )
+    service.get_participant_submission = mock.Mock(return_value={"status": "TIMED-OUT"})
+    service._req = mock.Mock()
+
+    with pytest.raises(ProlificSubmissionNotApprovableError) as ex_info:
+        service.approve_participant_submission("fake-submission-id")
+
+    assert ex_info.value.status == "TIMED-OUT"
+    assert "not approvable" in str(ex_info.value)
+    service.get_participant_submission.assert_called_once_with("fake-submission-id")
+    service._req.assert_not_called()
+
+
+def test_approve_participant_submission_retries_active_submission():
+    service = ProlificService(
+        api_token="fake-token",
+        api_version="v1",
+        referer_header="fake-referer",
+    )
+    service.get_participant_submission = mock.Mock(
+        side_effect=[
+            {"status": "ACTIVE"},
+            {"status": "AWAITING REVIEW"},
+        ]
+    )
+    service._req = mock.Mock(return_value={"id": "fake-submission-id"})
+    sleep = mock.Mock()
+
+    result = service.approve_participant_submission.retry_with(sleep=sleep)(
+        service, "fake-submission-id"
+    )
+
+    assert result == {"id": "fake-submission-id"}
+    assert service.get_participant_submission.call_args_list == [
+        mock.call("fake-submission-id"),
+        mock.call("fake-submission-id"),
+    ]
+    service._req.assert_called_once_with(
+        method="POST",
+        endpoint="/submissions/fake-submission-id/transition/",
+        json={"action": "APPROVE"},
+    )
+    sleep.assert_called_once()
 
 
 @pytest.mark.usefixtures("check_prolific")

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -629,6 +629,31 @@ class TestProlificRecruiter:
 
         mock_logger.exception.assert_called_once_with("Boom!")
 
+    @pytest.mark.parametrize(
+        "prolific_status, participant_status",
+        [
+            ("TIMED-OUT", "abandoned"),
+            ("RETURNED", "returned"),
+        ],
+    )
+    def test_approve_hit_returns_failed_result_for_terminal_submission(
+        self, recruiter, prolific_status, participant_status
+    ):
+        from dallinger.prolific import ProlificSubmissionNotApprovableError
+        from dallinger.recruiters import RecruiterApprovalResult
+
+        recruiter.prolificservice.approve_participant_submission.side_effect = (
+            ProlificSubmissionNotApprovableError(prolific_status)
+        )
+
+        with mock.patch("dallinger.recruiters.logger"):
+            result = recruiter.approve_hit("fake-hit-id")
+
+        assert result == RecruiterApprovalResult(
+            approved=False,
+            participant_status=participant_status,
+        )
+
     def test_recruit_calls_add_participants_to_study(self, recruiter):
         recruiter.open_recruitment()
         recruiter.recruit(n=1)


### PR DESCRIPTION
## Motivation

A PsyNet/Dallinger Prolific deployment showed a participant marked `approved` locally even though the matching Prolific submission ended as `TIMED-OUT`. The worker log showed `approve_participant_submission` failed because the Prolific submission was not approvable, but Dallinger continued through bonus/status processing and marked the participant approved.

## Summary of changes

- Added explicit handling for non-approvable Prolific submission statuses during approval.
- Kept `ACTIVE` submissions retryable, while terminal statuses such as `TIMED-OUT` and `RETURNED` stop local approval processing.
- Added a small recruiter approval result contract so experiment completion can avoid bonus payment and local `approved` status when Prolific approval fails terminally.
- Added regression coverage for `TIMED-OUT`, `RETURNED`, and transient `ACTIVE -> AWAITING REVIEW` approval behavior.

## Behavior changes

Dallinger no longer marks a Prolific participant as locally `approved` when Prolific rejects approval because the submission is terminally `TIMED-OUT` or `RETURNED`. Those statuses are mapped to local `abandoned` and `returned` respectively, and the normal bonus/approval success path is skipped.

## Testing

- `python -m pytest tests/test_prolific.py::test_approve_participant_submission_fails_immediately_for_timed_out_submission tests/test_prolific.py::test_approve_participant_submission_retries_active_submission tests/test_recruiters.py::TestProlificRecruiter tests/test_experiment.py::TestExperimentBaseClass` - 64 passed.
- `python -m ruff check dallinger/prolific.py dallinger/recruiters.py tests/test_prolific.py tests/test_recruiters.py tests/test_experiment.py` - passed.
- `python -m pre_commit run --files dallinger/prolific.py dallinger/recruiters.py tests/test_prolific.py tests/test_recruiters.py tests/test_experiment.py` - passed.

## Changelog

Added an unreleased `CHANGELOG.md` entry under Fixed.

## Automatic code review

Ran the repo-local `/branch-review` workflow against Dallinger `master`; no blocking issues were found. Follow-up missing tests identified by the review were added before opening this pull request.

## Screenshots

Not applicable; this is backend recruiter/status handling.

Made with [Cursor](https://cursor.com)