### PR TITLE
Resolve config values by source priority and preserve experiment config after CWD changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,13 @@ install those extras as needed:
 python -m pip install -e ".[dev,ec2,docker]"
 ```
 
+## Branches and pull requests
+
+Unless otherwise instructed, always create a feature branch in the upstream
+`Dallinger/Dallinger` repository and open the pull request from that branch.
+Only use a fork branch when you lack push access to upstream (e.g. Cloud
+Agents) or when the user explicitly asks for a fork.
+
 ## Pre-commit
 
 Run the full pre-commit suite before submitting changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed config loading so experiment-defined config defaults are still applied
+  when a process loads its configuration after changing away from the
+  experiment directory.
+- Fixed `get_config()` so calling it without `load=True` no longer eagerly
+  loads the configuration when an experiment is available.
+
 ### Updated
 
 - Updated Python dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,16 +11,18 @@
 
 ### Changed
 
-- Configuration values are now resolved by source priority (package defaults <
-  experiment class defaults < `~/.dallingerconfig` < `config.txt` < environment
-  variables < runtime writes) instead of by load order, so out-of-order or
-  partial (re)loads can no longer change which source wins.
+- Tagged configuration values are now resolved by source priority (package
+  defaults < experiment class defaults < `~/.dallingerconfig` < experiment
+  settings from `Experiment.config_settings()` and `config.txt` < environment
+  variables < runtime writes) instead of layer insertion order. Untagged
+  `config.extend()` and `config.load_from_file()` calls remain highest-priority
+  runtime writes.
 
 ### Fixed
 
 - Fixed config loading so the experiment's config layers (class defaults and
-  `config.txt`) are still applied when a process loads its configuration after
-  changing away from the experiment directory.
+  `config.txt`) are still applied after an initialized experiment process
+  changes into a non-experiment directory.
 - Fixed `get_config()` so calling it without `load=True` no longer eagerly
   loads the configuration when an experiment is available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,16 +5,16 @@
 ### Added
 
 - Added `Experiment.config_settings()` for authoritative experiment config
-  values set in code. Unlike `Experiment.config_defaults()`, these share the
-  resolution priority of the experiment's `config.txt` (which wins ties) and
-  override the user's `~/.dallingerconfig`.
+  values set in code. Unlike `Experiment.config_defaults()`, these override
+  the user's `~/.dallingerconfig`, while still being overridden by the
+  experiment's `config.txt`.
 
 ### Changed
 
 - Tagged configuration values are now resolved by source priority (package
-  defaults < experiment class defaults < `~/.dallingerconfig` < experiment
-  settings from `Experiment.config_settings()` and `config.txt` < environment
-  variables < runtime writes) instead of layer insertion order. Untagged
+  defaults < experiment class defaults < `~/.dallingerconfig` <
+  `Experiment.config_settings()` < `config.txt` < environment variables <
+  runtime writes) instead of layer insertion order. Untagged
   `config.extend()` and `config.load_from_file()` calls remain highest-priority
   runtime writes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   changes into a non-experiment directory.
 - Fixed `get_config()` so calling it without `load=True` no longer eagerly
   loads the configuration when an experiment is available.
+- Fixed the `config.txt` reload performed on `Experiment.run()` so it is
+  tagged with the experiment-config priority and no longer overrides
+  environment variables.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,18 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Configuration values are now resolved by source priority (package defaults <
+  experiment class defaults < `~/.dallingerconfig` < `config.txt` < environment
+  variables < runtime writes) instead of by load order, so out-of-order or
+  partial (re)loads can no longer change which source wins.
+
 ### Fixed
 
-- Fixed config loading so experiment-defined config defaults are still applied
-  when a process loads its configuration after changing away from the
-  experiment directory.
+- Fixed config loading so the experiment's config layers (class defaults and
+  `config.txt`) are still applied when a process loads its configuration after
+  changing away from the experiment directory.
 - Fixed `get_config()` so calling it without `load=True` no longer eagerly
   loads the configuration when an experiment is available.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- Added `Experiment.config_settings()` for authoritative experiment config
+  values set in code. Unlike `Experiment.config_defaults()`, these share the
+  resolution priority of the experiment's `config.txt` (which wins ties) and
+  override the user's `~/.dallingerconfig`.
+
 ### Changed
 
 - Configuration values are now resolved by source priority (package defaults <

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -1,4 +1,31 @@
+"""Experiment configuration loading and resolution.
+
+Configuration values come from several sources with a fixed precedence,
+lowest to highest:
+
+1. Dallinger package defaults (``dallinger/default_configs/``)
+2. Experiment class defaults (``Experiment.config_defaults()``)
+3. The user's ``~/.dallingerconfig``
+4. The experiment's ``config.txt``
+5. Environment variables
+6. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
+
+Precedence is a property of the source, not of load order: each loaded
+layer is tagged with a :class:`ConfigSource`, and lookups resolve layers
+by source priority (newest first within a source). This keeps resolution
+correct even when sources are (re)loaded out of order or a process loads
+its configuration after changing its working directory.
+
+The experiment's location is likewise resolved from process state, not
+just the current working directory: once an experiment package has been
+initialized (see :func:`initialize_experiment_package`), its directory is
+used to find ``config.txt`` and the experiment's config defaults, so all
+processes of an experiment resolve the same configuration regardless of
+their working directory.
+"""
+
 import configparser
+import enum
 import io
 import json
 import logging
@@ -142,6 +169,31 @@ default_keys = (
 )
 
 
+class ConfigSource(enum.IntEnum):
+    """Configuration sources, ordered by resolution priority (higher wins)."""
+
+    PACKAGE_DEFAULTS = 10
+    EXPERIMENT_DEFAULTS = 20
+    USER_CONFIG = 30
+    EXPERIMENT_CONFIG = 40
+    ENVIRONMENT = 50
+    RUNTIME = 60
+
+
+class ConfigLayer(dict):
+    """A mapping of config values tagged with the source that provided them.
+
+    Subclassing dict keeps layers directly iterable for callers that
+    inspect ``Configuration.data`` (e.g. PsyNet's deployment snapshot).
+    """
+
+    __slots__ = ("source",)
+
+    def __init__(self, mapping, source):
+        super().__init__(mapping)
+        self.source = source
+
+
 class Configuration:
     SUPPORTED_TYPES = {bytes, str, int, float, bool}
     _experiment_params_loaded = False
@@ -169,7 +221,14 @@ class Configuration:
             for registration in default_keys:
                 self.register(*registration)
 
-    def extend(self, mapping, cast_types=False, strict=False):
+    def extend(self, mapping, cast_types=False, strict=False, source=None):
+        """Add a layer of config values, tagged with their source.
+
+        ``source`` defaults to :attr:`ConfigSource.RUNTIME`, the highest
+        priority, so ad-hoc writes always win over file-based sources.
+        """
+        if source is None:
+            source = ConfigSource.RUNTIME
         normalized_mapping = {}
         for key, value in mapping.items():
             key = self.synonyms.get(key, key)
@@ -207,7 +266,15 @@ class Configuration:
                     e.dallinger_config_value = value
                     raise e
             normalized_mapping[key] = value
-        self.data.extendleft([normalized_mapping])
+        self.data.extendleft([ConfigLayer(normalized_mapping, source)])
+
+    def _layers_by_priority(self):
+        """Return layers ordered highest-priority first.
+
+        ``self.data`` is newest-first; the stable sort preserves that order
+        within a source, so the newest layer of a source wins.
+        """
+        return sorted(self.data, key=lambda layer: -layer.source)
 
     @contextmanager
     def override(self, *args, **kwargs):
@@ -228,7 +295,7 @@ class Configuration:
                 return bool(int(auto_recruit))
         if not self.ready:
             raise RuntimeError("Config not loaded")
-        for layer in self.data:
+        for layer in self._layers_by_priority():
             try:
                 value = layer[key]
                 if isinstance(value, str):
@@ -288,18 +355,21 @@ class Configuration:
         if sensitive:
             self.sensitive.add(key)
 
-    def load_from_file(self, filename, strict=True):
+    def load_from_file(self, filename, strict=True, source=None):
         parser = configparser.ConfigParser()
         parser.read(filename)
         data = {}
         for section in parser.sections():
             data.update(dict(parser.items(section)))
-        self.extend(data, cast_types=True, strict=strict)
+        self.extend(data, cast_types=True, strict=strict, source=source)
 
     def write(self, filter_sensitive=False, directory=None):
         parser = configparser.ConfigParser()
         parser.add_section("Parameters")
-        for layer in reversed(self.data):
+        # Lowest priority first (oldest first within a source), so later
+        # parser.set calls overwrite earlier ones and the written file
+        # reflects the resolved configuration.
+        for layer in sorted(reversed(self.data), key=lambda layer: layer.source):
             for k, v in layer.items():
                 if filter_sensitive and self.is_sensitive(k):
                     continue
@@ -311,7 +381,7 @@ class Configuration:
             parser.write(fp)
 
     def load_from_environment(self):
-        self.extend(os.environ, cast_types=True)
+        self.extend(os.environ, cast_types=True, source=ConfigSource.ENVIRONMENT)
 
     def load_defaults(self, strict=True):
         """Load default configuration values"""
@@ -330,21 +400,32 @@ class Configuration:
             defaults_folder, "global_config_defaults.txt"
         )
 
-        # Load the configuration, with local parameters overriding global ones.
+        # Load the package defaults, with local parameters overriding global ones.
         for config_file in [global_defaults_file, local_defaults_file]:
-            self.load_from_file(config_file, strict)
+            self.load_from_file(
+                config_file, strict, source=ConfigSource.PACKAGE_DEFAULTS
+            )
 
         if experiment_available():
             self.load_experiment_config_defaults()
 
-        self.load_from_file(global_config, strict)
+        self.load_from_file(global_config, strict, source=ConfigSource.USER_CONFIG)
 
     def load(self, strict=True):
         self.load_defaults(strict)
 
-        localConfig = os.path.join(os.getcwd(), LOCAL_CONFIG)
-        if os.path.exists(localConfig):
-            self.load_from_file(localConfig, strict)
+        local_config = os.path.join(os.getcwd(), LOCAL_CONFIG)
+        if not os.path.exists(local_config):
+            # Fall back to the initialized experiment's directory, so
+            # processes that changed their working directory still load
+            # the experiment's config.txt.
+            exp_dir = experiment_directory()
+            if exp_dir is not None:
+                local_config = os.path.join(exp_dir, LOCAL_CONFIG)
+        if os.path.exists(local_config):
+            self.load_from_file(
+                local_config, strict, source=ConfigSource.EXPERIMENT_CONFIG
+            )
 
         self.load_from_environment()
         self.ready = True
@@ -387,7 +468,11 @@ class Configuration:
         from dallinger.experiment import load
 
         exp_klass = load()
-        self.extend(exp_klass.config_defaults(), strict=True)
+        self.extend(
+            exp_klass.config_defaults(),
+            strict=True,
+            source=ConfigSource.EXPERIMENT_DEFAULTS,
+        )
 
 
 config = None
@@ -439,32 +524,38 @@ def initialize_experiment_package(path):
     sys.path.pop(0)
 
 
-def experiment_available():
-    """Return True if an experiment is available in the current process.
+def experiment_directory():
+    """Return the directory of the current experiment, or None.
 
-    An experiment counts as available if the current working directory
-    contains an ``experiment.py`` file, or if an experiment package has
-    already been initialized (via ``initialize_experiment_package``) in this
-    process. The latter check keeps config loading consistent for processes
-    that change their working directory after importing the experiment;
-    without it, such processes would silently skip the experiment's config
-    defaults and resolve different config values than other processes.
+    The current working directory counts if it contains an
+    ``experiment.py`` file. Otherwise, fall back to the directory of the
+    experiment package initialized in this process (via
+    ``initialize_experiment_package``). The fallback keeps config loading
+    consistent for processes that change their working directory after
+    importing the experiment; without it, such processes would silently
+    skip the experiment's config layers and resolve different config
+    values than other processes.
     """
     if Path("experiment.py").exists():
-        return True
+        return os.getcwd()
     module = sys.modules.get("dallinger_experiment")
     if module is None:
-        return False
+        return None
     # Only count initialized packages that actually contain an experiment
     # module that ``dallinger.experiment.load`` could import; this guards
     # against stale or accidental `dallinger_experiment` entries (e.g.
     # namespace packages without any real location).
     module_paths = getattr(module, "__path__", None) or []
-    return any(
-        Path(path, filename).exists()
-        for path in module_paths
-        for filename in ("experiment.py", "dallinger_experiment.py")
-    )
+    for path in module_paths:
+        for filename in ("experiment.py", "dallinger_experiment.py"):
+            if Path(path, filename).exists():
+                return path
+    return None
+
+
+def experiment_available():
+    """Return True if an experiment is available in the current process."""
+    return experiment_directory() is not None
 
 
 def raise_invalid_key_error(key):

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -12,11 +12,6 @@ lowest to highest:
 5. Environment variables
 6. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
 
-Precedence is a property of the tagged source, not load order: lookups
-resolve layers by source priority (newest first within a source). Untagged
-``extend()`` and ``load_from_file()`` calls are treated as runtime writes,
-preserving their historical last-write-wins behavior.
-
 After an experiment package has been initialized (see
 :func:`initialize_experiment_package`), its directory is used when the
 process changes into a non-experiment directory. A current working

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -12,18 +12,16 @@ lowest to highest:
 5. Environment variables
 6. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
 
-Precedence is a property of the source, not of load order: each loaded
-layer is tagged with a :class:`ConfigSource`, and lookups resolve layers
-by source priority (newest first within a source). This keeps resolution
-correct even when sources are (re)loaded out of order or a process loads
-its configuration after changing its working directory.
+Precedence is a property of the tagged source, not load order: lookups
+resolve layers by source priority (newest first within a source). Untagged
+``extend()`` and ``load_from_file()`` calls are treated as runtime writes,
+preserving their historical last-write-wins behavior.
 
-The experiment's location is likewise resolved from process state, not
-just the current working directory: once an experiment package has been
-initialized (see :func:`initialize_experiment_package`), its directory is
-used to find ``config.txt`` and the experiment's config defaults, so all
-processes of an experiment resolve the same configuration regardless of
-their working directory.
+After an experiment package has been initialized (see
+:func:`initialize_experiment_package`), its directory is used when the
+process changes into a non-experiment directory. A current working
+directory containing ``experiment.py`` still takes precedence, so a process
+should not move between different experiment roots.
 """
 
 import configparser
@@ -185,8 +183,10 @@ class ConfigSource(enum.IntEnum):
 class ConfigLayer(dict):
     """A mapping of config values tagged with the source that provided them.
 
-    Subclassing dict keeps layers directly iterable for callers that
-    inspect ``Configuration.data`` (e.g. PsyNet's deployment snapshot).
+    Subclassing dict preserves structural compatibility for callers that
+    inspect ``Configuration.data``. Raw layer iteration still follows load
+    order; callers needing resolved values should use
+    :meth:`Configuration.get` or :meth:`Configuration.as_dict`.
     """
 
     __slots__ = ("source",)
@@ -547,11 +547,11 @@ def experiment_directory():
     The current working directory counts if it contains an
     ``experiment.py`` file. Otherwise, fall back to the directory of the
     experiment package initialized in this process (via
-    ``initialize_experiment_package``). The fallback keeps config loading
-    consistent for processes that change their working directory after
-    importing the experiment; without it, such processes would silently
-    skip the experiment's config layers and resolve different config
-    values than other processes.
+    ``initialize_experiment_package``), provided that package contains
+    ``experiment.py`` or ``dallinger_experiment.py``. This preserves the
+    experiment's config layers after changing into a non-experiment
+    directory. If the new directory contains another ``experiment.py``, the
+    current working directory takes precedence.
     """
     if Path("experiment.py").exists():
         return os.getcwd()

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -421,14 +421,12 @@ class Configuration:
             # wins ties (newest layer wins within a source).
             self.load_experiment_config_settings()
 
-        local_config = os.path.join(os.getcwd(), LOCAL_CONFIG)
-        if not os.path.exists(local_config):
-            # Fall back to the initialized experiment's directory, so
-            # processes that changed their working directory still load
-            # the experiment's config.txt.
-            exp_dir = experiment_directory()
-            if exp_dir is not None:
-                local_config = os.path.join(exp_dir, LOCAL_CONFIG)
+        # Load config.txt from the experiment's directory, so processes
+        # that changed their working directory still resolve the same
+        # configuration (and unrelated config.txt files in the current
+        # directory cannot shadow the experiment's). Outside an experiment,
+        # fall back to the current directory.
+        local_config = os.path.join(experiment_directory() or os.getcwd(), LOCAL_CONFIG)
         if os.path.exists(local_config):
             self.load_from_file(
                 local_config, strict, source=ConfigSource.EXPERIMENT_CONFIG

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -6,7 +6,9 @@ lowest to highest:
 1. Dallinger package defaults (``dallinger/default_configs/``)
 2. Experiment class defaults (``Experiment.config_defaults()``)
 3. The user's ``~/.dallingerconfig``
-4. The experiment's ``config.txt``
+4. The experiment's settings: ``Experiment.config_settings()`` and
+   ``config.txt`` share this priority, with ``config.txt`` winning ties
+   because it is loaded later
 5. Environment variables
 6. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
 
@@ -414,6 +416,11 @@ class Configuration:
     def load(self, strict=True):
         self.load_defaults(strict)
 
+        if experiment_available():
+            # Loaded before config.txt at the same priority, so config.txt
+            # wins ties (newest layer wins within a source).
+            self.load_experiment_config_settings()
+
         local_config = os.path.join(os.getcwd(), LOCAL_CONFIG)
         if not os.path.exists(local_config):
             # Fall back to the initialized experiment's directory, so
@@ -473,6 +480,18 @@ class Configuration:
             strict=True,
             source=ConfigSource.EXPERIMENT_DEFAULTS,
         )
+
+    def load_experiment_config_settings(self):
+        from dallinger.experiment import load
+
+        exp_klass = load()
+        settings = exp_klass.config_settings()
+        if settings:
+            self.extend(
+                settings,
+                strict=True,
+                source=ConfigSource.EXPERIMENT_CONFIG,
+            )
 
 
 config = None

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -366,7 +366,7 @@ class Configuration:
         # Lowest priority first (oldest first within a source), so later
         # parser.set calls overwrite earlier ones and the written file
         # reflects the resolved configuration.
-        for layer in sorted(reversed(self.data), key=lambda layer: layer.source):
+        for layer in reversed(self._layers_by_priority()):
             for k, v in layer.items():
                 if filter_sensitive and self.is_sensitive(k):
                     continue

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -6,11 +6,10 @@ lowest to highest:
 1. Dallinger package defaults (``dallinger/default_configs/``)
 2. Experiment class defaults (``Experiment.config_defaults()``)
 3. The user's ``~/.dallingerconfig``
-4. The experiment's settings: ``Experiment.config_settings()`` and
-   ``config.txt`` share this priority, with ``config.txt`` winning ties
-   because it is loaded later
-5. Environment variables
-6. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
+4. Experiment class settings (``Experiment.config_settings()``)
+5. The experiment's ``config.txt``
+6. Environment variables
+7. Runtime writes (``config.set()``, ``config.extend()``, ``config.override()``)
 
 After an experiment package has been initialized (see
 :func:`initialize_experiment_package`), its directory is used when the
@@ -170,6 +169,7 @@ class ConfigSource(enum.IntEnum):
     PACKAGE_DEFAULTS = 10
     EXPERIMENT_DEFAULTS = 20
     USER_CONFIG = 30
+    EXPERIMENT_SETTINGS = 35
     EXPERIMENT_CONFIG = 40
     ENVIRONMENT = 50
     RUNTIME = 60
@@ -412,8 +412,6 @@ class Configuration:
         self.load_defaults(strict)
 
         if experiment_available():
-            # Loaded before config.txt at the same priority, so config.txt
-            # wins ties (newest layer wins within a source).
             self.load_experiment_config_settings()
 
         # Load config.txt from the experiment's directory, so processes
@@ -483,7 +481,7 @@ class Configuration:
             self.extend(
                 settings,
                 strict=True,
-                source=ConfigSource.EXPERIMENT_CONFIG,
+                source=ConfigSource.EXPERIMENT_SETTINGS,
             )
 
 

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -317,7 +317,9 @@ class Configuration:
         """Load default configuration values"""
         # Apply extra parameters before loading the configs
         if experiment_available():
-            # In practice, experiment_available should only return False in tests
+            # In practice this is False only in non-experiment contexts such
+            # as tests: no experiment.py in the current directory and no
+            # experiment package initialized in this process.
             self.register_extra_parameters()
 
         global_config_name = ".dallingerconfig"
@@ -396,9 +398,11 @@ def get_config(load=False):
 
     if config is None:
         if experiment_available():
-            from dallinger.experiment import load
+            # Import under a different name to avoid shadowing the `load`
+            # parameter, which would otherwise force config loading below.
+            from dallinger.experiment import load as load_experiment
 
-            exp_klass = load()
+            exp_klass = load_experiment()
             config_class = exp_klass.config_class()
         else:
             config_class = Configuration
@@ -436,7 +440,31 @@ def initialize_experiment_package(path):
 
 
 def experiment_available():
-    return Path("experiment.py").exists()
+    """Return True if an experiment is available in the current process.
+
+    An experiment counts as available if the current working directory
+    contains an ``experiment.py`` file, or if an experiment package has
+    already been initialized (via ``initialize_experiment_package``) in this
+    process. The latter check keeps config loading consistent for processes
+    that change their working directory after importing the experiment;
+    without it, such processes would silently skip the experiment's config
+    defaults and resolve different config values than other processes.
+    """
+    if Path("experiment.py").exists():
+        return True
+    module = sys.modules.get("dallinger_experiment")
+    if module is None:
+        return False
+    # Only count initialized packages that actually contain an experiment
+    # module that ``dallinger.experiment.load`` could import; this guards
+    # against stale or accidental `dallinger_experiment` entries (e.g.
+    # namespace packages without any real location).
+    module_paths = getattr(module, "__path__", None) or []
+    return any(
+        Path(path, filename).exists()
+        for path in module_paths
+        for filename in ("experiment.py", "dallinger_experiment.py")
+    )
 
 
 def raise_invalid_key_error(key):

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -462,27 +462,26 @@ class Configuration:
             extra_parameters()
             self._module_params_loaded = True
 
-    def load_experiment_config_defaults(self):
+    def _load_experiment_mapping(self, method_name, source):
+        """Load a config mapping returned by a classmethod on the experiment class."""
         from dallinger.experiment import load
 
         exp_klass = load()
-        self.extend(
-            exp_klass.config_defaults(),
-            strict=True,
-            source=ConfigSource.EXPERIMENT_DEFAULTS,
+        mapping = getattr(exp_klass, method_name)()
+        if mapping:
+            self.extend(mapping, strict=True, source=source)
+
+    def load_experiment_config_defaults(self):
+        """Load suggested defaults from ``Experiment.config_defaults()``."""
+        self._load_experiment_mapping(
+            "config_defaults", ConfigSource.EXPERIMENT_DEFAULTS
         )
 
     def load_experiment_config_settings(self):
-        from dallinger.experiment import load
-
-        exp_klass = load()
-        settings = exp_klass.config_settings()
-        if settings:
-            self.extend(
-                settings,
-                strict=True,
-                source=ConfigSource.EXPERIMENT_SETTINGS,
-            )
+        """Load authoritative settings from ``Experiment.config_settings()``."""
+        self._load_experiment_mapping(
+            "config_settings", ConfigSource.EXPERIMENT_SETTINGS
+        )
 
 
 config = None

--- a/dallinger/config.py
+++ b/dallinger/config.py
@@ -429,7 +429,7 @@ class Configuration:
         self.ready = True
 
     def register_extra_parameters(self):
-        initialize_experiment_package(os.getcwd())
+        initialize_experiment_package(experiment_directory() or os.getcwd())
         extra_parameters = None
 
         # Import and instantiate the experiment class if available

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -299,7 +299,27 @@ class Experiment:
 
     @classmethod
     def config_defaults(cls):
-        """Override this classmethod to register new default values for config variables."""
+        """Override this classmethod to register new default values for config variables.
+
+        These are low-priority *suggestions*: a user's ``~/.dallingerconfig``,
+        the experiment's ``config.txt``, environment variables, and runtime
+        writes all override them. For authoritative experiment settings, use
+        :meth:`config_settings` instead.
+        """
+        return {}
+
+    @classmethod
+    def config_settings(cls):
+        """Override this classmethod to set authoritative config values in code.
+
+        Unlike :meth:`config_defaults`, values returned here are the
+        experiment's *decisions*: they share the resolution priority of the
+        experiment's ``config.txt`` and override the user's
+        ``~/.dallingerconfig``. If a key is set both here and in
+        ``config.txt``, the ``config.txt`` value wins, since it is loaded
+        later within the same priority. Environment variables and runtime
+        writes still override these values.
+        """
         return {}
 
     @property

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -313,12 +313,10 @@ class Experiment:
         """Override this classmethod to set authoritative config values in code.
 
         Unlike :meth:`config_defaults`, values returned here are the
-        experiment's *decisions*: they share the resolution priority of the
-        experiment's ``config.txt`` and override the user's
-        ``~/.dallingerconfig``. If a key is set both here and in
-        ``config.txt``, the ``config.txt`` value wins, since it is loaded
-        later within the same priority. Environment variables and runtime
-        writes still override these values.
+        experiment's *decisions*: they override the user's
+        ``~/.dallingerconfig``. The experiment's ``config.txt``,
+        environment variables, and runtime writes still override these
+        values, in that order.
         """
         return {}
 

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -25,7 +25,12 @@ from sqlalchemy.orm.attributes import InstrumentedAttribute
 from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from dallinger import db, models, recruiters
-from dallinger.config import LOCAL_CONFIG, get_config, initialize_experiment_package
+from dallinger.config import (
+    LOCAL_CONFIG,
+    experiment_directory,
+    get_config,
+    initialize_experiment_package,
+)
 from dallinger.data import (
     Data,
     export,
@@ -2179,7 +2184,7 @@ def is_experiment_class(cls):
 def load():
     """Load the active experiment."""
     first_err = second_err = None
-    initialize_experiment_package(os.getcwd())
+    initialize_experiment_package(experiment_directory() or os.getcwd())
     try:
         try:
             from dallinger_experiment import experiment

--- a/dallinger/experiment.py
+++ b/dallinger/experiment.py
@@ -27,6 +27,7 @@ from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 from dallinger import db, models, recruiters
 from dallinger.config import (
     LOCAL_CONFIG,
+    ConfigSource,
     experiment_directory,
     get_config,
     initialize_experiment_package,
@@ -68,7 +69,7 @@ def exp_class_working_dir(meth):
             os.chdir(new_path)
             # Override configs
             config.register_extra_parameters()
-            config.load_from_file(LOCAL_CONFIG)
+            config.load_from_file(LOCAL_CONFIG, source=ConfigSource.EXPERIMENT_CONFIG)
             return meth(self, *args, **kwargs)
         finally:
             config.clear()

--- a/dallinger/pytest_dallinger.py
+++ b/dallinger/pytest_dallinger.py
@@ -181,12 +181,14 @@ def stub_config():
         "replay": False,
         "worker_multiplier": 1.5,
     }
-    from dallinger.config import Configuration, default_keys
+    from dallinger.config import ConfigSource, Configuration, default_keys
 
     config = Configuration()
     for key in default_keys:
         config.register(*key)
-    config.extend(defaults.copy())
+    # The stub values stand in for a fully loaded baseline configuration,
+    # so tag them as low-priority defaults rather than runtime overrides.
+    config.extend(defaults.copy(), source=ConfigSource.PACKAGE_DEFAULTS)
     # Patch load() so we don't update any key/value pairs from actual files:
     config.load = mock.Mock(
         side_effect=lambda strict=True, exp_klass=None: setattr(config, "ready", True)

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -18,14 +18,36 @@ You can then get and set parameters:
     config.get("duration")
     config.set("duration", 0.50)
 
-When retrieving a configuration parameter, Dallinger will look for the parameter
-first among environment variables, then in a ``config.txt`` in the experiment
-directory, and then in the ``.dallingerconfig`` file, using whichever value
-is found first. If the parameter is not found, Dallinger will use the default.
-
 If a value is extracted from the environment or a config file it will be converted
 to the correct type. You can also specify a value of ``file:/path/to/file`` to
 use the contents of that file on your local computer.
+
+
+Load order and precedence
+-------------------------
+
+Configuration values can come from several sources. When the same parameter is
+set in more than one source, the value from the higher-priority source wins.
+The sources are, from lowest to highest priority:
+
+1. **Dallinger package defaults** — shipped in ``dallinger/default_configs/``.
+2. **Experiment class defaults** — values returned by
+   :meth:`~dallinger.experiment.Experiment.config_defaults` on your experiment
+   class. These are suggestions that all of the sources below override.
+3. **~/.dallingerconfig** — the global, per-user config file in your home
+   directory.
+4. **The experiment's settings** — values returned by
+   :meth:`~dallinger.experiment.Experiment.config_settings` and the
+   ``config.txt`` file in the experiment directory. These share the same
+   priority; if a parameter is set in both, the ``config.txt`` value wins.
+5. **Environment variables** — a variable named after the config parameter
+   (e.g. ``dashboard_user``).
+6. **Runtime writes** — values set from code via ``config.set()``,
+   ``config.extend()``, or ``config.override()``.
+
+Precedence is a fixed property of the source, not of load order, and it does
+not depend on the process's working directory: every process of an experiment
+resolves the same values.
 
 
 Built-in configuration

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -45,9 +45,15 @@ The sources are, from lowest to highest priority:
 6. **Runtime writes** — values set from code via ``config.set()``,
    ``config.extend()``, or ``config.override()``.
 
-Precedence is a fixed property of the source, not of load order, and it does
-not depend on the process's working directory: every process of an experiment
-resolves the same values.
+Tagged sources resolve by this fixed priority rather than layer insertion
+order. Untagged calls to ``config.extend()`` or ``config.load_from_file()`` are
+treated as runtime writes and therefore take the highest priority.
+
+Once an experiment package has been initialized, changing into a
+non-experiment directory does not prevent its class defaults, class settings,
+or ``config.txt`` from loading. A working directory containing another
+``experiment.py`` still takes precedence, and environment variables or runtime
+writes may differ between processes.
 
 
 Built-in configuration

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -36,13 +36,13 @@ The sources are, from lowest to highest priority:
    class. These are suggestions that all of the sources below override.
 3. **~/.dallingerconfig** — the global, per-user config file in your home
    directory.
-4. **The experiment's settings** — values returned by
-   :meth:`~dallinger.experiment.Experiment.config_settings` and the
-   ``config.txt`` file in the experiment directory. These share the same
-   priority; if a parameter is set in both, the ``config.txt`` value wins.
-5. **Environment variables** — a variable named after the config parameter
+4. **Experiment class settings** — values returned by
+   :meth:`~dallinger.experiment.Experiment.config_settings` on your experiment
+   class.
+5. **config.txt** — the ``config.txt`` file in the experiment directory.
+6. **Environment variables** — a variable named after the config parameter
    (e.g. ``dashboard_user``).
-6. **Runtime writes** — values set from code via ``config.set()``,
+7. **Runtime writes** — values set from code via ``config.set()``,
    ``config.extend()``, or ``config.override()``.
 
 Tagged sources resolve by this fixed priority rather than layer insertion

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -31,3 +31,25 @@ parameter can be used anywhere that built-in parameters are used.
 An optional ``validators`` parameter can also be passed, which must be either
 None or a list of callables that take a single argument (the value of the config)
 and may raise a ``ValueError`` describing why the value is invalid.
+
+To supply *values* for parameters from experiment code, override one of two
+classmethods on your Experiment class, depending on the intent:
+
+- :meth:`~dallinger.experiment.Experiment.config_defaults` — default values
+  that a user's ``~/.dallingerconfig``, the experiment's ``config.txt``,
+  environment variables, and runtime writes may override.
+- :meth:`~dallinger.experiment.Experiment.config_settings` — authoritative
+  values that share the priority of ``config.txt`` (which wins ties) and
+  override ``~/.dallingerconfig``.
+
+::
+
+    @classmethod
+    def config_defaults(cls):
+        return {**super().config_defaults(), "duration": 2.0}
+
+    @classmethod
+    def config_settings(cls):
+        return {**super().config_settings(), "dashboard_user": "my-user"}
+
+See :doc:`Configuration <configuration>` for the full precedence order.

--- a/docs/source/extra_configuration.rst
+++ b/docs/source/extra_configuration.rst
@@ -39,8 +39,8 @@ classmethods on your Experiment class, depending on the intent:
   that a user's ``~/.dallingerconfig``, the experiment's ``config.txt``,
   environment variables, and runtime writes may override.
 - :meth:`~dallinger.experiment.Experiment.config_settings` — authoritative
-  values that share the priority of ``config.txt`` (which wins ties) and
-  override ``~/.dallingerconfig``.
+  values that override ``~/.dallingerconfig`` but are still overridden by
+  the experiment's ``config.txt``.
 
 ::
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,7 +392,7 @@ class TestConfigurationIntegrationTests:
             else:
                 sys.modules["dallinger_experiment"] = saved_experiment_module
 
-    def test_get_config_without_load_does_not_load(self, monkeypatch):
+    def test_get_config_without_load_does_not_load(self):
         # The experiment loader import inside get_config() used to shadow the
         # `load` parameter, forcing an eager config load whenever an
         # experiment was available.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -309,6 +309,39 @@ class TestConfigurationIntegrationTests:
 
         assert config.get("duration") == 12345.0
 
+    def test_experiment_config_settings_priority(self, tmpdir, monkeypatch):
+        # Experiment.config_settings() values are authoritative: they beat
+        # ~/.dallingerconfig, but config.txt wins ties within the shared
+        # EXPERIMENT_CONFIG priority because it is loaded later.
+        import dallinger.config
+        from dallinger.experiment import load as load_experiment
+
+        exp_klass = load_experiment()
+        monkeypatch.setattr(
+            exp_klass,
+            "config_settings",
+            classmethod(
+                lambda cls: {
+                    # Not in config.txt: should win over ~/.dallingerconfig.
+                    "group_name": "from_class_settings",
+                    # Also in config.txt: config.txt should win the tie.
+                    "organization_name": "settings_should_lose",
+                }
+            ),
+        )
+        monkeypatch.setenv("HOME", str(tmpdir))
+        with open(os.path.join(str(tmpdir), ".dallingerconfig"), "w") as f:
+            f.write("[Parameters]\ngroup_name = from_user_config\n")
+
+        saved_config = dallinger.config.config
+        try:
+            dallinger.config.config = None
+            config = get_config(load=True)
+            assert config.get("group_name") == "from_class_settings"
+            assert config.get("organization_name") != "settings_should_lose"
+        finally:
+            dallinger.config.config = saved_config
+
     def test_load_resolves_same_config_after_cwd_change(self, tmpdir, monkeypatch):
         # Long-running processes (workers, CLI tools) may load config after
         # the current working directory has changed away from the experiment

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -265,3 +265,72 @@ class TestConfigurationIntegrationTests:
         config.load_experiment_config_defaults()
 
         assert config.get("duration") == 12345.0
+
+    def test_load_applies_experiment_defaults_after_cwd_change(
+        self, tmpdir, monkeypatch
+    ):
+        # Long-running processes (workers, CLI tools) may load config after
+        # the current working directory has changed away from the experiment
+        # directory. Once the experiment package has been initialized, the
+        # experiment's config defaults should still be applied; otherwise
+        # different processes can silently resolve different config values
+        # (see https://gitlab.com/PsyNetDev/PsyNet/-/issues/1040).
+        import sys
+
+        import dallinger.config
+        from dallinger.config import initialize_experiment_package
+
+        saved_experiment_module = sys.modules.get("dallinger_experiment")
+        saved_config = dallinger.config.config
+        initialize_experiment_package(os.getcwd())
+        original_cwd = os.getcwd()
+        # Isolate the test from any real ~/.dallingerconfig.
+        monkeypatch.setenv("HOME", str(tmpdir))
+        os.chdir(str(tmpdir))
+        try:
+            # Simulate a fresh process by discarding the cached config.
+            dallinger.config.config = None
+            config = get_config(load=True)
+            assert config.get("duration") == 12345.0
+        finally:
+            os.chdir(original_cwd)
+            dallinger.config.config = saved_config
+            if saved_experiment_module is None:
+                sys.modules.pop("dallinger_experiment", None)
+            else:
+                sys.modules["dallinger_experiment"] = saved_experiment_module
+
+    def test_get_config_without_load_does_not_load(self, monkeypatch):
+        # The experiment loader import inside get_config() used to shadow the
+        # `load` parameter, forcing an eager config load whenever an
+        # experiment was available.
+        import dallinger.config
+
+        saved_config = dallinger.config.config
+        try:
+            dallinger.config.config = None
+            config = get_config()
+            assert not config.ready
+        finally:
+            dallinger.config.config = saved_config
+
+    def test_experiment_available_ignores_stale_experiment_module(
+        self, tmpdir, monkeypatch
+    ):
+        # A `dallinger_experiment` entry in sys.modules that does not point at
+        # a real experiment (e.g. a leftover namespace package) should not make
+        # experiment_available() return True.
+        import sys
+        import types
+
+        from dallinger.config import experiment_available
+
+        stale = types.ModuleType("dallinger_experiment")
+        stale.__path__ = [str(tmpdir)]  # No experiment module in there.
+        monkeypatch.setitem(sys.modules, "dallinger_experiment", stale)
+        original_cwd = os.getcwd()
+        os.chdir(str(tmpdir))
+        try:
+            assert not experiment_available()
+        finally:
+            os.chdir(original_cwd)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -311,8 +311,8 @@ class TestConfigurationIntegrationTests:
 
     def test_experiment_config_settings_priority(self, tmpdir, monkeypatch):
         # Experiment.config_settings() values are authoritative: they beat
-        # ~/.dallingerconfig, but config.txt wins ties within the shared
-        # EXPERIMENT_CONFIG priority because it is loaded later.
+        # ~/.dallingerconfig, but config.txt still wins because it has a
+        # higher source priority (EXPERIMENT_CONFIG > EXPERIMENT_SETTINGS).
         import dallinger.config
         from dallinger.experiment import load as load_experiment
 
@@ -324,7 +324,7 @@ class TestConfigurationIntegrationTests:
                 lambda cls: {
                     # Not in config.txt: should win over ~/.dallingerconfig.
                     "group_name": "from_class_settings",
-                    # Also in config.txt: config.txt should win the tie.
+                    # Also in config.txt: config.txt should win.
                     "organization_name": "settings_should_lose",
                 }
             ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -360,6 +360,10 @@ class TestConfigurationIntegrationTests:
         original_cwd = os.getcwd()
         # Isolate the test from any real ~/.dallingerconfig.
         monkeypatch.setenv("HOME", str(tmpdir))
+        # An unrelated config.txt in the directory the process changes into
+        # must not shadow the experiment's own config.txt.
+        with open(os.path.join(str(tmpdir), "config.txt"), "w") as f:
+            f.write("[Parameters]\norganization_name = stray_config\n")
         try:
             # Reference: a fresh config loaded from the experiment directory.
             dallinger.config.config = None
@@ -372,6 +376,7 @@ class TestConfigurationIntegrationTests:
 
             assert config.get("duration") == reference.get("duration")
             assert config.get("title") == reference.get("title")
+            assert config.get("organization_name") == reference.get("organization_name")
             # The experiment class defaults layer was applied, not skipped.
             defaults_layers = [
                 layer

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,6 +76,49 @@ class TestConfigurationUnitTests:
         config.extend({"num_participants": 2})
         assert config.get("num_participants", 1) == 2
 
+    def test_source_priority_beats_load_order(self):
+        from dallinger.config import ConfigSource
+
+        config = Configuration()
+        config.register("mode", str)
+        config.extend({"mode": "live"}, source=ConfigSource.ENVIRONMENT)
+        # Loaded later, but from a lower-priority source.
+        config.extend({"mode": "sandbox"}, source=ConfigSource.USER_CONFIG)
+        config.ready = True
+        assert config.get("mode") == "live"
+
+    def test_runtime_writes_beat_all_sources(self):
+        from dallinger.config import ConfigSource
+
+        config = Configuration()
+        config.register("mode", str)
+        config.extend({"mode": "live"}, source=ConfigSource.ENVIRONMENT)
+        config.ready = True
+        config.set("mode", "debug")
+        assert config.get("mode") == "debug"
+
+    def test_newest_layer_wins_within_a_source(self):
+        from dallinger.config import ConfigSource
+
+        config = Configuration()
+        config.register("mode", str)
+        config.extend({"mode": "sandbox"}, source=ConfigSource.USER_CONFIG)
+        config.extend({"mode": "live"}, source=ConfigSource.USER_CONFIG)
+        config.ready = True
+        assert config.get("mode") == "live"
+
+    def test_write_reflects_source_priority(self, in_tempdir):
+        from dallinger.config import LOCAL_CONFIG, ConfigSource
+
+        config = Configuration()
+        config.register("mode", str)
+        config.extend({"mode": "live"}, source=ConfigSource.ENVIRONMENT)
+        config.extend({"mode": "sandbox"}, source=ConfigSource.USER_CONFIG)
+        config.ready = True
+        config.write()
+        with open(LOCAL_CONFIG) as txt:
+            assert "mode = live" in txt.read()
+
     def test_setting_unknown_key_is_ignored(self):
         config = Configuration()
         config.ready = True
@@ -266,19 +309,17 @@ class TestConfigurationIntegrationTests:
 
         assert config.get("duration") == 12345.0
 
-    def test_load_applies_experiment_defaults_after_cwd_change(
-        self, tmpdir, monkeypatch
-    ):
+    def test_load_resolves_same_config_after_cwd_change(self, tmpdir, monkeypatch):
         # Long-running processes (workers, CLI tools) may load config after
         # the current working directory has changed away from the experiment
-        # directory. Once the experiment package has been initialized, the
-        # experiment's config defaults should still be applied; otherwise
-        # different processes can silently resolve different config values
-        # (see https://gitlab.com/PsyNetDev/PsyNet/-/issues/1040).
+        # directory. Once the experiment package has been initialized, such
+        # processes must resolve the same config values (experiment defaults
+        # and config.txt included) as processes loading from the experiment
+        # directory (see https://gitlab.com/PsyNetDev/PsyNet/-/issues/1040).
         import sys
 
         import dallinger.config
-        from dallinger.config import initialize_experiment_package
+        from dallinger.config import ConfigSource, initialize_experiment_package
 
         saved_experiment_module = sys.modules.get("dallinger_experiment")
         saved_config = dallinger.config.config
@@ -286,12 +327,25 @@ class TestConfigurationIntegrationTests:
         original_cwd = os.getcwd()
         # Isolate the test from any real ~/.dallingerconfig.
         monkeypatch.setenv("HOME", str(tmpdir))
-        os.chdir(str(tmpdir))
         try:
-            # Simulate a fresh process by discarding the cached config.
+            # Reference: a fresh config loaded from the experiment directory.
+            dallinger.config.config = None
+            reference = get_config(load=True)
+
+            # A fresh config loaded after changing the working directory.
+            os.chdir(str(tmpdir))
             dallinger.config.config = None
             config = get_config(load=True)
-            assert config.get("duration") == 12345.0
+
+            assert config.get("duration") == reference.get("duration")
+            assert config.get("title") == reference.get("title")
+            # The experiment class defaults layer was applied, not skipped.
+            defaults_layers = [
+                layer
+                for layer in config.data
+                if layer.source == ConfigSource.EXPERIMENT_DEFAULTS
+            ]
+            assert defaults_layers and defaults_layers[0]["duration"] == 12345.0
         finally:
             os.chdir(original_cwd)
             dallinger.config.config = saved_config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -392,6 +392,45 @@ class TestConfigurationIntegrationTests:
             else:
                 sys.modules["dallinger_experiment"] = saved_experiment_module
 
+    def test_exp_class_working_dir_reload_keeps_env_priority(self, tmpdir, monkeypatch):
+        # Regression test: the config.txt reload performed by the
+        # exp_class_working_dir decorator must be tagged EXPERIMENT_CONFIG,
+        # so environment variables keep their higher priority.
+        import sys
+        import types
+
+        import dallinger.config
+        from dallinger.experiment import exp_class_working_dir
+
+        # Isolate the test from any real ~/.dallingerconfig.
+        monkeypatch.setenv("HOME", str(tmpdir))
+        module = types.ModuleType("fake_experiment_module")
+        module.__file__ = os.path.join(os.getcwd(), "experiment.py")
+        monkeypatch.setitem(sys.modules, "fake_experiment_module", module)
+        monkeypatch.setenv("organization_name", "from_environment")
+
+        captured = {}
+
+        class Runner:
+            __module__ = "fake_experiment_module"
+
+            @exp_class_working_dir
+            def run(self):
+                captured["organization_name"] = get_config().get("organization_name")
+
+        saved_config = dallinger.config.config
+        try:
+            dallinger.config.config = None
+            config = get_config(load=True)
+            # Sanity check: the environment beats config.txt in a full load.
+            assert config.get("organization_name") == "from_environment"
+            Runner().run()
+        finally:
+            dallinger.config.config = saved_config
+
+        # The decorator's config.txt reload must not demote the environment.
+        assert captured["organization_name"] == "from_environment"
+
     def test_get_config_without_load_does_not_load(self):
         # The experiment loader import inside get_config() used to shadow the
         # `load` parameter, forcing an eager config load whenever an


### PR DESCRIPTION
## Motivation

PsyNet issue [#1040](https://gitlab.com/PsyNetDev/PsyNet/-/work_items/1040) reports that config parameters registered in the Experiment class do not always make it to worker processes; in one reported case, a `dashboard_user` set on the Experiment class was seen by some processes but not others, causing bots to authenticate with credentials the web server did not expect (HTTP 401 on protected routes).

There are two root causes in `dallinger/config.py`, both forms of the same underlying problem — configuration assembly depends on ambient, mutable process state (current working directory and load-call order):

1. `experiment_available()` was purely CWD-based (`Path("experiment.py").exists()`). A process that loaded its configuration after changing away from the experiment directory silently skipped `register_extra_parameters()` and `load_experiment_config_defaults()`, so the entire Experiment-class config layer was missing from that process, and the config was cached (`config.ready`) for the process lifetime. Similarly, `config.txt` was only read from `os.getcwd()`.
2. Config precedence was an emergent side effect of the load call sequence (`Configuration.data` layers resolved newest-first). Standard configuration layers now carry an explicit source priority; untagged ad-hoc `config.extend()` and `load_from_file()` calls retain last-write-wins behavior as runtime writes.

This PR supersedes #9565, which contained only the targeted fix for cause 1; this PR contains that fix plus the structural fix for cause 2.

## Summary of changes

Configuration values are resolved by declared source priority:

| Priority | `ConfigSource` | Contents |
|---|---|---|
| 1 | `PACKAGE_DEFAULTS` | Dallinger's built-in defaults (`dallinger/default_configs/`) |
| 2 | `EXPERIMENT_DEFAULTS` | Default suggestions from the experiment's own class(es): `Experiment.config_defaults()` inheritance chain |
| 3 | `USER_CONFIG` | `~/.dallingerconfig` |
| 4 | `EXPERIMENT_SETTINGS` | Authoritative in-code settings: `Experiment.config_settings()` |
| 5 | `EXPERIMENT_CONFIG` | The experiment's `config.txt` |
| 6 | `ENVIRONMENT` | Environment variables |
| 7 | `RUNTIME` | `config.set()`, `config.extend()`, `config.override()` |

- `dallinger/config.py`:
  - New `ConfigSource` enum declaring the priorities above. Each layer is tagged with its source through `ConfigLayer`, a dict subclass that preserves structural compatibility. Raw `Configuration.data` iteration still follows load order; callers needing resolved values must use `get()` or `as_dict()`. `get()` resolves layers by source priority, newest first within a source, and `write()` writes in ascending priority.
  - New `experiment_directory()`: uses the current directory when it contains `experiment.py`; otherwise it falls back to an initialized experiment package containing `experiment.py` or `dallinger_experiment.py` (with a guard against stale `sys.modules` entries). This keeps experiment class layers and `config.txt` available after an initialized process changes into a non-experiment directory, and prevents an unrelated CWD `config.txt` from shadowing the experiment's file. A CWD containing another `experiment.py` still takes precedence, and package-`__init__.py`-only experiments are not treated as available by this helper.
  - Fixed `get_config()` so the imported experiment loader no longer shadows the `load` parameter, which forced an eager config load on the first call whenever an experiment was available.
  - Added a module docstring documenting the precedence design.
  - Sphinx docs: new "Load order and precedence" section in `docs/source/configuration.rst` mirroring the `ConfigSource` order, and `config_defaults()` vs `config_settings()` documented in `docs/source/extra_configuration.rst`.
- `dallinger/experiment.py`: new `Experiment.config_settings()` classmethod for authoritative in-code settings (priority 4, overridden by `config.txt`), complementing `config_defaults()` (priority 2), which conflated framework baseline defaults with deliberate per-experiment decisions. Frameworks like PsyNet can route their experiment-level `config = {...}` dicts here so a stale `~/.dallingerconfig` can no longer override an experimenter's explicit choice.
- `dallinger/pytest_dallinger.py`: `stub_config` tags its baseline values as `PACKAGE_DEFAULTS` instead of runtime overrides, since they stand in for a fully loaded baseline configuration.
- `tests/test_config.py`: new unit tests for priority-over-load-order, runtime-writes-win, newest-within-source, and `write()` ordering; integration tests for CWD-independent resolution (fresh config loaded after a CWD change resolves identically to one loaded in the experiment directory, including `config.txt` values), `config_settings()` precedence (beats `~/.dallingerconfig`, overridden by `config.txt`), non-eager `get_config()`, and stale experiment module handling.

## Behavior changes

- After an experiment package has been initialized, changing into a non-experiment directory no longer drops its Experiment-class config layers or `config.txt`. A directory containing another `experiment.py` still takes precedence.
- Tagged config sources resolve in the documented precedence order regardless of insertion order. Untagged `config.extend()` and `load_from_file()` calls default to the highest (`RUNTIME`) priority, preserving previous last-write-wins behavior for ad-hoc writes; callers loading a known source must tag it explicitly.
- New opt-in `Experiment.config_settings()` hook; no behavior change for experiments that do not override it.
- The `config.txt` reload performed by `exp_class_working_dir` on `Experiment.run()` is now tagged `EXPERIMENT_CONFIG` instead of defaulting to `RUNTIME`, so it no longer overrides environment variables.
- `get_config()` without `load=True` no longer eagerly loads the config on its first call in an experiment context. Bootstrap callers that require a loaded config must pass `load=True`; downstream bare `get_config()` calls continue to reuse the initialized singleton.

## Testing

- `python -m pytest tests/test_config.py -q` — 39 passed.
- The DB/Redis-dependent experiment and full suites were not reproduced cleanly in the current local environment; an earlier branch/master comparison found no branch-specific failures.
- `pre-commit` (ruff check + format) — passed.
- Red/green verified for the original bug: the CWD-change test fails with the pre-branch `experiment_available()` implementation and passes with the fix.

## Changelog

CHANGELOG.md has unreleased "Added", "Changed" and "Fixed" entries for this pull request.

## Automatic code review

The full combined branch at `cf3bd29b7` was reviewed via the repo-local `/branch-review` command. The CWD scope, untagged-runtime behavior, raw-layer compatibility boundary, and experiment-format limitations are documented above.

## Screenshots

Not applicable.

Made with [Cursor](https://cursor.com)
