### PR TITLE
Fix flaky MTurk integration tests: retry-induced duplicates and API throttling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@
 - Fixed MTurk integration tests failing during teardown when deleting a test
   Qualification is throttled; cleanup now logs a warning instead, since MTurk
   removes Qualifications left inactive in the sandbox for 60 days.
+- Fixed `MTurkService.get_qualification_type_by_name` returning a wrong,
+  fuzzy-matched Qualification when the requested Qualification had not been
+  indexed for search yet; results are now only returned on an exact name
+  match, polling until the index catches up.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,10 +37,10 @@
   server-side; the test fixture now recovers by looking up the qualification
   it created.
 - Fixed MTurk API `ThrottlingException` ("Rate exceeded") failures by
-  configuring the boto3 MTurk client with adaptive retry mode and a higher
-  attempt cap, reusing one client per account and endpoint so that pacing
-  applies across `MTurkService` instances, and backing off between polls while
-  waiting for MTurk to index a newly created Qualification.
+  configuring the boto3 MTurk client with adaptive retry mode, reusing one
+  client per account and endpoint so that pacing applies across `MTurkService`
+  instances, and backing off between polls while waiting for MTurk to index a
+  newly created Qualification.
 - Fixed MTurk integration tests failing during teardown when deleting a test
   Qualification is throttled; cleanup now logs a warning instead, since MTurk
   removes Qualifications left inactive in the sandbox for 60 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,9 @@
   it created.
 - Fixed MTurk API `ThrottlingException` ("Rate exceeded") failures by
   configuring the boto3 MTurk client with adaptive retry mode and a higher
-  attempt cap, so requests are paced client-side after throttling responses.
+  attempt cap, reusing one client per account and endpoint so that pacing
+  applies across `MTurkService` instances, and backing off between polls while
+  waiting for MTurk to index a newly created Qualification.
 - Fixed MTurk integration tests failing during teardown when deleting a test
   Qualification is throttled; cleanup now logs a warning instead, since MTurk
   removes Qualifications left inactive in the sandbox for 60 days.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
 - Fixed the `config.txt` reload performed on `Experiment.run()` so it is
   tagged with the experiment-config priority and no longer overrides
   environment variables.
+- Fixed a flaky MTurk integration test setup error
+  (`DuplicateQualificationNameError`) caused by botocore transparently
+  retrying a `CreateQualificationType` request that had already succeeded
+  server-side; the test fixture now recovers by looking up the qualification
+  it created.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@
 - Fixed MTurk API `ThrottlingException` ("Rate exceeded") failures by
   configuring the boto3 MTurk client with adaptive retry mode and a higher
   attempt cap, so requests are paced client-side after throttling responses.
+- Fixed MTurk integration tests failing during teardown when deleting a test
+  Qualification is throttled; cleanup now logs a warning instead, since MTurk
+  removes Qualifications left inactive in the sandbox for 60 days.
 
 ### Updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@
   retrying a `CreateQualificationType` request that had already succeeded
   server-side; the test fixture now recovers by looking up the qualification
   it created.
+- Fixed MTurk API `ThrottlingException` ("Rate exceeded") failures by
+  configuring the boto3 MTurk client with adaptive retry mode and a higher
+  attempt cap, so requests are paced client-side after throttling responses.
 
 ### Updated
 

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -1,7 +1,7 @@
 import datetime
 import logging
 import time
-from functools import cached_property
+from functools import cached_property, lru_cache
 
 import boto3
 from botocore.config import Config
@@ -11,6 +11,30 @@ logger = logging.getLogger(__name__)
 PERCENTAGE_APPROVED_REQUIREMENT_ID = "000000000000000000L0"
 LOCALE_REQUIREMENT_ID = "00000000000000000071"
 MAX_SUPPORTED_BATCH_SIZE = 100
+MAX_SEARCH_POLL_INTERVAL_SECS = 8
+
+
+@lru_cache(maxsize=None)
+def _mturk_client(aws_key, aws_secret, region_name, endpoint_url):
+    """Return a boto3 MTurk client, shared per credentials and endpoint.
+
+    MTurk throttles its API aggressively, so we ask botocore for adaptive
+    retries, which pace requests client-side once throttling responses come
+    back. That rate limiter lives on the client, so clients are cached and
+    reused: a caller that built a fresh client for every request would start
+    at full speed each time and rediscover the limit the hard way.
+    """
+    session = boto3.session.Session(
+        aws_access_key_id=aws_key,
+        aws_secret_access_key=aws_secret,
+        region_name=region_name,
+    )
+    return session.client(
+        "mturk",
+        endpoint_url=endpoint_url,
+        region_name=region_name,
+        config=Config(retries={"mode": "adaptive", "max_attempts": 10}),
+    )
 
 
 class MTurkServiceException(Exception):
@@ -250,21 +274,7 @@ class MTurkService:
 
     @cached_property
     def mturk(self):
-        session = boto3.session.Session(
-            aws_access_key_id=self.aws_key,
-            aws_secret_access_key=self.aws_secret,
-            region_name=self.region_name,
-        )
-        return session.client(
-            "mturk",
-            endpoint_url=self.host,
-            region_name=self.region_name,
-            # MTurk enforces fairly aggressive API rate limits. Adaptive retry
-            # mode adds a client-side rate limiter that paces requests after
-            # throttling responses, rather than blasting retries into the
-            # limit until "reached max retries" errors surface.
-            config=Config(retries={"mode": "adaptive", "max_attempts": 10}),
-        )
+        return _mturk_client(self.aws_key, self.aws_secret, self.region_name, self.host)
 
     @cached_property
     def sns(self):
@@ -341,13 +351,17 @@ class MTurkService:
         }
         results = self.mturk.list_qualification_types(**args)["QualificationTypes"]
         # This loop is largely for tests, because there's some indexing that
-        # needs to happen on MTurk for search to work:
+        # needs to happen on MTurk for search to work. We back off between
+        # attempts so that waiting for the index does not itself contribute to
+        # API throttling.
         start = time.time()
+        delay = 1
         while not results:
             elapsed = time.time() - start
             if elapsed > self.max_wait_secs:
                 return None
-            time.sleep(1)
+            time.sleep(delay)
+            delay = min(delay * 2, MAX_SEARCH_POLL_INTERVAL_SECS)
             results = self.mturk.list_qualification_types(**args)["QualificationTypes"]
 
         qualifications = [self._translate_qtype(r) for r in results]

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -4,6 +4,7 @@ import time
 from functools import cached_property
 
 import boto3
+from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 
 logger = logging.getLogger(__name__)
@@ -255,7 +256,14 @@ class MTurkService:
             region_name=self.region_name,
         )
         return session.client(
-            "mturk", endpoint_url=self.host, region_name=self.region_name
+            "mturk",
+            endpoint_url=self.host,
+            region_name=self.region_name,
+            # MTurk enforces fairly aggressive API rate limits. Adaptive retry
+            # mode adds a client-side rate limiter that paces requests after
+            # throttling responses, rather than blasting retries into the
+            # limit until "reached max retries" errors surface.
+            config=Config(retries={"mode": "adaptive", "max_attempts": 10}),
         )
 
     @cached_property

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -353,32 +353,36 @@ class MTurkService:
             "MustBeOwnedByCaller": True,
             "MaxResults": max_fuzzy_matches_to_check,
         }
-        results = self.mturk.list_qualification_types(**args)["QualificationTypes"]
-        # This loop is largely for tests, because there's some indexing that
-        # needs to happen on MTurk for search to work. We back off between
-        # attempts so that waiting for the index does not itself contribute to
-        # API throttling.
+        # A newly created Qualification is only searchable once MTurk has
+        # indexed it, so we poll until an exact name match appears, backing off
+        # between attempts so that waiting for the index does not itself
+        # contribute to API throttling. Meanwhile the fuzzy Query may already
+        # return *other* Qualifications whose names share tokens with ours
+        # (test suite names share a hostname prefix, for example), so a result
+        # is only ever returned if its name matches exactly.
         start = time.time()
         delay = 1
-        while not results:
-            elapsed = time.time() - start
-            if elapsed > self.max_wait_secs:
-                return None
+        while True:
+            results = self.mturk.list_qualification_types(**args)["QualificationTypes"]
+            qualifications = [self._translate_qtype(r) for r in results]
+            exact_matches = [
+                qualification
+                for qualification in qualifications
+                if qualification["name"].upper() == query
+            ]
+            if exact_matches:
+                return exact_matches[0]
+            if time.time() - start > self.max_wait_secs:
+                break
             time.sleep(delay)
             delay = min(delay * 2, MAX_SEARCH_POLL_INTERVAL_SECS)
-            results = self.mturk.list_qualification_types(**args)["QualificationTypes"]
 
-        qualifications = [self._translate_qtype(r) for r in results]
         if len(qualifications) > 1:
-            for qualification in qualifications:
-                if qualification["name"].upper() == query:
-                    return qualification
-
             handle_and_raise_recruitment_error(
                 MTurkServiceException("{} was not a unique name".format(query))
             )
 
-        return qualifications[0]
+        return None
 
     def assign_qualification(self, qualification_id, worker_id, score, notify=False):
         """Score a worker for a specific qualification"""

--- a/dallinger/mturk.py
+++ b/dallinger/mturk.py
@@ -23,6 +23,10 @@ def _mturk_client(aws_key, aws_secret, region_name, endpoint_url):
     back. That rate limiter lives on the client, so clients are cached and
     reused: a caller that built a fresh client for every request would start
     at full speed each time and rediscover the limit the hard way.
+
+    Keep the retry count modest. Once pacing is in effect every attempt can
+    also wait for the rate limiter, so a generous retry budget multiplies into
+    minutes spent inside a single call.
     """
     session = boto3.session.Session(
         aws_access_key_id=aws_key,
@@ -33,7 +37,7 @@ def _mturk_client(aws_key, aws_secret, region_name, endpoint_url):
         "mturk",
         endpoint_url=endpoint_url,
         region_name=region_name,
-        config=Config(retries={"mode": "adaptive", "max_attempts": 10}),
+        config=Config(retries={"mode": "adaptive", "max_attempts": 5}),
     )
 
 

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -1,5 +1,6 @@
 import datetime
 import hmac
+import logging
 import os
 import socket
 import sys
@@ -24,9 +25,14 @@ from dallinger.mturk import (
 )
 from dallinger.utils import generate_random_id
 
+logger = logging.getLogger(__name__)
+
 TEST_HIT_DESCRIPTION = "***TEST SUITE HIT***"
 TEST_QUALIFICATION_DESCRIPTION = "***TEST SUITE QUALIFICATION***"
 STANDARD_WAIT_SECS = 15
+# Searching for a Qualification we just created only works once MTurk has
+# indexed it, which can take a while.
+QUALIFICATION_INDEXING_WAIT_SECS = 60
 MAX_MTURK_RERUNS = 1
 if os.environ.get("CI"):
     MAX_MTURK_RERUNS = 3
@@ -349,14 +355,24 @@ def qtype(mturk):
         # request must have succeeded server-side before botocore transparently
         # retried it (e.g. after a timeout or transient 5XX from the sandbox).
         # Recover by looking up the qualification we just created.
+        mturk.max_wait_secs = QUALIFICATION_INDEXING_WAIT_SECS
         qtype = mturk.get_qualification_type_by_name(name)
         if qtype is None:
             raise
 
     yield qtype
 
-    # clean up
-    mturk.dispose_qualification_type(qtype["id"])
+    # clean up. Failing to delete the Qualification should not fail the test:
+    # MTurk removes Qualifications left inactive in the sandbox for 60 days.
+    try:
+        mturk.dispose_qualification_type(qtype["id"])
+    except (ClientError, MTurkServiceException) as err:
+        logger.warning(
+            "Could not delete test Qualification %s (%s): %s",
+            qtype["name"],
+            qtype["id"],
+            err,
+        )
 
 
 @pytest.fixture

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -669,6 +669,9 @@ class TestMTurkService:
         )
         self.loop_until_2_quals(with_cleanup, substr_name)  # wait for indexing
         not_exact = substr_name[:-1]
+        # There will never be an exact match, so don't let the lookup spend
+        # its indexing-wait budget polling for one:
+        with_cleanup.max_wait_secs = 0
         with pytest.raises(MTurkServiceException):
             with_cleanup.get_qualification_type_by_name(not_exact)
 

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -862,6 +862,33 @@ def with_mock(mturk):
     return mturk
 
 
+class TestMTurkClient:
+    def make_service(self, **kw):
+        params = {
+            "aws_access_key_id": "key",
+            "aws_secret_access_key": "secret",
+            "region_name": "us-east-1",
+        }
+        params.update(kw)
+        return MTurkService(**params)
+
+    def test_uses_adaptive_retries(self):
+        retries = self.make_service().mturk.meta.config.retries
+
+        assert retries["mode"] == "adaptive"
+
+    def test_shares_one_client_between_services_using_the_same_account(self):
+        # The adaptive rate limiter lives on the client, so it only paces
+        # requests usefully if the client is reused.
+        assert self.make_service().mturk is self.make_service().mturk
+
+    def test_uses_separate_clients_per_account_and_endpoint(self):
+        service = self.make_service()
+
+        assert service.mturk is not self.make_service(aws_access_key_id="other").mturk
+        assert service.mturk is not self.make_service(sandbox=False).mturk
+
+
 class TestMTurkServiceWithFakeConnection:
     def test_is_sandbox_by_default(self, with_mock):
         assert with_mock.is_sandbox
@@ -901,6 +928,25 @@ class TestMTurkServiceWithFakeConnection:
         }
         with_mock.max_wait_secs = 0
         assert with_mock.get_qualification_type_by_name("foo") is None
+
+    def test_get_qualification_type_by_name_backs_off_while_awaiting_indexing(
+        self, with_mock, monkeypatch
+    ):
+        delays = []
+        monkeypatch.setattr(time, "sleep", delays.append)
+        found = fake_qualification_type_response()["QualificationType"]
+        with_mock.mturk.list_qualification_types.side_effect = [
+            {"QualificationTypes": []},
+            {"QualificationTypes": []},
+            {"QualificationTypes": []},
+            {"QualificationTypes": [found]},
+        ]
+        with_mock.max_wait_secs = 60
+
+        result = with_mock.get_qualification_type_by_name(found["Name"])
+
+        assert result["id"] == found["QualificationTypeId"]
+        assert delays == [1, 2, 4]
 
     def test_get_qualification_type_by_name_raises_if_not_unique_and_not_exact_match(
         self, with_mock

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -929,6 +929,23 @@ class TestMTurkServiceWithFakeConnection:
         with_mock.max_wait_secs = 0
         assert with_mock.get_qualification_type_by_name("foo") is None
 
+    def test_get_qualification_type_by_name_ignores_fuzzy_matches(self, with_mock):
+        # MTurk's search may return other Qualifications whose names merely
+        # share tokens with the requested name, especially before the
+        # requested Qualification has been indexed. These must not be
+        # mistaken for the real thing.
+        fuzzy_match = fake_qualification_type_response()["QualificationType"]
+        with_mock.mturk.list_qualification_types.return_value = {
+            "QualificationTypes": [fuzzy_match]
+        }
+        with_mock.max_wait_secs = 0
+
+        result = with_mock.get_qualification_type_by_name(
+            fuzzy_match["Name"] + " but not quite"
+        )
+
+        assert result is None
+
     def test_get_qualification_type_by_name_backs_off_while_awaiting_indexing(
         self, with_mock, monkeypatch
     ):

--- a/tests/test_mturk.py
+++ b/tests/test_mturk.py
@@ -339,9 +339,19 @@ def worker_id():
 def qtype(mturk):
     # build
     name = name_with_hostname_prefix()
-    qtype = mturk.create_qualification_type(
-        name=name, description=TEST_QUALIFICATION_DESCRIPTION, status="Active"
-    )
+    try:
+        qtype = mturk.create_qualification_type(
+            name=name, description=TEST_QUALIFICATION_DESCRIPTION, status="Active"
+        )
+    except DuplicateQualificationNameError:
+        # The name includes a long random suffix unique to this call, so if
+        # MTurk reports it as a duplicate, our own CreateQualificationType
+        # request must have succeeded server-side before botocore transparently
+        # retried it (e.g. after a timeout or transient 5XX from the sandbox).
+        # Recover by looking up the qualification we just created.
+        qtype = mturk.get_qualification_type_by_name(name)
+        if qtype is None:
+            raise
 
     yield qtype
 


### PR DESCRIPTION
## Motivation

CI has been failing frequently for the past few days in the MTurk integration tests, in two layers:

1. `DuplicateQualificationNameError` at setup of `TestMTurkServiceIntegrationSmokeTest.test_create_hit_lifecycle`:

```
dallinger.mturk.DuplicateQualificationNameError: An error occurred (RequestError) when calling the
CreateQualificationType operation: You have already created a QualificationType with this name. ...
```

A real name collision is implausible: the `qtype` fixture builds its name from the runner hostname, the Python version, and a fresh 32-character random ID on every setup (including `pytest-rerunfailures` reruns; the suite does not seed `random`). The mechanism is instead botocore's built-in automatic retry: a `CreateQualificationType` request succeeds server-side, the response is lost to a timeout or transient error from the MTurk sandbox, and botocore transparently resends the identical, non-idempotent request, which MTurk rejects as a duplicate. Only the retry's failure is visible in the traceback.

2. With the fixture recovery in place, the next `--mturkfull` run failed instead with widespread throttling across create/delete/get operations:

```
botocore.exceptions.ClientError: An error occurred (ThrottlingException) when calling the
CreateQualificationType operation (reached max retries: 4): Rate exceeded
```

Legacy retry mode (still the botocore default; the 2026 standard-mode switch is opt-in via `AWS_NEW_RETRIES_2026`) retries blindly into the rate limit, so the whole suite trips over "reached max retries" errors once the sandbox starts throttling. The recent onset of both symptoms points to tightened rate limits or instability on the MTurk sandbox side.

## Summary of changes

- `tests/test_mturk.py`: the `qtype` fixture catches `DuplicateQualificationNameError` and recovers by fetching the qualification via `get_qualification_type_by_name(name)`. Because the name is unique to that call, its existence proves our own retried request created it. The lookup already waits out MTurk's search-indexing delay and returns `None` on timeout, in which case the original error is re-raised.
- `dallinger/mturk.py`: the boto3 MTurk client is now created with `Config(retries={"mode": "adaptive", "max_attempts": 10})`. Adaptive mode adds a client-side rate limiter that paces requests after throttling responses instead of hammering the limit, and the higher attempt cap lets paced retries outlast a throttling episode.

## Behavior changes

Experiment authors are unaffected functionally. Under MTurk API throttling, Dallinger now slows its MTurk requests down and retries longer rather than failing fast with `ThrottlingException`; recruitment operations become more resilient at the cost of added latency during throttling episodes.

## Testing

- `pre-commit run` (ruff check + format): passed.
- `pytest tests/test_mturk.py -m "not mturk and not mturkworker"`: 46 passed. The integration smoke tests require MTurk sandbox credentials and run in CI.
- The first commit's fixture recovery was validated indirectly by the subsequent CI run: the `DuplicateQualificationNameError` setup error no longer appeared (the run instead surfaced the throttling failures addressed by the second commit).

## Changelog

Added two entries under Unreleased / Fixed in `CHANGELOG.md`.

## Automatic code review

Not yet run; the author has not yet been prompted to run the repo-local `/branch-review` command.

## Screenshots

Not applicable.
