### PR TITLE
Fix repeat participant recruitment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed repeat-worker recruitment after multiple prior participations and added structured participant lookup errors for clients.
+
 ### Updated
 
 - Updated Python dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixed
 
-- Fixed repeat-worker recruitment after multiple prior participations and added structured participant lookup errors for clients.
+- Fixed repeat-worker recruitment after multiple prior participations and added structured participant lookup errors for clients (``assignment_id_missing`` / ``participant_not_found`` via ``error_code`` / ``AjaxRejection.errorCode``).
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,6 @@
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed repeat-worker recruitment after multiple prior participations and added structured participant lookup errors for clients (``assignment_id_missing`` / ``participant_not_found`` via ``error_code`` / ``AjaxRejection.errorCode``).
 ### Added
 
 - Added `Experiment.config_settings()` for authoritative experiment config
@@ -23,6 +20,9 @@
 
 ### Fixed
 
+- Fixed repeat-worker recruitment after multiple prior participations and added
+  structured participant lookup errors for clients (`assignment_id_missing` /
+  `participant_not_found` via `error_code` / `AjaxRejection.errorCode`).
 - Fixed config loading so the experiment's config layers (class defaults and
   `config.txt`) are still applied after an initialized experiment process
   changes into a non-experiment directory.

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -591,7 +591,7 @@ def prepare_advertisement():
             is not None
         )
 
-        if already_participated:
+        if already_participated and not config.get("allow_repeat_worker_ids", False):
             raise ExperimentError("already_did_exp_hit")
 
     kwargs = {
@@ -933,7 +933,7 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         # For now we just log a warning.
 
     already_participated = (
-        session.query(models.Participant).filter_by(worker_id=worker_id).one_or_none()
+        session.query(models.Participant).filter_by(worker_id=worker_id).first()
     )
 
     allow_repeat_worker_ids = config.get("allow_repeat_worker_ids", False)
@@ -1063,12 +1063,16 @@ def load_participant():
     assignment_id = participant_info.get("assignment_id")
     if assignment_id is None:
         return error_response(
-            error_type="/load-participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found",
+            error_code="participant_not_found",
+            status=403,
         )
     ppt = exp.load_participant(assignment_id)
     if ppt is None:
         return error_response(
-            error_type="/load-participant POST: no participant found", status=403
+            error_type="/load-participant POST: no participant found",
+            error_code="participant_not_found",
+            status=403,
         )
 
     # return the data

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -584,12 +584,11 @@ def prepare_advertisement():
 
     if worker_id is not None:
         # Check if this workerId has completed the task before
-        already_participated = (
+        already_participated = session.query(
             session.query(models.Participant)
             .filter(models.Participant.worker_id == worker_id)
-            .first()
-            is not None
-        )
+            .exists()
+        ).scalar()
 
         if already_participated and not config.get("allow_repeat_worker_ids", False):
             raise ExperimentError("already_did_exp_hit")
@@ -907,10 +906,13 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
 
     exp = Experiment()
 
-    if fingerprint_hash and (
-        session.query(models.Participant)
-        .filter_by(fingerprint_hash=fingerprint_hash)
-        .first()
+    if (
+        fingerprint_hash
+        and session.query(
+            session.query(models.Participant)
+            .filter_by(fingerprint_hash=fingerprint_hash)
+            .exists()
+        ).scalar()
     ):
         db.logger.warning("Same browser fingerprint detected.")
 
@@ -925,9 +927,9 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
         # If this proves to be a problem, we can make this configurable via a config parameter in the future.
         # For now we just log a warning.
 
-    already_participated = (
-        session.query(models.Participant).filter_by(worker_id=worker_id).first()
-    )
+    already_participated = session.query(
+        session.query(models.Participant).filter_by(worker_id=worker_id).exists()
+    ).scalar()
 
     allow_repeat_worker_ids = config.get("allow_repeat_worker_ids", False)
     if already_participated:

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -23,7 +23,7 @@ from jinja2 import TemplateNotFound
 from psycopg2.extensions import TransactionRollbackError
 from rq import Queue
 from sqlalchemy import exc, func
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
+from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.sql.expression import true
 
 from dallinger import db, experiment, models, recruiters
@@ -909,14 +909,12 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
 
     fingerprint_found = False
     if fingerprint_hash:
-        try:
-            fingerprint_found = (
-                session.query(models.Participant)
-                .filter_by(fingerprint_hash=fingerprint_hash)
-                .one_or_none()
-            )
-        except MultipleResultsFound:
-            fingerprint_found = True
+        fingerprint_found = (
+            session.query(models.Participant)
+            .filter_by(fingerprint_hash=fingerprint_hash)
+            .first()
+            is not None
+        )
 
     if fingerprint_hash and fingerprint_found:
         db.logger.warning("Same browser fingerprint detected.")
@@ -1064,7 +1062,7 @@ def load_participant():
     if assignment_id is None:
         return error_response(
             error_type="/load-participant POST: no participant found",
-            error_code="participant_not_found",
+            error_code="assignment_id_missing",
             status=403,
         )
     ppt = exp.load_participant(assignment_id)

--- a/dallinger/experiment_server/experiment_server.py
+++ b/dallinger/experiment_server/experiment_server.py
@@ -907,16 +907,11 @@ def create_participant(worker_id, hit_id, assignment_id, mode, entry_information
 
     exp = Experiment()
 
-    fingerprint_found = False
-    if fingerprint_hash:
-        fingerprint_found = (
-            session.query(models.Participant)
-            .filter_by(fingerprint_hash=fingerprint_hash)
-            .first()
-            is not None
-        )
-
-    if fingerprint_hash and fingerprint_found:
+    if fingerprint_hash and (
+        session.query(models.Participant)
+        .filter_by(fingerprint_hash=fingerprint_hash)
+        .first()
+    ):
         db.logger.warning("Same browser fingerprint detected.")
 
         # if mode == "live":

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -178,6 +178,7 @@ def error_response(
     participant=None,
     simple=False,
     request_data="",
+    error_code=None,
 ):
     """Return a generic server error response."""
     last_exception = sys.exc_info()
@@ -189,6 +190,8 @@ def error_response(
         )
 
     data = {"status": "error"}
+    if error_code is not None:
+        data["error_code"] = error_code
 
     if simple:
         data["message"] = error_text

--- a/dallinger/experiment_server/utils.py
+++ b/dallinger/experiment_server/utils.py
@@ -180,7 +180,27 @@ def error_response(
     request_data="",
     error_code=None,
 ):
-    """Return a generic server error response."""
+    """Return a generic server error response.
+
+    Parameters
+    ----------
+    error_type : str, optional
+        Human-readable error category shown in the rendered error page.
+    error_text : str, optional
+        Additional detail for the error page or simple JSON message.
+    status : int, optional
+        HTTP status code for the response.
+    participant : Participant, optional
+        Participant used when rendering a full error page.
+    simple : bool, optional
+        When True, return a JSON body with ``message`` instead of ``html``.
+    request_data : str, optional
+        Request context embedded in the rendered error page.
+    error_code : str, optional
+        Machine-readable code included in the JSON body as ``error_code``
+        when provided. Clients can read this via
+        ``AjaxRejection.errorCode`` without parsing HTML.
+    """
     last_exception = sys.exc_info()
     if last_exception[0]:
         request_info = dict(request.args) if has_request_context() else {}

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -184,7 +184,7 @@ var dallinger = (function () {
   dlgr.AjaxRejection = (function () {
     // Capture information related to a rejected dallinger.ajax() call.
 
-    var _responseHTML = function (response) {
+    var _responseData = function (response) {
       var parsed;
       try {
         parsed = JSON.parse(response);
@@ -192,10 +192,7 @@ var dallinger = (function () {
         console.log('Error response not parseable.');
         parsed = {};
       }
-      if (parsed.hasOwnProperty('html')) {
-        return parsed.html;
-      }
-      return '';
+      return parsed;
     };
 
     var AjaxRejection = function (options) {
@@ -208,7 +205,9 @@ var dallinger = (function () {
       this.data = options.data || {};
       this.error = options.error;
       this.status = options.error.status;
-      this.html = _responseHTML(this.error.response);
+      this.response = _responseData(this.error.response);
+      this.html = this.response.html || '';
+      this.errorCode = this.response.error_code;
       this.requestJSON = JSON.stringify({
         'route': this.route,
         'data': JSON.stringify(this.data),

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -196,12 +196,14 @@ var dallinger = (function () {
    *
    * ``status``     - HTTP status code from the failed request
    *
-   * ``response``   - Parsed JSON body from the server, when available
+   * ``response``   - Parsed JSON object body from the server, ``{}`` when the
+   *                  body is missing, unparseable, or not a JSON object
    *
    * ``html``       - Rendered error HTML from the server response, if present
    *
    * ``errorCode``  - Optional machine-readable ``error_code`` from the server
-   *                  JSON body (for example ``participant_not_found``)
+   *                  JSON body (for example ``participant_not_found`` or
+   *                  ``assignment_id_missing``)
    *
    * ``requestJSON`` - Serialized request details for error reporting
    *
@@ -215,7 +217,10 @@ var dallinger = (function () {
         parsed = JSON.parse(response);
       } catch (error) {
         console.log('Error response not parseable.');
-        parsed = {};
+        return {};
+      }
+      if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+        return {};
       }
       return parsed;
     };

--- a/dallinger/frontend/static/scripts/dallinger2.js
+++ b/dallinger/frontend/static/scripts/dallinger2.js
@@ -181,9 +181,34 @@ var dallinger = (function () {
     return BusyForm;
   }());
 
+  /**
+   * Information about a rejected ``dallinger.get`` / ``dallinger.post`` call.
+   *
+   * Properties:
+   *
+   * ``route``      - Requested experiment route
+   *
+   * ``method``     - HTTP method used for the request
+   *
+   * ``data``       - Data that was sent with the request
+   *
+   * ``error``      - Underlying transport error object
+   *
+   * ``status``     - HTTP status code from the failed request
+   *
+   * ``response``   - Parsed JSON body from the server, when available
+   *
+   * ``html``       - Rendered error HTML from the server response, if present
+   *
+   * ``errorCode``  - Optional machine-readable ``error_code`` from the server
+   *                  JSON body (for example ``participant_not_found``)
+   *
+   * ``requestJSON`` - Serialized request details for error reporting
+   *
+   * @constructor
+   * @param {Object} options - Rejection details from the AJAX helper
+   */
   dlgr.AjaxRejection = (function () {
-    // Capture information related to a rejected dallinger.ajax() call.
-
     var _responseData = function (response) {
       var parsed;
       try {

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -46,6 +46,27 @@ describe('getUrlParameter', function () {
 
 });
 
+describe('AjaxRejection', function () {
+  test('exposes structured server error codes', () => {
+    var dlgr = require('./dallinger2').dallinger;
+    var rejection = dlgr.AjaxRejection({
+      route: '/load-participant',
+      method: 'post',
+      error: {
+        status: 403,
+        response: JSON.stringify({
+          status: 'error',
+          error_code: 'participant_not_found',
+          html: '<p>Not found</p>'
+        })
+      }
+    });
+
+    expect(rejection.errorCode).toBe('participant_not_found');
+    expect(rejection.html).toBe('<p>Not found</p>');
+  });
+});
+
 describe('AD block functions', function () {
 
   var dlgr;

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -82,6 +82,22 @@ describe('AjaxRejection', function () {
     expect(rejection.html).toBe('');
     expect(rejection.response).toEqual({});
   });
+
+  test.each([['null'], ['"a string"'], ['[1, 2]']])(
+    'handles non-object JSON body %s',
+    (body) => {
+      var dlgr = require('./dallinger2').dallinger;
+      var rejection = dlgr.AjaxRejection({
+        route: '/load-participant',
+        method: 'post',
+        error: {status: 500, response: body}
+      });
+
+      expect(rejection.response).toEqual({});
+      expect(rejection.html).toBe('');
+      expect(rejection.errorCode).toBeUndefined();
+    }
+  );
 });
 
 describe('AD block functions', function () {

--- a/dallinger/frontend/static/scripts/dallinger2.test.js
+++ b/dallinger/frontend/static/scripts/dallinger2.test.js
@@ -64,6 +64,23 @@ describe('AjaxRejection', function () {
 
     expect(rejection.errorCode).toBe('participant_not_found');
     expect(rejection.html).toBe('<p>Not found</p>');
+    expect(rejection.response.error_code).toBe('participant_not_found');
+  });
+
+  test('handles unparseable responses without an error code', () => {
+    var dlgr = require('./dallinger2').dallinger;
+    var rejection = dlgr.AjaxRejection({
+      route: '/load-participant',
+      method: 'post',
+      error: {
+        status: 500,
+        response: '<html>not json</html>'
+      }
+    });
+
+    expect(rejection.errorCode).toBeUndefined();
+    expect(rejection.html).toBe('');
+    expect(rejection.response).toEqual({});
   });
 });
 

--- a/docs/source/javascript_api.rst
+++ b/docs/source/javascript_api.rst
@@ -66,6 +66,16 @@ The fail_callback function will be passed a `dallinger.AjaxRejection` object whi
 includes detailed information about the error. Unexpected errors should be handled
 by calling the :func:`dallinger.error` method with the `AjaxRejection` object.
 
+``AjaxRejection`` exposes:
+
+* ``html`` - rendered error HTML from the server, when present
+* ``errorCode`` - optional machine-readable ``error_code`` from the JSON body
+  (for example ``participant_not_found`` or ``assignment_id_missing``)
+* ``response`` - the parsed JSON error body
+* ``status``, ``route``, ``method``, ``data``, and ``requestJSON``
+
+.. js:autoclass:: dallinger.AjaxRejection
+
 
 Experiment Initialization and Completion
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/javascript_api.rst
+++ b/docs/source/javascript_api.rst
@@ -66,14 +66,6 @@ The fail_callback function will be passed a `dallinger.AjaxRejection` object whi
 includes detailed information about the error. Unexpected errors should be handled
 by calling the :func:`dallinger.error` method with the `AjaxRejection` object.
 
-``AjaxRejection`` exposes:
-
-* ``html`` - rendered error HTML from the server, when present
-* ``errorCode`` - optional machine-readable ``error_code`` from the JSON body
-  (for example ``participant_not_found`` or ``assignment_id_missing``)
-* ``response`` - the parsed JSON error body
-* ``status``, ``route``, ``method``, ``data``, and ``requestJSON``
-
 .. js:autoclass:: dallinger.AjaxRejection
 
 

--- a/docs/source/web_api.rst
+++ b/docs/source/web_api.rst
@@ -267,6 +267,16 @@ responsible for transforming ``entry_information`` data into an
 ``assignment_id`` data needed to lookup a participant.
 See :func:`~dallinger.experiment.Experiment.normalize_entry_information`.
 
+When the lookup fails, the JSON error response may include a machine-readable
+``error_code``:
+
+* ``assignment_id_missing`` - no ``assignment_id`` could be resolved from the
+  request
+* ``participant_not_found`` - an ``assignment_id`` was present, but no matching
+  participant exists
+
+JavaScript clients can read these values from ``AjaxRejection.errorCode``.
+
 ::
 
     POST /question/<participant_id>

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -167,6 +167,21 @@ class TestAdvertisement:
         assert resp.status_code == 500
         assert b"already_did_exp_hit" in resp.data
 
+    def test_previously_completed_same_exp_is_allowed_when_configured(
+        self, a, active_config, webapp
+    ):
+        p = a.participant()
+        active_config.set("allow_repeat_worker_ids", True)
+
+        resp = webapp.get(
+            "/ad?hitId={}&assignmentId={}&workerId={}".format(
+                p.hit_id, "new-assignment", p.worker_id
+            )
+        )
+
+        assert resp.status_code == 200
+        assert b"Thanks for accepting this HIT." in resp.data
+
     def test_generate_tokens_redirects(self, webapp):
         resp = webapp.get("/ad?generate_tokens=1")
         assert resp.status_code == 302
@@ -709,6 +724,7 @@ class TestParticipantByAssignmentRoute:
         resp = webapp.post("/load-participant")
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
+        assert data.get("error_code") == "participant_not_found"
         assert "no participant found" in data.get("html")
 
     def test_assignment_invalid(self, webapp):
@@ -718,6 +734,7 @@ class TestParticipantByAssignmentRoute:
         )
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
+        assert data.get("error_code") == "participant_not_found"
         assert "no participant found" in data.get("html")
 
     def test_load_participant_calls_normalize_entry_information(
@@ -837,13 +854,19 @@ class TestParticipantCreateRoute:
         )
 
         assert resp.status_code == 200
+        third_resp = webapp.post(
+            "/participant/{}/{}/{}/debug".format(
+                p.worker_id, p.hit_id, "third-assignment"
+            )
+        )
+        assert third_resp.status_code == 200
         with db.sessions_scope(commit=True) as session:
             count = (
                 session.query(models.Participant)
                 .filter_by(worker_id=p.worker_id)
                 .count()
             )
-        assert count == 2
+        assert count == 3
 
     def test_sets_status_when_participant_is_overrecruited(self, webapp, overrecruited):
         worker_id = "1"

--- a/tests/test_experiment_server.py
+++ b/tests/test_experiment_server.py
@@ -724,7 +724,7 @@ class TestParticipantByAssignmentRoute:
         resp = webapp.post("/load-participant")
         data = json.loads(resp.data.decode("utf8"))
         assert data.get("status") == "error"
-        assert data.get("error_code") == "participant_not_found"
+        assert data.get("error_code") == "assignment_id_missing"
         assert "no participant found" in data.get("html")
 
     def test_assignment_invalid(self, webapp):


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

PsyNet’s participant resume flow exposed two issues with repeat participation:

- `/ad` rejected returning workers even when `allow_repeat_worker_ids` was enabled.
- Creating a third participant with the same worker ID raised `MultipleResultsFound` because the existence check used `.one_or_none()`.

PsyNet also needed a stable, machine-readable way to distinguish a missing participant from other `/load-participant` errors without parsing rendered HTML.

This is a fresh recreation of https://github.com/Dallinger/Dallinger/pull/9494 as a branch on `Dallinger/Dallinger` (not a fork PR).

## Summary of changes

- Made `/ad` respect `allow_repeat_worker_ids`.
- Replaced worker/fingerprint existence lookups with `.exists()` queries, which are multi-row safe and avoid loading a row.
- Added optional structured `error_code` values to `error_response`.
- Exposed structured errors through `AjaxRejection.errorCode`, with `AjaxRejection.response` falling back to `{}` for missing, unparseable, or non-object JSON bodies.
- Returned distinct codes from `/load-participant`:
  - `assignment_id_missing` when no assignment ID can be resolved
  - `participant_not_found` when the assignment ID has no matching participant
- Documented the structured error API in the web API docs and via the `AjaxRejection` JSDoc rendered by `js:autoclass`.
- Added Python and JavaScript regression tests.
- Updated the Unreleased changelog entry.

## Behavior changes

- Workers can re-enter through `/ad` when repeat participation is enabled.
- More than two participants can share a worker ID when configured.
- Clients can distinguish missing-assignment vs missing-participant failures using `errorCode`.
- Existing HTTP statuses, rendered error HTML, and default repeat-worker restrictions remain unchanged.

## Testing

- `python -m pre_commit run --all-files` — passed.
- `pytest -q --runslow -p no:pytest_psynet tests/test_experiment_server.py tests/test_config.py` — 234 passed, 1 xpassed (includes the merged `master` config work).
- `yarn test --runInBand dallinger/frontend/static/scripts/dallinger2.test.js` — 14 passed, 1 skipped.
- Built the docs (`python -m sphinx -b html source`) and confirmed the `AjaxRejection` class documentation renders the full property list from the JSDoc.

![Rendered AjaxRejection class documentation showing route, method, data, error, status, response, html, errorCode, and requestJSON properties](https://cursor.com/artifacts/c/art-fe8477ac-db4b-4e2b-b96f-546609d16954)

## Changelog

- Updated the Unreleased changelog entry in `CHANGELOG.md`, merged into the shared `### Fixed` section after merging `master`.

## Automatic code review

- Ran the repo-local `/branch-review` workflow against `master` and addressed its follow-ups: docs for structured errors, consistent existence checks, and distinct `/load-participant` error codes.
- Addressed @fmhoeger's review feedback:
  - `AjaxRejection` now returns `{}` for non-object JSON bodies (for example `null`, a bare string, or an array), so `response`, `html`, and `errorCode` are always safe to read.
  - Removed the hand-written property bullet list from `javascript_api.rst`, keeping only the `js:autoclass` directive so the docs cannot drift from the JSDoc.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0e1599b8-f8ee-4827-b316-75406db033f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0e1599b8-f8ee-4827-b316-75406db033f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

