### PR TITLE
Approve working Prolific submissions stuck in AWAITING REVIEW

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed Prolific status reconciliation so locally ``working`` participants
+  whose Prolific submission is ``AWAITING REVIEW`` or already ``APPROVED``
+  are marked ``submitted`` and processed via ``RecruiterSubmissionComplete``,
+  instead of leaving the study stuck awaiting review.
+
 ## [v12.2.1](https://github.com/dallinger/dallinger/tree/v12.2.1) (2026-07-02)
 
 ### Changed

--- a/dallinger/recruiters.py
+++ b/dallinger/recruiters.py
@@ -482,6 +482,13 @@ def check_for_prolific_worker_status_discrepancy(local_status, prolific_status):
         # (local status, remote Prolific status): action to take
         ("working", "TIMED-OUT"): "AssignmentAbandoned",
         ("working", "RETURNED"): "AssignmentReturned",
+        # Participant submitted on Prolific (e.g. completion code / NOCODE)
+        # without going through our exit listener — approve via the normal
+        # RecruiterSubmissionComplete path after marking them submitted.
+        ("working", "AWAITING REVIEW"): "RecruiterSubmissionComplete",
+        # Already approved on Prolific; sync local status the same way
+        # (approve_hit is a no-op when Prolific status is already APPROVED).
+        ("working", "APPROVED"): "RecruiterSubmissionComplete",
     }
 
     return actions.get((local_status, prolific_status))
@@ -917,6 +924,11 @@ class ProlificRecruiter(Recruiter):
                 logger.warning(
                     f"Taking corrective action on participant {participant.id}: {corrective_action}"
                 )
+                # RecruiterSubmissionComplete / on_recruiter_submission_complete
+                # only proceeds when status is "submitted" (same precondition as
+                # /prolific-submission-listener).
+                if corrective_action == "RecruiterSubmissionComplete":
+                    participant.status = "submitted"
                 q.enqueue(
                     worker_function,
                     corrective_action,

--- a/tests/test_recruiters.py
+++ b/tests/test_recruiters.py
@@ -781,6 +781,48 @@ class TestProlificRecruiter:
             ]
         )
 
+    def test_verify_status_approves_working_awaiting_review(self, a, recruiter, queue):
+        p1 = a.participant(assignment_id="aaa111", recruiter_id="prolific")
+        assert p1.status == "working"
+
+        recruiter.prolificservice.get_assignments_for_study.return_value = {
+            p1.assignment_id: {
+                "participant_id": p1.assignment_id,
+                "hit_id": "some-study-id",
+                "worker_id": "some-prolific-worker-id-1",
+                "started_at": "2021-05-20T11:23:00.457Z",
+                "status": "AWAITING REVIEW",
+            },
+        }
+
+        recruiter.verify_status_of([p1])
+
+        assert p1.status == "submitted"
+        queue.enqueue.assert_called_once_with(
+            mock.ANY, "RecruiterSubmissionComplete", "aaa111", p1.id
+        )
+
+    def test_verify_status_syncs_working_already_approved(self, a, recruiter, queue):
+        p1 = a.participant(assignment_id="aaa111", recruiter_id="prolific")
+        assert p1.status == "working"
+
+        recruiter.prolificservice.get_assignments_for_study.return_value = {
+            p1.assignment_id: {
+                "participant_id": p1.assignment_id,
+                "hit_id": "some-study-id",
+                "worker_id": "some-prolific-worker-id-1",
+                "started_at": "2021-05-20T11:23:00.457Z",
+                "status": "APPROVED",
+            },
+        }
+
+        recruiter.verify_status_of([p1])
+
+        assert p1.status == "submitted"
+        queue.enqueue.assert_called_once_with(
+            mock.ANY, "RecruiterSubmissionComplete", "aaa111", p1.id
+        )
+
     def test_verify_status_copes_with_assignments_not_in_prolific(
         self, a, recruiter, queue
     ):


### PR DESCRIPTION
## Motivation

Failed / screened-out participants are told to return their Prolific submission, but sometimes they submit on Prolific instead (completion code or NOCODE). That leaves the submission in `AWAITING REVIEW` while the local participant stays `working`. Dallinger's status sync only corrected `TIMED-OUT` and `RETURNED`, so the study could remain stuck awaiting review (seen in PsyNet deployment-test `fh-test-deployment-2`).

## Summary of changes

- Extended `check_for_prolific_worker_status_discrepancy` to map `(working, AWAITING REVIEW)` and `(working, APPROVED)` to `RecruiterSubmissionComplete`.
- In `ProlificRecruiter.verify_status_of`, mark the participant `submitted` before enqueueing that event (same precondition as `/prolific-submission-listener`), so `on_recruiter_submission_complete` can approve and finalize.
- Added recruiter unit tests for both new discrepancy cases.
- Changelog entry under Unreleased.

## Behavior changes

Locally `working` participants whose Prolific submission is already submitted (`AWAITING REVIEW`) or already `APPROVED` are now reconciled via the normal submission-complete path (approve if needed, then mark approved). Studies are less likely to remain stuck with one awaiting-review submission.

## Testing

- `python -m pytest tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_triggers_corrections tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_approves_working_awaiting_review tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_syncs_working_already_approved tests/test_recruiters.py::TestProlificRecruiter::test_verify_status_copes_with_assignments_not_in_prolific` — passed
- `pre-commit` on touched files — passed

## Changelog

Unreleased Fixed entry added in `CHANGELOG.md`.

## Automatic code review

Not run yet; please run the repo-local `/branch-review` command before merge.

## Screenshots

N/A

Made with [Cursor](https://cursor.com)