### PR TITLE
Tag SSH and Heroku-docker images per launch and remove them on docker-ssh destroy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
 
 ### Fixed
 
+- SSH and Heroku-docker deploys now tag the experiment image with the
+  per-launch experiment UID instead of a hash of ``requirements.txt`` and
+  ``prepare_docker_image.sh``. Those files do not identify the copied
+  experiment code, so two variants (for example PsyNet ``audio_gibbs``
+  Lucid vs Prolific) could share one tag, race each other's builds, and
+  one app could run the other variant's code. Local ``docker debug`` still
+  uses the dependency hash because it bind-mounts the experiment directory.
+  ``dallinger docker build`` / ``push --use-existing`` also still use that
+  hash. ``dallinger docker-ssh destroy`` removes the compose-pinned
+  experiment image after ``compose down``. The image is kept if another
+  app's compose still pins it, and ``docker rmi`` is not forced, so a
+  shared ``docker_image_name`` in use by a container is also kept.
 - Frozen-plan Heroku and docker-ssh assembly now compile ``constraints.txt``
   in the staging directory instead of skipping generation. Experiments with
   ``deploy.toml`` no longer need a pre-existing ``constraints.txt`` in the

--- a/dallinger/command_line/docker.py
+++ b/dallinger/command_line/docker.py
@@ -337,7 +337,7 @@ def _deploy_in_mode(mode, verbose, app=None):
 
 
 def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
-    from dallinger.docker.tools import build_image
+    from dallinger.docker.tools import build_image, docker_tag_from_experiment_id
 
     config = get_config(load=True)
     heroku_app_id, tmp = setup_experiment(
@@ -353,12 +353,14 @@ def deploy_heroku_docker(log, verbose=True, app=None, exp_config=None):
         log("Registering the experiment on configured services...")
         registration.register(heroku_app_id, snapshot=None)
 
-    # Build experiment image
+    # Build experiment image. Tag with the launch UID so concurrent deploys
+    # cannot share or overwrite one image (the experiment is COPYd in, not mounted).
     image_name = build_image(
         tmp,
         config.get("docker_image_base_name") or Path(os.getcwd()).name,
         Output(),
         force_build=True,
+        image_tag=docker_tag_from_experiment_id(config.get("id")),
     )
     image_name = push_image(image_name)
 

--- a/dallinger/command_line/docker_ssh.py
+++ b/dallinger/command_line/docker_ssh.py
@@ -17,7 +17,7 @@ from email.utils import parseaddr
 from functools import wraps
 from getpass import getuser
 from io import BytesIO
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from secrets import token_urlsafe
 from shlex import quote
 from socket import gethostbyname_ex, gethostname
@@ -532,7 +532,7 @@ def build_and_push_image(f):
         import docker
 
         from dallinger.command_line.docker import push_image
-        from dallinger.docker.tools import build_image
+        from dallinger.docker.tools import build_image, docker_tag_from_experiment_id
 
         config = get_config(load=True)
         image_name = config.get("docker_image_name", None)
@@ -614,7 +614,10 @@ def build_and_push_image(f):
                 experiment_files=files,
             )
             image_name = build_image(
-                tmp_dir, config.get("docker_image_base_name"), out=Output()
+                tmp_dir,
+                config.get("docker_image_base_name"),
+                out=Output(),
+                image_tag=docker_tag_from_experiment_id(config.get("id")),
             )
 
             remote_build = not local_build
@@ -1083,6 +1086,72 @@ It currently resolves to {ipaddr_experiment}."""
     }
 
 
+def experiment_image_from_compose(compose_yml: str) -> str | None:
+    """Return the image compose pins on the experiment ``web`` service."""
+    if not compose_yml:
+        return None
+    match = re.search(r"(?m)^  web:\n(?:    .*\n)*?    image: (\S+)", compose_yml)
+    if not match:
+        return None
+    return match.group(1).strip().strip("'\"") or None
+
+
+def read_remote_experiment_image(executor, app: str) -> str | None:
+    """Read the experiment image name from an app's remote compose file."""
+    raw = executor.run(
+        f"cat ~/dallinger/{app}/docker-compose.yml",
+        raise_=False,
+    )
+    return experiment_image_from_compose(raw or "")
+
+
+def apps_pinning_image(grep_paths: str, except_app: str) -> list[str]:
+    """Return app names whose compose files pin an image, excluding ``except_app``."""
+    apps = []
+    for line in (grep_paths or "").splitlines():
+        line = line.strip()
+        if not line.endswith("docker-compose.yml"):
+            continue
+        app_name = PurePosixPath(line).parent.name
+        if app_name and app_name != except_app:
+            apps.append(app_name)
+    return apps
+
+
+def image_pinned_by_other_apps(executor, image_name: str, except_app: str) -> bool:
+    """True if another app's compose file still pins this experiment image."""
+    needle = f"    image: {image_name}"
+    raw = executor.run(
+        f"grep -xF -l {quote(needle)} $HOME/dallinger/*/docker-compose.yml",
+        raise_=False,
+    )
+    return bool(apps_pinning_image(raw or "", except_app))
+
+
+def remove_experiment_image(executor, image_name: str | None) -> None:
+    """Remove a compose-pinned experiment image.
+
+    ``docker rmi`` without ``--force`` leaves the image if a container still
+    uses it.
+    """
+    if not image_name:
+        return
+    print(f"Removing experiment image {image_name}")
+    executor.run(f"docker rmi {quote(image_name)}", raise_=False)
+
+
+def remove_unshared_experiment_image(
+    executor, image_name: str | None, except_app: str
+) -> None:
+    """Remove an experiment image unless another app's compose still pins it."""
+    if not image_name:
+        return
+    if image_pinned_by_other_apps(executor, image_name, except_app):
+        print(f"Not removing image {image_name}: another app still pins it in compose")
+        return
+    remove_experiment_image(executor, image_name)
+
+
 def get_experiment_id_from_archive(archive_path):
     with zipfile.ZipFile(archive_path) as archive:
         with archive.open("experiment_id.md") as fh:
@@ -1298,6 +1367,10 @@ def destroy(server, app):
         print(f"App {app} is not deployed")
         raise click.Abort()
 
+    experiment_image = None
+    if docker_compose_exists:
+        experiment_image = read_remote_experiment_image(executor, app)
+
     # Inspect the active Caddyfile only after we know the app exists.
     caddyfile_content = executor.run("cat ~/dallinger/Caddyfile", raise_=False)
     uses_root_domain = f"reverse_proxy {app}_web:5000" in caddyfile_content
@@ -1324,6 +1397,7 @@ def destroy(server, app):
     executor.run(
         f"docker compose -f ~/dallinger/{app}/docker-compose.yml down", raise_=False
     )
+    remove_unshared_experiment_image(executor, experiment_image, except_app=app)
     executor.run(f"rm -rf ~/dallinger/{app}/")
     print(f"App {app} removed")
 

--- a/dallinger/docker/tools.py
+++ b/dallinger/docker/tools.py
@@ -258,15 +258,13 @@ def get_required_dallinger_version(experiment_tmp_path: str) -> str:
 
 
 def get_experiment_image_tag(experiment_tmp_path: str) -> str:
-    """Return a docker image tag to be used for the experiment.
+    """Return a docker image tag from the experiment's dependency inputs.
 
-    The tag needs to be a hash of all the files that, when changed,
-    require the image to be rebuilt.
-
-    When an experiment is changed an older image can still be used,
-    as long as no dependencies or build script changed.
-    The experiment directory can then be mounted to have the latest changes.
-    This saves the need to rebuild the image too often.
+    Used for local ``docker debug`` (the experiment directory is bind-mounted,
+    so the image is only a deps environment) and for ``dallinger docker build``
+    / ``push --use-existing``. SSH and Heroku-docker deploys instead pass
+    :func:`docker_tag_from_experiment_id` into :func:`build_image`, because
+    those paths ``COPY`` the experiment into the image.
     """
     files = "requirements.txt", "prepare_docker_image.sh"
     hash = sha256()
@@ -276,14 +274,40 @@ def get_experiment_image_tag(experiment_tmp_path: str) -> str:
     return hash.hexdigest()[:8]
 
 
+def docker_tag_from_experiment_id(experiment_id: str) -> str:
+    """Return a Docker tag unique to this launch.
+
+    On SSH and Heroku-docker deploy the experiment directory is copied into
+    the image and compose pins that tag for the life of the app. A deps-only
+    hash is then unsafe: two variants with the same ``requirements.txt`` and
+    ``prepare_docker_image.sh`` share a tag, race each other's builds, and
+    one app can run the other variant's code.
+
+    ``experiment_id`` is the per-launch UID from ``setup_experiment``. Docker
+    tags allow ``[A-Za-z0-9_.-]`` and must not start with ``.`` or ``-``.
+    """
+    tag = "".join(
+        ch if ch.isalnum() or ch in "_.-" else "-" for ch in str(experiment_id)
+    )
+    tag = tag.lstrip(".-") or "latest"
+    return tag[:128]
+
+
 def build_image(
-    tmp_dir, base_image_name, out, needs_chrome=False, force_build=True
+    tmp_dir,
+    base_image_name,
+    out,
+    needs_chrome=False,
+    force_build=True,
+    image_tag=None,
 ) -> str:
     """Build the docker image for the experiment and return its name.
-    If force_build=False, then the image will only be rebuilt if requirements.txt or prepare_docker_image.sh
-    have changed.
+
+    If ``image_tag`` is set, use it (deploy: per-launch UID). Otherwise hash
+    ``requirements.txt`` and ``prepare_docker_image.sh``. If
+    ``force_build`` is False, skip the build when that tag already exists.
     """
-    tag = get_experiment_image_tag(tmp_dir)
+    tag = image_tag or get_experiment_image_tag(tmp_dir)
     image_name = f"{base_image_name}:{tag}"
     base_image_name = get_base_image(tmp_dir, needs_chrome)
     client = docker.client.from_env()

--- a/tests/test_docker.py
+++ b/tests/test_docker.py
@@ -105,10 +105,14 @@ def test_deploy_heroku_docker_pushes_without_reassembling(tmp_path):
     config.get.side_effect = lambda key, default=None: {
         "mode": "debug",
         "docker_image_base_name": "registry/exp",
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     }.get(key, default)
 
     fake_tools = mock.Mock()
     fake_tools.build_image.return_value = "registry/exp:tag"
+    fake_tools.docker_tag_from_experiment_id.side_effect = lambda experiment_id: (
+        experiment_id
+    )
 
     with (
         mock.patch.object(docker_cli, "get_config", return_value=config),
@@ -126,7 +130,11 @@ def test_deploy_heroku_docker_pushes_without_reassembling(tmp_path):
 
     setup.assert_called_once()
     fake_tools.build_image.assert_called_once_with(
-        str(tmp_path), "registry/exp", mock.ANY, force_build=True
+        str(tmp_path),
+        "registry/exp",
+        mock.ANY,
+        force_build=True,
+        image_tag="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     )
     push_image.assert_called_once_with("registry/exp:tag")
 
@@ -146,3 +154,63 @@ def test_num_dynos():
     result = get_yaml({"num_dynos_worker": n})
     for i in range(n):
         assert f"worker_{i + 1}" in result["services"]
+
+
+def make_experiment_tmp_dir(tmp_path, name="exp"):
+    """Create a minimal assembled experiment directory for tag hashing tests."""
+    exp_dir = tmp_path / name
+    (exp_dir / "static").mkdir(parents=True)
+    (exp_dir / "requirements.txt").write_text("dallinger==12.3.0\n")
+    (exp_dir / "prepare_docker_image.sh").write_text("#!/bin/sh\ntrue\n")
+    (exp_dir / "experiment.py").write_text("class Exp:\n    pass\n")
+    (exp_dir / "static" / "script.js").write_text("console.log('hi');\n")
+    return exp_dir
+
+
+def test_deps_image_tag_ignores_experiment_code(tmp_path):
+    """Local docker debug hashes only dependency inputs.
+
+    experiment.py is bind-mounted, so a code-only change must keep the same
+    tag. SSH/Heroku-docker deploys do not use this hash.
+    """
+    from dallinger.docker.tools import get_experiment_image_tag
+
+    exp_dir = make_experiment_tmp_dir(tmp_path)
+    tag_before = get_experiment_image_tag(str(exp_dir))
+    (exp_dir / "experiment.py").write_text("class Exp:\n    variant = 'other'\n")
+    (exp_dir / "static" / "script.js").write_text("console.log('changed');\n")
+    assert get_experiment_image_tag(str(exp_dir)) == tag_before
+
+
+def test_deps_image_tag_changes_when_requirements_change(tmp_path):
+    from dallinger.docker.tools import get_experiment_image_tag
+
+    exp_dir = make_experiment_tmp_dir(tmp_path)
+    tag_before = get_experiment_image_tag(str(exp_dir))
+    (exp_dir / "requirements.txt").write_text("dallinger==12.4.0\n")
+    assert get_experiment_image_tag(str(exp_dir)) != tag_before
+
+
+def test_deps_image_tag_changes_when_prepare_script_changes(tmp_path):
+    from dallinger.docker.tools import get_experiment_image_tag
+
+    exp_dir = make_experiment_tmp_dir(tmp_path)
+    tag_before = get_experiment_image_tag(str(exp_dir))
+    (exp_dir / "prepare_docker_image.sh").write_text("#!/bin/sh\necho other\n")
+    assert get_experiment_image_tag(str(exp_dir)) != tag_before
+
+
+def test_deploy_image_tag_is_unique_per_launch():
+    """Copied-in deploys must not share a tag across launches."""
+    from dallinger.docker.tools import docker_tag_from_experiment_id
+
+    lucid = docker_tag_from_experiment_id("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+    prolific = docker_tag_from_experiment_id("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+    assert lucid != prolific
+    assert lucid == "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+
+
+def test_deploy_image_tag_sanitizes_invalid_docker_characters():
+    from dallinger.docker.tools import docker_tag_from_experiment_id
+
+    assert docker_tag_from_experiment_id("exp=id:with/slash") == "exp-id-with-slash"

--- a/tests/test_docker_ssh_apps.py
+++ b/tests/test_docker_ssh_apps.py
@@ -1,10 +1,14 @@
 import importlib
+import subprocess
 import sys
+import uuid
 from pathlib import Path
 from unittest import mock
 
 import click
 import pytest
+
+from dallinger.docker.tools import docker_tag_from_experiment_id
 
 docker_ssh_module = importlib.import_module("dallinger.command_line.docker_ssh")
 
@@ -164,6 +168,7 @@ def test_docker_ssh_reuses_validated_source_after_destructive_preflight(
     config.get.side_effect = lambda key, default=None: {
         "docker_image_name": None,
         "docker_image_base_name": "base-image",
+        "id": "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
     }.get(key, default)
     config.as_dict.return_value = {"example": "value"}
     docker_client = mock.Mock()
@@ -216,7 +221,9 @@ def test_docker_ssh_reuses_validated_source_after_destructive_preflight(
         mock.patch.object(docker_ssh_module, "ensure_remote_host_in_known_hosts"),
         mock.patch.object(docker_ssh_module, "add_server_pem_to_ssh_agent"),
         mock.patch("docker.from_env", return_value=docker_client),
-        mock.patch("dallinger.docker.tools.build_image", return_value="built:image"),
+        mock.patch(
+            "dallinger.docker.tools.build_image", return_value="built:image"
+        ) as build_image,
     ):
         result = wrapper(
             server="test-server",
@@ -235,6 +242,9 @@ def test_docker_ssh_reuses_validated_source_after_destructive_preflight(
         "remote-discovery",
         "assemble",
     ]
+    assert build_image.call_args.kwargs["image_tag"] == (
+        "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    )
 
 
 def test_docker_ssh_local_build_pushes_without_reassembling(tmp_path, monkeypatch):
@@ -243,6 +253,7 @@ def test_docker_ssh_local_build_pushes_without_reassembling(tmp_path, monkeypatc
     config.get.side_effect = lambda key, default=None: {
         "docker_image_name": None,
         "docker_image_base_name": "base-image",
+        "id": "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
     }.get(key, default)
     config.as_dict.return_value = {}
     wrapped_command = mock.Mock(return_value="deployed")
@@ -252,6 +263,7 @@ def test_docker_ssh_local_build_pushes_without_reassembling(tmp_path, monkeypatc
     fake_docker = mock.MagicMock()
     fake_tools = mock.Mock()
     fake_tools.build_image.return_value = "built:image"
+    fake_tools.docker_tag_from_experiment_id = docker_tag_from_experiment_id
 
     monkeypatch.chdir(tmp_path)
     with (
@@ -285,3 +297,173 @@ def test_docker_ssh_local_build_pushes_without_reassembling(tmp_path, monkeypatc
     push_image.assert_called_once_with("built:image")
     wrapped_command.assert_called_once()
     assert wrapped_command.call_args.kwargs["image_name"] == "pushed:image"
+    assert fake_tools.build_image.call_args.kwargs["image_tag"] == (
+        "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    )
+
+
+def test_experiment_image_from_compose_reads_web_not_infra_images():
+    yml = docker_ssh_module.get_docker_compose_yml(
+        {
+            "num_dynos_worker": 2,
+            "clock_on": True,
+            "docker_worker_cpu_shares": 1024,
+            "docker_image_name": "ghcr.io/org/exp:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        },
+        "my-app",
+        "ghcr.io/org/exp:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+        "pw",
+    )
+    parsed = docker_ssh_module.experiment_image_from_compose(yml)
+    assert parsed == "ghcr.io/org/exp:aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    assert parsed not in {
+        "redis",
+        "postgres:12",
+        "caddy:2",
+        "docker.io/bitnamilegacy/pgbouncer:1.24.1",
+        "amir20/dozzle:v10.0.2",
+    }
+
+
+def test_remove_experiment_image_runs_docker_rmi_without_force():
+    executor = mock.Mock()
+    docker_ssh_module.remove_experiment_image(executor, "registry/exp:old-uid")
+    executor.run.assert_called_once_with(
+        "docker rmi registry/exp:old-uid", raise_=False
+    )
+    assert "--force" not in executor.run.call_args[0][0]
+
+
+def test_remove_unshared_skips_rmi_when_another_app_pins_the_image():
+    executor = mock.Mock()
+    executor.run.return_value = "/home/ubuntu/dallinger/otherapp/docker-compose.yml\n"
+    docker_ssh_module.remove_unshared_experiment_image(
+        executor, "registry/exp:shared", except_app="myapp"
+    )
+    commands = [call.args[0] for call in executor.run.call_args_list]
+    assert any(cmd.startswith("grep -xF -l") for cmd in commands)
+    assert not any(cmd.startswith("docker rmi") for cmd in commands)
+
+
+def _patch_destroy_executor(monkeypatch, run):
+    executor = mock.Mock()
+    executor.run.side_effect = run
+    monkeypatch.setattr(
+        docker_ssh_module,
+        "CONFIGURED_HOSTS",
+        {"test-server": {"host": "example.com", "user": "ubuntu"}},
+    )
+    monkeypatch.setattr(docker_ssh_module, "Executor", lambda *args, **kwargs: executor)
+    return executor
+
+
+def test_destroy_removes_unique_image_after_down_not_infra(monkeypatch):
+    compose_yml = docker_ssh_module.get_docker_compose_yml(
+        {},
+        "myapp",
+        "registry/exp:old-uid",
+        "pw",
+    )
+    commands = []
+
+    def run(cmd, raise_=True):
+        commands.append(cmd)
+        if cmd.startswith("test -f") and "caddy.d" in cmd:
+            return ""
+        if cmd.startswith("test -f") and "docker-compose.yml" in cmd:
+            return "Yes"
+        if cmd == "cat ~/dallinger/myapp/docker-compose.yml":
+            return compose_yml
+        if cmd == "cat ~/dallinger/Caddyfile":
+            return "https://example.com {\n    reverse_proxy other_web:5000\n}\n"
+        if cmd.startswith("grep -xF -l"):
+            return "/home/ubuntu/dallinger/myapp/docker-compose.yml\n"
+        return ""
+
+    _patch_destroy_executor(monkeypatch, run)
+    docker_ssh_module.destroy.callback(server="test-server", app="myapp")
+
+    down = "docker compose -f ~/dallinger/myapp/docker-compose.yml down"
+    rmi = "docker rmi registry/exp:old-uid"
+    rm_tree = "rm -rf ~/dallinger/myapp/"
+    assert commands.index(down) < commands.index(rmi) < commands.index(rm_tree)
+    rmi_commands = [cmd for cmd in commands if cmd.startswith("docker rmi")]
+    assert rmi_commands == [rmi]
+    for forbidden in (
+        "redis",
+        "postgres:12",
+        "caddy:2",
+        "pgbouncer",
+        "amir20/dozzle",
+    ):
+        assert not any(forbidden in cmd for cmd in rmi_commands)
+
+
+class _LocalDockerExecutor:
+    def run(self, cmd, raise_=True):
+        result = subprocess.run(
+            cmd, shell=True, capture_output=True, text=True, check=False
+        )
+        if raise_ and result.returncode != 0:
+            raise RuntimeError(result.stderr)
+        return result.stdout
+
+
+def _docker_image_exists(tag):
+    return (
+        subprocess.run(
+            ["docker", "image", "inspect", tag],
+            capture_output=True,
+            check=False,
+        ).returncode
+        == 0
+    )
+
+
+def _import_empty_image(tag):
+    empty_tar = subprocess.check_output(["tar", "-c", "-T", "/dev/null"])
+    subprocess.run(
+        ["docker", "import", "--change", 'CMD ["true"]', "-", tag],
+        input=empty_tar,
+        check=True,
+    )
+
+
+@pytest.mark.docker
+def test_real_docker_rmi_removes_unused_tag_and_keeps_in_use_and_prefix_tags():
+    suffix = uuid.uuid4().hex[:12]
+    unused = f"dallinger-cleanup-test-{suffix}:unused"
+    in_use = f"dallinger-cleanup-test-{suffix}:in-use"
+    prefix_short = f"dallinger-cleanup-test-{suffix}:abc"
+    prefix_long = f"dallinger-cleanup-test-{suffix}:abcd"
+    container = f"dallinger-cleanup-test-{suffix}"
+    executor = _LocalDockerExecutor()
+    created = []
+    try:
+        for tag in (unused, in_use, prefix_short, prefix_long):
+            _import_empty_image(tag)
+            created.append(tag)
+            assert _docker_image_exists(tag)
+
+        subprocess.run(
+            ["docker", "create", "--name", container, in_use],
+            check=True,
+            capture_output=True,
+        )
+
+        docker_ssh_module.remove_experiment_image(executor, unused)
+        docker_ssh_module.remove_experiment_image(executor, in_use)
+        docker_ssh_module.remove_experiment_image(executor, prefix_short)
+
+        assert not _docker_image_exists(unused)
+        assert _docker_image_exists(in_use)
+        assert not _docker_image_exists(prefix_short)
+        assert _docker_image_exists(prefix_long)
+    finally:
+        subprocess.run(
+            ["docker", "rm", "-f", container], capture_output=True, check=False
+        )
+        for tag in created:
+            subprocess.run(
+                ["docker", "rmi", "-f", tag], capture_output=True, check=False
+            )


### PR DESCRIPTION
## Motivation

`get_experiment_image_tag` hashed only `requirements.txt` and `prepare_docker_image.sh`. That answers "do we need a new pip install?", not "is this the same launch?". On SSH and Heroku-docker deploy the Dockerfile ends with `COPY . /experiment` and compose does **not** mount the experiment directory. Two experiment variants that share those two hashed files therefore get the **same image name**, race each other's builds, and one app can end up running the other variant's code.

This was observed in PsyNet's `audio_gibbs` deployment tests ([MR !1180](https://gitlab.com/PsyNetDev/PsyNet/-/merge_requests/1180), [discussion](https://gitlab.com/PsyNetDev/PsyNet/-/merge_requests/1180#note_3775576879)): the Lucid app ran the Prolific `experiment.py` and a paid survey stayed live. Image tagging is Dallinger's job; PsyNet can only stamp `prepare_docker_image.sh` as a workaround.

This PR is the smaller deploy-path fix from that discussion rather than a full build-context hash. A context hash would in practice be unique per launch anyway, because `assemble_experiment_temp_dir` writes the fresh `experiment_id.txt` and a generated `dashboard_password` into the build context — so the UID is the same guarantee for less work. Local `docker debug` bind-mounts the experiment tree, so the dependency hash stays correct there.

Per-launch tags mean images no longer replace each other, so `dallinger docker-ssh destroy` now removes the app's image.

## Summary of changes

**Per-launch image tag**

- `build_image(..., image_tag=None)` in `dallinger/docker/tools.py`: when `image_tag` is given, use it; otherwise keep hashing `requirements.txt` and `prepare_docker_image.sh`. The new parameter is appended last, so existing positional callers are unaffected.
- New `docker_tag_from_experiment_id` sanitizes the per-launch UID that `setup_experiment` writes to `config["id"]` into a valid Docker tag.
- `dallinger docker-ssh` (`build_and_push_image`) and Heroku-docker deploy (`deploy_heroku_docker`) pass that UID tag. Both call sites run after `setup_experiment`, so `config["id"]` is always populated.
- A unique tag never hits the inspect-and-skip branch; `force_build` stays true as before, and BuildKit layer caching still applies.
- Local `docker debug` still uses the dependency hash (the experiment directory is bind-mounted). `dallinger docker build` and `dallinger docker push` also still use that hash; those paths `COPY` the experiment into the image and are out of scope for this PR.

**Image cleanup on `destroy`** (`dallinger/command_line/docker_ssh.py`)

- After `docker compose down`, `destroy` removes the image pinned by the app's compose `web.image` (parsed from `~/dallinger/<app>/docker-compose.yml`, which has had the same `    image:` line since the original deploy code), then `rm -rf`s the app directory as before.
- Safety: the image is kept if any other app's compose still pins it (`grep -xF` over `~/dallinger/*/docker-compose.yml`), `docker rmi` is never `--force`d (Docker refuses while any container, running or stopped, uses the image), and the cleanup commands run with `raise_=False`. Infra images (redis, postgres, pgbouncer, caddy, dozzle) live in the server compose file and are never named.
- `--update` does not touch images. The image from before an update stays on the server until that app is destroyed.
- Fresh deploys and `--update` run no extra commands; `destroy` adds one `cat`, one `grep`, and one `rmi` over SSH.

## Behavior changes

Each SSH/Heroku-docker launch gets its own image tag, so concurrent deploys (Lucid vs Prolific, or any two variants) can no longer overwrite each other or run each other's code.

`dallinger docker-ssh destroy` now removes the app's experiment image from the server; previously the image stayed until someone pruned it.

`docker rmi` removes the image from `docker images`, but with BuildKit the layer bytes stay in the build cache and become *reclaimable* (verified locally: image size dropped, `Build Cache RECLAIMABLE` grew by the same amount). That is what keeps a redeploy fast — after removing every tag, a rebuild still reported the dependency `RUN` step as `CACHED` (0.4 s vs 4 s). Disk is actually freed by BuildKit's GC policy or `docker builder prune`, not immediately by `rmi`.

Users of a shared `docker_image_name`: destroying the last app that pins the image removes the server's local copy; the next deploy re-pulls it from the registry.

Not addressed: images left by `--update` until `destroy`, images for apps that are never destroyed, registry tags pushed with `--local-build` / `--push-build`, and per-launch images left on the developer's machine by Heroku-docker and `--local-build`.

## Testing

- `python -m pytest tests/test_docker.py tests/test_docker_ssh_apps.py tests/test_deployment.py` — 123 passed, 18 skipped (includes the docker-marked test).
- `RUN_DOCKER=1 python -m pytest tests/test_docker_ssh_apps.py::test_real_docker_rmi_removes_unused_tag_and_keeps_in_use_and_prefix_tags` against a real daemon (Docker 29.1.3): unused tag removed, tag with a stopped container kept, `:abc` vs `:abcd` tags independent.
- Real-shell check of `grep -xF -l` over fake `~/dallinger/*/docker-compose.yml` files: exact-line matches only, `except_app` excluded.
- BuildKit probe (see Behavior changes) confirming `rmi` does not slow the next build.
- `pre-commit` (ruff check/format) passes.
- Not exercised: a real SSH deploy / `destroy` round trip.

New tests: deps hash ignoring experiment code and reacting to `requirements.txt` / `prepare_docker_image.sh`; per-launch tag uniqueness and sanitization; both deploy call sites passing `image_tag`; compose `web.image` parsing (not infra images); `rmi` never forced; skipping `rmi` when another app pins the image; `destroy` ordering (`down` → `rmi` → `rm -rf`); the real-daemon `rmi` test.

## Changelog

`CHANGELOG.md` has an entry under Unreleased → Fixed describing the UID-on-deploy tagging and the `destroy` cleanup.

## Automatic code review

Ran the repo-local `/branch-review` command against `origin/master...HEAD` (2026-09-07, final pass on `4b910d728`), plus an explicit walk of every `docker rmi` path for unwanted deletions and real-daemon checks that deletion is effective and does not add rebuild overhead. No correctness bugs found in the final diff. Findings and how they were handled:

1. **Commit history does not match the final diff.** `c016798a4` is titled "Hash the whole build context…" but the branch never ships a context hash; `0a0b33133` adds `--update` image rotation that `4b910d728` removes. Recommend squash-merging this PR (or reorganising into two commits: tag + destroy cleanup).
2. An earlier revision deleted the previous image on `--update`, then added a rollback slot to keep it. Both were dropped: Dallinger has no rollback command, and the slot was a second ledger next to compose. `--update` now leaves images alone; only `destroy` removes them.
3. Image retention after the switch to per-launch tags — addressed by the cleanup on `destroy`; remaining cases listed under **Behavior changes**.
4. The changelog originally implied `dallinger docker build` / `push` bind-mount like `docker debug`; only debug does — wording fixed.
5. `docker_tag_from_experiment_id` falls back silently on degenerate input — `None` becomes the tag `"None"`, an all-punctuation id becomes `"latest"` — which would reintroduce a shared tag. `config.get("id")` raises when unset and `setup_experiment` always sets a UUID, so this is unreachable from the current call sites; left as is and untested.
6. `dallinger docker build` / `push` still tag a code-baked image with the dependency hash; the same class of collision remains there and is deliberately out of scope.
7. Shared `docker_image_name`: destroying the last pinning app evicts the server's local copy (cache eviction, not data loss) — documented, not changed.
8. Nit, not changed: `apps_pinning_image` returns a list that is only consumed as a bool.
9. The cleanup test suite was trimmed to the tests that lock an invariant; helper-level restatements were removed.

## Screenshots

Not applicable.
