### PR TITLE
Bump version on master branch post-release

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 12.3.0
+current_version = 12.4.0a1
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)((?P<release>[a-z]+)(?P<build>\d+))?
 serialize = 
 	{major}.{minor}.{patch}{release}{build}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [Unreleased]
+
 ## [v12.3.0](https://github.com/dallinger/dallinger/tree/v12.3.0) (2026-08-22)
 
 ### Migration Notes

--- a/dallinger/version.py
+++ b/dallinger/version.py
@@ -1,3 +1,3 @@
 """Dallinger version number."""
 
-__version__ = "12.3.0"
+__version__ = "12.4.0a1"

--- a/demos/pyproject.toml
+++ b/demos/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dlgr.demos"
-version = "12.3.0"
+version = "12.4.0a1"
 description = "Demonstration experiments for Dallinger"
 requires-python = ">=3.11"
 license = {text = "MIT"}

--- a/demos/requirements.txt
+++ b/demos/requirements.txt
@@ -1,2 +1,2 @@
 -c constraints.txt
-Dallinger==12.3.0
+Dallinger==12.4.0a1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "dallinger"
-version = "12.3.0"
+version = "12.4.0a1"
 maintainers = [
   {name = "Jordan Suchow", email = "jws@stevens.edu"},
   {name = "Peter Harrison", email = "pmch2@cam.ac.uk"},


### PR DESCRIPTION
## Motivation

Post-release version bump after v12.3.0 so `master` is no longer pinned at the released version.

## Summary of changes

- `bumpversion minor`: `12.3.0` → `12.4.0a1` in `.bumpversion.cfg`, `pyproject.toml`, `dallinger/version.py`, `demos/pyproject.toml`, and `demos/requirements.txt`
- Restored `## [Unreleased]` at the top of `CHANGELOG.md`

## Behavior changes

None. Bookkeeping only.

## Testing

- Version files read `12.4.0a1`

## Changelog

Restored `## [Unreleased]` above the `## [v12.3.0]` section. No new user-facing entries.

## Automatic code review

Skipped `/branch-review`. Post-release version bump only.

## Screenshots

N/A

Made with [Cursor](https://cursor.com)