### PR TITLE
Follow Prolific 'next' links when paginating list endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,10 +25,12 @@
   `participant_not_found` via `error_code` / `AjaxRejection.errorCode`).
 - Fixed Prolific pagination so that fetching submissions and studies follows
   the "next" link in Prolific's list responses instead of assuming that a
-  page shorter than the requested `page_size` is the final one. This ensures
-  participant status verification sees all submissions even when Prolific
-  caps the served page size (e.g. at 20), and makes `get_studies` paginated
-  for the first time. Fixes
+  page shorter than the requested `page_size` is the final one. This fixes a
+  crash in participant status verification when a study's submission count
+  is an exact multiple of the page size (Prolific returns a 404 error for
+  page requests past the end), keeps pagination correct regardless of how
+  Prolific sizes served pages, and makes `get_studies` paginated for the
+  first time. See
   [#9601](https://github.com/Dallinger/Dallinger/issues/9601).
 - Fixed config loading so the experiment's config layers (class defaults and
   `config.txt`) are still applied after an initialized experiment process

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@
 - Fixed repeat-worker recruitment after multiple prior participations and added
   structured participant lookup errors for clients (`assignment_id_missing` /
   `participant_not_found` via `error_code` / `AjaxRejection.errorCode`).
+- Fixed Prolific pagination so that fetching submissions and studies follows
+  the "next" link in Prolific's list responses instead of assuming that a
+  page shorter than the requested `page_size` is the final one. This ensures
+  participant status verification sees all submissions even when Prolific
+  caps the served page size (e.g. at 20), and makes `get_studies` paginated
+  for the first time. Fixes
+  [#9601](https://github.com/Dallinger/Dallinger/issues/9601).
 - Fixed config loading so the experiment's config layers (class defaults and
   `config.txt`) are still applied after an initialized experiment process
   changes into a non-experiment directory.

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -176,33 +176,49 @@ class ProlificService:
                 "Cannot fetch Prolific submissions without a study_id."
             )
 
-        page_size = 100
-        page = 1
-        submissions = []
-
-        while True:
-            query_params = {
-                "study": study_id,
-                "ordering": "started_at",
-                "page": page,
-                "page_size": page_size,
-            }
-            results = self._req(
-                method="GET", endpoint="/submissions/", params=query_params
-            )["results"]
-            submissions.extend(results)
-
-            if len(results) < page_size:
-                return submissions
-
-            page += 1
+        return self._get_all_pages(
+            endpoint="/submissions/",
+            params={"study": study_id, "ordering": "started_at"},
+        )
 
     def get_studies(self, states: List[str] = None) -> List[dict]:
+        """Return all studies in the given states (default: all states)."""
         if not states:
             states = AVAILABLE_STATES
         assert all([state in AVAILABLE_STATES for state in states])
-        studies = self._req(method="GET", endpoint="/studies/")["results"]
+        studies = self._get_all_pages(endpoint="/studies/")
         return [study for study in studies if study["status"] in states]
+
+    def _get_all_pages(
+        self, endpoint: str, params: Optional[dict] = None, page_size: int = 100
+    ) -> List[dict]:
+        """Fetch every page of results from a paginated Prolific list endpoint.
+
+        Prolific paginates list responses (defaulting to 20 items per page)
+        and includes link metadata indicating whether a further page exists.
+        That "next" link is the authoritative continuation signal: we keep
+        fetching as long as it is present, even if Prolific serves smaller
+        pages than requested. If a response contains no link metadata (as in
+        some tests and mocks), we fall back to stopping at the first partial
+        page.
+        """
+        base_params = dict(params or {})
+        page = 1
+        results = []
+
+        while True:
+            response = self._req(
+                method="GET",
+                endpoint=endpoint,
+                params={**base_params, "page": page, "page_size": page_size},
+            )
+            page_results = response["results"]
+            results.extend(page_results)
+
+            if not _has_next_page(response, len(page_results), page_size):
+                return results
+
+            page += 1
 
     def get_assignments_for_study(self, study_id: str) -> dict:
         """Return all submissions for the current Prolific study, keyed by
@@ -605,6 +621,26 @@ def _translate_submission_from_get_submission(prolific_assignment_info):
         "started_at": p["started_at"],
         "status": p["status"],
     }
+
+
+def _has_next_page(response: dict, page_length: int, page_size: int) -> bool:
+    """Whether a paginated Prolific list response points to a further page.
+
+    Prolific list responses include link metadata of the form
+    ``{"_links": {"next": {"href": <url-or-null>}, ...}}``. When such
+    metadata is present, the presence of a non-null "next" link is
+    authoritative. Otherwise we fall back to treating a partial page as the
+    final one.
+    """
+    links = response.get("_links")
+    if isinstance(links, dict) and "next" in links:
+        next_link = links["next"]
+        if isinstance(next_link, dict):
+            next_link = next_link.get("href")
+        return bool(next_link)
+    if "next" in response:
+        return bool(response["next"])
+    return page_length >= page_size
 
 
 def _translate_submission_from_get_submissions(prolific_assignment_info, study_id):

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -194,13 +194,14 @@ class ProlificService:
     ) -> List[dict]:
         """Fetch every page of results from a paginated Prolific list endpoint.
 
-        Prolific paginates list responses (defaulting to 20 items per page)
-        and includes link metadata indicating whether a further page exists.
-        That "next" link is the authoritative continuation signal: we keep
-        fetching as long as it is present, even if Prolific serves smaller
-        pages than requested. If a response contains no link metadata (as in
-        some tests and mocks), we fall back to stopping at the first partial
-        page.
+        Prolific list responses include ``_links`` metadata whose "next" href
+        is the authoritative continuation signal: it is a URL while further
+        pages exist and null on the last page. Requesting a page past the end
+        returns a 404 error, so we must stop exactly when "next" becomes null
+        rather than probing for an empty page. The next href simply preserves
+        the requested page_size and increments the page number (verified
+        against the live API), so re-requesting with an incremented ``page``
+        param is equivalent to following the href itself.
         """
         base_params = dict(params or {})
         page = 1
@@ -627,10 +628,10 @@ def _has_next_page(response: dict, page_length: int, page_size: int) -> bool:
     """Whether a paginated Prolific list response points to a further page.
 
     Prolific list responses include link metadata of the form
-    ``{"_links": {"next": {"href": <url-or-null>}, ...}}``. When such
-    metadata is present, the presence of a non-null "next" link is
-    authoritative. Otherwise we fall back to treating a partial page as the
-    final one.
+    ``{"_links": {"next": {"href": <url-or-null>}, ...}}``; a non-null "next"
+    href is the authoritative signal that a further page exists. If a response
+    were ever to omit the link metadata, we fall back to treating a partial
+    page as the final one.
     """
     links = response.get("_links")
     if isinstance(links, dict) and "next" in links:
@@ -638,8 +639,6 @@ def _has_next_page(response: dict, page_length: int, page_size: int) -> bool:
         if isinstance(next_link, dict):
             next_link = next_link.get("href")
         return bool(next_link)
-    if "next" in response:
-        return bool(response["next"])
     return page_length >= page_size
 
 

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -534,8 +534,7 @@ def test_get_submissions_requires_study_id(subject):
     subject._req.assert_not_called()
 
 
-@pytest.mark.parametrize("page_lengths", ([100, 1], [100, 0], [100, 100, 50]))
-def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
+def _make_pages(page_lengths):
     pages = []
     next_id = 0
     for length in page_lengths:
@@ -543,12 +542,11 @@ def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
             [{"id": f"submission-{i}"} for i in range(next_id, next_id + length)]
         )
         next_id += length
-    subject._req = mock.MagicMock(side_effect=[{"results": page} for page in pages])
+    return pages
 
-    assert subject.get_submissions("study_123") == [
-        item for page in pages for item in page
-    ]
-    assert subject._req.call_args_list == [
+
+def _expected_submission_calls(page_count):
+    return [
         mock.call(
             method="GET",
             endpoint="/submissions/",
@@ -559,7 +557,80 @@ def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
                 "page_size": 100,
             },
         )
-        for page in range(1, len(page_lengths) + 1)
+        for page in range(1, page_count + 1)
+    ]
+
+
+@pytest.mark.parametrize("page_lengths", ([100, 1], [100, 0], [100, 100, 50]))
+def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
+    """Without link metadata, a partial page marks the end of the results."""
+    pages = _make_pages(page_lengths)
+    subject._req = mock.MagicMock(side_effect=[{"results": page} for page in pages])
+
+    assert subject.get_submissions("study_123") == [
+        item for page in pages for item in page
+    ]
+    assert subject._req.call_args_list == _expected_submission_calls(len(page_lengths))
+
+
+def test_get_submissions_follows_next_link_despite_capped_page_size(subject):
+    """The "next" link is authoritative even if Prolific serves smaller pages
+    than requested (e.g. caps the page size at 20)."""
+    pages = _make_pages([20, 20, 3])
+    responses = []
+    for i, page in enumerate(pages):
+        is_last = i == len(pages) - 1
+        responses.append(
+            {
+                "results": page,
+                "_links": {
+                    "next": {"href": None if is_last else f"https://api/{i + 2}"}
+                },
+            }
+        )
+    subject._req = mock.MagicMock(side_effect=responses)
+
+    assert subject.get_submissions("study_123") == [
+        item for page in pages for item in page
+    ]
+    assert subject._req.call_args_list == _expected_submission_calls(len(pages))
+
+
+def test_get_submissions_stops_on_null_next_link_despite_full_page(subject):
+    """A null "next" link ends pagination even when the page came back full."""
+    pages = _make_pages([100])
+    subject._req = mock.MagicMock(
+        side_effect=[{"results": pages[0], "_links": {"next": {"href": None}}}]
+    )
+
+    assert subject.get_submissions("study_123") == pages[0]
+    assert subject._req.call_args_list == _expected_submission_calls(1)
+
+
+def test_get_studies_returns_all_paginated_results(subject):
+    responses = [
+        {
+            "results": [{"id": "study-1", "status": "ACTIVE"}],
+            "_links": {"next": {"href": "https://api/2"}},
+        },
+        {
+            "results": [{"id": "study-2", "status": "COMPLETED"}],
+            "_links": {"next": {"href": None}},
+        },
+    ]
+    subject._req = mock.MagicMock(side_effect=responses)
+
+    assert subject.get_studies() == [
+        {"id": "study-1", "status": "ACTIVE"},
+        {"id": "study-2", "status": "COMPLETED"},
+    ]
+    assert subject._req.call_args_list == [
+        mock.call(
+            method="GET",
+            endpoint="/studies/",
+            params={"page": page, "page_size": 100},
+        )
+        for page in (1, 2)
     ]
 
 

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -573,9 +573,10 @@ def test_get_submissions_returns_all_paginated_results(subject, page_lengths):
     assert subject._req.call_args_list == _expected_submission_calls(len(page_lengths))
 
 
-def test_get_submissions_follows_next_link_despite_capped_page_size(subject):
-    """The "next" link is authoritative even if Prolific serves smaller pages
-    than requested (e.g. caps the page size at 20)."""
+def test_get_submissions_follows_next_link_despite_short_pages(subject):
+    """The "next" link is authoritative even if Prolific were to serve smaller
+    pages than requested. (The live API honors the requested page_size, so
+    this is a robustness check rather than an observed behavior.)"""
     pages = _make_pages([20, 20, 3])
     responses = []
     for i, page in enumerate(pages):


### PR DESCRIPTION
## Motivation

Addresses #9601. Two distinct problems were identified:

1. `ProlificService.get_submissions` was paginated in #9343 (released in v12.2.1) using `page`/`page_size` parameters, terminating when a page comes back shorter than the requested `page_size` (100). Live testing against the Prolific API confirmed that requesting a page **past the end** of the results returns an HTTP 404 error payload rather than an empty page. So for any study whose submission count is an exact multiple of 100, the v12.2.1 loop requests one page too many and `get_submissions` raises a `ProlificServiceException`, breaking participant status verification at exactly those counts.
2. The partial-page termination heuristic is an assumption about server behavior rather than a contract. As @jessesnyder suggested in the issue thread, the standard and robust approach is to use the `next` link in Prolific's list responses as the continuation signal. Live testing confirmed that `/submissions/` and `/studies/` responses include the standard envelope (`_links.next.href`, `meta.count`) even though Prolific's API reference documents only `results`.

Note: the original "stops at 20" symptom reported in #9601 quotes pre-#9343 code and is already fixed in v12.2.1 for studies whose counts are not exact multiples of 100 (live check: `page_size=100` is honored and returned all 21 submissions of a test study in one page).

## Summary of changes

- Added `ProlificService._get_all_pages`, a shared pagination helper that requests pages with explicit `page`/`page_size` parameters and continues as long as the response's `_links.next.href` is non-null. If a response were ever to omit the `_links` metadata, it falls back to stopping at the first partial page.
- `get_submissions` now uses this helper. Because the null `next` link terminates the loop even when the final page is full, the out-of-range 404 request at exact multiples of the page size no longer happens.
- `get_studies` now also uses the helper; previously it fetched only the first page of `/studies/`.

## Behavior changes

- Participant status verification no longer crashes when a study's submission count is an exact multiple of 100.
- Pagination no longer depends on how Prolific sizes served pages; statuses stay in sync for any submission count.
- `get_studies` returns all studies rather than the first 20.

## Testing

- Live Prolific API checks against a real study with 21 submissions:
  - Default request (no `page_size`) returns 20 of 21 results with `_links.next.href` set and `meta.count: 21` — confirming the `_links` envelope exists on `/submissions/` and that unpaginated requests truncate.
  - `page=1&page_size=100` returns all 21 results with `_links.next.href: null`.
  - `page=2&page_size=100` (past the end) returns an HTTP 404 error payload — confirming the exact-multiple crash scenario in the pre-branch code.
- Additional live pagination checks against `/studies/` (workspace with 1254 studies):
  - `_links.next.href` is present on every list response and null exactly on the last page; there is no top-level `next` key, so an earlier DRF-style fallback branch was removed as dead code.
  - The server honors the requested `page_size` (verified for 1, 2, 5, 100, 200, and 2000), and the `next` href simply preserves the requested `page_size` and increments `page` — so re-requesting with an incremented `page` parameter is equivalent to following the href itself.
  - Past-the-end pages on `/studies/` also return HTTP 404.
- `python -m pytest tests/test_prolific.py` — 26 passed, 8 skipped. New regression tests cover: next-link pagination when served pages are shorter than requested (a robustness check; the live API honors the requested `page_size`), termination on a null next link despite a full page (the exact-multiple scenario), the no-link-metadata fallback, and `get_studies` pagination.
- `python -m pytest tests/test_recruiters.py -k prolific` — 24 passed.
- `python -m pre_commit run` on changed files — passed.

## Changelog

Added an entry under the unreleased Fixed section of `CHANGELOG.md`.

## Automatic code review

The repo-local `/branch-review` command was run twice; findings (verify that live `/submissions/` responses actually include `_links`; verify the page-number-reconstruction assumption against the live API and trim speculative branches in `_has_next_page`) were addressed via the live API checks described above.

## Screenshots

Not applicable.
