### PR TITLE
Fix repeat participant recruitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed repeat-worker recruitment after multiple prior participations and added structured participant lookup errors for clients.
+
 ### Updated
 
 - Updated Python dependencies

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -591,7 +591,7 @@ def prepare_advertisement():
             is not None
         )
 
-        if already_participated:
+        if already_participated and not config.get("allow_repeat_worker_ids", False):
             raise ExperimentError("already_did_exp_hit")
 
     kwargs = {
@@ -933,7 +933,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         # For now we just log a warning.
 
     already_participated = (
-        session.query(models.Participant).filter_by(worker_id=worker_id).one_or_none()
+        session.query(models.Participant).filter_by(worker_id=worker_id).first()
     )
 
     allow_repeat_worker_ids = config.get("allow_repeat_worker_ids", False)
@@ -1063,12 +1063,16 @@ def load_participant():
     assignment_id = participant_info.get("assignment_id")
     if assignment_id is None:
         return error_response(
-            error_type="/load-participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found",
+            error_code="participant_not_found",
+            status=403,
         )
     ppt = exp.load_participant(assignment_id)
     if ppt is None:
         return error_response(
-            error_type="/load-participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found",
+            error_code="participant_not_found",
+            status=403,
         )
 
     # return the data

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -178,6 +178,7 @@ def error_response(
     participant=None,
     simple=False,
     request_data="",
+    error_code=None,
 ):
     """Return a generic server error response."""
     last_exception = sys.exc_info()
@@ -189,6 +190,8 @@ def error_response(
         )
 
     data = {"status": "error"}
+    if error_code is not None:
+        data["error_code"] = error_code
 
     if simple:
         data["message"] = error_text

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -184,7 +184,7 @@ var dallinger = (function () {
   dlgr.AjaxRejection = (function () {
     // Capture information related to a rejected dallinger.ajax() call.
 
-    var _responseHTML = function (response) {
+    var _responseData = function (response) {
       var parsed;
       try {
         parsed = JSON.parse(response);
@@ -192,10 +192,7 @@ var dallinger = (function () {
         console.log('Error response not parseable.');
         parsed = {};
       }
-      if (parsed.hasOwnProperty('html')) {
-        return parsed.html;
-      }
-      return '';
+      return parsed;
     };
 
     var AjaxRejection = function (options) {
@@ -208,7 +205,9 @@ var dallinger = (function () {
       this.data = options.data || {};
       this.error = options.error;
       this.status = options.error.status;
-      this.html = _responseHTML(this.error.response);
+      this.response = _responseData(this.error.response);
+      this.html = this.response.html || '';
+      this.errorCode = this.response.error_code;
       this.requestJSON = JSON.stringify({
         'route': this.route,
         'data': JSON.stringify(this.data),

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -46,6 +46,27 @@ describe('getUrlParameter', function () {
 
 });
 
+describe('AjaxRejection', function () {
+  test('exposes structured server error codes', () => {
+    var dlgr = require('./dallinger2').dallinger;
+    var rejection = dlgr.AjaxRejection({
+      route: '/load-participant',
+      method: 'post',
+      error: {
+        status: 403,
+        response: JSON.stringify({
+          status: 'error',
+          error_code: 'participant_not_found',
+          html: '<p>Not found</p>'
+        })
+      }
+    });
+
+    expect(rejection.errorCode).toBe('participant_not_found');
+    expect(rejection.html).toBe('<p>Not found</p>');
+  });
+});
+
 describe('AD block functions', function () {
 
   var dlgr;

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -167,6 +167,21 @@ class TestAdvertisement:
         assert resp.status_code == 500
         assert b"already_did_exp_hit" in resp.data
 
+    def test_previously_completed_same_exp_is_allowed_when_configured(
+        self, a, active_config, webapp
+    ):
+        p = a.participant()
+        active_config.set("allow_repeat_worker_ids", True)
+
+        resp = webapp.get(
+            "/ad?hitId={}&assignmentId={}&workerId={}".format(
+                p.hit_id, "new-assignment", p.worker_id
+            )
+        )
+
+        assert resp.status_code == 200
+        assert b"Thanks for accepting this HIT." in resp.data
+
     def test_generate_tokens_redirects(self, webapp):
         resp = webapp.get("/ad?generate_tokens=1")
         assert resp.status_code == 302
@@ -709,6 +724,7 @@ class TestParticipantByAssignmentRoute:
         resp = webapp.post("/load-participant")
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
+        assert data.get("error_code") == "participant_not_found"
         assert "no participant found" in data.get("html")
 
     def test_assignment_invalid(self, webapp):
@@ -718,6 +734,7 @@ class TestParticipantByAssignmentRoute:
         )
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
+        assert data.get("error_code") == "participant_not_found"
         assert "no participant found" in data.get("html")
 
     def test_load_participant_calls_normalize_entry_information(
@@ -837,13 +854,19 @@ class TestParticipantCreateRoute:
         )
 
         assert resp.status_code == 200
+        third_resp = webapp.post(
+            "/participant/{}/{}/{}/debug".format(
+                p.worker_id, p.hit_id, "third-assignment"
+            )
+        )
+        assert third_resp.status_code == 200
         with db.sessions_scope(commit=True) as session:
             count = (
                 session.query(models.Participant)
                 .filter_by(worker_id=p.worker_id)
                 .count()
             )
-        assert count == 2
+        assert count == 3
 
     def test_sets_status_when_participant_is_overrecruited(self, webapp, overrecruited):
         worker_id = "1"


### PR DESCRIPTION
## Motivation

PsyNet’s participant resume flow exposed two issues with repeat participation:

- `/ad` rejected returning workers even when `allow_repeat_worker_ids` was enabled.
- Creating a third participant with the same worker ID raised `MultipleResultsFound` because the existence check used `.one_or_none()`.

PsyNet also needed a stable, machine-readable way to distinguish a missing participant from other `/load-participant` errors without parsing rendered HTML.

## Summary of changes

- Made `/ad` respect `allow_repeat_worker_ids`.
- Replaced the worker existence lookup with a multi-row-safe query.
- Added optional structured `error_code` values to error responses.
- Exposed structured errors through `AjaxRejection.errorCode`.
- Returned `participant_not_found` for unsuccessful `/load-participant` lookups.
- Added Python and JavaScript regression tests.
- Added an Unreleased changelog entry.

## Behavior changes

- Workers can re-enter through `/ad` when repeat participation is enabled.
- More than two participants can share a worker ID when configured.
- Clients can distinguish missing participants using `errorCode === "participant_not_found"`.
- Existing HTTP statuses, rendered error HTML, and default repeat-worker restrictions remain unchanged.

## Testing

- `python -m pre_commit run --all-files` — passed.
- `pytest -q --runslow -p no:pytest_psynet tests/test_experiment_server.py::TestAdvertisement tests/test_experiment_server.py::TestParticipantByAssignmentRoute tests/test_experiment_server.py::TestParticipantCreateRoute` — 24 passed.
- `yarn test --runInBand dallinger/frontend/static/scripts/dallinger2.test.js` — 10 passed, 1 skipped.
- PsyNet’s dependent browser regressions — 3 passed.
- PsyNet timeline end-to-end test — passed.

## Automatic code review

The repository branch-review workflow was run against `master`. It found no blocking correctness issues and confirmed that the structured-error API is additive and backward compatible when the updated server and bundled JavaScript client are deployed together.