### PR TITLE
Reduce Prolific status logging noise

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+- Reduced traceback-style logging for expected non-approvable Prolific
+  submission statuses during approval.
 - Fixed Prolific timed-out submissions so they are not marked approved locally
   after Prolific rejects the approval request.
 - Fixed Docker SSH deployments so app containers use an app-scoped Redis

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -484,15 +484,6 @@ def prolific_submission_listener():
 # with the right values when they redirect participants to us
 PROLIFIC_AD_QUERYSTRING = "&PROLIFIC_PID={{%PROLIFIC_PID%}}&STUDY_ID={{%STUDY_ID%}}&SESSION_ID={{%SESSION_ID%}}"
 
-
-@dataclass(frozen=True)
-class _ProlificTerminalStatusHandling:
-    """How to reconcile a terminal Prolific status locally."""
-
-    worker_event_name: str
-    participant_status: str
-
-
 PROLIFIC_TERMINAL_STATUS_HANDLING = {
     "RETURNED": _ProlificTerminalStatusHandling(
         worker_event_name="AssignmentReturned",
@@ -810,11 +801,9 @@ class ProlificRecruiter(Recruiter):
             return self.prolificservice.approve_participant_submission(
                 submission_id=assignment_id
             )
-        except ProlificServiceException as ex:
-            participant_status = None
-            if isinstance(ex, ProlificSubmissionNotApprovableError):
-                handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(ex.status)
-                participant_status = handling.participant_status if handling else None
+        except ProlificSubmissionNotApprovableError as ex:
+            handling = PROLIFIC_TERMINAL_STATUS_HANDLING.get(ex.status)
+            participant_status = handling.participant_status if handling else None
             next_step = (
                 f"Marking the local participant as '{participant_status}'."
                 if participant_status is not None
@@ -822,14 +811,19 @@ class ProlificRecruiter(Recruiter):
             )
             logger.warning(
                 f"approve_participant_submission for assignment_id '{assignment_id}' "
-                f"failed with error '{str(ex)}'. {next_step}"
+                f"found a non-approvable Prolific submission: {str(ex)}. {next_step}"
             )
-            handle_recruitment_error(ex)
             if participant_status is not None:
                 return RecruiterApprovalResult(
                     approved=False,
                     participant_status=participant_status,
                 )
+        except ProlificServiceException as ex:
+            logger.warning(
+                f"approve_participant_submission for assignment_id '{assignment_id}' "
+                f"failed with error '{str(ex)}'. Will try to proceed anyway."
+            )
+            handle_recruitment_error(ex)
 
     def close_recruitment(self):
         """Do nothing.

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -484,6 +484,15 @@ def prolific_submission_listener():
 # with the right values when they redirect participants to us
 PROLIFIC_AD_QUERYSTRING = "&PROLIFIC_PID={{%PROLIFIC_PID%}}&STUDY_ID={{%STUDY_ID%}}&SESSION_ID={{%SESSION_ID%}}"
 
+
+@dataclass(frozen=True)
+class _ProlificTerminalStatusHandling:
+    """How to reconcile a terminal Prolific status locally."""
+
+    worker_event_name: str
+    participant_status: str
+
+
 PROLIFIC_TERMINAL_STATUS_HANDLING = {
     "RETURNED": _ProlificTerminalStatusHandling(
         worker_event_name="AssignmentReturned",

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -646,13 +646,32 @@ class TestProlificRecruiter:
             ProlificSubmissionNotApprovableError(prolific_status)
         )
 
-        with mock.patch("dallinger.recruiters.logger"):
+        with mock.patch("dallinger.recruiters.logger") as mock_logger:
             result = recruiter.approve_hit("fake-hit-id")
 
         assert result == RecruiterApprovalResult(
             approved=False,
             participant_status=participant_status,
         )
+        mock_logger.warning.assert_called_once()
+        mock_logger.exception.assert_not_called()
+
+    def test_approve_hit_logs_status_warning_without_exception(self, recruiter):
+        from dallinger.prolific import ProlificSubmissionNotApprovableError
+
+        recruiter.prolificservice.approve_participant_submission.side_effect = (
+            ProlificSubmissionNotApprovableError("ACTIVE")
+        )
+
+        with mock.patch("dallinger.recruiters.logger") as mock_logger:
+            result = recruiter.approve_hit("fake-hit-id")
+
+        assert result is None
+        mock_logger.warning.assert_called_once()
+        assert "non-approvable Prolific submission" in str(
+            mock_logger.warning.call_args.args[0]
+        )
+        mock_logger.exception.assert_not_called()
 
     def test_recruit_calls_add_participants_to_study(self, recruiter):
         recruiter.open_recruitment()


### PR DESCRIPTION
## Motivation

Follow-up to the Prolific approval status handling fix. `approve_participant_submission()` can encounter expected status states such as persistent `ACTIVE`, `TIMED-OUT`, or `RETURNED`. These are status outcomes rather than generic Prolific service failures, so they should not be routed through traceback-style recruitment error logging.

## Summary of changes

- Split `ProlificSubmissionNotApprovableError` handling from generic `ProlificServiceException` handling in `ProlificRecruiter.approve_hit()`.
- Log non-approvable Prolific submission statuses as warnings without calling `handle_recruitment_error()`.
- Keep unexpected/generic Prolific service failures on the existing recruitment-error path.
- Added tests confirming terminal and persistent `ACTIVE` status cases use warning-only logging.

## Behavior changes

Expected non-approvable Prolific submission statuses no longer emit traceback-style recruitment error logs from `approve_hit()`. Terminal statuses such as `TIMED-OUT` and `RETURNED` still return the non-approved result introduced by the base PR.

## Testing

- `python -m pytest tests/test_recruiters.py::TestProlificRecruiter::test_approve_hit_logs_exception tests/test_recruiters.py::TestProlificRecruiter::test_approve_hit_returns_failed_result_for_terminal_submission tests/test_recruiters.py::TestProlificRecruiter::test_approve_hit_logs_status_warning_without_exception tests/test_experiment.py::TestExperimentBaseClass::test_on_recruiter_submission_complete__does_not_approve_terminal_submission tests/test_prolific.py::test_approve_participant_submission_retries_active_submission tests/test_prolific.py::test_approve_participant_submission_fails_immediately_for_timed_out_submission` - 8 passed.
- `python -m pytest tests/test_prolific.py::test_approve_participant_submission_fails_immediately_for_timed_out_submission tests/test_prolific.py::test_approve_participant_submission_retries_active_submission tests/test_recruiters.py::TestProlificRecruiter tests/test_experiment.py::TestExperimentBaseClass` - 65 passed.
- `python -m pre_commit run --files dallinger/recruiters.py tests/test_recruiters.py` - passed.

## Changelog

Added an unreleased `CHANGELOG.md` entry for reducing traceback-style logging for expected non-approvable Prolific submission statuses during approval.

## Automatic code review

Not run separately yet. The base PR has been reviewed with the repo-local `/branch-review`; this follow-up is intentionally small and stacked on that branch.

## Screenshots

Not applicable; backend logging behavior only.