### PR TITLE
Show a progress bar while the experiment URL starts up and fail launch without a traceback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,12 @@
   assembling the experiment a second time.
 - Editable installs now fall back to the source tree when
   ``importlib.metadata`` omits a file list or packaged Docker templates.
+- Experiment launch waits for the URL to become reachable (TLS, connection,
+  or gateway startup) with a pulsing progress bar instead of printing those
+  retries as launch failures. The last error is still reported if launch does
+  not succeed before the timeout, and a failed launch now ends with a short
+  ``Error: Experiment launch failed. ...`` diagnosis instead of a Python
+  traceback.
 
 ### Updated
 

--- a/dallinger/deployment.py
+++ b/dallinger/deployment.py
@@ -2,13 +2,23 @@ import codecs
 import json
 import os
 import re
+import sys
 import threading
 import time
 from shlex import quote
 from urllib.parse import urlparse, urlunparse
 
+import click
 import redis
 import requests
+from rich.console import Console
+from rich.progress import (
+    BarColumn,
+    Progress,
+    SpinnerColumn,
+    TextColumn,
+    TimeElapsedColumn,
+)
 
 from dallinger import data, db, heroku, recruiters, registration
 from dallinger.config import get_config
@@ -27,6 +37,63 @@ from dallinger.utils import (
 DEFAULT_DELAY = 1
 BACKOFF_FACTOR = 2
 MAX_ATTEMPTS = 6
+STARTUP_STATUS_CODES = frozenset({502, 503, 504})
+HTTPS_WAIT_MESSAGE = "Waiting for the experiment URL to become reachable"
+# Status, not an error: write to stdout. Only the bar is restyled; Rich's
+# default complete/pulse color is magenta-red.
+_HTTPS_WAIT_BAR_STYLE = "green"
+
+
+def _is_startup_exception(exc):
+    """True when the launch URL is not accepting HTTPS/HTTP yet."""
+    return isinstance(
+        exc,
+        (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.RetryError,
+            requests.exceptions.ChunkedEncodingError,
+        ),
+    )
+
+
+def _is_startup_status(status_code):
+    """True for gateway statuses that mean the app is still starting."""
+    try:
+        return int(status_code) in STARTUP_STATUS_CODES
+    except (TypeError, ValueError):
+        return False
+
+
+def _https_wait_progress():
+    """Progress bar for the HTTPS wait. Disabled when stdout is not a TTY.
+
+    The wait has no known length (the first POST may succeed, or we may retry
+    until the timeout), so the bar is indeterminate: it pulses instead of
+    sitting at 0%.
+    """
+    return Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(
+            complete_style=_HTTPS_WAIT_BAR_STYLE,
+            finished_style=_HTTPS_WAIT_BAR_STYLE,
+            pulse_style=_HTTPS_WAIT_BAR_STYLE,
+        ),
+        TimeElapsedColumn(),
+        console=Console(highlight=False),
+        transient=True,
+        disable=not sys.stdout.isatty(),
+    )
+
+
+def _announce_https_wait(announced):
+    """Print a one-line wait notice on non-TTY logs; the progress bar covers TTYs."""
+    if announced:
+        return True
+    if not sys.stdout.isatty():
+        Console(highlight=False).print(HTTPS_WAIT_MESSAGE)
+    return True
 
 
 def handle_launch_data(
@@ -38,9 +105,13 @@ def handle_launch_data(
     dozzle_password=None,
     context=None,
 ):
-    """Sends a POST request to the given `url`, retrying it with exponential backoff.
-    The passed `error` function is invoked to give feedback as each error occurs,
-    possibly multiple times. If all attempts fail, an exception is raised.
+    """POST to ``url`` (``/launch``), retrying with exponential backoff.
+
+    Connection, TLS, and gateway-startup failures are expected while the
+    server becomes reachable. Those retries show a progress bar instead of
+    error output. Application errors are still reported as they happen. If
+    every attempt fails, the last error is reported and a
+    ``click.ClickException`` summarizing the failure is raised.
 
     Args:
         url: The URL to send the POST request to
@@ -53,58 +124,112 @@ def handle_launch_data(
     """
     launch_data = None
     launch_request = None
-    for remaining_attempt in sorted(range(attempts), reverse=True):  # [3, 2, 1, 0]
-        try:
-            launch_request = requests.post(url)
-            request_happened = True
-        except requests.exceptions.RequestException as err:
-            request_happened = False
-            error(f"Error accessing {url}:\n{err}")
+    last_startup_error = None
+    saw_application_error = False
+    announced_wait = False
 
-        if request_happened:
+    with _https_wait_progress() as progress:
+        task_id = progress.add_task(HTTPS_WAIT_MESSAGE, total=None)
+        for remaining_attempt in sorted(range(attempts), reverse=True):
+            startup_failure = False
             try:
-                launch_data = launch_request.json()
-            except json.decoder.JSONDecodeError:
-                # The backend did not return JSON. It means our dallinger instance
-                # was not (yet) running at the time of the request.
-                # We treat this similarly to a RequestException: we'll try again after waiting.
+                launch_request = requests.post(url)
+                request_happened = True
+            except requests.exceptions.RequestException as err:
                 request_happened = False
-                error(
-                    f"Error parsing response from {url}, "
-                    f"check server logs for details.\n{launch_request.text}"
-                )
-            except ValueError as err:
-                error(
-                    f"Error parsing response from {url}, "
-                    f"check server logs for details.\n{err}\n{launch_request.text}"
-                )
-                raise
+                if _is_startup_exception(err):
+                    startup_failure = True
+                    last_startup_error = f"Error accessing {url}:\n{err}"
+                else:
+                    saw_application_error = True
+                    error(f"Error accessing {url}:\n{err}")
 
-        # Early return if successful
-        if request_happened and launch_request.ok:
-            return launch_data
-
-        if request_happened:
-            error(
-                "Error accessing {} ({}):\n{}".format(
+            if request_happened and _is_startup_status(launch_request.status_code):
+                startup_failure = True
+                request_happened = False
+                last_startup_error = "Error accessing {} ({}):\n{}".format(
                     url, launch_request.status_code, launch_request.text
                 )
-            )
 
-        if remaining_attempt:
-            delay = delay * BACKOFF_FACTOR
-            next_attempt_count = attempts - (remaining_attempt - 1)
-            error(
-                "Experiment launch failed. Trying again "
-                "(attempt {} of {}) in {} seconds ...".format(
-                    next_attempt_count, attempts, delay
+            if request_happened:
+                try:
+                    launch_data = launch_request.json()
+                except json.decoder.JSONDecodeError:
+                    # Non-JSON usually means the app is not serving yet, or a
+                    # real HTML error page. Treat a successful HTTP response
+                    # as startup; treat error statuses as application failures.
+                    request_happened = False
+                    detail = (
+                        f"Error parsing response from {url}, "
+                        f"check server logs for details.\n{launch_request.text}"
+                    )
+                    if launch_request.ok:
+                        startup_failure = True
+                        last_startup_error = detail
+                    else:
+                        saw_application_error = True
+                        error(detail)
+                except ValueError as err:
+                    error(
+                        f"Error parsing response from {url}, "
+                        f"check server logs for details.\n{err}\n{launch_request.text}"
+                    )
+                    raise
+
+            if request_happened and launch_request.ok:
+                progress.update(task_id, total=1, completed=1)
+                return launch_data
+
+            if request_happened:
+                saw_application_error = True
+                error(
+                    "Error accessing {} ({}):\n{}".format(
+                        url, launch_request.status_code, launch_request.text
+                    )
                 )
-            )
-        time.sleep(delay)
 
-    error("Experiment launch failed after multiple attempts.")
-    if launch_data and launch_data.get("message"):
-        error(launch_data["message"])
+            if startup_failure and not saw_application_error:
+                announced_wait = _announce_https_wait(announced_wait)
+                attempt_number = attempts - remaining_attempt
+                progress.update(
+                    task_id,
+                    description=(
+                        f"{HTTPS_WAIT_MESSAGE} (attempt {attempt_number} of {attempts})"
+                    ),
+                )
+            elif saw_application_error:
+                progress.update(task_id, visible=False)
+
+            if remaining_attempt:
+                delay = delay * BACKOFF_FACTOR
+                if not startup_failure or saw_application_error:
+                    next_attempt_count = attempts - (remaining_attempt - 1)
+                    error(
+                        "Experiment launch failed. Trying again "
+                        "(attempt {} of {}) in {} seconds ...".format(
+                            next_attempt_count, attempts, delay
+                        )
+                    )
+                time.sleep(delay)
+
+    if not saw_application_error and last_startup_error:
+        error("Timed out waiting for the experiment URL to become reachable.")
+        error(last_startup_error)
+        summary = (
+            f"{url} never became reachable. The experiment server may still be "
+            "starting up, or its TLS certificate may not have been issued yet."
+        )
+    else:
+        error("Experiment launch failed after multiple attempts.")
+        if launch_data and launch_data.get("message"):
+            error(launch_data["message"])
+        if launch_request is not None:
+            summary = (
+                f"{url} returned HTTP {launch_request.status_code}. "
+                "Check the experiment server logs for details."
+            )
+        else:
+            summary = f"Could not reach {url}."
 
     # Show appropriate log location message based on deployment context
     if context == "heroku":
@@ -116,10 +241,9 @@ def handle_launch_data(
             f"Check the detailed server logs at https://logs.{dns_host} (user = dallinger, password = {dozzle_password})"
         )
 
-    if launch_request is not None:
-        launch_request.raise_for_status()
-
-    raise requests.exceptions.ConnectionError
+    # A ClickException prints as "Error: <message>" and exits non-zero, so a
+    # failed launch reads as a diagnosis rather than a Python traceback.
+    raise click.ClickException(f"Experiment launch failed. {summary}")
 
 
 def deploy_sandbox_shared_setup(

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -11,6 +11,7 @@ import warnings
 from pathlib import Path
 from unittest import mock
 
+import click
 import pexpect
 import pytest
 import requests
@@ -1647,6 +1648,126 @@ class Testhandle_launch_data:
             mock_post.return_value = result
             assert handler("/some-launch-url", error=log) == {"message": "msg!"}
 
+    def test_https_wait_progress_is_status_not_error(self):
+        from dallinger.deployment import _HTTPS_WAIT_BAR_STYLE, _https_wait_progress
+
+        progress = _https_wait_progress()
+        assert progress.console.file is sys.stdout
+        assert _HTTPS_WAIT_BAR_STYLE != "red"
+        assert not any(
+            "percentage" in getattr(column, "text_format", "")
+            for column in progress.columns
+        )
+
+    def test_https_wait_bar_is_indeterminate(self, handler):
+        from dallinger.deployment import HTTPS_WAIT_MESSAGE, Progress
+
+        log = mock.Mock()
+        added = {}
+        original = Progress.add_task
+
+        def spy(self, description, *args, **kwargs):
+            if description == HTTPS_WAIT_MESSAGE:
+                added.update(kwargs)
+            return original(self, description, *args, **kwargs)
+
+        result = mock.Mock(ok=True, json=mock.Mock(return_value={"message": "msg!"}))
+        with (
+            mock.patch("dallinger.deployment.requests.post", return_value=result),
+            mock.patch.object(Progress, "add_task", spy),
+        ):
+            assert handler("/some-launch-url", error=log) == {"message": "msg!"}
+
+        assert added.get("total") is None
+
+    def test_startup_failure_classification(self):
+        from dallinger.deployment import _is_startup_exception, _is_startup_status
+
+        assert _is_startup_exception(requests.exceptions.SSLError("tls"))
+        assert _is_startup_exception(requests.exceptions.ConnectionError("down"))
+        assert not _is_startup_exception(requests.exceptions.HTTPError("500"))
+        assert _is_startup_status(502)
+        assert _is_startup_status("503")
+        assert not _is_startup_status(500)
+
+    def test_ssl_errors_are_quiet_until_success(self, handler):
+        log = mock.Mock()
+        ssl_error = requests.exceptions.SSLError(
+            "[SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error"
+        )
+        success = mock.Mock(ok=True, json=mock.Mock(return_value={"message": "msg!"}))
+        with (
+            mock.patch("dallinger.deployment.requests.post") as mock_post,
+            mock.patch("dallinger.deployment.time.sleep"),
+        ):
+            mock_post.side_effect = [ssl_error, ssl_error, success]
+            assert handler("/some-launch-url", error=log, delay=0.05, attempts=3) == {
+                "message": "msg!"
+            }
+
+        log.assert_not_called()
+
+    def test_ssl_errors_are_reported_after_timeout(self, handler):
+        log = mock.Mock()
+        ssl_error = requests.exceptions.SSLError(
+            "[SSL: TLSV1_ALERT_INTERNAL_ERROR] tlsv1 alert internal error"
+        )
+        with (
+            mock.patch("dallinger.deployment.requests.post") as mock_post,
+            mock.patch("dallinger.deployment.time.sleep"),
+        ):
+            mock_post.side_effect = ssl_error
+            with pytest.raises(click.ClickException) as excinfo:
+                handler("/some-launch-url", error=log, delay=0.05, attempts=3)
+
+        messages = [call.args[0] for call in log.call_args_list]
+        assert messages[0] == (
+            "Timed out waiting for the experiment URL to become reachable."
+        )
+        assert "Error accessing /some-launch-url" in messages[1]
+        assert "tlsv1 alert internal error" in messages[1]
+        assert "never became reachable" in excinfo.value.message
+        assert not any(
+            "Experiment launch failed. Trying again" in msg for msg in messages
+        )
+
+    def test_gateway_errors_are_quiet_until_success(self, handler):
+        log = mock.Mock()
+        gateway = mock.Mock(ok=False, status_code=502, text="Bad Gateway")
+        success = mock.Mock(ok=True, json=mock.Mock(return_value={"message": "msg!"}))
+        with (
+            mock.patch("dallinger.deployment.requests.post") as mock_post,
+            mock.patch("dallinger.deployment.time.sleep"),
+        ):
+            mock_post.side_effect = [gateway, success]
+            assert handler("/some-launch-url", error=log, delay=0.05, attempts=3) == {
+                "message": "msg!"
+            }
+
+        log.assert_not_called()
+
+    def test_gateway_errors_are_reported_after_timeout(self, handler):
+        log = mock.Mock()
+        gateway = mock.Mock(ok=False, status_code=502, text="Bad Gateway")
+        gateway.raise_for_status = mock.Mock(side_effect=requests.exceptions.HTTPError)
+        with (
+            mock.patch("dallinger.deployment.requests.post") as mock_post,
+            mock.patch("dallinger.deployment.time.sleep"),
+        ):
+            mock_post.return_value = gateway
+            with pytest.raises(click.ClickException) as excinfo:
+                handler("/some-launch-url", error=log, delay=0.05, attempts=3)
+
+        messages = [call.args[0] for call in log.call_args_list]
+        assert messages[0] == (
+            "Timed out waiting for the experiment URL to become reachable."
+        )
+        assert "Error accessing /some-launch-url (502)" in messages[1]
+        assert "never became reachable" in excinfo.value.message
+        assert not any(
+            "Experiment launch failed. Trying again" in msg for msg in messages
+        )
+
     def test_failure_mock(self, handler):
         log = mock.Mock()
         with mock.patch("dallinger.deployment.requests.post") as mock_post:
@@ -1657,7 +1778,7 @@ class Testhandle_launch_data:
                 status_code=500,
                 text="Failure",
             )
-            with pytest.raises(requests.exceptions.HTTPError):
+            with pytest.raises(click.ClickException) as excinfo:
                 handler("/some-launch-url", error=log, delay=0.05, attempts=3)
 
         log.assert_has_calls(
@@ -1675,13 +1796,28 @@ class Testhandle_launch_data:
                 mock.call("msg!"),
             ]
         )
+        assert excinfo.value.message == (
+            "Experiment launch failed. /some-launch-url returned HTTP 500. "
+            "Check the experiment server logs for details."
+        )
+
+    def test_failed_launch_prints_error_without_traceback(self, handler):
+        @click.command()
+        def launch():
+            handler("http://127.0.0.1:1/launch", print, attempts=1)
+
+        result = click.testing.CliRunner().invoke(launch)
+        assert result.exit_code == 1
+        assert "Error: Experiment launch failed." in result.output
+        assert "never became reachable" in result.output
+        assert "Traceback" not in result.output
 
     def test_failure_real(self, handler):
         log = mock.Mock()
 
         try:
             handler("https://httpbingo.org/status/500", log, attempts=1)
-        except requests.exceptions.HTTPError:
+        except click.ClickException:
             pass
         log.assert_has_calls(
             [
@@ -1695,12 +1831,13 @@ class Testhandle_launch_data:
         log.reset_mock()
         try:
             handler("https://nonexistent.example.com/", log, attempts=1)
-        except requests.exceptions.ConnectionError:
+        except click.ClickException:
             pass
-        assert (
-            "Error accessing https://nonexistent.example.com/"
-            in log.call_args_list[0][0][0]
+        messages = [call.args[0] for call in log.call_args_list]
+        assert messages[0] == (
+            "Timed out waiting for the experiment URL to become reachable."
         )
+        assert "Error accessing https://nonexistent.example.com/" in messages[1]
 
     def test_non_json_response_error(self, handler):
         log = mock.Mock()
@@ -1735,7 +1872,7 @@ class Testhandle_launch_data:
             mock_post.return_value = mock_response
 
             # Test Heroku context
-            with pytest.raises(requests.exceptions.HTTPError):
+            with pytest.raises(click.ClickException):
                 handler(
                     "https://example.com/some-launch-url", error=log, context="heroku"
                 )
@@ -1745,7 +1882,7 @@ class Testhandle_launch_data:
 
             # Test SSH context with Dozzle
             mock_print.reset_mock()
-            with pytest.raises(requests.exceptions.HTTPError):
+            with pytest.raises(click.ClickException):
                 handler(
                     "https://example.com/some-launch-url",
                     error=log,
@@ -1759,7 +1896,7 @@ class Testhandle_launch_data:
 
             # Test local context
             mock_print.reset_mock()
-            with pytest.raises(requests.exceptions.HTTPError):
+            with pytest.raises(click.ClickException):
                 handler("/some-launch-url", error=log, context="local")
             mock_print.assert_not_called()
 


### PR DESCRIPTION
## Motivation

[PsyNet work item 1019](https://gitlab.com/PsyNetDev/PsyNet/-/work_items/1019): `psynet debug ssh` / `dallinger docker-ssh` launch retries TLS handshake failures (`TLSV1_ALERT_INTERNAL_ERROR`) as red "Experiment launch failed" errors. Those failures are expected while Caddy finishes issuing certificates. Printing them makes a successful deploy look broken.

A failed launch then ended with a Python traceback (`HTTPError` / `ConnectionError`). Operators need a short diagnosis, not a stack trace.

The native operation remains `POST /launch`. The wait is for that URL to become reachable, not a separate health-check protocol, and not a fixed sleep before the first request.

## Summary of changes

Two commits on `origin/master`:

1. Quiet URL wait and Click diagnosis (`dallinger/deployment.py`, `tests/test_deployment.py`)
2. Unreleased changelog Fixed entry (`CHANGELOG.md`)

- `handle_launch_data` classifies TLS, connection, timeout, and 502/503/504 responses as startup unreadiness.
- Unreadiness retries show a Rich pulsing progress bar on stdout (or a one-line notice when stdout is not a TTY) instead of error output.
- Application errors (for example HTTP 500 JSON) are still reported immediately and retried with the existing backoff copy.
- If every attempt is still unreadiness, the timeout message includes the last real error.
- A failed launch now raises `click.ClickException` (`Error: Experiment launch failed. ...`) instead of `requests` exceptions that print a traceback.
- Tests cover quiet SSL/502 success, reporting after timeout, Click diagnosis without a traceback, and unchanged application-error reporting.

This applies to every `handle_launch_data` caller (docker-ssh, Heroku, local develop, Docker), not only SSH.

## Behavior changes

During experiment launch, operators see a progress bar:

`Waiting for the experiment URL to become reachable`

instead of SSL stack traces and "Experiment launch failed. Trying again" for TLS, connection, and gateway-startup failures. If launch never succeeds, the last TLS/connection/gateway error is printed, plus the existing Heroku/SSH log hints.

HTTP 500 and other application failures still print as they happen.

Failed launches exit with Click's `Error: Experiment launch failed. ...` line instead of a Python traceback. Callers that caught `requests.exceptions.HTTPError` or `ConnectionError` from `handle_launch_data` must catch `click.ClickException` instead. In-repo callers already use a broad `except Exception` or do not catch.

## Testing

- `python -m pytest tests/test_deployment.py::Testhandle_launch_data` — 13 passed (`/branch-review` on 2026-09-14)
- GitHub Actions on the pre-rewrite history: `build` (3.11–3.14), `docker`, `pre-commit`, `check_changelog`, `check_mturk_changes` passing
- Not run: full `tox` matrix (unit change is isolated to launch retry UX)
- Not run: live `psynet debug ssh` / `dallinger docker-ssh` against a remote host in this review session

## Changelog

Unreleased Fixed entry in `CHANGELOG.md`.

## Automatic code review

`/branch-review` was run on 2026-09-14 against `origin/master...HEAD` (branch already contained current `master`; no merge commit). Review was acceptable.

Non-blocking notes from this review:
- Hide the wait bar *before* calling `error()` / `print` on application failures. `progress.update(visible=False)` currently runs after the error line, so docker-ssh (`error=print`) can still interleave the bar with the 500 message on a TTY.
- The 502/503/504 retry of `POST /launch` is pre-existing and can still repeat launch if a proxy times out a slow `/launch`.
- Exception type change (`ClickException` instead of `HTTPError` / `ConnectionError`) is intentional and documented above.

`/reorganize-onto-master` was run after an earlier review. The tree is unchanged; history is two logical commits.

## Screenshots

N/A — CLI progress bar on stdout; disabled when stdout is not a TTY.
