### PR TITLE
Silence docker-py shell-out SSH ResourceWarnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@
 
 - Silenced spurious ResourceWarnings emitted during Docker-over-SSH
   deployments by docker-py's shell-out SSH transport, which does not close
-  its connections when the client is closed.
+  its connections when the client is closed. The filters are installed
+  before the Docker client is created so mid-command garbage collection
+  cannot print them.
 - Fixed repeat-worker recruitment after multiple prior participations and added
   structured participant lookup errors for clients (`assignment_id_missing` /
   `participant_not_found` via `error_code` / `AjaxRejection.errorCode`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@
 
 ### Fixed
 
+- Silenced spurious ResourceWarnings emitted during Docker-over-SSH
+  deployments by docker-py's shell-out SSH transport, which does not close
+  its connections when the client is closed.
 - Fixed repeat-worker recruitment after multiple prior participations and added
   structured participant lookup errors for clients (`assignment_id_missing` /
   `participant_not_found` via `error_code` / `AjaxRejection.errorCode`).

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -494,9 +494,10 @@ def _ignore_docker_ssh_resource_warnings():
     The filters must be installed process-wide (not via a scoped
     ``catch_warnings`` block) because the warnings fire at garbage
     collection, after any scoped context would have exited. They are
-    installed after the deploy work is done, so they also take precedence
-    over Dallinger's ``setup_warning_hooks()``, which enables display of
-    all warnings and may run mid-command.
+    installed before the Docker client is created so mid-command GC
+    cannot print them, and again after the deploy work so they take
+    precedence over Dallinger's ``setup_warning_hooks()``, which enables
+    display of all warnings and may run mid-command.
     """
     warnings.filterwarnings(
         "ignore",
@@ -565,6 +566,9 @@ def build_and_push_image(f):
                 # Add server_pem to SSH agent so docker-py's SSH client can use it
                 # (necessary because docker.from_env() does not accept PEM files directly).
                 add_server_pem_to_ssh_agent()
+            # docker-py leaks shell-out SSH resources; mute the GC warnings
+            # before the client exists so they cannot fire mid-command.
+            _ignore_docker_ssh_resource_warnings()
             # Avoid Paramiko by using the system ssh client
             docker_client = docker.from_env(use_ssh_client=True)
 
@@ -626,8 +630,7 @@ def build_and_push_image(f):
                     docker_client.close()
                 except Exception:
                     pass
-                # docker-py leaks its shell-out SSH resources despite close();
-                # silence the resulting garbage-collection warnings.
+                # Re-apply in case setup_warning_hooks() re-enabled warnings.
                 _ignore_docker_ssh_resource_warnings()
 
             # Restore DOCKER_HOST

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -509,6 +509,11 @@ def _ignore_docker_ssh_resource_warnings():
         category=ResourceWarning,
         message=r"unclosed <docker\.transport\.sshconn\.SSHSocket",
     )
+    warnings.filterwarnings(
+        "ignore",
+        category=ResourceWarning,
+        message=r"unclosed file <_io\.FileIO name=\d+ mode='[rw]b' closefd=True>",
+    )
 
 
 def build_and_push_image(f):

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -9,6 +9,7 @@ import select
 import socket
 import subprocess
 import sys
+import warnings
 import zipfile
 from contextlib import contextmanager, redirect_stdout
 from dataclasses import dataclass
@@ -480,6 +481,35 @@ def ensure_root_domain_ready(server, update):
     return True
 
 
+def _ignore_docker_ssh_resource_warnings():
+    """Suppress ResourceWarnings from docker-py's shell-out SSH transport.
+
+    In shell-out mode (``use_ssh_client=True``), docker-py never tracks the
+    connection pools it creates, so ``client.close()`` cannot reach the
+    spawned ``ssh`` subprocesses or their sockets. They are only reclaimed
+    at garbage collection, which emits ResourceWarnings. This is harmless
+    for a short-lived CLI process, so we mute those specific warnings
+    rather than patching docker-py internals.
+
+    The filters must be installed process-wide (not via a scoped
+    ``catch_warnings`` block) because the warnings fire at garbage
+    collection, after any scoped context would have exited. They are
+    installed after the deploy work is done, so they also take precedence
+    over Dallinger's ``setup_warning_hooks()``, which enables display of
+    all warnings and may run mid-command.
+    """
+    warnings.filterwarnings(
+        "ignore",
+        category=ResourceWarning,
+        message=r"subprocess \d+ is still running",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        category=ResourceWarning,
+        message=r"unclosed <docker\.transport\.sshconn\.SSHSocket",
+    )
+
+
 def build_and_push_image(f):
     """Decorator for click commands that depend on a pushed docker image.
 
@@ -596,6 +626,9 @@ def build_and_push_image(f):
                     docker_client.close()
                 except Exception:
                     pass
+                # docker-py leaks its shell-out SSH resources despite close();
+                # silence the resulting garbage-collection warnings.
+                _ignore_docker_ssh_resource_warnings()
 
             # Restore DOCKER_HOST
             if original_docker_host is None:

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -495,9 +495,7 @@ def _ignore_docker_ssh_resource_warnings():
     ``catch_warnings`` block) because the warnings fire at garbage
     collection, after any scoped context would have exited. They are
     installed before the Docker client is created so mid-command GC
-    cannot print them, and again after the deploy work so they take
-    precedence over Dallinger's ``setup_warning_hooks()``, which enables
-    display of all warnings and may run mid-command.
+    cannot print them.
     """
     warnings.filterwarnings(
         "ignore",
@@ -635,8 +633,6 @@ def build_and_push_image(f):
                     docker_client.close()
                 except Exception:
                     pass
-                # Re-apply in case setup_warning_hooks() re-enabled warnings.
-                _ignore_docker_ssh_resource_warnings()
 
             # Restore DOCKER_HOST
             if original_docker_host is None:

--- a/tests/test_docker_ssh_resources.py
+++ b/tests/test_docker_ssh_resources.py
@@ -1,0 +1,22 @@
+import importlib
+import warnings
+
+docker_ssh = importlib.import_module("dallinger.command_line.docker_ssh")
+
+
+def test_docker_ssh_resource_warnings_are_muted():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("default")
+        docker_ssh._ignore_docker_ssh_resource_warnings()
+        warnings.warn("subprocess 123 is still running", ResourceWarning)
+        warnings.warn(
+            "unclosed <docker.transport.sshconn.SSHSocket fd=5>", ResourceWarning
+        )
+        # Unrelated leaks, including plain sockets, must not be muted.
+        warnings.warn("unclosed <socket.socket fd=6>", ResourceWarning)
+        warnings.warn("some unrelated warning", ResourceWarning)
+
+    assert [str(w.message) for w in caught] == [
+        "unclosed <socket.socket fd=6>",
+        "some unrelated warning",
+    ]

--- a/tests/test_docker_ssh_resources.py
+++ b/tests/test_docker_ssh_resources.py
@@ -33,25 +33,3 @@ def test_docker_ssh_resource_warnings_are_muted():
         "unclosed file <_io.TextIOWrapper name='foo.txt' mode='w'>",
         "some unrelated warning",
     ]
-
-
-def test_docker_ssh_resource_warnings_stay_muted_after_warning_hooks():
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("default")
-        docker_ssh._ignore_docker_ssh_resource_warnings()
-        # setup_warning_hooks() re-enables all Warning subclasses.
-        warnings.simplefilter("default", Warning)
-        docker_ssh._ignore_docker_ssh_resource_warnings()
-        warnings.warn("subprocess 123 is still running", ResourceWarning)
-        warnings.warn(
-            "unclosed <docker.transport.sshconn.SSHSocket fd=5>", ResourceWarning
-        )
-        warnings.warn(
-            "unclosed file <_io.FileIO name=10 mode='wb' closefd=True>",
-            ResourceWarning,
-        )
-        warnings.warn("unclosed <socket.socket fd=6>", ResourceWarning)
-
-    assert [str(w.message) for w in caught] == [
-        "unclosed <socket.socket fd=6>",
-    ]

--- a/tests/test_docker_ssh_resources.py
+++ b/tests/test_docker_ssh_resources.py
@@ -20,3 +20,21 @@ def test_docker_ssh_resource_warnings_are_muted():
         "unclosed <socket.socket fd=6>",
         "some unrelated warning",
     ]
+
+
+def test_docker_ssh_resource_warnings_stay_muted_after_warning_hooks():
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("default")
+        docker_ssh._ignore_docker_ssh_resource_warnings()
+        # setup_warning_hooks() re-enables all Warning subclasses.
+        warnings.simplefilter("default", Warning)
+        docker_ssh._ignore_docker_ssh_resource_warnings()
+        warnings.warn("subprocess 123 is still running", ResourceWarning)
+        warnings.warn(
+            "unclosed <docker.transport.sshconn.SSHSocket fd=5>", ResourceWarning
+        )
+        warnings.warn("unclosed <socket.socket fd=6>", ResourceWarning)
+
+    assert [str(w.message) for w in caught] == [
+        "unclosed <socket.socket fd=6>",
+    ]

--- a/tests/test_docker_ssh_resources.py
+++ b/tests/test_docker_ssh_resources.py
@@ -12,12 +12,25 @@ def test_docker_ssh_resource_warnings_are_muted():
         warnings.warn(
             "unclosed <docker.transport.sshconn.SSHSocket fd=5>", ResourceWarning
         )
-        # Unrelated leaks, including plain sockets, must not be muted.
+        warnings.warn(
+            "unclosed file <_io.FileIO name=10 mode='wb' closefd=True>",
+            ResourceWarning,
+        )
+        warnings.warn(
+            "unclosed file <_io.FileIO name=11 mode='rb' closefd=True>",
+            ResourceWarning,
+        )
+        # Unrelated leaks, including plain sockets and named files, must not be muted.
         warnings.warn("unclosed <socket.socket fd=6>", ResourceWarning)
+        warnings.warn(
+            "unclosed file <_io.TextIOWrapper name='foo.txt' mode='w'>",
+            ResourceWarning,
+        )
         warnings.warn("some unrelated warning", ResourceWarning)
 
     assert [str(w.message) for w in caught] == [
         "unclosed <socket.socket fd=6>",
+        "unclosed file <_io.TextIOWrapper name='foo.txt' mode='w'>",
         "some unrelated warning",
     ]
 
@@ -32,6 +45,10 @@ def test_docker_ssh_resource_warnings_stay_muted_after_warning_hooks():
         warnings.warn("subprocess 123 is still running", ResourceWarning)
         warnings.warn(
             "unclosed <docker.transport.sshconn.SSHSocket fd=5>", ResourceWarning
+        )
+        warnings.warn(
+            "unclosed file <_io.FileIO name=10 mode='wb' closefd=True>",
+            ResourceWarning,
         )
         warnings.warn("unclosed <socket.socket fd=6>", ResourceWarning)
 


### PR DESCRIPTION
## Motivation

`psynet debug ssh` (and other Docker-over-SSH deployments) can emit `ResourceWarning` messages for unclosed `docker.transport.sshconn.SSHSocket` instances, unreaped SSH subprocesses, and their leftover stdin/stdout `FileIO` pipes. The investigation in [PsyNetDev/PsyNet#1018](https://gitlab.com/PsyNetDev/PsyNet/-/work_items/1018) traced this to docker-py's shell-out SSH adapter: its connection pools are never tracked, so `docker_client.close()` cannot reach the spawned `ssh` subprocesses or their sockets, and they are only reclaimed at garbage collection. The warnings surface because Dallinger's `setup_warning_hooks()` enables display of all warnings, and GC can fire mid-command (for example during later imports).

An earlier revision of this PR fixed the leak by monkeypatching docker-py's SSH adapter classes. Review concluded that approach was too fragile: it subclassed four private docker-py classes with no version pin on `docker`, so a routine dependency upgrade could break every remote deploy. Since the leak is bounded by a short-lived CLI process (everything is reclaimed at exit), the PR now mutes the symptom instead.

Installing the filters only after `docker_client.close()` was not enough: the warnings appear during mid-command GC, before that `finally` block runs.

## Summary of changes

- Add `_ignore_docker_ssh_resource_warnings()` in `dallinger/command_line/docker_ssh.py`, which installs process-wide `warnings` filters for three `ResourceWarning` messages:
  - `subprocess N is still running`
  - `unclosed <docker.transport.sshconn.SSHSocket ...>`
  - `unclosed file <_io.FileIO name=N mode='wb'|'rb' closefd=True>` (the leaked SSH pipes)
- Call it in `build_and_push_image` **before** `docker.from_env()`, so mid-command GC cannot print the warnings.
- Named-file and plain-socket ResourceWarnings are left visible.
- Add tests for the three muted messages and for unrelated warnings that must still appear.

## Behavior changes

Docker-over-SSH image operations no longer print these spurious ResourceWarnings during the command or at interpreter cleanup. The underlying docker-py behavior is unchanged: `ssh` subprocesses still linger until the CLI process exits moments later, which is harmless for these short-lived commands. Local Docker and Paramiko-backed connections are unaffected.

## Testing

- `python -m pre_commit run --files dallinger/command_line/docker_ssh.py tests/test_docker_ssh_resources.py` — ruff check and format pass
- `python -m pytest tests/test_docker_ssh_resources.py` — 1 passed
- Live `psynet debug ssh --app fh-test-warning --server experiments1.cococo-lab.cornell.edu` from `demos/experiments/timeline`: after installing the filters before client creation and adding the FileIO filter, the previous `SSHSocket`, subprocess, and `FileIO` ResourceWarnings no longer appear after `Deployment temp directory`.

## Changelog

Added an unreleased `Fixed` entry to `CHANGELOG.md`.

## Automatic code review

The repo-local `/branch-review` command was offered when this pull request was first opened; the user chose to skip it. Later revisions of the mute approach were reviewed in follow-up sessions. This description update was not re-reviewed with `/branch-review`.

## Screenshots

Not applicable; there are no UI changes.
