### PR TITLE
Apply experiment config defaults after cwd changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,13 @@ install those extras as needed:
 python -m pip install -e ".[dev,ec2,docker]"
 ```
 
+## Branches and pull requests
+
+Unless otherwise instructed, always create a feature branch in the upstream
+`Dallinger/Dallinger` repository and open the pull request from that branch.
+Only use a fork branch when you lack push access to upstream (e.g. Cloud
+Agents) or when the user explicitly asks for a fork.
+
 ## Pre-commit
 
 Run the full pre-commit suite before submitting changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed config loading so experiment-defined config defaults are still applied
+  when a process loads its configuration after changing away from the
+  experiment directory.
+- Fixed `get_config()` so calling it without `load=True` no longer eagerly
+  loads the configuration when an experiment is available.
+
 ### Updated
 
 - Updated Python dependencies

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -317,7 +317,9 @@ class Configuration:
         """Load default configuration values"""
         # Apply extra parameters before loading the configs
         if experiment_available():
-            # In practice, experiment_available should only return False in tests
+            # In practice this is False only in non-experiment contexts such
+            # as tests: no experiment.py in the current directory and no
+            # experiment package initialized in this process.
             self.register_extra_parameters()
 
         global_config_name = ".dallingerconfig"
@@ -396,9 +398,11 @@ def get_config(load=False):
 
     if config is None:
         if experiment_available():
-            from dallinger.experiment import load
+            # Import under a different name to avoid shadowing the `load`
+            # parameter, which would otherwise force config loading below.
+            from dallinger.experiment import load as load_experiment
 
-            exp_klass = load()
+            exp_klass = load_experiment()
             config_class = exp_klass.config_class()
         else:
             config_class = Configuration
@@ -436,7 +440,31 @@ def initialize_experiment_package(path):
 
 
 def experiment_available():
-    return Path("experiment.py").exists()
+    """Return True if an experiment is available in the current process.
+
+    An experiment counts as available if the current working directory
+    contains an ``experiment.py`` file, or if an experiment package has
+    already been initialized (via ``initialize_experiment_package``) in this
+    process. The latter check keeps config loading consistent for processes
+    that change their working directory after importing the experiment;
+    without it, such processes would silently skip the experiment's config
+    defaults and resolve different config values than other processes.
+    """
+    if Path("experiment.py").exists():
+        return True
+    module = sys.modules.get("dallinger_experiment")
+    if module is None:
+        return False
+    # Only count initialized packages that actually contain an experiment
+    # module that ``dallinger.experiment.load`` could import; this guards
+    # against stale or accidental `dallinger_experiment` entries (e.g.
+    # namespace packages without any real location).
+    module_paths = getattr(module, "__path__", None) or []
+    return any(
+        Path(path, filename).exists()
+        for path in module_paths
+        for filename in ("experiment.py", "dallinger_experiment.py")
+    )
 
 
 def raise_invalid_key_error(key):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,3 +265,72 @@ class TestConfigurationIntegrationTests:
         config.load_experiment_config_defaults()
 
         assert config.get("duration") == 12345.0
+
+    def test_load_applies_experiment_defaults_after_cwd_change(
+        self, tmpdir, monkeypatch
+    ):
+        # Long-running processes (workers, CLI tools) may load config after
+        # the current working directory has changed away from the experiment
+        # directory. Once the experiment package has been initialized, the
+        # experiment's config defaults should still be applied; otherwise
+        # different processes can silently resolve different config values
+        # (see https://gitlab.com/PsyNetDev/PsyNet/-/issues/1040).
+        import sys
+
+        import dallinger.config
+        from dallinger.config import initialize_experiment_package
+
+        saved_experiment_module = sys.modules.get("dallinger_experiment")
+        saved_config = dallinger.config.config
+        initialize_experiment_package(os.getcwd())
+        original_cwd = os.getcwd()
+        # Isolate the test from any real ~/.dallingerconfig.
+        monkeypatch.setenv("HOME", str(tmpdir))
+        os.chdir(str(tmpdir))
+        try:
+            # Simulate a fresh process by discarding the cached config.
+            dallinger.config.config = None
+            config = get_config(load=True)
+            assert config.get("duration") == 12345.0
+        finally:
+            os.chdir(original_cwd)
+            dallinger.config.config = saved_config
+            if saved_experiment_module is None:
+                sys.modules.pop("dallinger_experiment", None)
+            else:
+                sys.modules["dallinger_experiment"] = saved_experiment_module
+
+    def test_get_config_without_load_does_not_load(self, monkeypatch):
+        # The experiment loader import inside get_config() used to shadow the
+        # `load` parameter, forcing an eager config load whenever an
+        # experiment was available.
+        import dallinger.config
+
+        saved_config = dallinger.config.config
+        try:
+            dallinger.config.config = None
+            config = get_config()
+            assert not config.ready
+        finally:
+            dallinger.config.config = saved_config
+
+    def test_experiment_available_ignores_stale_experiment_module(
+        self, tmpdir, monkeypatch
+    ):
+        # A `dallinger_experiment` entry in sys.modules that does not point at
+        # a real experiment (e.g. a leftover namespace package) should not make
+        # experiment_available() return True.
+        import sys
+        import types
+
+        from dallinger.config import experiment_available
+
+        stale = types.ModuleType("dallinger_experiment")
+        stale.__path__ = [str(tmpdir)]  # No experiment module in there.
+        monkeypatch.setitem(sys.modules, "dallinger_experiment", stale)
+        original_cwd = os.getcwd()
+        os.chdir(str(tmpdir))
+        try:
+            assert not experiment_available()
+        finally:
+            os.chdir(original_cwd)


### PR DESCRIPTION
## Motivation

PsyNet issue [#1040](https://gitlab.com/PsyNetDev/PsyNet/-/work_items/1040) reports that config parameters registered in the Experiment class do not always make it to worker processes; in one reported case, a `dashboard_user` set on the Experiment class was seen by some processes but not others, causing bots to authenticate with credentials the web server did not expect (HTTP 401 on protected routes).

The root cause is that `experiment_available()` in `dallinger/config.py` is purely CWD-based (`Path("experiment.py").exists()`). A process that loads its configuration after changing away from the experiment directory silently skips `load_experiment_config_defaults()`, so the entire Experiment-class config layer is missing from that process, and the config is cached (`config.ready`) for the process lifetime. Different processes of the same experiment can therefore resolve different config values.

## Summary of changes

- `dallinger/config.py`:
  - `experiment_available()` now also returns True when the experiment package has already been initialized in the current process (`sys.modules["dallinger_experiment"]` is set), not only when the current working directory contains `experiment.py`. `initialize_experiment_package()` and `dallinger.experiment.load()` already handle this case correctly (they early-return / import the cached package), so config loading now behaves consistently after a CWD change.
  - The initialized-package check is hardened: it only counts a `dallinger_experiment` module whose package directory actually contains an importable experiment module (`experiment.py` or `dallinger_experiment.py`), so stale or accidental `sys.modules` entries (e.g. namespace packages with no real location) do not make `get_config()` attempt to load a nonexistent experiment.
  - Fixed `get_config()` so the imported experiment loader no longer shadows the `load` parameter, which forced an eager config load on the first call whenever an experiment was available. All process entry points already pass `load=True` explicitly, so no caller in this repository relied on the accidental eager load.
- `tests/test_config.py`: new tests covering the three behaviors: experiment defaults applied after a CWD change (red without the fix, green with it), `get_config()` without `load=True` not eagerly loading, and stale `dallinger_experiment` modules being ignored.
- `AGENTS.md` (separate commit): documents that upstream feature branches are preferred over fork branches.

## Behavior changes

- Processes that import an experiment and later load config from a different working directory now resolve the same config values (including Experiment-class defaults) as processes that load config from the experiment directory. No change for processes that never initialize an experiment package.
- `get_config()` without `load=True` no longer eagerly loads the config on its first call in an experiment context. Third-party code that relied on this accidental eager load must pass `load=True` (as all Dallinger entry points already do).

## Testing

- `python -m pytest tests/test_config.py` — 34 passed.
- `python -m pytest tests/test_experiment.py` — 36 passed.
- `pre-commit` (ruff check + format) on changed files — passed.
- Red/green verified: the CWD-change test fails with the previous `experiment_available()` implementation and passes with the fix.

## Changelog

CHANGELOG.md has unreleased "Fixed" entries for both config fixes.

## Automatic code review

Run via the repo-local `/branch-review` command. No blocking findings; a comment describing `experiment_available()` behavior was updated as a result. Known pre-existing limitation (unchanged by this PR): `config.load()` still reads `config.txt` from the current working directory, so only Experiment-class defaults are restored after a CWD change.

## Screenshots

Not applicable.

Made with [Cursor](https://cursor.com)