### PR TITLE
Add translate=False to get_participant_submission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,13 @@
 - Matched the documented ``dallinger deployment-files init`` starter
   ``paths``, ``names``, and ``suffixes`` lists to the CLI.
 
+### Changed
+
+- ``ProlificService.get_participant_submission`` accepts ``translate=False``
+  to return the Prolific payload (including ``bonus_payments``) or ``None``
+  on a miss, instead of translating fields and raising a recruitment
+  error. ``_req`` takes ``raise_on_error`` (default ``True``).
+
 ## [v12.3.0](https://github.com/dallinger/dallinger/tree/v12.3.0) (2026-08-22)
 
 ### Migration Notes

--- a/dallinger/prolific.py
+++ b/dallinger/prolific.py
@@ -121,26 +121,40 @@ class ProlificService:
             json={"action": "APPROVE"},
         )
 
-    def get_participant_submission(self, submission_id: str) -> dict:
-        """Retrieve details of a participant Submission
+    def get_participant_submission(
+        self, submission_id: str, *, translate: bool = True
+    ) -> Optional[dict]:
+        """Retrieve details of a participant Submission.
 
         See: https://docs.prolific.com/api-reference/submissions
 
         This is roughly equivalent to an Assignment on MTurk.
 
-        Example return value:
+        By default the result is translated to Dallinger assignment fields
+        and a miss is a recruitment error. Pass ``translate=False`` to return
+        the Prolific payload (including ``bonus_payments``) or ``None`` on a
+        miss.
+
+        Example return value (default):
 
         {
-            "id": "60d9aadeb86739de712faee0",
-            "study_id": "60aca280709ee40ec37d4885",
-            "participant": "60bf9310e8dec401be6e9615",
+            "assignment_id": "60d9aadeb86739de712faee0",
+            "hit_id": "60aca280709ee40ec37d4885",
+            "worker_id": "60bf9310e8dec401be6e9615",
             "started_at": "2021-05-20T11:03:00.457Z",
             "status": "ACTIVE",
         }
         """
-        response = self._req(method="GET", endpoint=f"/submissions/{submission_id}/")
-        if response:
-            return _translate_submission_from_get_submission(response)
+        response = self._req(
+            method="GET",
+            endpoint=f"/submissions/{submission_id}/",
+            raise_on_error=translate,
+        )
+        if not response:
+            return None
+        if not translate:
+            return response
+        return _translate_submission_from_get_submission(response)
 
     def get_total_cost(self, study_id: str) -> float:
         """Get the total cost of a study including platform fees in cents."""
@@ -561,7 +575,9 @@ class ProlificService:
         """
         return self._req(method="GET", endpoint="/users/me/")
 
-    def _req(self, method: str, endpoint: str, **kw) -> dict:
+    def _req(
+        self, method: str, endpoint: str, *, raise_on_error: bool = True, **kw
+    ) -> Optional[dict]:
         """Runs the actual request/response cycle:
         * Adds Authorization header
         * Adds Referer header to help Prolific identify our requests
@@ -569,6 +585,9 @@ class ProlificService:
         * Logs all requests (we might want to stop doing this when we're
           out of our "beta" period with Prolific)
         * Parses response and does error handling
+
+        When ``raise_on_error`` is false, a miss returns ``None`` instead of a
+        recruitment error.
         """
         from dallinger.recruiters import handle_and_raise_recruitment_error
 
@@ -583,7 +602,12 @@ class ProlificService:
             "args": kw,
         }
         logger.warning(f"Prolific API request: {json.dumps(summary)}")
-        response = requests.request(method, url, headers=headers, **kw)
+        try:
+            response = requests.request(method, url, headers=headers, **kw)
+        except requests.RequestException:
+            if not raise_on_error:
+                return None
+            raise
 
         if method == "DELETE" and response.ok:
             return {"status_code": response.status_code}
@@ -591,13 +615,17 @@ class ProlificService:
         try:
             parsed = response.json()
         except requests.exceptions.JSONDecodeError as err:
+            if not raise_on_error:
+                return None
             handle_and_raise_recruitment_error(
                 ProlificServiceException(
                     f"Failed to parse the following JSON response from Prolific: {err.doc}"
                 )
             )
 
-        if "error" in parsed:
+        if isinstance(parsed, dict) and "error" in parsed:
+            if not raise_on_error:
+                return None
             error = {
                 "method": method,
                 "token": self.api_token_fragment,
@@ -608,6 +636,9 @@ class ProlificService:
             handle_and_raise_recruitment_error(
                 ProlificServiceException(json.dumps(error))
             )
+
+        if not raise_on_error and not response.ok:
+            return None
 
         return parsed
 
@@ -721,7 +752,9 @@ class DevProlificService(ProlificService):
 
         return True
 
-    def _req(self, method: str, endpoint: str, **kw) -> dict:
+    def _req(
+        self, method: str, endpoint: str, *, raise_on_error: bool = True, **kw
+    ) -> Optional[dict]:
         """Does NOT make any requests but instead writes to the log."""
         self.log_request(method=method, endpoint=endpoint, **kw)
         response = None

--- a/tests/test_prolific.py
+++ b/tests/test_prolific.py
@@ -534,6 +534,65 @@ def test_get_submissions_requires_study_id(subject):
     subject._req.assert_not_called()
 
 
+def test_get_participant_submission_without_translate_returns_payload(subject):
+    payload = {
+        "id": "sub-1",
+        "status": "ACTIVE",
+        "bonus_payments": [20, 30],
+    }
+    response = mock.MagicMock()
+    response.ok = True
+    response.json.return_value = payload
+    with mock.patch(
+        "dallinger.prolific.requests.request", return_value=response
+    ) as req:
+        assert subject.get_participant_submission("sub-1", translate=False) == payload
+    assert req.call_args.args[:2] == (
+        "GET",
+        f"{subject.api_root}/submissions/sub-1/",
+    )
+
+
+def test_get_participant_submission_without_translate_returns_none_on_http_error(
+    subject,
+):
+    response = mock.MagicMock()
+    response.ok = False
+    response.status_code = 404
+    with mock.patch("dallinger.prolific.requests.request", return_value=response):
+        with mock.patch(
+            "dallinger.recruiters.handle_and_raise_recruitment_error"
+        ) as handle:
+            assert (
+                subject.get_participant_submission("missing", translate=False) is None
+            )
+            handle.assert_not_called()
+
+
+def test_get_participant_submission_still_raises_on_error_payload(subject):
+    response = mock.MagicMock()
+    response.ok = True
+    response.json.return_value = {"error": "not found"}
+    with mock.patch("dallinger.prolific.requests.request", return_value=response):
+        with pytest.raises(ProlificServiceException):
+            subject.get_participant_submission("sub-1")
+
+
+def test_dev_get_participant_submission_without_translate_goes_through_req(
+    active_config,
+):
+    active_config.extend(
+        {"prolific_workspace": "My Workspace", "prolific_project": "My Project"}
+    )
+    service = DevProlificService(
+        api_token="fake-token", api_version="v1", referer_header="test-header"
+    )
+    with mock.patch("dallinger.prolific.requests.request") as req:
+        fetched = service.get_participant_submission("sub1", translate=False)
+    req.assert_not_called()
+    assert fetched["status"] == "AWAITING REVIEW"
+
+
 def _make_pages(page_lengths):
     pages = []
     next_id = 0


### PR DESCRIPTION
## Motivation

PsyNet dashboard and unpaid-base retry reads need the raw Prolific submission, including `bonus_payments`, and must tolerate a miss. `get_participant_submission` translated the row and treated a miss as a recruitment error, so PsyNet issued a raw `requests.get` that bypassed `_req` and `DevProlificService`.

The native operation is the existing `GET /submissions/{id}/` through `_req`. This PR adds a `translate` flag on that method instead of a second getter.

## Summary of changes

- `ProlificService.get_participant_submission(submission_id, *, translate=True)`: default path is unchanged (translated fields, raise on miss).
- `translate=False` returns the Prolific payload (including `bonus_payments`) or `None` on a miss, without calling `handle_and_raise_recruitment_error`.
- `_req(..., raise_on_error=True)` is the explicit flag (default raise). `translate=False` passes `raise_on_error=False`.
- `DevProlificService` is unchanged except it accepts the new keyword on `_req`.

## Behavior changes

Existing `get_participant_submission` callers are unchanged. New `translate=False` callers get the full Prolific row or `None`.

## Testing

- Local: four `get_participant_submission` cases (untranslated hit, untranslated miss without the error hook, default still raises, Dev canned GET)
- Full `pytest` / `tox` not run

## Changelog

Unreleased Changed entry in `CHANGELOG.md`.

## Automatic code review

Addressed review comments: merged the two single-id GETs into one method with `translate=`, and renamed `quiet` to `raise_on_error`.

## Screenshots

N/A